### PR TITLE
Block multiple verify codes from being sent within a given timeframe

### DIFF
--- a/app/dao/users_dao.py
+++ b/app/dao/users_dao.py
@@ -73,6 +73,7 @@ def use_user_code(id):
     db.session.add(verify_code)
     db.session.commit()
 
+
 def delete_model_user(user):
     db.session.delete(user)
     db.session.commit()

--- a/app/dao/users_dao.py
+++ b/app/dao/users_dao.py
@@ -73,7 +73,6 @@ def use_user_code(id):
     db.session.add(verify_code)
     db.session.commit()
 
-
 def delete_model_user(user):
     db.session.delete(user)
     db.session.commit()
@@ -89,6 +88,15 @@ def count_user_verify_codes(user):
         VerifyCode.user == user,
         VerifyCode.expiry_datetime > datetime.utcnow(),
         VerifyCode.code_used.is_(False)
+    )
+    return query.count()
+
+
+def verify_within_time(user, age=timedelta(seconds=30)):
+    query = VerifyCode.query.filter(
+        VerifyCode.user == user,
+        VerifyCode.code_used.is_(False),
+        VerifyCode.created_at > datetime.utcnow() - age
     )
     return query.count()
 

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -23,6 +23,7 @@ from app.dao.users_dao import (
     count_user_verify_codes,
     get_user_and_accounts,
     dao_archive_user,
+    verify_within_time
 )
 from app.dao.permissions_dao import permission_dao
 from app.dao.service_user_dao import dao_get_service_user, dao_update_service_user
@@ -184,6 +185,10 @@ def verify_user_code(user_id):
     user_to_verify = get_user_by_id(user_id=user_id)
 
     code = get_user_code(user_to_verify, data['code'], data['code_type'])
+
+    if(verify_within_time(user_to_verify) >= 2):
+        raise InvalidRequest("Code already sent", status_code=400)
+
     if user_to_verify.failed_login_count >= current_app.config.get('MAX_VERIFY_CODE_COUNT'):
         raise InvalidRequest("Code not found", status_code=404)
     if not code:

--- a/tests/app/dao/test_users_dao.py
+++ b/tests/app/dao/test_users_dao.py
@@ -22,6 +22,7 @@ from app.dao.users_dao import (
     create_secret_code,
     user_can_be_archived,
     dao_archive_user,
+    verify_within_time
 )
 from app.errors import InvalidRequest
 from app.models import EMAIL_AUTH_TYPE, User, VerifyCode
@@ -119,6 +120,15 @@ def test_should_not_delete_verification_codes_less_than_one_day_old(sample_user)
     assert VerifyCode.query.count() == 2
     delete_codes_older_created_more_than_a_day_ago()
     assert VerifyCode.query.one()._code == "12345"
+
+
+def test_will_find_verify_codes_sent_within_seconds(notify_api, notify_db, notify_db_session, sample_user):
+    make_verify_code(sample_user)
+    make_verify_code(sample_user, timedelta(seconds=10))
+    make_verify_code(sample_user, timedelta(seconds=32))
+    make_verify_code(sample_user, timedelta(hours=1))
+    count = verify_within_time(sample_user)
+    assert count == 2
 
 
 def make_verify_code(user, age=timedelta(hours=0), expiry_age=timedelta(0), code="12335", code_used=False):


### PR DESCRIPTION
Fixes: https://github.com/cds-snc/notification-api/issues/124

This PR adds a query to look at verification codes sent within a given timeframe.

If multiple codes are founds it will fire an 
```
raise InvalidRequest("Code already sent", status_code=400)
```

Not sure if that's the best response code.

@JuliannaR had this occur today as well as 2 other testers so far.

