### PR TITLE
SES callback

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -123,6 +123,7 @@ def register_blueprint(application):
     from app.inbound_number.rest import inbound_number_blueprint
     from app.inbound_sms.rest import inbound_sms as inbound_sms_blueprint
     from app.notifications.receive_notifications import receive_notifications_blueprint
+    from app.celery.process_ses_receipts_tasks import ses_callback_blueprint
     from app.notifications.notifications_sms_callback import sms_callback_blueprint
     from app.notifications.notifications_letter_callback import letter_callback_blueprint
     from app.authentication.auth import requires_admin_auth, requires_auth, requires_no_auth
@@ -148,6 +149,9 @@ def register_blueprint(application):
     application.register_blueprint(status_blueprint)
 
     # delivery receipts
+    ses_callback_blueprint.before_request(requires_no_auth)
+    application.register_blueprint(ses_callback_blueprint)
+
     # TODO: make sure research mode can still trigger sms callbacks, then re-enable this
     sms_callback_blueprint.before_request(requires_no_auth)
     application.register_blueprint(sms_callback_blueprint)

--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -101,8 +101,6 @@ def sns_callback_handler():
 
     process_ses_results.apply_async(response=message)
 
-    print(message)
-
     return jsonify(
         result="success", message="SES-SNS callback succeeded"
     ), 200

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -19,6 +19,7 @@ marshmallow==2.19.2
 psycopg2-binary==2.8.2
 PyJWT==1.7.1
 SQLAlchemy==1.3.3
+validatesns==0.1.1
 
 notifications-python-client==5.3.0
 python-dotenv==0.10.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ marshmallow==2.19.2
 psycopg2-binary==2.8.2
 PyJWT==1.7.1
 SQLAlchemy==1.3.3
+validatesns==0.1.1
 
 notifications-python-client==5.3.0
 python-dotenv==0.10.3
@@ -40,13 +41,14 @@ git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
 alembic==1.0.11
 amqp==1.4.9
 anyjson==0.3.3
+asn1crypto==0.24.0
 attrs==19.1.0
-awscli==1.16.197
+awscli==1.16.198
 bcrypt==3.1.7
 billiard==3.3.0.23
 bleach==3.1.0
 boto3==1.6.16
-botocore==1.12.187
+botocore==1.12.188
 certifi==2019.6.16
 chardet==3.0.4
 Click==7.0
@@ -65,6 +67,7 @@ MarkupSafe==1.1.1
 mistune==0.8.4
 monotonic==1.5
 orderedset==2.0.1
+oscrypto==0.19.1
 phonenumbers==8.10.13
 pyasn1==0.4.5
 pycparser==2.19


### PR DESCRIPTION
There is currently no way for SES to report the status of message delivery back to the API. Based on code fragments and some of the code in AU code base it looks like there used to be a route that was called by SNS when an email was processed. It looks like the GDS code base took this out and put it into a lambda function that updates the database directly, or uses a second non-api queue to handle the insertion. I have restored the URL based on the AU code and added tests. This should close #63 