### PR TITLE
Added statsd container for stackdriver

### DIFF
--- a/ci/Dockerfile.statsD
+++ b/ci/Dockerfile.statsD
@@ -1,0 +1,14 @@
+FROM debian:stretch-slim
+
+RUN apt-get update
+RUN apt-get install -y curl gnupg2
+
+RUN curl -sSO https://dl.google.com/cloudagents/install-monitoring-agent.sh
+RUN bash install-monitoring-agent.sh
+
+RUN (cd /opt/stackdriver/collectd/etc/collectd.d/ && curl -O https://raw.githubusercontent.com/Stackdriver/stackdriver-agent-service-configs/master/etc/collectd.d/statsd.conf)
+
+# Allows the StatsD agent to collect data from other pods
+RUN sed -i 's/127.0.0.1/0.0.0.0/g' /opt/stackdriver/collectd/etc/collectd.d/statsd.conf
+
+CMD ["service", "stackdriver-agent", "start", "&&", "tail", "-f", "/dev/null"]

--- a/ci/cloudbuild-statsd.yaml
+++ b/ci/cloudbuild-statsd.yaml
@@ -1,0 +1,18 @@
+steps:  
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      [
+        'build',
+        '-t',
+        'gcr.io/$PROJECT_ID/statsd:$SHORT_SHA',
+        '-t',
+        'gcr.io/$PROJECT_ID/statsd:latest',
+        '-f',
+        'ci/Dockerfile.statsD',
+        '.',
+      ]
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', 'gcr.io/$PROJECT_ID/statsd:$SHORT_SHA']
+images:
+  - 'gcr.io/$PROJECT_ID/statsd:$SHORT_SHA'
+  - 'gcr.io/$PROJECT_ID/statsd:latest'


### PR DESCRIPTION
Added a docker file that can be used to deploys to a k8s cluster in GKE that will forward the StatsD data to Stackdriver. Closes #92 