### PR TITLE
Migrations to remove default email branding

### DIFF
--- a/migrations/versions/0300c_remove_email_branding.py
+++ b/migrations/versions/0300c_remove_email_branding.py
@@ -1,0 +1,52 @@
+"""
+
+Revision ID: 0300c_remove_email_branding
+Revises: 0300b_support_email_templates
+Create Date: 2019-07-29 16:18:27.467361
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '0300c_remove_email_branding'
+down_revision = '0300b_support_email_templates'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    # UK Visas & Immigration
+    op.execute(f"""
+        DELETE FROM 
+          email_branding
+        WHERE 
+          id = '9d25d02d-2915-4e98-874b-974e123e8536'
+    """)
+
+    # data gov.uk
+    op.execute(f"""
+        DELETE FROM 
+          email_branding
+        WHERE 
+          id = '123496d4-44cb-4324-8e0a-4187101f4bdc'
+    """)
+
+    # tfl
+    op.execute(f"""
+        DELETE FROM 
+          email_branding
+        WHERE 
+          id = '1d70f564-919b-4c68-8bdf-b8520d92516e'
+    """)
+
+    # een
+    op.execute(f"""
+        DELETE FROM 
+          email_branding
+        WHERE 
+          id = '89ce468b-fb29-4d5d-bd3f-d468fb6f7c36'
+    """)
+
+
+def downgrade():
+    pass

--- a/migrations/versions/0300d_update_invite_email.py
+++ b/migrations/versions/0300d_update_invite_email.py
@@ -1,0 +1,49 @@
+"""
+
+Revision ID: 0300d_update_invite_email
+Revises: 0300c_remove_email_branding
+Create Date: 2019-07-29 16:18:27.467361
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '0300d_update_invite_email'
+down_revision = '0300c_remove_email_branding'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+
+    op.execute("""
+            UPDATE
+                templates
+            SET
+                content = 
+                  REPLACE(
+                    content,
+                    'create an account on Notification',
+                    'accept the invitation'
+                  )
+            WHERE
+                id = '4f46df42-f795-4cc4-83bb-65ca312f49cc'
+        """)
+
+    op.execute("""
+            UPDATE
+                templates_history
+            SET
+                content = 
+                  REPLACE(
+                    content,
+                    'create an account on Notification',
+                    'accept the invitation'
+                  )
+            WHERE
+                id = '4f46df42-f795-4cc4-83bb-65ca312f49cc'
+        """)
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
Closes #140 and also removes the default email branding