### PR TITLE
Utils bump

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -304,7 +304,7 @@ class Config(object):
         'simulate-delivered-3@notifications.service.gov.uk',
     )
 
-    SIMULATED_SMS_NUMBERS = ('+16502532222', '+16502532223', '+16502532224')
+    SIMULATED_SMS_NUMBERS = ('+16132532222', '+16132532223', '+16132532224')
 
     DVLA_BUCKETS = {
         'job': '{}-dvla-file-per-job'.format(os.getenv('NOTIFY_ENVIRONMENT', 'development')),

--- a/app/config.py
+++ b/app/config.py
@@ -304,7 +304,7 @@ class Config(object):
         'simulate-delivered-3@notifications.service.gov.uk',
     )
 
-    SIMULATED_SMS_NUMBERS = ('+447700900000', '+447700900111', '+447700900222')
+    SIMULATED_SMS_NUMBERS = ('+16502532222', '+16502532223', '+16502532224')
 
     DVLA_BUCKETS = {
         'job': '{}-dvla-file-per-job'.format(os.getenv('NOTIFY_ENVIRONMENT', 'development')),

--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -87,7 +87,7 @@ def get_all_notifications():
 
 @notifications.route('/notifications/<string:notification_type>', methods=['POST'])
 def send_notification(notification_type):
-
+    
     if notification_type not in [SMS_TYPE, EMAIL_TYPE]:
         msg = "{} notification type is not supported".format(notification_type)
         msg = msg + ", please use the latest version of the client" if notification_type == LETTER_TYPE else msg
@@ -121,6 +121,7 @@ def send_notification(notification_type):
     if notification_type == SMS_TYPE:
         _service_can_send_internationally(authenticated_service, notification_form['to'])
     # Do not persist or send notification to the queue if it is a simulated recipient
+
     simulated = simulated_recipient(notification_form['to'], notification_type)
     notification_model = persist_notification(template_id=template.id,
                                               template_version=template.version,

--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -87,7 +87,7 @@ def get_all_notifications():
 
 @notifications.route('/notifications/<string:notification_type>', methods=['POST'])
 def send_notification(notification_type):
-    
+
     if notification_type not in [SMS_TYPE, EMAIL_TYPE]:
         msg = "{} notification type is not supported".format(notification_type)
         msg = msg + ", please use the latest version of the client" if notification_type == LETTER_TYPE else msg

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -30,6 +30,6 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@34.0.5#egg=notifications-utils==34.0.5
+git+https://github.com/cds-snc/notifier-utils.git@34.0.6#egg=notifications-utils==34.0.6
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@34.0.5#egg=notifications-utils==34.0.5
+git+https://github.com/cds-snc/notifier-utils.git@34.0.6#egg=notifications-utils==34.0.6
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
 

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -1,5 +1,5 @@
-import json
 import uuid
+import json
 from datetime import datetime, timedelta
 from unittest.mock import Mock, call
 
@@ -457,7 +457,7 @@ def test_process_row_when_sender_id_is_provided(mocker, fake_uuid):
 
 def test_should_send_template_to_correct_sms_task_and_persist(sample_template_with_placeholders, mocker):
     notification = _notification_json(sample_template_with_placeholders,
-                                      to="+447234123123", personalisation={"name": "Jo"})
+                                      to="+1 650 253 2222", personalisation={"name": "Jo"})
 
     mocked_deliver_sms = mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
 
@@ -468,7 +468,7 @@ def test_should_send_template_to_correct_sms_task_and_persist(sample_template_wi
     )
 
     persisted_notification = Notification.query.one()
-    assert persisted_notification.to == '+447234123123'
+    assert persisted_notification.to == '+1 650 253 2222'
     assert persisted_notification.template_id == sample_template_with_placeholders.id
     assert persisted_notification.template_version == sample_template_with_placeholders.version
     assert persisted_notification.status == 'created'
@@ -490,7 +490,7 @@ def test_should_put_save_sms_task_in_research_mode_queue_if_research_mode_servic
 
     template = create_template(service=service)
 
-    notification = _notification_json(template, to="+447234123123")
+    notification = _notification_json(template, to="+1 650 253 2222")
 
     mocked_deliver_sms = mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
 
@@ -510,10 +510,10 @@ def test_should_put_save_sms_task_in_research_mode_queue_if_research_mode_servic
 
 
 def test_should_save_sms_if_restricted_service_and_valid_number(notify_db_session, mocker):
-    user = create_user(mobile_number="07700 900890")
+    user = create_user(mobile_number="6502532222")
     service = create_service(user=user, restricted=True)
     template = create_template(service=service)
-    notification = _notification_json(template, "+447700900890")  # The user’s own number, but in a different format
+    notification = _notification_json(template, "+16502532222")  # The user’s own number, but in a different format
 
     mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
 
@@ -526,7 +526,7 @@ def test_should_save_sms_if_restricted_service_and_valid_number(notify_db_sessio
     )
 
     persisted_notification = Notification.query.one()
-    assert persisted_notification.to == '+447700900890'
+    assert persisted_notification.to == '+16502532222'
     assert persisted_notification.template_id == template.id
     assert persisted_notification.template_version == template.version
     assert persisted_notification.status == 'created'
@@ -565,7 +565,7 @@ def test_save_sms_should_save_default_smm_sender_notification_reply_to_text_on(n
     service = create_service_with_defined_sms_sender(sms_sender_value='12345')
     template = create_template(service=service)
 
-    notification = _notification_json(template, to="07700 900205")
+    notification = _notification_json(template, to="6502532222")
     mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
 
     notification_id = uuid.uuid4()
@@ -580,7 +580,7 @@ def test_save_sms_should_save_default_smm_sender_notification_reply_to_text_on(n
 
 
 def test_should_not_save_sms_if_restricted_service_and_invalid_number(notify_db_session, mocker):
-    user = create_user(mobile_number="07700 900205")
+    user = create_user(mobile_number="6502532222")
     service = create_service(user=user, restricted=True)
     template = create_template(service=service)
 
@@ -642,7 +642,7 @@ def test_should_put_save_email_task_in_research_mode_queue_if_research_mode_serv
 def test_should_save_sms_template_to_and_persist_with_job_id(sample_job, mocker):
     notification = _notification_json(
         sample_job.template,
-        to="+447234123123",
+        to="+1 650 253 2222",
         job_id=sample_job.id,
         row_number=2)
     mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
@@ -655,7 +655,7 @@ def test_should_save_sms_template_to_and_persist_with_job_id(sample_job, mocker)
         encryption.encrypt(notification),
     )
     persisted_notification = Notification.query.one()
-    assert persisted_notification.to == '+447234123123'
+    assert persisted_notification.to == '+1 650 253 2222'
     assert persisted_notification.job_id == sample_job.id
     assert persisted_notification.template_id == sample_job.template.id
     assert persisted_notification.status == 'created'
@@ -675,7 +675,7 @@ def test_should_save_sms_template_to_and_persist_with_job_id(sample_job, mocker)
 
 def test_should_not_save_sms_if_team_key_and_recipient_not_in_team(notify_db_session, mocker):
     assert Notification.query.count() == 0
-    user = create_user(mobile_number="07700 900205")
+    user = create_user(mobile_number="6502532222")
     service = create_service(user=user, restricted=True)
     template = create_template(service=service)
 
@@ -857,7 +857,7 @@ def test_should_use_email_template_and_persist_without_personalisation(sample_em
 
 
 def test_save_sms_should_go_to_retry_queue_if_database_errors(sample_template, mocker):
-    notification = _notification_json(sample_template, "+447234123123")
+    notification = _notification_json(sample_template, "+1 650 253 2222")
 
     expected_exception = SQLAlchemyError()
 
@@ -920,7 +920,7 @@ def test_save_email_does_not_send_duplicate_and_does_not_put_in_retry_queue(samp
 
 
 def test_save_sms_does_not_send_duplicate_and_does_not_put_in_retry_queue(sample_notification, mocker):
-    json = _notification_json(sample_notification.template, sample_notification.to, job_id=uuid.uuid4(), row_number=1)
+    json = _notification_json(sample_notification.template, "6502532222", job_id=uuid.uuid4(), row_number=1)
     deliver_sms = mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
     retry = mocker.patch('app.celery.tasks.save_sms.retry', side_effect=Exception())
 
@@ -1105,10 +1105,10 @@ def test_save_letter_uses_template_reply_to_text(mocker, notify_db_session):
 
 
 def test_save_sms_uses_sms_sender_reply_to_text(mocker, notify_db_session):
-    service = create_service_with_defined_sms_sender(sms_sender_value='07123123123')
+    service = create_service_with_defined_sms_sender(sms_sender_value='6502532222')
     template = create_template(service=service)
 
-    notification = _notification_json(template, to="07700 900205")
+    notification = _notification_json(template, to="6502532222")
     mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
 
     notification_id = uuid.uuid4()
@@ -1119,7 +1119,7 @@ def test_save_sms_uses_sms_sender_reply_to_text(mocker, notify_db_session):
     )
 
     persisted_notification = Notification.query.one()
-    assert persisted_notification.reply_to_text == '447123123123'
+    assert persisted_notification.reply_to_text == '+16502532222'
 
 
 def test_save_sms_uses_non_default_sms_sender_reply_to_text_if_provided(mocker, notify_db_session):
@@ -1127,7 +1127,7 @@ def test_save_sms_uses_non_default_sms_sender_reply_to_text_if_provided(mocker, 
     template = create_template(service=service)
     new_sender = service_sms_sender_dao.dao_add_sms_sender_for_service(service.id, 'new-sender', False)
 
-    notification = _notification_json(template, to="07700 900205")
+    notification = _notification_json(template, to="6502532222")
     mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
 
     notification_id = uuid.uuid4()

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -513,7 +513,7 @@ def test_should_save_sms_if_restricted_service_and_valid_number(notify_db_sessio
     user = create_user(mobile_number="6502532222")
     service = create_service(user=user, restricted=True)
     template = create_template(service=service)
-    notification = _notification_json(template, "+16502532222")  # The user’s own number, but in a different format
+    notification = _notification_json(template, "+16502532222") 
 
     mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
 

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -513,7 +513,7 @@ def test_should_save_sms_if_restricted_service_and_valid_number(notify_db_sessio
     user = create_user(mobile_number="6502532222")
     service = create_service(user=user, restricted=True)
     template = create_template(service=service)
-    notification = _notification_json(template, "+16502532222") 
+    notification = _notification_json(template, "+16502532222")
 
     mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
 

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -568,7 +568,7 @@ def sample_notification(
     if to_field:
         to = to_field
     else:
-        to = '+447700900855'
+        to = '+16502532222'
 
     data = {
         'id': notification_id,

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -1009,8 +1009,8 @@ def test_delivery_is_delivery_slow_for_provider_filters_out_notifications_it_sho
 def test_dao_get_notifications_by_to_field(sample_template):
 
     recipient_to_search_for = {
-        'to_field': '+447700900855',
-        'normalised_to': '447700900855'
+        'to_field': '+16502532222',
+        'normalised_to': '16502532222'
     }
 
     notification1 = create_notification(
@@ -1157,19 +1157,19 @@ def test_dao_get_notifications_by_to_field_accepts_invalid_phone_numbers_and_ema
 
 def test_dao_get_notifications_by_to_field_search_ignores_spaces(sample_template):
     notification1 = create_notification(
-        template=sample_template, to_field='+447700900855', normalised_to='447700900855'
+        template=sample_template, to_field='+16502532222', normalised_to='16502532222'
     )
     notification2 = create_notification(
-        template=sample_template, to_field='+44 77 00900 855', normalised_to='447700900855'
+        template=sample_template, to_field='+1 650 253 2222', normalised_to='16502532222'
     )
     notification3 = create_notification(
-        template=sample_template, to_field=' +4477009 00 855 ', normalised_to='447700900855'
+        template=sample_template, to_field=' +1650253 2 222', normalised_to='16502532222'
     )
     create_notification(
         template=sample_template, to_field='jaCK@gmail.com', normalised_to='jack@gmail.com'
     )
 
-    results = dao_get_notifications_by_to_field(notification1.service_id, '+447700900855', notification_type='sms')
+    results = dao_get_notifications_by_to_field(notification1.service_id, '+16502532222', notification_type='sms')
     notification_ids = [notification.id for notification in results]
 
     assert len(results) == 3
@@ -1179,7 +1179,7 @@ def test_dao_get_notifications_by_to_field_search_ignores_spaces(sample_template
 
 
 @pytest.mark.parametrize('phone_search', (
-    '077', '7-7', '+44(0)7711 111111'
+    '650', '502', '+16502532222'
 ))
 @pytest.mark.parametrize('email_search', (
     'example', 'eXaMpLe',
@@ -1192,9 +1192,9 @@ def test_dao_get_notifications_by_to_field_only_searches_one_notification_type(
     service = create_service()
     sms_template = create_template(service=service)
     email_template = create_template(service=service, template_type='email')
-    sms = create_notification(template=sms_template, to_field='07711111111', normalised_to='447711111111')
+    sms = create_notification(template=sms_template, to_field='6502532222', normalised_to='+16502532222')
     email = create_notification(
-        template=email_template, to_field='077@example.com', normalised_to='077@example.com'
+        template=email_template, to_field='165@example.com', normalised_to='165@example.com'
     )
     results = dao_get_notifications_by_to_field(service.id, phone_search, notification_type='sms')
     assert len(results) == 1
@@ -1202,7 +1202,7 @@ def test_dao_get_notifications_by_to_field_only_searches_one_notification_type(
     results = dao_get_notifications_by_to_field(service.id, phone_search)  # should assume SMS
     assert len(results) == 1
     assert results[0].id == sms.id
-    results = dao_get_notifications_by_to_field(service.id, '077', notification_type='email')
+    results = dao_get_notifications_by_to_field(service.id, '165', notification_type='email')
     assert len(results) == 1
     assert results[0].id == email.id
     results = dao_get_notifications_by_to_field(service.id, email_search)  # should assume email
@@ -1248,15 +1248,15 @@ def test_set_scheduled_notification_to_processed(sample_template):
 
 def test_dao_get_notifications_by_to_field_filters_status(sample_template):
     notification = create_notification(
-        template=sample_template, to_field='+447700900855',
-        normalised_to='447700900855', status='delivered'
+        template=sample_template, to_field='+16502532222',
+        normalised_to='16502532222', status='delivered'
     )
     create_notification(
-        template=sample_template, to_field='+447700900855',
-        normalised_to='447700900855', status='temporary-failure'
+        template=sample_template, to_field='+16502532222',
+        normalised_to='16502532222', status='temporary-failure'
     )
 
-    notifications = dao_get_notifications_by_to_field(notification.service_id, "+447700900855",
+    notifications = dao_get_notifications_by_to_field(notification.service_id, "+16502532222",
                                                       statuses=['delivered'],
                                                       notification_type='sms')
 
@@ -1266,16 +1266,16 @@ def test_dao_get_notifications_by_to_field_filters_status(sample_template):
 
 def test_dao_get_notifications_by_to_field_filters_multiple_statuses(sample_template):
     notification1 = create_notification(
-        template=sample_template, to_field='+447700900855',
-        normalised_to='447700900855', status='delivered'
+        template=sample_template, to_field='+16502532222',
+        normalised_to='16502532222', status='delivered'
     )
     notification2 = create_notification(
-        template=sample_template, to_field='+447700900855',
-        normalised_to='447700900855', status='sending'
+        template=sample_template, to_field='+16502532222',
+        normalised_to='16502532222', status='sending'
     )
 
     notifications = dao_get_notifications_by_to_field(
-        notification1.service_id, "+447700900855", statuses=['delivered', 'sending'], notification_type='sms'
+        notification1.service_id, "+16502532222", statuses=['delivered', 'sending'], notification_type='sms'
     )
     notification_ids = [notification.id for notification in notifications]
 
@@ -1286,16 +1286,16 @@ def test_dao_get_notifications_by_to_field_filters_multiple_statuses(sample_temp
 
 def test_dao_get_notifications_by_to_field_returns_all_if_no_status_filter(sample_template):
     notification1 = create_notification(
-        template=sample_template, to_field='+447700900855',
-        normalised_to='447700900855', status='delivered'
+        template=sample_template, to_field='+16502532222',
+        normalised_to='16502532222', status='delivered'
     )
     notification2 = create_notification(
-        template=sample_template, to_field='+447700900855',
-        normalised_to='447700900855', status='temporary-failure'
+        template=sample_template, to_field='+16502532222',
+        normalised_to='16502532222', status='temporary-failure'
     )
 
     notifications = dao_get_notifications_by_to_field(
-        notification1.service_id, "+447700900855", notification_type='sms'
+        notification1.service_id, "+16502532222", notification_type='sms'
     )
     notification_ids = [notification.id for notification in notifications]
 
@@ -1309,15 +1309,15 @@ def test_dao_get_notifications_by_to_field_orders_by_created_at_desc(sample_temp
     notification = partial(
         create_notification,
         template=sample_template,
-        to_field='+447700900855',
-        normalised_to='447700900855'
+        to_field='+16502532222',
+        normalised_to='16502532222'
     )
 
     notification_a_minute_ago = notification(created_at=datetime.utcnow() - timedelta(minutes=1))
     notification = notification(created_at=datetime.utcnow())
 
     notifications = dao_get_notifications_by_to_field(
-        sample_template.service_id, '+447700900855', notification_type='sms'
+        sample_template.service_id, '+16502532222', notification_type='sms'
     )
 
     assert len(notifications) == 2

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -1010,7 +1010,7 @@ def test_dao_get_notifications_by_to_field(sample_template):
 
     recipient_to_search_for = {
         'to_field': '+16502532222',
-        'normalised_to': '16502532222'
+        'normalised_to': '+16502532222'
     }
 
     notification1 = create_notification(
@@ -1157,13 +1157,13 @@ def test_dao_get_notifications_by_to_field_accepts_invalid_phone_numbers_and_ema
 
 def test_dao_get_notifications_by_to_field_search_ignores_spaces(sample_template):
     notification1 = create_notification(
-        template=sample_template, to_field='+16502532222', normalised_to='16502532222'
+        template=sample_template, to_field='+16502532222', normalised_to='+16502532222'
     )
     notification2 = create_notification(
-        template=sample_template, to_field='+1 650 253 2222', normalised_to='16502532222'
+        template=sample_template, to_field='+1 650 253 2222', normalised_to='+16502532222'
     )
     notification3 = create_notification(
-        template=sample_template, to_field=' +1650253 2 222', normalised_to='16502532222'
+        template=sample_template, to_field=' +1650253 2 222', normalised_to='+16502532222'
     )
     create_notification(
         template=sample_template, to_field='jaCK@gmail.com', normalised_to='jack@gmail.com'
@@ -1249,11 +1249,11 @@ def test_set_scheduled_notification_to_processed(sample_template):
 def test_dao_get_notifications_by_to_field_filters_status(sample_template):
     notification = create_notification(
         template=sample_template, to_field='+16502532222',
-        normalised_to='16502532222', status='delivered'
+        normalised_to='+16502532222', status='delivered'
     )
     create_notification(
         template=sample_template, to_field='+16502532222',
-        normalised_to='16502532222', status='temporary-failure'
+        normalised_to='+16502532222', status='temporary-failure'
     )
 
     notifications = dao_get_notifications_by_to_field(notification.service_id, "+16502532222",
@@ -1267,11 +1267,11 @@ def test_dao_get_notifications_by_to_field_filters_status(sample_template):
 def test_dao_get_notifications_by_to_field_filters_multiple_statuses(sample_template):
     notification1 = create_notification(
         template=sample_template, to_field='+16502532222',
-        normalised_to='16502532222', status='delivered'
+        normalised_to='+16502532222', status='delivered'
     )
     notification2 = create_notification(
         template=sample_template, to_field='+16502532222',
-        normalised_to='16502532222', status='sending'
+        normalised_to='+16502532222', status='sending'
     )
 
     notifications = dao_get_notifications_by_to_field(
@@ -1287,11 +1287,11 @@ def test_dao_get_notifications_by_to_field_filters_multiple_statuses(sample_temp
 def test_dao_get_notifications_by_to_field_returns_all_if_no_status_filter(sample_template):
     notification1 = create_notification(
         template=sample_template, to_field='+16502532222',
-        normalised_to='16502532222', status='delivered'
+        normalised_to='+16502532222', status='delivered'
     )
     notification2 = create_notification(
         template=sample_template, to_field='+16502532222',
-        normalised_to='16502532222', status='temporary-failure'
+        normalised_to='+16502532222', status='temporary-failure'
     )
 
     notifications = dao_get_notifications_by_to_field(
@@ -1310,7 +1310,7 @@ def test_dao_get_notifications_by_to_field_orders_by_created_at_desc(sample_temp
         create_notification,
         template=sample_template,
         to_field='+16502532222',
-        normalised_to='16502532222'
+        normalised_to='+16502532222'
     )
 
     notification_a_minute_ago = notification(created_at=datetime.utcnow() - timedelta(minutes=1))

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -219,7 +219,7 @@ def test_should_add_user_to_service(notify_db_session):
         name='Test User',
         email_address='new_user@digital.cabinet-office.gov.uk',
         password='password',
-        mobile_number='+447700900986'
+        mobile_number='+16502532222'
     )
     save_model_user(new_user)
     dao_add_user_to_service(service, new_user)
@@ -284,7 +284,7 @@ def test_should_remove_user_from_service(notify_db_session):
         name='Test User',
         email_address='new_user@digital.cabinet-office.gov.uk',
         password='password',
-        mobile_number='+447700900986'
+        mobile_number='+16502532222'
     )
     save_model_user(new_user)
     dao_add_user_to_service(service, new_user)
@@ -370,7 +370,7 @@ def test_get_all_only_services_user_has_access_to(notify_db_session):
         name='Test User',
         email_address='new_user@digital.cabinet-office.gov.uk',
         password='password',
-        mobile_number='+447700900986'
+        mobile_number='+16502532222'
     )
     save_model_user(new_user)
     dao_add_user_to_service(service_3, new_user)
@@ -428,7 +428,7 @@ def test_dao_fetch_live_services_data(sample_user):
     assert results == [
         {'service_id': mock.ANY, 'service_name': 'Sample service', 'organisation_name': 'test_org_1',
             'organisation_type': 'crown', 'consent_to_research': None, 'contact_name': 'Test User',
-            'contact_email': 'notify@digital.cabinet-office.gov.uk', 'contact_mobile': '+447700900986',
+            'contact_email': 'notify@digital.cabinet-office.gov.uk', 'contact_mobile': '+16502532222',
             'live_date': datetime(2014, 4, 20, 10, 0), 'sms_volume_intent': None, 'email_volume_intent': None,
             'letter_volume_intent': None, 'sms_totals': 2, 'email_totals': 1, 'letter_totals': 1,
             'free_sms_fragment_limit': 100},
@@ -440,7 +440,7 @@ def test_dao_fetch_live_services_data(sample_user):
             'free_sms_fragment_limit': 200},
         {'service_id': mock.ANY, 'service_name': 'second', 'organisation_name': None, 'consent_to_research': None,
             'contact_name': 'Test User', 'contact_email': 'notify@digital.cabinet-office.gov.uk',
-            'contact_mobile': '+447700900986', 'live_date': datetime(2017, 4, 20, 10, 0), 'sms_volume_intent': None,
+            'contact_mobile': '+16502532222', 'live_date': datetime(2017, 4, 20, 10, 0), 'sms_volume_intent': None,
             'organisation_type': None, 'email_volume_intent': None, 'letter_volume_intent': None,
             'sms_totals': 0, 'email_totals': 0, 'letter_totals': 1,
             'free_sms_fragment_limit': 300}

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -62,7 +62,7 @@ from app.models import (
 
 
 def create_user(
-    mobile_number="+447700900986",
+    mobile_number="+16502532222",
     email="notify@digital.cabinet-office.gov.uk",
     state='active',
     id_=None,
@@ -237,7 +237,7 @@ def create_notification(
         created_at = datetime.utcnow()
 
     if to_field is None:
-        to_field = '+447700900855' if template.template_type == SMS_TYPE else 'test@example.com'
+        to_field = '+16502532222' if template.template_type == SMS_TYPE else 'test@example.com'
 
     if status != 'created':
         sent_at = sent_at or datetime.utcnow()

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -407,7 +407,7 @@ def create_service_permission(service_id, permission=EMAIL_TYPE):
 def create_inbound_sms(
         service,
         notify_number=None,
-        user_number='447700900111',
+        user_number='+16502532222',
         provider_date=None,
         provider_reference=None,
         content='Hello',
@@ -417,7 +417,7 @@ def create_inbound_sms(
     if not service.inbound_number:
         create_inbound_number(
             # create random inbound number
-            notify_number or '07{:09}'.format(random.randint(0, 1e9 - 1)),
+            notify_number or '1{:10}'.format(random.randint(0, 1e9 - 1)),
             provider=provider,
             service_id=service.id
         )

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -70,7 +70,7 @@ def test_should_send_personalised_template_to_correct_sms_provider_and_persist(
     mocker
 ):
     db_notification = create_notification(template=sample_sms_template_with_html,
-                                          to_field="+447234123123", personalisation={"name": "Jo"},
+                                          to_field="+16502532222", personalisation={"name": "Jo"},
                                           status='created',
                                           reply_to_text=sample_sms_template_with_html.service.get_default_sms_sender())
 
@@ -81,7 +81,7 @@ def test_should_send_personalised_template_to_correct_sms_provider_and_persist(
     )
 
     aws_sns_client.send_sms.assert_called_once_with(
-        to=validate_and_format_phone_number("+447234123123"),
+        to=validate_and_format_phone_number("+16502532222"),
         content="Sample service: Hello Jo\nHere is <em>some HTML</em> & entities",
         reference=str(db_notification.id),
         sender=current_app.config['FROM_NUMBER']
@@ -160,7 +160,7 @@ def test_should_not_send_sms_message_when_service_is_inactive_notifcation_is_in_
 def test_send_sms_should_use_template_version_from_notification_not_latest(
         sample_template,
         mocker):
-    db_notification = create_notification(template=sample_template, to_field='+447234123123', status='created',
+    db_notification = create_notification(template=sample_template, to_field='+16502532222', status='created',
                                           reply_to_text=sample_template.service.get_default_sms_sender())
 
     mocker.patch('app.aws_sns_client.send_sms')
@@ -179,7 +179,7 @@ def test_send_sms_should_use_template_version_from_notification_not_latest(
     )
 
     aws_sns_client.send_sms.assert_called_once_with(
-        to=validate_and_format_phone_number("+447234123123"),
+        to=validate_and_format_phone_number("+16502532222"),
         content="Sample service: This is a template:\nwith a newline",
         reference=str(db_notification.id),
         sender=current_app.config['FROM_NUMBER']
@@ -703,12 +703,12 @@ def test_send_email_to_provider_should_format_reply_to_email_address(
 
 
 def test_send_sms_to_provider_should_format_phone_number(sample_notification, mocker):
-    sample_notification.to = '+44 (7123) 123-123'
+    sample_notification.to = '+1 650 253 2222'
     send_mock = mocker.patch('app.aws_sns_client.send_sms')
 
     send_to_providers.send_sms_to_provider(sample_notification)
 
-    assert send_mock.call_args[1]['to'] == '447123123123'
+    assert send_mock.call_args[1]['to'] == '+16502532222'
 
 
 def test_send_email_to_provider_should_format_email_address(sample_email_notification, mocker):

--- a/tests/app/inbound_sms/test_rest.py
+++ b/tests/app/inbound_sms/test_rest.py
@@ -32,14 +32,14 @@ def test_post_to_get_inbound_sms_with_no_params(admin_request, sample_service):
 
 
 @pytest.mark.parametrize('user_number', [
-    '(07700) 900-001',
-    '+4407700900001',
-    '447700900001',
+    '6502532222',
+    '+16502532222',
+    '16502532222',
 ])
 def test_post_to_get_inbound_sms_filters_user_number(admin_request, sample_service, user_number):
     # user_number in the db is international and normalised
-    one = create_inbound_sms(sample_service, user_number='447700900001')
-    create_inbound_sms(sample_service, user_number='447700900002')
+    one = create_inbound_sms(sample_service, user_number='+16502532222')
+    create_inbound_sms(sample_service, user_number='16502532223')
 
     data = {
         'phone_number': user_number
@@ -58,11 +58,11 @@ def test_post_to_get_inbound_sms_filters_user_number(admin_request, sample_servi
 
 def test_post_to_get_inbound_sms_filters_international_user_number(admin_request, sample_service):
     # user_number in the db is international and normalised
-    one = create_inbound_sms(sample_service, user_number='12025550104')
+    one = create_inbound_sms(sample_service, user_number='+16502532223')
     create_inbound_sms(sample_service)
 
     data = {
-        'phone_number': '+1 (202) 555-0104'
+        'phone_number': '+1 (650) 253-2223'
     }
 
     sms = admin_request.post(
@@ -158,7 +158,7 @@ def test_get_inbound_sms_summary_with_no_inbound(admin_request, sample_service):
 
 def test_get_inbound_sms_by_id_returns_200(admin_request, notify_db_session):
     service = create_service_with_inbound_number(inbound_number='12345')
-    inbound = create_inbound_sms(service=service, user_number='447700900001')
+    inbound = create_inbound_sms(service=service, user_number='16502532222')
 
     response = admin_request.get(
         'inbound_sms.get_inbound_by_id',
@@ -166,7 +166,7 @@ def test_get_inbound_sms_by_id_returns_200(admin_request, notify_db_session):
         inbound_sms_id=inbound.id,
     )
 
-    assert response['user_number'] == '447700900001'
+    assert response['user_number'] == '16502532222'
     assert response['service_id'] == str(service.id)
 
 

--- a/tests/app/inbound_sms/test_rest.py
+++ b/tests/app/inbound_sms/test_rest.py
@@ -34,12 +34,12 @@ def test_post_to_get_inbound_sms_with_no_params(admin_request, sample_service):
 @pytest.mark.parametrize('user_number', [
     '6502532222',
     '+16502532222',
-    '16502532222',
+    '+16502532222',
 ])
 def test_post_to_get_inbound_sms_filters_user_number(admin_request, sample_service, user_number):
     # user_number in the db is international and normalised
     one = create_inbound_sms(sample_service, user_number='+16502532222')
-    create_inbound_sms(sample_service, user_number='16502532223')
+    create_inbound_sms(sample_service, user_number='+16502532223')
 
     data = {
         'phone_number': user_number
@@ -158,7 +158,7 @@ def test_get_inbound_sms_summary_with_no_inbound(admin_request, sample_service):
 
 def test_get_inbound_sms_by_id_returns_200(admin_request, notify_db_session):
     service = create_service_with_inbound_number(inbound_number='12345')
-    inbound = create_inbound_sms(service=service, user_number='16502532222')
+    inbound = create_inbound_sms(service=service, user_number='+16502532222')
 
     response = admin_request.get(
         'inbound_sms.get_inbound_by_id',
@@ -166,7 +166,7 @@ def test_get_inbound_sms_by_id_returns_200(admin_request, notify_db_session):
         inbound_sms_id=inbound.id,
     )
 
-    assert response['user_number'] == '16502532222'
+    assert response['user_number'] == '+16502532222'
     assert response['service_id'] == str(service.id)
 
 

--- a/tests/app/notifications/rest/test_send_notification.py
+++ b/tests/app/notifications/rest/test_send_notification.py
@@ -222,7 +222,7 @@ def test_should_not_send_notification_for_archived_template(notify_api, sample_t
 
 
 @pytest.mark.parametrize('template_type, to',
-                         [(SMS_TYPE, '+16502532222'),
+                         [(SMS_TYPE, '+16502532223'),
                           (EMAIL_TYPE, 'not-someone-we-trust@email-address.com')])
 def test_should_not_send_notification_if_restricted_and_not_a_service_user(notify_api,
                                                                            sample_template,
@@ -331,7 +331,7 @@ def test_should_allow_valid_sms_notification(notify_api, sample_template, mocker
             mocked = mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
 
             data = {
-                'to': '07700 900 855',
+                'to': '6502532222',
                 'template': str(sample_template.id)
             }
 
@@ -563,7 +563,7 @@ def test_should_not_send_sms_if_team_api_key_and_not_a_service_user(notify_api, 
         mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
 
         data = {
-            'to': '07123123123',
+            'to': '6502532229',
             'template': str(sample_template.id),
         }
 
@@ -614,7 +614,7 @@ def test_should_send_sms_to_anyone_with_test_key(
     mocker.patch('app.notifications.process_notifications.uuid.uuid4', return_value=fake_uuid)
 
     data = {
-        'to': '07811111111',
+        'to': '6502532222',
         'template': sample_template.id
     }
     sample_template.service.restricted = restricted
@@ -820,9 +820,9 @@ def test_should_not_persist_notification_or_send_email_if_simulated_email(
 
 
 @pytest.mark.parametrize('to_sms', [
-    '07700 900000',
-    '07700 900111',
-    '07700 900222'
+    '6132532222',
+    '6132532223',
+    '6132532224'
 ])
 def test_should_not_persist_notification_or_send_sms_if_simulated_number(
         client,
@@ -852,7 +852,7 @@ def test_should_not_persist_notification_or_send_sms_if_simulated_number(
     KEY_TYPE_NORMAL, KEY_TYPE_TEAM
 ])
 @pytest.mark.parametrize('notification_type, to, _create_sample_template', [
-    (SMS_TYPE, '07827992635', create_sample_template),
+    (SMS_TYPE, '6502532229', create_sample_template),
     (EMAIL_TYPE, 'non_whitelist_recipient@mail.com', create_sample_email_template)]
 )
 def test_should_not_send_notification_to_non_whitelist_recipient_in_trial_mode(
@@ -907,7 +907,7 @@ def test_should_not_send_notification_to_non_whitelist_recipient_in_trial_mode(
     KEY_TYPE_NORMAL, KEY_TYPE_TEAM
 ])
 @pytest.mark.parametrize('notification_type, to, _create_sample_template', [
-    (SMS_TYPE, '07123123123', create_sample_template),
+    (SMS_TYPE, '6502532227', create_sample_template),
     (EMAIL_TYPE, 'whitelist_recipient@mail.com', create_sample_email_template)]
 )
 def test_should_send_notification_to_whitelist_recipient(
@@ -960,7 +960,7 @@ def test_should_send_notification_to_whitelist_recipient(
 @pytest.mark.parametrize(
     'notification_type, template_type, to', [
         (EMAIL_TYPE, SMS_TYPE, 'notify@digital.cabinet-office.gov.uk'),
-        (SMS_TYPE, EMAIL_TYPE, '+447700900986')
+        (SMS_TYPE, EMAIL_TYPE, '+16502532222')
     ])
 def test_should_error_if_notification_type_does_not_match_template_type(
         client,
@@ -1040,7 +1040,7 @@ def test_create_template_raises_invalid_request_when_content_too_large(
 
 
 @pytest.mark.parametrize("notification_type, send_to",
-                         [("sms", "07700 900 855"),
+                         [("sms", "6502532222"),
                           ("email", "sample@email.com")])
 def test_send_notification_uses_priority_queue_when_template_is_marked_as_priority(client, notify_db,
                                                                                    notify_db_session, mocker,
@@ -1074,7 +1074,7 @@ def test_send_notification_uses_priority_queue_when_template_is_marked_as_priori
 
 @pytest.mark.parametrize(
     "notification_type, send_to",
-    [("sms", "07700 900 855"), ("email", "sample@email.com")]
+    [("sms", "6502532222"), ("email", "sample@email.com")]
 )
 def test_returns_a_429_limit_exceeded_if_rate_limit_exceeded(
     client,
@@ -1122,7 +1122,7 @@ def test_should_allow_store_original_number_on_sms_notification(client, sample_t
     mocked = mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
 
     data = {
-        'to': '+(44) 7700-900 855',
+        'to': '+16502532222',
         'template': str(sample_template.id)
     }
 
@@ -1141,14 +1141,14 @@ def test_should_allow_store_original_number_on_sms_notification(client, sample_t
     assert notification_id
     notifications = Notification.query.all()
     assert len(notifications) == 1
-    assert '+(44) 7700-900 855' == notifications[0].to
+    assert '+16502532222' == notifications[0].to
 
 
 def test_should_not_allow_international_number_on_sms_notification(client, sample_template, mocker):
     mocked = mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
 
     data = {
-        'to': '20-12-1234-1234',
+        'to': '+20-12-1234-1234',
         'template': str(sample_template.id)
     }
 
@@ -1173,7 +1173,7 @@ def test_should_allow_international_number_on_sms_notification(client, notify_db
     template = create_sample_template(notify_db, notify_db_session, service=service)
 
     data = {
-        'to': '20-12-1234-1234',
+        'to': '+20-12-1234-1234',
         'template': str(template.id)
     }
 
@@ -1189,7 +1189,7 @@ def test_should_allow_international_number_on_sms_notification(client, notify_db
 
 @pytest.mark.parametrize(
     'template_factory, to, expected_error', [
-        (sample_template_without_sms_permission, '+447700900986', 'Cannot send text messages'),
+        (sample_template_without_sms_permission, '+16502532222', 'Cannot send text messages'),
         (sample_template_without_email_permission, 'notify@digital.cabinet-office.gov.uk', 'Cannot send emails')
     ])
 def test_should_not_allow_notification_if_service_permission_not_set(
@@ -1233,7 +1233,7 @@ def test_should_throw_exception_if_notification_type_is_invalid(client, sample_s
 
 
 @pytest.mark.parametrize("notification_type, recipient",
-                         [("sms", '07700 900 855'),
+                         [("sms", '6502532222'),
                           ("email", "test@gov.uk")
                           ]
                          )

--- a/tests/app/notifications/rest/test_send_notification.py
+++ b/tests/app/notifications/rest/test_send_notification.py
@@ -78,12 +78,12 @@ def test_should_reject_bad_phone_numbers(notify_api, sample_template, mocker):
             mocked.assert_not_called()
             assert json_resp['result'] == 'error'
             assert len(json_resp['message'].keys()) == 1
-            assert 'Invalid phone number: Must not contain letters or symbols' in json_resp['message']['to']
+            assert 'Invalid phone number: Not a valid international number' in json_resp['message']['to']
             assert response.status_code == 400
 
 
 @pytest.mark.parametrize('template_type, to',
-                         [(SMS_TYPE, '+447700900855'),
+                         [(SMS_TYPE, '+16502532222'),
                           (EMAIL_TYPE, 'ok@ok.com')])
 def test_send_notification_invalid_template_id(notify_api, sample_template, mocker, fake_uuid, template_type, to):
     with notify_api.test_request_context():
@@ -207,7 +207,7 @@ def test_should_not_send_notification_for_archived_template(notify_api, sample_t
             sample_template.archived = True
             dao_update_template(sample_template)
             json_data = json.dumps({
-                'to': '+447700900855',
+                'to': '+16502532222',
                 'template': sample_template.id
             })
             auth_header = create_authorization_header(service_id=sample_template.service_id)
@@ -222,7 +222,7 @@ def test_should_not_send_notification_for_archived_template(notify_api, sample_t
 
 
 @pytest.mark.parametrize('template_type, to',
-                         [(SMS_TYPE, '+447700900855'),
+                         [(SMS_TYPE, '+16502532222'),
                           (EMAIL_TYPE, 'not-someone-we-trust@email-address.com')])
 def test_should_not_send_notification_if_restricted_and_not_a_service_user(notify_api,
                                                                            sample_template,

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -61,7 +61,7 @@ def test_persist_notification_creates_and_save_to_db(sample_template, sample_api
     notification = persist_notification(
         template_id=sample_template.id,
         template_version=sample_template.version,
-        recipient='+447111111111',
+        recipient='+16502532222',
         service=sample_template.service,
         personalisation={},
         notification_type='sms',
@@ -102,7 +102,7 @@ def test_persist_notification_throws_exception_when_missing_template(sample_api_
     with pytest.raises(SQLAlchemyError):
         persist_notification(template_id=None,
                              template_version=None,
-                             recipient='+447111111111',
+                             recipient='+16502532222',
                              service=sample_api_key.service,
                              personalisation=None,
                              notification_type='sms',
@@ -118,7 +118,7 @@ def test_cache_is_not_incremented_on_failure_to_persist_notification(sample_api_
     with pytest.raises(SQLAlchemyError):
         persist_notification(template_id=None,
                              template_version=None,
-                             recipient='+447111111111',
+                             recipient='+16502532222',
                              service=sample_api_key.service,
                              personalisation=None,
                              notification_type='sms',
@@ -143,7 +143,7 @@ def test_persist_notification_does_not_increment_cache_if_test_key(
     persist_notification(
         template_id=sample_template.id,
         template_version=sample_template.version,
-        recipient='+447111111111',
+        recipient='+16502532222',
         service=sample_template.service,
         personalisation={},
         notification_type='sms',
@@ -170,7 +170,7 @@ def test_persist_notification_with_optionals(sample_job, sample_api_key, mocker)
     persist_notification(
         template_id=sample_job.template.id,
         template_version=sample_job.template.version,
-        recipient='+447111111111',
+        recipient='+16502532222',
         service=sample_job.service,
         personalisation=None,
         notification_type='sms',
@@ -194,7 +194,7 @@ def test_persist_notification_with_optionals(sample_job, sample_api_key, mocker)
     assert persisted_notification.client_reference == "ref from client"
     assert persisted_notification.reference is None
     assert persisted_notification.international is False
-    assert persisted_notification.phone_prefix == '44'
+    assert persisted_notification.phone_prefix == '1'
     assert persisted_notification.rate_multiplier == 1
     assert persisted_notification.created_by_id == sample_job.created_by_id
     assert not persisted_notification.reply_to_text
@@ -209,7 +209,7 @@ def test_persist_notification_doesnt_touch_cache_for_old_keys_that_dont_exist(sa
     persist_notification(
         template_id=sample_template.id,
         template_version=sample_template.version,
-        recipient='+447111111111',
+        recipient='+16502532222',
         service=sample_template.service,
         personalisation={},
         notification_type='sms',
@@ -230,7 +230,7 @@ def test_persist_notification_increments_cache_if_key_exists(sample_template, sa
     persist_notification(
         template_id=sample_template.id,
         template_version=sample_template.version,
-        recipient='+447111111122',
+        recipient='+16502532222',
         service=sample_template.service,
         personalisation={},
         notification_type='sms',
@@ -294,15 +294,13 @@ def test_send_notification_to_queue_throws_exception_deletes_notification(sample
 
 
 @pytest.mark.parametrize("to_address, notification_type, expected", [
-    ("+447700900000", "sms", True),
-    ("+447700900111", "sms", True),
-    ("+447700900222", "sms", True),
-    ("07700900000", "sms", True),
-    ("7700900111", "sms", True),
+    ("+16502532222", "sms", True),
+    ("+16502532223", "sms", True),
+    ("6502532222", "sms", True),
     ("simulate-delivered@notifications.service.gov.uk", "email", True),
     ("simulate-delivered-2@notifications.service.gov.uk", "email", True),
     ("simulate-delivered-3@notifications.service.gov.uk", "email", True),
-    ("07515896969", "sms", False),
+    ("6502532225", "sms", False),
     ("valid_email@test.com", "email", False)
 ])
 def test_simulated_recipient(notify_api, to_address, notification_type, expected):
@@ -314,7 +312,7 @@ def test_simulated_recipient(notify_api, to_address, notification_type, expected
         'simulate-delivered-2@notifications.service.gov.uk',
         'simulate-delivered-2@notifications.service.gov.uk'
     )
-    SIMULATED_SMS_NUMBERS = ('+447700900000', '+447700900111', '+447700900222')
+    SIMULATED_SMS_NUMBERS = ('6502532222', '+16502532222', '+16502532223')
     """
     formatted_address = None
 
@@ -329,11 +327,10 @@ def test_simulated_recipient(notify_api, to_address, notification_type, expected
 
 
 @pytest.mark.parametrize('recipient, expected_international, expected_prefix, expected_units', [
-    ('7900900123', False, '44', 1),  # UK
-    ('+447900900123', False, '44', 1),  # UK
-    ('07700900222', False, '44', 1),  # UK
-    ('73122345678', True, '7', 1),  # Russia
-    ('360623400400', True, '36', 3)]  # Hungary
+    ('6502532222', False, '1', 1),  # NA
+    ('+16502532222', False, '1', 1),  # NA
+    ('+79587714230', True, '7', 1),  # Russia
+    ('+360623400400', True, '36', 3)]  # Hungary
 )
 def test_persist_notification_with_international_info_stores_correct_info(
     sample_job,
@@ -399,15 +396,9 @@ def test_persist_scheduled_notification(sample_notification):
 
 
 @pytest.mark.parametrize('recipient, expected_recipient_normalised', [
-    ('7900900123', '447900900123'),
-    ('+447900   900 123', '447900900123'),
-    ('  07700900222', '447700900222'),
-    ('07700900222', '447700900222'),
-    (' 73122345678', '73122345678'),
-    ('360623400400', '360623400400'),
-    ('-077-00900222-', '447700900222'),
-    ('(360623(400400)', '360623400400')
-
+    ('6502532222', '+16502532222'),
+    ('  6502532223', '+16502532223'),
+    ('6502532223', '+16502532223'),
 ])
 def test_persist_sms_notification_stores_normalised_number(
     sample_job,

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -294,13 +294,13 @@ def test_send_notification_to_queue_throws_exception_deletes_notification(sample
 
 
 @pytest.mark.parametrize("to_address, notification_type, expected", [
-    ("+16502532222", "sms", True),
-    ("+16502532223", "sms", True),
-    ("6502532222", "sms", True),
+    ("+16132532222", "sms", True),
+    ("+16132532223", "sms", True),
+    ("6132532222", "sms", True),
     ("simulate-delivered@notifications.service.gov.uk", "email", True),
     ("simulate-delivered-2@notifications.service.gov.uk", "email", True),
     ("simulate-delivered-3@notifications.service.gov.uk", "email", True),
-    ("6502532225", "sms", False),
+    ("6132532225", "sms", False),
     ("valid_email@test.com", "email", False)
 ])
 def test_simulated_recipient(notify_api, to_address, notification_type, expected):
@@ -312,7 +312,7 @@ def test_simulated_recipient(notify_api, to_address, notification_type, expected
         'simulate-delivered-2@notifications.service.gov.uk',
         'simulate-delivered-2@notifications.service.gov.uk'
     )
-    SIMULATED_SMS_NUMBERS = ('6502532222', '+16502532222', '+16502532223')
+    SIMULATED_SMS_NUMBERS = ('6132532222', '+16132532222', '+16132532223')
     """
     formatted_address = None
 

--- a/tests/app/notifications/test_receive_notification.py
+++ b/tests/app/notifications/test_receive_notification.py
@@ -361,7 +361,7 @@ def test_receive_notification_from_firetext_persists_message_with_normalized_pho
     persisted = InboundSms.query.first()
 
     assert result['status'] == 'ok'
-    assert persisted.user_number == '447999999999'
+    assert persisted.user_number == '( 44)7999999999'
 
 
 def test_returns_ok_to_firetext_if_mismatched_sms_sender(notify_db_session, client, mocker):

--- a/tests/app/notifications/test_rest.py
+++ b/tests/app/notifications/test_rest.py
@@ -151,7 +151,7 @@ def test_get_all_notifications(client, sample_notification):
         'version': 1
     }
 
-    assert notifications['notifications'][0]['to'] == '+447700900855'
+    assert notifications['notifications'][0]['to'] == '+16502532222'
     assert notifications['notifications'][0]['service'] == str(sample_notification.service_id)
     assert notifications['notifications'][0]['body'] == 'Dear Sir/Madam, Hello. Yours Truly, The Government.'
 

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -208,15 +208,15 @@ def test_service_can_send_to_recipient_passes_for_whitelisted_recipient_passes(n
     assert service_can_send_to_recipient("some_other_email@test.com",
                                          'team',
                                          sample_service) is None
-    sample_service_whitelist(notify_db, notify_db_session, mobile_number='07513332413')
-    assert service_can_send_to_recipient('07513332413',
+    sample_service_whitelist(notify_db, notify_db_session, mobile_number='6502532222')
+    assert service_can_send_to_recipient('6502532222',
                                          'team',
                                          sample_service) is None
 
 
 @pytest.mark.parametrize('recipient', [
     {"email_address": "some_other_email@test.com"},
-    {"mobile_number": "07513332413"},
+    {"mobile_number": "6502532222"},
 ])
 def test_service_can_send_to_recipient_fails_when_ignoring_whitelist(
     notify_db,
@@ -357,7 +357,7 @@ def test_rejects_api_calls_with_international_numbers_if_service_does_not_allow_
 ):
     service = create_service(notify_db, notify_db_session, permissions=[SMS_TYPE])
     with pytest.raises(BadRequestError) as e:
-        validate_and_format_recipient('20-12-1234-1234', key_type, service, SMS_TYPE)
+        validate_and_format_recipient('+20-12-1234-1234', key_type, service, SMS_TYPE)
     assert e.value.status_code == 400
     assert e.value.message == 'Cannot send to international mobile numbers'
     assert e.value.fields == []
@@ -367,8 +367,8 @@ def test_rejects_api_calls_with_international_numbers_if_service_does_not_allow_
 def test_allows_api_calls_with_international_numbers_if_service_does_allow_int_sms(
         key_type, notify_db, notify_db_session):
     service = create_service(notify_db, notify_db_session, permissions=[SMS_TYPE, INTERNATIONAL_SMS_TYPE])
-    result = validate_and_format_recipient('20-12-1234-1234', key_type, service, SMS_TYPE)
-    assert result == '201212341234'
+    result = validate_and_format_recipient('+20-12-1234-1234', key_type, service, SMS_TYPE)
+    assert result == '+201212341234'
 
 
 def test_rejects_api_calls_with_no_recipient():

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -216,7 +216,7 @@ def test_service_can_send_to_recipient_passes_for_whitelisted_recipient_passes(n
 
 @pytest.mark.parametrize('recipient', [
     {"email_address": "some_other_email@test.com"},
-    {"mobile_number": "6502532222"},
+    {"mobile_number": "6502532223"},
 ])
 def test_service_can_send_to_recipient_fails_when_ignoring_whitelist(
     notify_db,

--- a/tests/app/public_contracts/test_POST_notification.py
+++ b/tests/app/public_contracts/test_POST_notification.py
@@ -23,7 +23,7 @@ def test_post_sms_contract(client, mocker, sample_template):
     mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
 
     response_json = return_json_from_response(_post_notification(
-        client, sample_template, url='/notifications/sms', to='07700 900 855'
+        client, sample_template, url='/notifications/sms', to='6502532222'
     ))
     validate_v0(response_json, 'POST_notification_return_sms.json')
 

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -2011,7 +2011,7 @@ def test_get_detailed_services_for_date_range(sample_template, start_date_delta,
 
 def test_search_for_notification_by_to_field(client, sample_template, sample_email_template):
 
-    notification1 = create_notification(template=sample_template, to_field='+447700900855',
+    notification1 = create_notification(template=sample_template, to_field='+16502532222',
                                         normalised_to='447700900855')
     notification2 = create_notification(template=sample_email_template, to_field='jack@gmail.com',
                                         normalised_to='jack@gmail.com')
@@ -2031,7 +2031,7 @@ def test_search_for_notification_by_to_field_return_empty_list_if_there_is_no_ma
     client, notify_db, notify_db_session
 ):
     create_notification = partial(create_sample_notification, notify_db, notify_db_session)
-    notification1 = create_notification(to_field='+447700900855')
+    notification1 = create_notification(to_field='+16502532222')
     create_notification(to_field='jack@gmail.com')
 
     response = client.get(
@@ -2046,13 +2046,13 @@ def test_search_for_notification_by_to_field_return_empty_list_if_there_is_no_ma
 
 def test_search_for_notification_by_to_field_return_multiple_matches(client, notify_db, notify_db_session):
     create_notification = partial(create_sample_notification, notify_db, notify_db_session)
-    notification1 = create_notification(to_field='+447700900855', normalised_to='447700900855')
+    notification1 = create_notification(to_field='+16502532222', normalised_to='447700900855')
     notification2 = create_notification(to_field=' +44 77009 00855 ', normalised_to='447700900855')
     notification3 = create_notification(to_field='+44770 0900 855', normalised_to='447700900855')
     notification4 = create_notification(to_field='jack@gmail.com', normalised_to='jack@gmail.com')
 
     response = client.get(
-        '/service/{}/notifications?to={}&template_type={}'.format(notification1.service_id, '+447700900855', 'sms'),
+        '/service/{}/notifications?to={}&template_type={}'.format(notification1.service_id, '+16502532222', 'sms'),
         headers=[create_authorization_header()]
     )
     notifications = json.loads(response.get_data(as_text=True))['notifications']
@@ -2151,7 +2151,7 @@ def test_search_for_notification_by_to_field_filters_by_status(client, notify_db
         create_sample_notification,
         notify_db,
         notify_db_session,
-        to_field='+447700900855',
+        to_field='+16502532222',
         normalised_to='447700900855'
     )
     notification1 = create_notification(status='delivered')
@@ -2159,7 +2159,7 @@ def test_search_for_notification_by_to_field_filters_by_status(client, notify_db
 
     response = client.get(
         '/service/{}/notifications?to={}&status={}&template_type={}'.format(
-            notification1.service_id, '+447700900855', 'delivered', 'sms'
+            notification1.service_id, '+16502532222', 'delivered', 'sms'
         ),
         headers=[create_authorization_header()]
     )
@@ -2176,7 +2176,7 @@ def test_search_for_notification_by_to_field_filters_by_statuses(client, notify_
         create_sample_notification,
         notify_db,
         notify_db_session,
-        to_field='+447700900855',
+        to_field='+16502532222',
         normalised_to='447700900855'
     )
     notification1 = create_notification(status='delivered')
@@ -2184,7 +2184,7 @@ def test_search_for_notification_by_to_field_filters_by_statuses(client, notify_
 
     response = client.get(
         '/service/{}/notifications?to={}&status={}&status={}&template_type={}'.format(
-            notification1.service_id, '+447700900855', 'delivered', 'sending', 'sms'
+            notification1.service_id, '+16502532222', 'delivered', 'sending', 'sms'
         ),
         headers=[create_authorization_header()]
     )
@@ -2206,7 +2206,7 @@ def test_search_for_notification_by_to_field_returns_content(
     notification = create_sample_notification(
         notify_db,
         notify_db_session,
-        to_field='+447700900855',
+        to_field='+16502532222',
         normalised_to='447700900855',
         template=sample_template_with_placeholders,
         personalisation={"name": "Foo"}
@@ -2214,7 +2214,7 @@ def test_search_for_notification_by_to_field_returns_content(
 
     response = client.get(
         '/service/{}/notifications?to={}&template_type={}'.format(
-            sample_template_with_placeholders.service_id, '+447700900855', 'sms'
+            sample_template_with_placeholders.service_id, '+16502532222', 'sms'
         ),
         headers=[create_authorization_header()]
     )
@@ -2223,7 +2223,7 @@ def test_search_for_notification_by_to_field_returns_content(
     assert len(notifications) == 1
 
     assert notifications[0]['id'] == str(notification.id)
-    assert notifications[0]['to'] == '+447700900855'
+    assert notifications[0]['to'] == '+16502532222'
     assert notifications[0]['template']['content'] == 'Hello (( Name))\nYour thing is due soon'
 
 
@@ -2327,7 +2327,7 @@ def test_search_for_notification_by_to_field_returns_personlisation(
     create_sample_notification(
         notify_db,
         notify_db_session,
-        to_field='+447700900855',
+        to_field='+16502532222',
         normalised_to='447700900855',
         template=sample_template_with_placeholders,
         personalisation={"name": "Foo"}
@@ -2335,7 +2335,7 @@ def test_search_for_notification_by_to_field_returns_personlisation(
 
     response = client.get(
         '/service/{}/notifications?to={}&template_type={}'.format(
-            sample_template_with_placeholders.service_id, '+447700900855', 'sms'
+            sample_template_with_placeholders.service_id, '+16502532222', 'sms'
         ),
         headers=[create_authorization_header()]
     )
@@ -2357,7 +2357,7 @@ def test_search_for_notification_by_to_field_returns_notifications_by_type(
     sms_notification = create_sample_notification(
         notify_db,
         notify_db_session,
-        to_field='+447700900855',
+        to_field='+16502532222',
         normalised_to='447700900855',
         template=sample_template
     )

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -160,7 +160,7 @@ def test_get_live_services_data(sample_user, admin_request):
         {
             'consent_to_research': None,
             'contact_email': 'notify@digital.cabinet-office.gov.uk',
-            'contact_mobile': '+447700900986',
+            'contact_mobile': '+16502532222',
             'contact_name': 'Test User',
             'email_totals': 1,
             'email_volume_intent': None,
@@ -178,7 +178,7 @@ def test_get_live_services_data(sample_user, admin_request):
         {
             'consent_to_research': None,
             'contact_email': 'notify@digital.cabinet-office.gov.uk',
-            'contact_mobile': '+447700900986',
+            'contact_mobile': '+16502532222',
             'contact_name': 'Test User',
             'email_totals': 0,
             'email_volume_intent': None,
@@ -2012,7 +2012,7 @@ def test_get_detailed_services_for_date_range(sample_template, start_date_delta,
 def test_search_for_notification_by_to_field(client, sample_template, sample_email_template):
 
     notification1 = create_notification(template=sample_template, to_field='+16502532222',
-                                        normalised_to='447700900855')
+                                        normalised_to='+16502532222')
     notification2 = create_notification(template=sample_email_template, to_field='jack@gmail.com',
                                         normalised_to='jack@gmail.com')
 
@@ -2046,9 +2046,9 @@ def test_search_for_notification_by_to_field_return_empty_list_if_there_is_no_ma
 
 def test_search_for_notification_by_to_field_return_multiple_matches(client, notify_db, notify_db_session):
     create_notification = partial(create_sample_notification, notify_db, notify_db_session)
-    notification1 = create_notification(to_field='+16502532222', normalised_to='447700900855')
-    notification2 = create_notification(to_field=' +44 77009 00855 ', normalised_to='447700900855')
-    notification3 = create_notification(to_field='+44770 0900 855', normalised_to='447700900855')
+    notification1 = create_notification(to_field='+16502532222', normalised_to='+16502532222')
+    notification2 = create_notification(to_field=' +165 0253 2222 ', normalised_to='+16502532222')
+    notification3 = create_notification(to_field='+1 650 253 2222', normalised_to='+16502532222')
     notification4 = create_notification(to_field='jack@gmail.com', normalised_to='jack@gmail.com')
 
     response = client.get(
@@ -2152,7 +2152,7 @@ def test_search_for_notification_by_to_field_filters_by_status(client, notify_db
         notify_db,
         notify_db_session,
         to_field='+16502532222',
-        normalised_to='447700900855'
+        normalised_to='+16502532222'
     )
     notification1 = create_notification(status='delivered')
     create_notification(status='sending')
@@ -2177,7 +2177,7 @@ def test_search_for_notification_by_to_field_filters_by_statuses(client, notify_
         notify_db,
         notify_db_session,
         to_field='+16502532222',
-        normalised_to='447700900855'
+        normalised_to='+16502532222'
     )
     notification1 = create_notification(status='delivered')
     notification2 = create_notification(status='sending')
@@ -2207,7 +2207,7 @@ def test_search_for_notification_by_to_field_returns_content(
         notify_db,
         notify_db_session,
         to_field='+16502532222',
-        normalised_to='447700900855',
+        normalised_to='+16502532222',
         template=sample_template_with_placeholders,
         personalisation={"name": "Foo"}
     )
@@ -2236,7 +2236,7 @@ def test_send_one_off_notification(sample_service, admin_request, mocker):
         service_id=sample_service.id,
         _data={
             'template_id': str(template.id),
-            'to': '07700900001',
+            'to': '+16502532222',
             'created_by': str(sample_service.created_by_id)
         },
         _expected_status=201
@@ -2328,7 +2328,7 @@ def test_search_for_notification_by_to_field_returns_personlisation(
         notify_db,
         notify_db_session,
         to_field='+16502532222',
-        normalised_to='447700900855',
+        normalised_to='+16502532222',
         template=sample_template_with_placeholders,
         personalisation={"name": "Foo"}
     )
@@ -2358,7 +2358,7 @@ def test_search_for_notification_by_to_field_returns_notifications_by_type(
         notify_db,
         notify_db_session,
         to_field='+16502532222',
-        normalised_to='447700900855',
+        normalised_to='+16502532222',
         template=sample_template
     )
     create_sample_notification(
@@ -2371,7 +2371,7 @@ def test_search_for_notification_by_to_field_returns_notifications_by_type(
 
     response = client.get(
         '/service/{}/notifications?to={}&template_type={}'.format(
-            sms_notification.service_id, '0770', 'sms'
+            sms_notification.service_id, '650', 'sms'
 
         ),
         headers=[create_authorization_header()]

--- a/tests/app/service/test_send_one_off_notification.py
+++ b/tests/app/service/test_send_one_off_notification.py
@@ -49,7 +49,7 @@ def test_send_one_off_notification_calls_celery_correctly(persist_mock, celery_m
 
     post_data = {
         'template_id': str(template.id),
-        'to': '07700 900 001',
+        'to': '6502532222',
         'created_by': str(service.created_by_id)
     }
 
@@ -80,7 +80,7 @@ def test_send_one_off_notification_calls_persist_correctly_for_sms(
 
     post_data = {
         'template_id': str(template.id),
-        'to': '07700 900 001',
+        'to': '6502532222',
         'personalisation': {'name': 'foo'},
         'created_by': str(service.created_by_id)
     }
@@ -196,7 +196,7 @@ def test_send_one_off_notification_honors_research_mode(notify_db_session, persi
 
     post_data = {
         'template_id': str(template.id),
-        'to': '07700 900 001',
+        'to': '6502532222',
         'created_by': str(service.created_by_id)
     }
 
@@ -212,7 +212,7 @@ def test_send_one_off_notification_honors_priority(notify_db_session, persist_mo
 
     post_data = {
         'template_id': str(template.id),
-        'to': '07700 900 001',
+        'to': '6502532222',
         'created_by': str(service.created_by_id)
     }
 
@@ -236,9 +236,9 @@ def test_send_one_off_notification_raises_if_invalid_recipient(notify_db_session
 
 
 @pytest.mark.parametrize('recipient', [
-    '07700 900 001',  # not in team or whitelist
-    '07700900123',  # in whitelist
-    '+447700-900-123',  # in whitelist in different format
+    '6502532228',  # not in team or whitelist
+    '+16502532229',  # in whitelist
+    '6502532229',  # in whitelist in different format
 ])
 def test_send_one_off_notification_raises_if_cant_send_to_recipient(
     notify_db_session,
@@ -247,7 +247,7 @@ def test_send_one_off_notification_raises_if_cant_send_to_recipient(
     service = create_service(restricted=True)
     template = create_template(service=service)
     dao_add_and_commit_whitelisted_contacts([
-        ServiceWhitelist.from_string(service.id, MOBILE_TYPE, '07700900123'),
+        ServiceWhitelist.from_string(service.id, MOBILE_TYPE, '+16502532229'),
     ])
 
     post_data = {
@@ -272,7 +272,7 @@ def test_send_one_off_notification_raises_if_over_limit(notify_db_session, mocke
 
     post_data = {
         'template_id': str(template.id),
-        'to': '07700 900 001',
+        'to': '6502532222',
         'created_by': str(service.created_by_id)
     }
 
@@ -286,7 +286,7 @@ def test_send_one_off_notification_raises_if_message_too_long(persist_mock, noti
 
     post_data = {
         'template_id': str(template.id),
-        'to': '07700 900 001',
+        'to': '6502532222',
         'personalisation': {'name': '🚫' * 700},
         'created_by': str(service.created_by_id)
     }
@@ -303,7 +303,7 @@ def test_send_one_off_notification_fails_if_created_by_other_service(sample_temp
 
     post_data = {
         'template_id': str(sample_template.id),
-        'to': '07700 900 001',
+        'to': '6502532222',
         'created_by': str(user_not_in_service.id)
     }
 
@@ -440,7 +440,7 @@ def test_send_one_off_notification_should_throw_exception_if_sms_sender_id_doesn
         sample_template
 ):
     data = {
-        'to': '07700 900 001',
+        'to': '6502532222',
         'template_id': str(sample_template.id),
         'sender_id': str(uuid.uuid4()),
         'created_by': str(sample_template.service.created_by_id)

--- a/tests/app/service/test_send_one_off_notification.py
+++ b/tests/app/service/test_send_one_off_notification.py
@@ -373,12 +373,12 @@ def test_send_one_off_sms_notification_should_use_sms_sender_reply_to_text(sampl
     template = create_template(service=sample_service, template_type=SMS_TYPE)
     sms_sender = create_service_sms_sender(
         service=sample_service,
-        sms_sender='07123123123',
+        sms_sender='6502532222',
         is_default=False
     )
 
     data = {
-        'to': '07111111111',
+        'to': '6502532223',
         'template_id': str(template.id),
         'created_by': str(sample_service.created_by_id),
         'sender_id': str(sms_sender.id),
@@ -392,7 +392,7 @@ def test_send_one_off_sms_notification_should_use_sms_sender_reply_to_text(sampl
         queue=None
     )
 
-    assert notification.reply_to_text == "447123123123"
+    assert notification.reply_to_text == "+16502532222"
 
 
 def test_send_one_off_sms_notification_should_use_default_service_reply_to_text(sample_service, celery_mock):
@@ -400,12 +400,12 @@ def test_send_one_off_sms_notification_should_use_default_service_reply_to_text(
     sample_service.service_sms_senders[0].is_default = False
     create_service_sms_sender(
         service=sample_service,
-        sms_sender='07123123456',
+        sms_sender='6502532222',
         is_default=True
     )
 
     data = {
-        'to': '07111111111',
+        'to': '6502532223',
         'template_id': str(template.id),
         'created_by': str(sample_service.created_by_id),
     }
@@ -418,7 +418,7 @@ def test_send_one_off_sms_notification_should_use_default_service_reply_to_text(
         queue=None
     )
 
-    assert notification.reply_to_text == "447123123456"
+    assert notification.reply_to_text == "+16502532222"
 
 
 def test_send_one_off_notification_should_throw_exception_if_reply_to_id_doesnot_exist(

--- a/tests/app/service/test_service_whitelist.py
+++ b/tests/app/service/test_service_whitelist.py
@@ -24,15 +24,15 @@ def test_get_whitelist_returns_data(client, sample_service_whitelist):
 def test_get_whitelist_separates_emails_and_phones(client, sample_service):
     dao_add_and_commit_whitelisted_contacts([
         ServiceWhitelist.from_string(sample_service.id, EMAIL_TYPE, 'service@example.com'),
-        ServiceWhitelist.from_string(sample_service.id, MOBILE_TYPE, '07123456789'),
-        ServiceWhitelist.from_string(sample_service.id, MOBILE_TYPE, '+1800-555-555'),
+        ServiceWhitelist.from_string(sample_service.id, MOBILE_TYPE, '6502532222'),
+        ServiceWhitelist.from_string(sample_service.id, MOBILE_TYPE, '+1800-234-1242'),
     ])
 
     response = client.get('service/{}/whitelist'.format(sample_service.id), headers=[create_authorization_header()])
     assert response.status_code == 200
     json_resp = json.loads(response.get_data(as_text=True))
     assert json_resp['email_addresses'] == ['service@example.com']
-    assert sorted(json_resp['phone_numbers']) == sorted(['+1800-555-555', '07123456789'])
+    assert sorted(json_resp['phone_numbers']) == sorted(['+1800-234-1242', '6502532222'])
 
 
 def test_get_whitelist_404s_with_unknown_service_id(client):
@@ -57,7 +57,7 @@ def test_get_whitelist_returns_no_data(client, sample_service):
 def test_update_whitelist_replaces_old_whitelist(client, sample_service_whitelist):
     data = {
         'email_addresses': ['foo@bar.com'],
-        'phone_numbers': ['07123456789']
+        'phone_numbers': ['6502532222']
     }
 
     response = client.put(
@@ -69,7 +69,7 @@ def test_update_whitelist_replaces_old_whitelist(client, sample_service_whitelis
     assert response.status_code == 204
     whitelist = ServiceWhitelist.query.order_by(ServiceWhitelist.recipient).all()
     assert len(whitelist) == 2
-    assert whitelist[0].recipient == '07123456789'
+    assert whitelist[0].recipient == '6502532222'
     assert whitelist[1].recipient == 'foo@bar.com'
 
 
@@ -77,7 +77,7 @@ def test_update_whitelist_doesnt_remove_old_whitelist_if_error(client, sample_se
 
     data = {
         'email_addresses': [''],
-        'phone_numbers': ['07123456789']
+        'phone_numbers': ['6502532222']
     }
 
     response = client.put(

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -34,8 +34,8 @@ from tests.app.db import (
 
 
 @pytest.mark.parametrize('mobile_number', [
-    '07700 900678',
-    '+44 7700 900678'
+    '650 253 2222',
+    '+1 650 253 2222'
 ])
 def test_should_build_service_whitelist_from_mobile_number(mobile_number):
     service_whitelist = ServiceWhitelist.from_string('service_id', MOBILE_TYPE, mobile_number)
@@ -95,7 +95,7 @@ def test_status_conversion(initial_statuses, expected_statuses):
 
 @freeze_time("2016-01-01 11:09:00.000000")
 @pytest.mark.parametrize('template_type, recipient', [
-    ('sms', '+447700900855'),
+    ('sms', '+16502532222'),
     ('email', 'foo@bar.com'),
 ])
 def test_notification_for_csv_returns_correct_type(sample_service, template_type, recipient):

--- a/tests/app/test_schemas.py
+++ b/tests/app/test_schemas.py
@@ -49,7 +49,7 @@ def test_notification_schema_has_correct_status(sample_notification, schema_name
 @pytest.mark.parametrize('user_attribute, user_value', [
     ('name', 'New User'),
     ('email_address', 'newuser@mail.com'),
-    ('mobile_number', '+4407700900460')
+    ('mobile_number', '+16502532222')
 ])
 def test_user_update_schema_accepts_valid_attribute_pairs(user_attribute, user_value):
     update_dict = {

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -240,7 +240,7 @@ def test_cannot_create_user_with_empty_strings(admin_request, notify_db_session)
 @pytest.mark.parametrize('user_attribute, user_value', [
     ('name', 'New User'),
     ('email_address', 'newuser@mail.com'),
-    ('mobile_number', '+16502532222')
+    ('mobile_number', '+16502532223')
 ])
 def test_post_user_attribute(client, sample_user, user_attribute, user_value):
     assert getattr(sample_user, user_attribute) != user_value
@@ -271,13 +271,13 @@ def test_post_user_attribute(client, sample_user, user_attribute, user_value):
         service=mock.ANY,
         template_id=UUID('c73f1d71-4049-46d5-a647-d013bdeca3f0'), template_version=1
     )),
-    ('mobile_number', '+16502532222', dict(
+    ('mobile_number', '+16502532223', dict(
         api_key_id=None, key_type='normal', notification_type='sms',
         personalisation={
             'name': 'Test User', 'servicemanagername': 'Service Manago',
             'email address': 'notify@digital.cabinet-office.gov.uk'
         },
-        recipient='+16502532222', reply_to_text='testing', service=mock.ANY,
+        recipient='+16502532223', reply_to_text='testing', service=mock.ANY,
         template_id=UUID('8a31520f-4751-4789-8ea1-fe54496725eb'), template_version=1
     ))
 ])

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -98,7 +98,7 @@ def test_post_user(client, notify_db, notify_db_session):
         "name": "Test User",
         "email_address": "user@digital.cabinet-office.gov.uk",
         "password": "password",
-        "mobile_number": "+447700900986",
+        "mobile_number": "+16502532222",
         "logged_in_at": None,
         "state": "active",
         "failed_login_count": 0,
@@ -125,7 +125,7 @@ def test_post_user_without_auth_type(admin_request, notify_db_session):
         "name": "Test User",
         "email_address": "user@digital.cabinet-office.gov.uk",
         "password": "password",
-        "mobile_number": "+447700900986",
+        "mobile_number": "+16502532222",
         "permissions": {},
     }
 
@@ -144,7 +144,7 @@ def test_post_user_missing_attribute_email(client, notify_db, notify_db_session)
     data = {
         "name": "Test User",
         "password": "password",
-        "mobile_number": "+447700900986",
+        "mobile_number": "+16502532222",
         "logged_in_at": None,
         "state": "active",
         "failed_login_count": 0,
@@ -170,7 +170,7 @@ def test_create_user_missing_attribute_password(client, notify_db, notify_db_ses
     data = {
         "name": "Test User",
         "email_address": "user@digital.cabinet-office.gov.uk",
-        "mobile_number": "+447700900986",
+        "mobile_number": "+16502532222",
         "logged_in_at": None,
         "state": "active",
         "failed_login_count": 0,
@@ -232,7 +232,7 @@ def test_cannot_create_user_with_empty_strings(admin_request, notify_db_session)
     )
     assert resp['message'] == {
         'email_address': ['Not a valid email address'],
-        'mobile_number': ['Invalid phone number: Not enough digits'],
+        'mobile_number': ['Invalid phone number: Not a valid international number'],
         'name': ['Invalid name']
     }
 
@@ -240,7 +240,7 @@ def test_cannot_create_user_with_empty_strings(admin_request, notify_db_session)
 @pytest.mark.parametrize('user_attribute, user_value', [
     ('name', 'New User'),
     ('email_address', 'newuser@mail.com'),
-    ('mobile_number', '+4407700900460')
+    ('mobile_number', '+16502532222')
 ])
 def test_post_user_attribute(client, sample_user, user_attribute, user_value):
     assert getattr(sample_user, user_attribute) != user_value
@@ -271,13 +271,13 @@ def test_post_user_attribute(client, sample_user, user_attribute, user_value):
         service=mock.ANY,
         template_id=UUID('c73f1d71-4049-46d5-a647-d013bdeca3f0'), template_version=1
     )),
-    ('mobile_number', '+4407700900460', dict(
+    ('mobile_number', '+16502532222', dict(
         api_key_id=None, key_type='normal', notification_type='sms',
         personalisation={
             'name': 'Test User', 'servicemanagername': 'Service Manago',
             'email address': 'notify@digital.cabinet-office.gov.uk'
         },
-        recipient='+4407700900460', reply_to_text='testing', service=mock.ANY,
+        recipient='+16502532222', reply_to_text='testing', service=mock.ANY,
         template_id=UUID('8a31520f-4751-4789-8ea1-fe54496725eb'), template_version=1
     ))
 ])
@@ -807,7 +807,7 @@ def test_cannot_update_user_with_mobile_number_as_empty_string(admin_request, sa
         _data={'mobile_number': ''},
         _expected_status=400
     )
-    assert resp['message']['mobile_number'] == ['Invalid phone number: Not enough digits']
+    assert resp['message']['mobile_number'] == ['Invalid phone number: Not a valid international number']
 
 
 def test_cannot_update_user_password_using_attributes_method(admin_request, sample_user):

--- a/tests/app/v2/notifications/test_get_notifications.py
+++ b/tests/app/v2/notifications/test_get_notifications.py
@@ -309,7 +309,7 @@ def test_get_all_notifications_except_job_notifications_returns_200(client, samp
         'uri': notification.template.get_link(),
         'version': 1
     }
-    assert json_response['notifications'][0]['phone_number'] == "+447700900855"
+    assert json_response['notifications'][0]['phone_number'] == "+16502532222"
     assert json_response['notifications'][0]['type'] == "sms"
     assert not json_response['notifications'][0]['scheduled_for']
 

--- a/tests/app/v2/notifications/test_notification_schemas.py
+++ b/tests/app/v2/notifications/test_notification_schemas.py
@@ -101,11 +101,11 @@ def test_get_notifications_request_invalid_statuses_and_template_types():
             .format(invalid_template_type) in error_messages
 
 
-valid_json = {"phone_number": "07515111111",
+valid_json = {"phone_number": "6502532222",
               "template_id": str(uuid.uuid4())
               }
 valid_json_with_optionals = {
-    "phone_number": "07515111111",
+    "phone_number": "6502532222",
     "template_id": str(uuid.uuid4()),
     "reference": "reference from caller",
     "personalisation": {"key": "value"}
@@ -129,7 +129,7 @@ def test_post_sms_schema_is_valid(input):
 def test_post_sms_json_schema_bad_uuid(template_id):
     j = {
         "template_id": template_id,
-        "phone_number": "07515111111"
+        "phone_number": "6502532222"
     }
     with pytest.raises(ValidationError) as e:
         validate(j, post_sms_request_schema)
@@ -157,7 +157,7 @@ def test_post_sms_json_schema_bad_uuid_and_missing_phone_number():
 
 def test_post_sms_schema_with_personalisation_that_is_not_a_dict():
     j = {
-        "phone_number": "07515111111",
+        "phone_number": "6502532222",
         "template_id": str(uuid.uuid4()),
         "reference": "reference from caller",
         "personalisation": "not_a_dict"
@@ -173,9 +173,9 @@ def test_post_sms_schema_with_personalisation_that_is_not_a_dict():
 
 
 @pytest.mark.parametrize('invalid_phone_number, err_msg', [
-    ('08515111111', 'phone_number Not a UK mobile number'),
-    ('07515111*11', 'phone_number Must not contain letters or symbols'),
-    ('notaphoneumber', 'phone_number Must not contain letters or symbols'),
+    ('08515111111', 'phone_number Not a valid international number'),
+    ('07515111*11', 'phone_number Not a valid international number'),
+    ('notaphoneumber', 'phone_number Not a valid international number'),
     (7700900001, 'phone_number 7700900001 is not of type string'),
     (None, 'phone_number None is not of type string'),
     ([], 'phone_number [] is not of type string'),
@@ -199,7 +199,7 @@ def test_post_sms_request_schema_invalid_phone_number_and_missing_template():
         validate(j, post_sms_request_schema)
     errors = json.loads(str(e.value)).get('errors')
     assert len(errors) == 2
-    assert {"error": "ValidationError", "message": "phone_number Not a UK mobile number"} in errors
+    assert {"error": "ValidationError", "message": "phone_number Not a valid international number"} in errors
     assert {"error": "ValidationError", "message": "template_id is a required property"} in errors
 
 
@@ -268,7 +268,7 @@ def test_post_schema_valid_scheduled_for(schema):
     if schema == post_email_request_schema:
         j.update({"email_address": "joe@gmail.com"})
     else:
-        j.update({"phone_number": "07515111111"})
+        j.update({"phone_number": "6502532222"})
     assert validate(j, schema) == j
 
 
@@ -285,7 +285,7 @@ def test_post_email_schema_invalid_scheduled_for(invalid_datetime, schema):
     if schema == post_email_request_schema:
         j.update({"email_address": "joe@gmail.com"})
     else:
-        j.update({"phone_number": "07515111111"})
+        j.update({"phone_number": "6502532222"})
     with pytest.raises(ValidationError) as e:
         validate(j, schema)
     error = json.loads(str(e.value))
@@ -298,7 +298,7 @@ def test_post_email_schema_invalid_scheduled_for(invalid_datetime, schema):
 
 @freeze_time("2017-05-12 13:00:00")
 def test_scheduled_for_raises_validation_error_when_in_the_past():
-    j = {"phone_number": "07515111111",
+    j = {"phone_number": "6502532222",
          "template_id": str(uuid.uuid4()),
          "scheduled_for": "2017-05-12 10:00"}
     with pytest.raises(ValidationError) as e:
@@ -311,7 +311,7 @@ def test_scheduled_for_raises_validation_error_when_in_the_past():
 
 @freeze_time("2017-05-12 13:00:00")
 def test_scheduled_for_raises_validation_error_when_more_than_24_hours_in_the_future():
-    j = {"phone_number": "07515111111",
+    j = {"phone_number": "6502532222",
          "template_id": str(uuid.uuid4()),
          "scheduled_for": "2017-05-13 14:00"}
     with pytest.raises(ValidationError) as e:

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -35,7 +35,7 @@ from tests.app.db import (
 def test_post_sms_notification_returns_201(client, sample_template_with_placeholders, mocker, reference):
     mocked = mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
     data = {
-        'phone_number': '+447700900855',
+        'phone_number': '+16502532222',
         'template_id': str(sample_template_with_placeholders.id),
         'personalisation': {' Name': 'Jo'}
     }
@@ -75,7 +75,7 @@ def test_post_sms_notification_uses_inbound_number_as_sender(client, notify_db_s
     template = create_template(service=service, content="Hello (( Name))\nYour thing is due soon")
     mocked = mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
     data = {
-        'phone_number': '+447700900855',
+        'phone_number': '+16502532222',
         'template_id': str(template.id),
         'personalisation': {' Name': 'Jo'}
     }
@@ -103,7 +103,7 @@ def test_post_sms_notification_uses_inbound_number_reply_to_as_sender(client, no
     template = create_template(service=service, content="Hello (( Name))\nYour thing is due soon")
     mocked = mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
     data = {
-        'phone_number': '+447700900855',
+        'phone_number': '+16502532222',
         'template_id': str(template.id),
         'personalisation': {' Name': 'Jo'}
     }
@@ -131,7 +131,7 @@ def test_post_sms_notification_returns_201_with_sms_sender_id(
     sms_sender = create_service_sms_sender(service=sample_template_with_placeholders.service, sms_sender='123456')
     mocked = mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
     data = {
-        'phone_number': '+447700900855',
+        'phone_number': '+16502532222',
         'template_id': str(sample_template_with_placeholders.id),
         'personalisation': {' Name': 'Jo'},
         'sms_sender_id': str(sms_sender.id)
@@ -158,7 +158,7 @@ def test_post_sms_notification_uses_sms_sender_id_reply_to(
     sms_sender = create_service_sms_sender(service=sample_template_with_placeholders.service, sms_sender='07123123123')
     mocked = mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
     data = {
-        'phone_number': '+447700900855',
+        'phone_number': '+16502532222',
         'template_id': str(sample_template_with_placeholders.id),
         'personalisation': {' Name': 'Jo'},
         'sms_sender_id': str(sms_sender.id)
@@ -185,7 +185,7 @@ def test_notification_reply_to_text_is_original_value_if_sender_is_changed_after
     sms_sender = create_service_sms_sender(service=sample_template.service, sms_sender='123456', is_default=False)
     mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
     data = {
-        'phone_number': '+447700900855',
+        'phone_number': '+16502532222',
         'template_id': str(sample_template.id),
         'sms_sender_id': str(sms_sender.id)
     }
@@ -208,7 +208,7 @@ def test_notification_reply_to_text_is_original_value_if_sender_is_changed_after
 
 
 @pytest.mark.parametrize("notification_type, key_send_to, send_to",
-                         [("sms", "phone_number", "+447700900855"),
+                         [("sms", "phone_number", "+16502532222"),
                           ("email", "email_address", "sample@email.com")])
 def test_post_notification_returns_400_and_missing_template(client, sample_service,
                                                             notification_type, key_send_to, send_to):
@@ -233,7 +233,7 @@ def test_post_notification_returns_400_and_missing_template(client, sample_servi
 
 
 @pytest.mark.parametrize("notification_type, key_send_to, send_to", [
-    ("sms", "phone_number", "+447700900855"),
+    ("sms", "phone_number", "+16502532222"),
     ("email", "email_address", "sample@email.com"),
     ("letter", "personalisation", {"address_line_1": "The queen", "postcode": "SW1 1AA"})
 ])
@@ -258,7 +258,7 @@ def test_post_notification_returns_401_and_well_formed_auth_error(client, sample
 
 
 @pytest.mark.parametrize("notification_type, key_send_to, send_to",
-                         [("sms", "phone_number", "+447700900855"),
+                         [("sms", "phone_number", "+16502532222"),
                           ("email", "email_address", "sample@email.com")])
 def test_notification_returns_400_and_for_schema_problems(client, sample_template, notification_type, key_send_to,
                                                           send_to):
@@ -486,7 +486,7 @@ def test_post_sms_notification_with_archived_reply_to_id_returns_400(client, sam
         archived=True)
     mocker.patch('app.celery.provider_tasks.deliver_email.apply_async')
     data = {
-        "phone_number": '+447700900855',
+        "phone_number": '+16502532222',
         "template_id": sample_template.id,
         'sms_sender_id': archived_sender.id
     }
@@ -687,7 +687,7 @@ def test_post_notification_with_wrong_type_of_sender(
         template = sample_template
         form_label = 'email_reply_to_id'
         data = {
-            'phone_number': '+447700900855',
+            'phone_number': '+16502532222',
             'template_id': str(template.id),
             form_label: fake_uuid
         }

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -98,7 +98,7 @@ def test_post_sms_notification_uses_inbound_number_as_sender(client, notify_db_s
 
 
 def test_post_sms_notification_uses_inbound_number_reply_to_as_sender(client, notify_db_session, mocker):
-    service = create_service_with_inbound_number(inbound_number='07123123123')
+    service = create_service_with_inbound_number(inbound_number='6502532222')
 
     template = create_template(service=service, content="Hello (( Name))\nYour thing is due soon")
     mocked = mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
@@ -120,8 +120,8 @@ def test_post_sms_notification_uses_inbound_number_reply_to_as_sender(client, no
     assert len(notifications) == 1
     notification_id = notifications[0].id
     assert resp_json['id'] == str(notification_id)
-    assert resp_json['content']['from_number'] == '447123123123'
-    assert notifications[0].reply_to_text == '447123123123'
+    assert resp_json['content']['from_number'] == '+16502532222'
+    assert notifications[0].reply_to_text == '+16502532222'
     mocked.assert_called_once_with([str(notification_id)], queue='send-sms-tasks')
 
 
@@ -155,7 +155,7 @@ def test_post_sms_notification_returns_201_with_sms_sender_id(
 def test_post_sms_notification_uses_sms_sender_id_reply_to(
         client, sample_template_with_placeholders, mocker
 ):
-    sms_sender = create_service_sms_sender(service=sample_template_with_placeholders.service, sms_sender='07123123123')
+    sms_sender = create_service_sms_sender(service=sample_template_with_placeholders.service, sms_sender='6502532222')
     mocked = mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
     data = {
         'phone_number': '+16502532222',
@@ -172,10 +172,10 @@ def test_post_sms_notification_uses_sms_sender_id_reply_to(
     assert response.status_code == 201
     resp_json = json.loads(response.get_data(as_text=True))
     assert validate(resp_json, post_sms_response) == resp_json
-    assert resp_json['content']['from_number'] == '447123123123'
+    assert resp_json['content']['from_number'] == '+16502532222'
     notifications = Notification.query.all()
     assert len(notifications) == 1
-    assert notifications[0].reply_to_text == '447123123123'
+    assert notifications[0].reply_to_text == '+16502532222'
     mocked.assert_called_once_with([resp_json['id']], queue='send-sms-tasks')
 
 
@@ -331,9 +331,9 @@ def test_post_email_notification_returns_201(client, sample_email_template_with_
     ('simulate-delivered@notifications.service.gov.uk', EMAIL_TYPE),
     ('simulate-delivered-2@notifications.service.gov.uk', EMAIL_TYPE),
     ('simulate-delivered-3@notifications.service.gov.uk', EMAIL_TYPE),
-    ('07700 900000', 'sms'),
-    ('07700 900111', 'sms'),
-    ('07700 900222', 'sms')
+    ('6132532222', 'sms'),
+    ('6132532223', 'sms'),
+    ('6132532224', 'sms')
 ])
 def test_should_not_persist_or_send_notification_if_simulated_recipient(
         client,
@@ -369,7 +369,7 @@ def test_should_not_persist_or_send_notification_if_simulated_recipient(
 
 
 @pytest.mark.parametrize("notification_type, key_send_to, send_to",
-                         [("sms", "phone_number", "07700 900 855"),
+                         [("sms", "phone_number", "6502532222"),
                           ("email", "email_address", "sample@email.com")])
 def test_send_notification_uses_priority_queue_when_template_is_marked_as_priority(
     client,
@@ -408,7 +408,7 @@ def test_send_notification_uses_priority_queue_when_template_is_marked_as_priori
 
 @pytest.mark.parametrize(
     "notification_type, key_send_to, send_to",
-    [("sms", "phone_number", "07700 900 855"), ("email", "email_address", "sample@email.com")]
+    [("sms", "phone_number", "6502532222"), ("email", "email_address", "sample@email.com")]
 )
 def test_returns_a_429_limit_exceeded_if_rate_limit_exceeded(
         client,
@@ -457,7 +457,7 @@ def test_post_sms_notification_returns_400_if_not_allowed_to_send_int_sms(
     template = create_template(service=service)
 
     data = {
-        'phone_number': '20-12-1234-1234',
+        'phone_number': '+20-12-1234-1234',
         'template_id': template.id
     }
     auth_header = create_authorization_header(service_id=service.id)
@@ -503,7 +503,7 @@ def test_post_sms_notification_with_archived_reply_to_id_returns_400(client, sam
 
 
 @pytest.mark.parametrize('recipient,label,permission_type, notification_type,expected_error', [
-    ('07700 900000', 'phone_number', 'email', 'sms', 'text messages'),
+    ('6502532222', 'phone_number', 'email', 'sms', 'text messages'),
     ('someone@test.com', 'email_address', 'sms', 'email', 'emails')])
 def test_post_sms_notification_returns_400_if_not_allowed_to_send_notification(
         notify_db_session, client, recipient, label, permission_type, notification_type, expected_error
@@ -540,7 +540,7 @@ def test_post_sms_notification_returns_400_if_number_not_whitelisted(
     create_api_key(service=service, key_type='team')
 
     data = {
-        "phone_number": '+327700900855',
+        "phone_number": '+16132532235',
         "template_id": template.id,
     }
     auth_header = create_authorization_header(service_id=service.id, key_type='team')
@@ -567,7 +567,7 @@ def test_post_sms_notification_returns_201_if_allowed_to_send_int_sms(
     mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
 
     data = {
-        'phone_number': '20-12-1234-1234',
+        'phone_number': '+20-12-1234-1234',
         'template_id': sample_template.id
     }
     auth_header = create_authorization_header(service_id=sample_service.id)
@@ -584,7 +584,7 @@ def test_post_sms_notification_returns_201_if_allowed_to_send_int_sms(
 def test_post_sms_should_persist_supplied_sms_number(client, sample_template_with_placeholders, mocker):
     mocked = mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
     data = {
-        'phone_number': '+(44) 77009-00855',
+        'phone_number': '+16502532222',
         'template_id': str(sample_template_with_placeholders.id),
         'personalisation': {' Name': 'Jo'}
     }
@@ -600,13 +600,13 @@ def test_post_sms_should_persist_supplied_sms_number(client, sample_template_wit
     notifications = Notification.query.all()
     assert len(notifications) == 1
     notification_id = notifications[0].id
-    assert '+(44) 77009-00855' == notifications[0].to
+    assert '+16502532222' == notifications[0].to
     assert resp_json['id'] == str(notification_id)
     assert mocked.called
 
 
 @pytest.mark.parametrize("notification_type, key_send_to, send_to",
-                         [("sms", "phone_number", "07700 900 855"),
+                         [("sms", "phone_number", "6502532222"),
                           ("email", "email_address", "sample@email.com")])
 @freeze_time("2017-05-14 14:00:00")
 def test_post_notification_with_scheduled_for(
@@ -634,7 +634,7 @@ def test_post_notification_with_scheduled_for(
 
 
 @pytest.mark.parametrize("notification_type, key_send_to, send_to",
-                         [("sms", "phone_number", "07700 900 855"),
+                         [("sms", "phone_number", "6502532222"),
                           ("email", "email_address", "sample@email.com")])
 @freeze_time("2017-05-14 14:00:00")
 def test_post_notification_raises_bad_request_if_service_not_invited_to_schedule(


### PR DESCRIPTION
Bumped the utils version to the version that uses `local` phone number function vs a `uk` phone number function. Many of the tests used UK specific prefixes, ex: `07`, replaced those with North American prefixed  `1-XXX` or just plain area code.