### PR TITLE
Mark SMS messages as SENT after sending

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ Contains:
 - the public-facing REST API for Notification built on the GOV.UK Notify platform, which teams can integrate with using [their clients](https://www.notifications.service.gov.uk/documentation)
 - an internal-only REST API built using Flask to manage services, users, templates, etc (this is what the [admin app](http://github.com/cds-snc/notification-admin) talks to)
 - asynchronous workers built using Celery to put things on queues and read them off to be processed, sent to providers, updated, etc
+  
+
+## Functional constraints
+
+- We currently do not support sending of letters
+- We currently do not receive a response if text messages were delivered or not
+
 
 ## Setting Up
 

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -124,7 +124,9 @@ def send_email_to_provider(notification):
 def update_notification_to_sending(notification, provider):
     notification.sent_at = datetime.utcnow()
     notification.sent_by = provider.get_name()
-    notification.status = NOTIFICATION_SENT if notification.international else NOTIFICATION_SENDING
+    # We currently have no callback method for SNS
+    # notification.status = NOTIFICATION_SENT if notification.international else NOTIFICATION_SENDING
+    notification.status = NOTIFICATION_SENT if notification.notification_type == "sms" else NOTIFICATION_SENDING
     dao_update_notification(notification)
 
 

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -89,7 +89,7 @@ def test_should_send_personalised_template_to_correct_sms_provider_and_persist(
 
     notification = Notification.query.filter_by(id=db_notification.id).one()
 
-    assert notification.status == 'sending'
+    assert notification.status == 'sent'
     assert notification.sent_at <= datetime.utcnow()
     assert notification.sent_by == 'sns'
     assert notification.billable_units == 1
@@ -190,7 +190,7 @@ def test_send_sms_should_use_template_version_from_notification_not_latest(
     assert persisted_notification.template_id == sample_template.id
     assert persisted_notification.template_version == version_on_notification
     assert persisted_notification.template_version != sample_template.version
-    assert persisted_notification.status == 'sending'
+    assert persisted_notification.status == 'sent'
     assert not persisted_notification.personalisation
 
 
@@ -223,13 +223,13 @@ def test_should_call_send_sms_response_task_if_research_mode(
     persisted_notification = notifications_dao.get_notification_by_id(sample_notification.id)
     assert persisted_notification.to == sample_notification.to
     assert persisted_notification.template_id == sample_notification.template_id
-    assert persisted_notification.status == 'sending'
+    assert persisted_notification.status == 'sent'
     assert persisted_notification.sent_at <= datetime.utcnow()
     assert persisted_notification.sent_by == 'sns'
     assert not persisted_notification.personalisation
 
 
-def test_should_have_sending_status_if_fake_callback_function_fails(sample_notification, mocker):
+def test_should_have_sent_status_if_fake_callback_function_fails(sample_notification, mocker):
     mocker.patch('app.delivery.send_to_providers.send_sms_response', side_effect=HTTPError)
 
     sample_notification.key_type = KEY_TYPE_TEST
@@ -238,7 +238,7 @@ def test_should_have_sending_status_if_fake_callback_function_fails(sample_notif
         send_to_providers.send_sms_to_provider(
             sample_notification
         )
-    assert sample_notification.status == 'sending'
+    assert sample_notification.status == 'sent'
     assert sample_notification.sent_by == 'sns'
 
 
@@ -519,11 +519,11 @@ def __update_notification(notification_to_update, research_mode, expected_status
 
 @pytest.mark.parametrize('research_mode,key_type, billable_units, expected_status', [
     (True, KEY_TYPE_NORMAL, 0, 'delivered'),
-    (False, KEY_TYPE_NORMAL, 1, 'sending'),
-    (False, KEY_TYPE_TEST, 0, 'sending'),
-    (True, KEY_TYPE_TEST, 0, 'sending'),
+    (False, KEY_TYPE_NORMAL, 1, 'sent'),
+    (False, KEY_TYPE_TEST, 0, 'sent'),
+    (True, KEY_TYPE_TEST, 0, 'sent'),
     (True, KEY_TYPE_TEAM, 0, 'delivered'),
-    (False, KEY_TYPE_TEAM, 1, 'sending')
+    (False, KEY_TYPE_TEAM, 1, 'sent')
 ])
 def test_should_update_billable_units_and_status_according_to_research_mode_and_key_type(
     sample_template,


### PR DESCRIPTION
Mark SMS messages as SENT after sending, because SNS has no success callback, closes #96 