### PR TITLE
Added functionality for local timezone in API

### DIFF
--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -37,7 +37,7 @@ from app.models import (
 )
 from app.performance_platform import total_sent_notifications, processing_time
 from app.cronitor import cronitor
-from app.utils import get_toronto_midnight_in_utc
+from app.utils import get_local_timezone_midnight_in_utc
 
 
 @notify_celery.task(name="remove_sms_email_jobs")
@@ -165,7 +165,7 @@ def send_daily_performance_platform_stats(date=None):
 
 def send_total_sent_notifications_to_performance_platform(bst_date):
     count_dict = total_sent_notifications.get_total_sent_notifications_for_day(bst_date)
-    start_time = get_toronto_midnight_in_utc(bst_date)
+    start_time = get_local_timezone_midnight_in_utc(bst_date).strftime("%Y-%m-%d")
 
     email_sent_count = count_dict['email']
     sms_sent_count = count_dict['sms']

--- a/app/celery/reporting_tasks.py
+++ b/app/celery/reporting_tasks.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 
 from flask import current_app
 from notifications_utils.statsd_decorators import statsd
-from notifications_utils.timezones import convert_utc_to_est
+from notifications_utils.timezones import convert_utc_to_local_timezone
 
 from app import notify_celery
 from app.cronitor import cronitor
@@ -20,7 +20,7 @@ def create_nightly_billing(day_start=None):
     # day_start is a datetime.date() object. e.g.
     # up to 10 days of data counting back from day_start is consolidated
     if day_start is None:
-        day_start = convert_utc_to_est(datetime.utcnow()).date() - timedelta(days=1)
+        day_start = convert_utc_to_local_timezone(datetime.utcnow()).date() - timedelta(days=1)
     else:
         # When calling the task its a string in the format of "YYYY-MM-DD"
         day_start = datetime.strptime(day_start, "%Y-%m-%d").date()
@@ -43,7 +43,7 @@ def create_nightly_notification_status(day_start=None):
     # day_start is a datetime.date() object. e.g.
     # 4 days of data counting back from day_start is consolidated
     if day_start is None:
-        day_start = convert_utc_to_est(datetime.utcnow()).date() - timedelta(days=1)
+        day_start = convert_utc_to_local_timezone(datetime.utcnow()).date() - timedelta(days=1)
     else:
         # When calling the task its a string in the format of "YYYY-MM-DD"
         day_start = datetime.strptime(day_start, "%Y-%m-%d").date()

--- a/app/celery/reporting_tasks.py
+++ b/app/celery/reporting_tasks.py
@@ -24,6 +24,7 @@ def create_nightly_billing(day_start=None):
     else:
         # When calling the task its a string in the format of "YYYY-MM-DD"
         day_start = datetime.strptime(day_start, "%Y-%m-%d").date()
+ 
     for i in range(0, 10):
         process_day = day_start - timedelta(days=i)
 

--- a/app/celery/reporting_tasks.py
+++ b/app/celery/reporting_tasks.py
@@ -24,7 +24,7 @@ def create_nightly_billing(day_start=None):
     else:
         # When calling the task its a string in the format of "YYYY-MM-DD"
         day_start = datetime.strptime(day_start, "%Y-%m-%d").date()
- 
+
     for i in range(0, 10):
         process_day = day_start - timedelta(days=i)
 

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -11,7 +11,7 @@ from notifications_utils.template import (
     SMSMessageTemplate,
     WithSubjectTemplate,
 )
-from notifications_utils.timezones import convert_utc_to_est
+from notifications_utils.timezones import convert_utc_to_local_timezone
 from requests import (
     HTTPError,
     request,
@@ -455,7 +455,7 @@ def get_billing_date_in_est_from_filename(filename):
     # exclude seconds from the date since we don't need it. We got a date ending in 60 second - which is not valid.
     datetime_string = filename.split('-')[1][:-2]
     datetime_obj = datetime.strptime(datetime_string, '%Y%m%d%H%M')
-    return convert_utc_to_est(datetime_obj).date()
+    return convert_utc_to_local_timezone(datetime_obj).date()
 
 
 def persist_daily_sorted_letter_counts(day, file_name, sorted_letter_counts):

--- a/app/clients/performance_platform/performance_platform_client.py
+++ b/app/clients/performance_platform/performance_platform_client.py
@@ -4,7 +4,7 @@ import json
 from flask import current_app
 import requests
 
-from notifications_utils.timezones import convert_utc_to_est
+from notifications_utils.timezones import convert_utc_to_local_timezone
 
 
 class PerformancePlatformClient:
@@ -56,7 +56,7 @@ class PerformancePlatformClient:
         :param period - the period that this data covers - "day", "week", "month", "quarter".
         """
         payload = {
-            '_timestamp': convert_utc_to_est(start_time).isoformat(),
+            '_timestamp': convert_utc_to_local_timezone(start_time).isoformat(),
             'service': 'govuk-notify',
             'dataType': dataset,
             'period': period,

--- a/app/commands.py
+++ b/app/commands.py
@@ -47,7 +47,7 @@ from app.models import (
     LetterBranding
 )
 from app.performance_platform.processing_time import send_processing_time_for_start_and_end
-from app.utils import get_toronto_midnight_in_utc, get_midnight_for_day_before
+from app.utils import get_local_timezone_midnight_in_utc, get_midnight_for_day_before
 
 
 @click.group(name='command', help='Additional commands')
@@ -239,7 +239,7 @@ def backfill_processing_time(start_date, end_date):
         process_date = start_date + timedelta(days=i + 1)
 
         process_start_date = get_midnight_for_day_before(process_date)
-        process_end_date = get_toronto_midnight_in_utc(process_date)
+        process_end_date = get_local_timezone_midnight_in_utc(process_date)
 
         print('Sending notification processing-time for {} - {}'.format(
             process_start_date.isoformat(),
@@ -471,8 +471,8 @@ def rebuild_ft_billing_for_day(service_id, day):
         rebuild_ft_data(day, service_id)
     else:
         services = get_service_ids_that_need_billing_populated(
-            get_toronto_midnight_in_utc(day),
-            get_toronto_midnight_in_utc(day + timedelta(days=1))
+            get_local_timezone_midnight_in_utc(day),
+            get_local_timezone_midnight_in_utc(day + timedelta(days=1))
         )
         for row in services:
             rebuild_ft_data(day, row.service_id)

--- a/app/config.py
+++ b/app/config.py
@@ -173,7 +173,7 @@ class Config(object):
         'queue_name_prefix': NOTIFICATION_QUEUE_PREFIX
     }
     CELERY_ENABLE_UTC = True
-    CELERY_TIMEZONE = 'America/Toronto'
+    CELERY_TIMEZONE = os.getenv("TIMEZONE","America/Toronto")
     CELERY_ACCEPT_CONTENT = ['json']
     CELERY_TASK_SERIALIZER = 'json'
     CELERY_IMPORTS = (

--- a/app/config.py
+++ b/app/config.py
@@ -173,7 +173,7 @@ class Config(object):
         'queue_name_prefix': NOTIFICATION_QUEUE_PREFIX
     }
     CELERY_ENABLE_UTC = True
-    CELERY_TIMEZONE = os.getenv("TIMEZONE","America/Toronto")
+    CELERY_TIMEZONE = os.getenv("TIMEZONE", "America/Toronto")
     CELERY_ACCEPT_CONTENT = ['json']
     CELERY_TASK_SERIALIZER = 'json'
     CELERY_IMPORTS = (

--- a/app/dao/complaint_dao.py
+++ b/app/dao/complaint_dao.py
@@ -6,7 +6,7 @@ from sqlalchemy import desc
 from app import db
 from app.dao.dao_utils import transactional
 from app.models import Complaint
-from app.utils import get_toronto_midnight_in_utc
+from app.utils import get_local_timezone_midnight_in_utc
 
 
 @transactional
@@ -28,7 +28,7 @@ def fetch_complaints_by_service(service_id):
 
 
 def fetch_count_of_complaints(start_date, end_date):
-    start_date = get_toronto_midnight_in_utc(start_date)
-    end_date = get_toronto_midnight_in_utc(end_date + timedelta(days=1))
+    start_date = get_local_timezone_midnight_in_utc(start_date)
+    end_date = get_local_timezone_midnight_in_utc(end_date + timedelta(days=1))
 
     return Complaint.query.filter(Complaint.created_at >= start_date, Complaint.created_at < end_date).count()

--- a/app/dao/date_util.py
+++ b/app/dao/date_util.py
@@ -39,7 +39,8 @@ def get_april_fools(year):
      :param year: the year to calculate the April 1, 00:00 BST for
      :return: the datetime of April 1 for the given year, for example 2016 = 2016-03-31 23:00:00
     """
-    return pytz.timezone(os.getenv('TIMEZONE', 'America/Toronto')).localize(datetime(year, 4, 1, 0, 0, 0)).astimezone(pytz.UTC).replace(
+    return pytz.timezone(os.getenv('TIMEZONE', 'America/Toronto')).localize(
+        datetime(year, 4, 1, 0, 0, 0)).astimezone(pytz.UTC).replace(
         tzinfo=None)
 
 

--- a/app/dao/date_util.py
+++ b/app/dao/date_util.py
@@ -1,16 +1,16 @@
 from datetime import datetime, timedelta
 
-from notifications_utils.timezones import convert_est_to_utc
+from notifications_utils.timezones import convert_local_timezone_to_utc
 import pytz
 
 
 def get_months_for_financial_year(year):
     return [
-        convert_est_to_utc(month) for month in (
+        convert_local_timezone_to_utc(month) for month in (
             get_months_for_year(4, 13, year)
             + get_months_for_year(1, 4, year + 1)
         )
-        if convert_est_to_utc(month) < datetime.now()
+        if convert_local_timezone_to_utc(month) < datetime.now()
     ]
 
 
@@ -51,7 +51,7 @@ def get_month_start_and_end_date_in_utc(month_year):
     _, num_days = calendar.monthrange(month_year.year, month_year.month)
     first_day = datetime(month_year.year, month_year.month, 1, 0, 0, 0)
     last_day = datetime(month_year.year, month_year.month, num_days, 23, 59, 59, 99999)
-    return convert_est_to_utc(first_day), convert_est_to_utc(last_day)
+    return convert_local_timezone_to_utc(first_day), convert_local_timezone_to_utc(last_day)
 
 
 def get_current_financial_year_start_year():

--- a/app/dao/date_util.py
+++ b/app/dao/date_util.py
@@ -1,3 +1,5 @@
+import os
+
 from datetime import datetime, timedelta
 
 from notifications_utils.timezones import convert_local_timezone_to_utc
@@ -37,7 +39,7 @@ def get_april_fools(year):
      :param year: the year to calculate the April 1, 00:00 BST for
      :return: the datetime of April 1 for the given year, for example 2016 = 2016-03-31 23:00:00
     """
-    return pytz.timezone('America/Toronto').localize(datetime(year, 4, 1, 0, 0, 0)).astimezone(pytz.UTC).replace(
+    return pytz.timezone(os.getenv('TIMEZONE', 'America/Toronto')).localize(datetime(year, 4, 1, 0, 0, 0)).astimezone(pytz.UTC).replace(
         tzinfo=None)
 
 

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta, time
 
 from flask import current_app
-from notifications_utils.timezones import convert_est_to_utc, convert_utc_to_est
+from notifications_utils.timezones import convert_local_timezone_to_utc, convert_utc_to_local_timezone
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy import func, case, desc, Date, Integer
 
@@ -75,7 +75,7 @@ def fetch_billing_totals_for_year(service_id, year):
 def fetch_monthly_billing_for_year(service_id, year):
     year_start_date, year_end_date = get_financial_year(year)
     utcnow = datetime.utcnow()
-    today = convert_utc_to_est(utcnow)
+    today = convert_utc_to_local_timezone(utcnow)
     # if year end date is less than today, we are calculating for data in the past and have no need for deltas.
     if year_end_date >= today:
         yesterday = today - timedelta(days=1)
@@ -144,8 +144,8 @@ def delete_billing_data_for_service_for_day(process_day, service_id):
 
 
 def fetch_billing_data_for_day(process_day, service_id=None):
-    start_date = convert_est_to_utc(datetime.combine(process_day, time.min))
-    end_date = convert_est_to_utc(datetime.combine(process_day + timedelta(days=1), time.min))
+    start_date = convert_local_timezone_to_utc(datetime.combine(process_day, time.min))
+    end_date = convert_local_timezone_to_utc(datetime.combine(process_day + timedelta(days=1), time.min))
     # use notification_history if process day is older than 7 days
     # this is useful if we need to rebuild the ft_billing table for a date older than 7 days ago.
     current_app.logger.info("Populate ft_billing for {} to {}".format(start_date, end_date))

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -26,7 +26,7 @@ from app.utils import get_local_timezone_midnight_in_utc
 
 def fetch_billing_totals_for_year(service_id, year):
     year_start_date, year_end_date = get_financial_year(year)
-    print(year_start_date, year_end_date )
+    print(year_start_date, year_end_date)
     """
       Billing for email: only record the total number of emails.
       Billing for letters: The billing units is used to fetch the correct rate for the sheet count of the letter.
@@ -41,6 +41,7 @@ def fetch_billing_totals_for_year(service_id, year):
     ).filter(
         FactBilling.service_id == service_id,
         FactBilling.bst_date >= year_start_date.strftime("%Y-%m-%d"),
+        # This works only for timezones to the west of GMT
         FactBilling.bst_date < year_end_date.strftime("%Y-%m-%d"),
         FactBilling.notification_type.in_([EMAIL_TYPE, LETTER_TYPE])
     ).group_by(
@@ -58,7 +59,7 @@ def fetch_billing_totals_for_year(service_id, year):
     ).filter(
         FactBilling.service_id == service_id,
         FactBilling.bst_date >= year_start_date.strftime("%Y-%m-%d"),
-        FactBilling.bst_date < year_end_date.strftime("%Y-%m-%d"),
+        FactBilling.bst_date < year_end_date.strftime("%Y-%m-%d"),  # This works only for timezones to the west of GMT
         FactBilling.notification_type == SMS_TYPE
     ).group_by(
         FactBilling.rate,

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -21,7 +21,7 @@ from app.models import (
     EMAIL_TYPE,
     NOTIFICATION_STATUS_TYPES_BILLABLE_FOR_LETTERS
 )
-from app.utils import get_toronto_midnight_in_utc
+from app.utils import get_local_timezone_midnight_in_utc
 
 
 def fetch_billing_totals_for_year(service_id, year):
@@ -250,7 +250,7 @@ def get_service_ids_that_need_billing_populated(start_date, end_date):
 def get_rate(
     non_letter_rates, letter_rates, notification_type, date, crown=None, letter_page_count=None, post_class='second'
 ):
-    start_of_day = get_toronto_midnight_in_utc(date)
+    start_of_day = get_local_timezone_midnight_in_utc(date)
 
     if notification_type == LETTER_TYPE:
         if letter_page_count == 0:

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -39,8 +39,8 @@ def fetch_billing_totals_for_year(service_id, year):
         FactBilling.notification_type.label('notification_type')
     ).filter(
         FactBilling.service_id == service_id,
-        FactBilling.bst_date >= year_start_date,
-        FactBilling.bst_date <= year_end_date,
+        FactBilling.bst_date >= year_start_date.strftime("%Y-%m-%d"),
+        FactBilling.bst_date <= year_end_date.strftime("%Y-%m-%d"),
         FactBilling.notification_type.in_([EMAIL_TYPE, LETTER_TYPE])
     ).group_by(
         FactBilling.rate,
@@ -56,8 +56,8 @@ def fetch_billing_totals_for_year(service_id, year):
         FactBilling.notification_type
     ).filter(
         FactBilling.service_id == service_id,
-        FactBilling.bst_date >= year_start_date,
-        FactBilling.bst_date <= year_end_date,
+        FactBilling.bst_date >= year_start_date.strftime("%Y-%m-%d"),
+        FactBilling.bst_date <= year_end_date.strftime("%Y-%m-%d"),
         FactBilling.notification_type == SMS_TYPE
     ).group_by(
         FactBilling.rate,
@@ -93,8 +93,8 @@ def fetch_monthly_billing_for_year(service_id, year):
         FactBilling.postage
     ).filter(
         FactBilling.service_id == service_id,
-        FactBilling.bst_date >= year_start_date,
-        FactBilling.bst_date <= year_end_date,
+        FactBilling.bst_date >= year_start_date.strftime("%Y-%m-%d"),
+        FactBilling.bst_date <= year_end_date.strftime("%Y-%m-%d"),
         FactBilling.notification_type.in_([EMAIL_TYPE, LETTER_TYPE])
     ).group_by(
         'month',
@@ -112,8 +112,8 @@ def fetch_monthly_billing_for_year(service_id, year):
         FactBilling.postage
     ).filter(
         FactBilling.service_id == service_id,
-        FactBilling.bst_date >= year_start_date,
-        FactBilling.bst_date <= year_end_date,
+        FactBilling.bst_date >= year_start_date.strftime("%Y-%m-%d"),
+        FactBilling.bst_date <= year_end_date.strftime("%Y-%m-%d"),
         FactBilling.notification_type == SMS_TYPE
     ).group_by(
         'month',

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -26,6 +26,7 @@ from app.utils import get_local_timezone_midnight_in_utc
 
 def fetch_billing_totals_for_year(service_id, year):
     year_start_date, year_end_date = get_financial_year(year)
+    print(year_start_date, year_end_date )
     """
       Billing for email: only record the total number of emails.
       Billing for letters: The billing units is used to fetch the correct rate for the sheet count of the letter.
@@ -40,7 +41,7 @@ def fetch_billing_totals_for_year(service_id, year):
     ).filter(
         FactBilling.service_id == service_id,
         FactBilling.bst_date >= year_start_date.strftime("%Y-%m-%d"),
-        FactBilling.bst_date <= year_end_date.strftime("%Y-%m-%d"),
+        FactBilling.bst_date < year_end_date.strftime("%Y-%m-%d"),
         FactBilling.notification_type.in_([EMAIL_TYPE, LETTER_TYPE])
     ).group_by(
         FactBilling.rate,
@@ -57,7 +58,7 @@ def fetch_billing_totals_for_year(service_id, year):
     ).filter(
         FactBilling.service_id == service_id,
         FactBilling.bst_date >= year_start_date.strftime("%Y-%m-%d"),
-        FactBilling.bst_date <= year_end_date.strftime("%Y-%m-%d"),
+        FactBilling.bst_date < year_end_date.strftime("%Y-%m-%d"),
         FactBilling.notification_type == SMS_TYPE
     ).group_by(
         FactBilling.rate,

--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -28,7 +28,7 @@ from app.models import (
     SMS_TYPE,
     Template,
 )
-from app.utils import get_local_timezone_midnight_in_utc, midnight_n_days_ago, get_london_month_from_utc_column
+from app.utils import get_local_timezone_midnight_in_utc, midnight_n_days_ago, get_local_timezone_month_from_utc_column
 
 
 def fetch_notification_status_for_day(process_day, service_id=None):
@@ -121,8 +121,8 @@ def fetch_notification_status_for_service_by_month(start_date, end_date, service
         func.sum(FactNotificationStatus.notification_count).label('count')
     ).filter(
         FactNotificationStatus.service_id == service_id,
-        FactNotificationStatus.bst_date >= start_date,
-        FactNotificationStatus.bst_date < end_date,
+        FactNotificationStatus.bst_date >= start_date.strftime("%Y-%m-%d"),
+        FactNotificationStatus.bst_date < end_date.strftime("%Y-%m-%d"),
         FactNotificationStatus.key_type != KEY_TYPE_TEST
     ).group_by(
         func.date_trunc('month', FactNotificationStatus.bst_date).label('month'),
@@ -368,8 +368,8 @@ def fetch_monthly_template_usage_for_service(start_date, end_date, service_id):
         Template, FactNotificationStatus.template_id == Template.id
     ).filter(
         FactNotificationStatus.service_id == service_id,
-        FactNotificationStatus.bst_date >= start_date,
-        FactNotificationStatus.bst_date <= end_date,
+        FactNotificationStatus.bst_date >= start_date.strftime("%Y-%m-%d"),
+        FactNotificationStatus.bst_date < end_date.strftime("%Y-%m-%d"),
         FactNotificationStatus.key_type != KEY_TYPE_TEST,
         FactNotificationStatus.notification_status != NOTIFICATION_CANCELLED,
     ).group_by(
@@ -387,7 +387,7 @@ def fetch_monthly_template_usage_for_service(start_date, end_date, service_id):
 
     if start_date <= datetime.utcnow() <= end_date:
         today = get_local_timezone_midnight_in_utc(datetime.utcnow())
-        month = get_london_month_from_utc_column(Notification.created_at)
+        month = get_local_timezone_month_from_utc_column(Notification.created_at)
 
         stats_for_today = db.session.query(
             Notification.template_id.label('template_id'),

--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -28,7 +28,7 @@ from app.models import (
     SMS_TYPE,
     Template,
 )
-from app.utils import get_toronto_midnight_in_utc, midnight_n_days_ago, get_london_month_from_utc_column
+from app.utils import get_local_timezone_midnight_in_utc, midnight_n_days_ago, get_london_month_from_utc_column
 
 
 def fetch_notification_status_for_day(process_day, service_id=None):
@@ -139,8 +139,8 @@ def fetch_notification_status_for_service_for_day(bst_day, service_id):
         Notification.status.label('notification_status'),
         func.count().label('count')
     ).filter(
-        Notification.created_at >= get_toronto_midnight_in_utc(bst_day),
-        Notification.created_at < get_toronto_midnight_in_utc(bst_day + timedelta(days=1)),
+        Notification.created_at >= get_local_timezone_midnight_in_utc(bst_day),
+        Notification.created_at < get_local_timezone_midnight_in_utc(bst_day + timedelta(days=1)),
         Notification.service_id == service_id,
         Notification.key_type != KEY_TYPE_TEST
     ).group_by(
@@ -169,7 +169,7 @@ def fetch_notification_status_for_service_for_today_and_7_previous_days(service_
         *([Notification.template_id] if by_template else []),
         func.count().label('count')
     ).filter(
-        Notification.created_at >= get_toronto_midnight_in_utc(now),
+        Notification.created_at >= get_local_timezone_midnight_in_utc(now),
         Notification.service_id == service_id,
         Notification.key_type != KEY_TYPE_TEST
     ).group_by(
@@ -215,7 +215,7 @@ def fetch_notification_status_totals_for_all_services(start_date, end_date):
         FactNotificationStatus.notification_status,
         FactNotificationStatus.key_type,
     )
-    today = get_toronto_midnight_in_utc(datetime.utcnow())
+    today = get_local_timezone_midnight_in_utc(datetime.utcnow())
     if start_date <= datetime.utcnow().date() <= end_date:
         stats_for_today = db.session.query(
             Notification.notification_type.cast(db.Text).label('notification_type'),
@@ -292,7 +292,7 @@ def fetch_stats_for_all_services_by_date_range(start_date, end_date, include_fro
         stats = stats.filter(FactNotificationStatus.key_type != KEY_TYPE_TEST)
 
     if start_date <= datetime.utcnow().date() <= end_date:
-        today = get_toronto_midnight_in_utc(datetime.utcnow())
+        today = get_local_timezone_midnight_in_utc(datetime.utcnow())
         subquery = db.session.query(
             Notification.notification_type.cast(db.Text).label('notification_type'),
             Notification.status.label('status'),
@@ -386,7 +386,7 @@ def fetch_monthly_template_usage_for_service(start_date, end_date, service_id):
     )
 
     if start_date <= datetime.utcnow() <= end_date:
-        today = get_toronto_midnight_in_utc(datetime.utcnow())
+        today = get_local_timezone_midnight_in_utc(datetime.utcnow())
         month = get_london_month_from_utc_column(Notification.created_at)
 
         stats_for_today = db.session.query(

--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta, time
 
 from flask import current_app
-from notifications_utils.timezones import convert_est_to_utc
+from notifications_utils.timezones import convert_local_timezone_to_utc
 from sqlalchemy import case, func, Date
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.sql.expression import literal, extract
@@ -32,8 +32,8 @@ from app.utils import get_toronto_midnight_in_utc, midnight_n_days_ago, get_lond
 
 
 def fetch_notification_status_for_day(process_day, service_id=None):
-    start_date = convert_est_to_utc(datetime.combine(process_day, time.min))
-    end_date = convert_est_to_utc(datetime.combine(process_day + timedelta(days=1), time.min))
+    start_date = convert_local_timezone_to_utc(datetime.combine(process_day, time.min))
+    end_date = convert_local_timezone_to_utc(datetime.combine(process_day + timedelta(days=1), time.min))
     # use notification_history if process day is older than 7 days
     # this is useful if we need to rebuild the ft_billing table for a date older than 7 days ago.
     current_app.logger.info("Fetch ft_notification_status for {} to {}".format(start_date, end_date))

--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -122,6 +122,7 @@ def fetch_notification_status_for_service_by_month(start_date, end_date, service
     ).filter(
         FactNotificationStatus.service_id == service_id,
         FactNotificationStatus.bst_date >= start_date.strftime("%Y-%m-%d"),
+        # This works only for timezones to the west of GMT
         FactNotificationStatus.bst_date < end_date.strftime("%Y-%m-%d"),
         FactNotificationStatus.key_type != KEY_TYPE_TEST
     ).group_by(
@@ -369,6 +370,7 @@ def fetch_monthly_template_usage_for_service(start_date, end_date, service_id):
     ).filter(
         FactNotificationStatus.service_id == service_id,
         FactNotificationStatus.bst_date >= start_date.strftime("%Y-%m-%d"),
+        # This works only for timezones to the west of GMT
         FactNotificationStatus.bst_date < end_date.strftime("%Y-%m-%d"),
         FactNotificationStatus.key_type != KEY_TYPE_TEST,
         FactNotificationStatus.notification_status != NOTIFICATION_CANCELLED,

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -307,7 +307,8 @@ def delete_notifications_older_than_retention_by_type(notification_type, qry_lim
     current_app.logger.info(
         'Deleting {} notifications for services without flexible data retention'.format(notification_type))
 
-    seven_days_ago = get_local_timezone_midnight_in_utc(convert_utc_to_local_timezone(datetime.utcnow()).date()) - timedelta(days=7)
+    seven_days_ago = get_local_timezone_midnight_in_utc(
+        convert_utc_to_local_timezone(datetime.utcnow()).date()) - timedelta(days=7)
     services_with_data_retention = [x.service_id for x in flexible_data_retention]
     service_ids_to_purge = db.session.query(Service.id).filter(Service.id.notin_(services_with_data_retention)).all()
 

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -48,7 +48,7 @@ from app.models import (
     ServiceDataRetention,
     Service
 )
-from app.utils import get_toronto_midnight_in_utc
+from app.utils import get_local_timezone_midnight_in_utc
 from app.utils import midnight_n_days_ago, escape_special_characters
 
 
@@ -290,7 +290,7 @@ def delete_notifications_older_than_retention_by_type(notification_type, qry_lim
     ).all()
     deleted = 0
     for f in flexible_data_retention:
-        days_of_retention = get_toronto_midnight_in_utc(
+        days_of_retention = get_local_timezone_midnight_in_utc(
             convert_utc_to_local_timezone(datetime.utcnow()).date()) - timedelta(days=f.days_of_retention)
 
         if notification_type == LETTER_TYPE:
@@ -307,7 +307,7 @@ def delete_notifications_older_than_retention_by_type(notification_type, qry_lim
     current_app.logger.info(
         'Deleting {} notifications for services without flexible data retention'.format(notification_type))
 
-    seven_days_ago = get_toronto_midnight_in_utc(convert_utc_to_local_timezone(datetime.utcnow()).date()) - timedelta(days=7)
+    seven_days_ago = get_local_timezone_midnight_in_utc(convert_utc_to_local_timezone(datetime.utcnow()).date()) - timedelta(days=7)
     services_with_data_retention = [x.service_id for x in flexible_data_retention]
     service_ids_to_purge = db.session.query(Service.id).filter(Service.id.notin_(services_with_data_retention)).all()
 

--- a/app/dao/provider_details_dao.py
+++ b/app/dao/provider_details_dao.py
@@ -112,8 +112,8 @@ def dao_get_sms_provider_with_equal_priority(identifier, priority):
 def dao_get_provider_stats():
     # this query does not include the current day since the task to populate ft_billing runs overnight
 
-    current_bst_datetime = convert_utc_to_local_timezone(datetime.utcnow())
-    first_day_of_the_month = current_bst_datetime.date().replace(day=1)
+    current_local_datetime = convert_utc_to_local_timezone(datetime.utcnow())
+    first_day_of_the_month = current_local_datetime.date().replace(day=1)
 
     subquery = db.session.query(
         FactBilling.provider,

--- a/app/dao/provider_details_dao.py
+++ b/app/dao/provider_details_dao.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from notifications_utils.timezones import convert_utc_to_est
+from notifications_utils.timezones import convert_utc_to_local_timezone
 from sqlalchemy import asc, desc, func
 
 from app.dao.dao_utils import transactional
@@ -112,7 +112,7 @@ def dao_get_sms_provider_with_equal_priority(identifier, priority):
 def dao_get_provider_stats():
     # this query does not include the current day since the task to populate ft_billing runs overnight
 
-    current_bst_datetime = convert_utc_to_est(datetime.utcnow())
+    current_bst_datetime = convert_utc_to_local_timezone(datetime.utcnow())
     first_day_of_the_month = current_bst_datetime.date().replace(day=1)
 
     subquery = db.session.query(

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -45,7 +45,7 @@ from app.models import (
     NON_CROWN_ORGANISATION_TYPES,
     SMS_TYPE,
 )
-from app.utils import email_address_is_nhs, get_toronto_midnight_in_utc, midnight_n_days_ago
+from app.utils import email_address_is_nhs, get_local_timezone_midnight_in_utc, midnight_n_days_ago
 
 DEFAULT_SERVICE_PERMISSIONS = [
     SMS_TYPE,
@@ -439,8 +439,8 @@ def _stats_for_service_query(service_id):
 @statsd(namespace='dao')
 def dao_fetch_todays_stats_for_all_services(include_from_test_key=True, only_active=True):
     today = date.today()
-    start_date = get_toronto_midnight_in_utc(today)
-    end_date = get_toronto_midnight_in_utc(today + timedelta(days=1))
+    start_date = get_local_timezone_midnight_in_utc(today)
+    end_date = get_local_timezone_midnight_in_utc(today + timedelta(days=1))
 
     subquery = db.session.query(
         Notification.notification_type,

--- a/app/letters/utils.py
+++ b/app/letters/utils.py
@@ -6,7 +6,7 @@ from flask import current_app
 
 from notifications_utils.letter_timings import LETTER_PROCESSING_DEADLINE
 from notifications_utils.s3 import s3upload
-from notifications_utils.timezones import convert_utc_to_est
+from notifications_utils.timezones import convert_utc_to_local_timezone
 
 from app.models import KEY_TYPE_TEST, SECOND_CLASS, RESOLVE_POSTAGE_FOR_FILE_NAME, NOTIFICATION_VALIDATION_FAILED
 
@@ -26,7 +26,7 @@ def get_folder_name(_now, is_test_or_scan_letter=False):
     if is_test_or_scan_letter:
         folder_name = ''
     else:
-        print_datetime = convert_utc_to_est(_now)
+        print_datetime = convert_utc_to_local_timezone(_now)
         if print_datetime.time() > LETTER_PROCESSING_DEADLINE:
             print_datetime += timedelta(days=1)
         folder_name = '{}/'.format(print_datetime.date())
@@ -164,10 +164,10 @@ def _move_s3_object(source_bucket, source_filename, target_bucket, target_filena
 
 
 def letter_print_day(created_at):
-    bst_print_datetime = convert_utc_to_est(created_at) + timedelta(hours=6, minutes=30)
+    bst_print_datetime = convert_utc_to_local_timezone(created_at) + timedelta(hours=6, minutes=30)
     bst_print_date = bst_print_datetime.date()
 
-    current_bst_date = convert_utc_to_est(datetime.utcnow()).date()
+    current_bst_date = convert_utc_to_local_timezone(datetime.utcnow()).date()
 
     if bst_print_date >= current_bst_date:
         return 'today'

--- a/app/models.py
+++ b/app/models.py
@@ -26,7 +26,7 @@ from notifications_utils.template import (
     SMSMessageTemplate,
     LetterPrintTemplate,
 )
-from notifications_utils.timezones import convert_est_to_utc, convert_utc_to_est
+from notifications_utils.timezones import convert_local_timezone_to_utc, convert_utc_to_local_timezone
 
 from app.encryption import (
     hashpw,
@@ -1572,7 +1572,7 @@ class Notification(db.Model):
             return None
 
     def serialize_for_csv(self):
-        created_at_in_bst = convert_utc_to_est(self.created_at)
+        created_at_in_bst = convert_utc_to_local_timezone(self.created_at)
         serialized = {
             "row_number": '' if self.job_row_number is None else self.job_row_number + 1,
             "recipient": self.to,
@@ -1616,7 +1616,7 @@ class Notification(db.Model):
             "sent_at": self.sent_at.strftime(DATETIME_FORMAT) if self.sent_at else None,
             "completed_at": self.completed_at(),
             "scheduled_for": (
-                convert_est_to_utc(
+                convert_local_timezone_to_utc(
                     self.scheduled_notification.scheduled_for
                 ).strftime(DATETIME_FORMAT)
                 if self.scheduled_notification

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -9,7 +9,7 @@ from notifications_utils.recipients import (
     validate_and_format_phone_number,
     format_email_address
 )
-from notifications_utils.timezones import convert_est_to_utc
+from notifications_utils.timezones import convert_local_timezone_to_utc
 
 from app import redis_store
 from app.celery import provider_tasks
@@ -162,7 +162,7 @@ def simulated_recipient(to_address, notification_type):
 
 
 def persist_scheduled_notification(notification_id, scheduled_for):
-    scheduled_datetime = convert_est_to_utc(datetime.strptime(scheduled_for, "%Y-%m-%d %H:%M"))
+    scheduled_datetime = convert_local_timezone_to_utc(datetime.strptime(scheduled_for, "%Y-%m-%d %H:%M"))
     scheduled_notification = ScheduledNotification(notification_id=notification_id,
                                                    scheduled_for=scheduled_datetime)
     dao_created_scheduled_notification(scheduled_notification)

--- a/app/notifications/receive_notifications.py
+++ b/app/notifications/receive_notifications.py
@@ -3,7 +3,7 @@ from urllib.parse import unquote
 import iso8601
 from flask import jsonify, Blueprint, current_app, request, abort
 from notifications_utils.recipients import try_validate_and_format_phone_number
-from notifications_utils.timezones import convert_est_to_utc
+from notifications_utils.timezones import convert_local_timezone_to_utc
 
 from app import statsd_client
 from app.celery import tasks
@@ -118,7 +118,7 @@ def format_mmg_datetime(date):
     """
     orig_date = format_mmg_message(date)
     parsed_datetime = iso8601.parse_date(orig_date).replace(tzinfo=None)
-    return convert_est_to_utc(parsed_datetime)
+    return convert_local_timezone_to_utc(parsed_datetime)
 
 
 def create_inbound_sms_object(service, content, from_number, provider_ref, date_received, provider_name):

--- a/app/performance_platform/processing_time.py
+++ b/app/performance_platform/processing_time.py
@@ -2,14 +2,14 @@ from datetime import timedelta
 
 from flask import current_app
 
-from app.utils import get_toronto_midnight_in_utc
+from app.utils import get_local_timezone_midnight_in_utc
 from app.dao.notifications_dao import dao_get_total_notifications_sent_per_day_for_performance_platform
 from app import performance_platform_client
 
 
 def send_processing_time_to_performance_platform(bst_date):
-    start_time = get_toronto_midnight_in_utc(bst_date)
-    end_time = get_toronto_midnight_in_utc(bst_date + timedelta(days=1))
+    start_time = get_local_timezone_midnight_in_utc(bst_date)
+    end_time = get_local_timezone_midnight_in_utc(bst_date + timedelta(days=1))
 
     send_processing_time_for_start_and_end(start_time, end_time)
 

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -8,7 +8,7 @@ from flask import (
     Blueprint
 )
 from notifications_utils.letter_timings import letter_can_be_cancelled
-from notifications_utils.timezones import convert_utc_to_est
+from notifications_utils.timezones import convert_utc_to_local_timezone
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -472,7 +472,7 @@ def get_monthly_notification_stats(service_id):
 
     now = datetime.utcnow()
     if end_date > now:
-        todays_deltas = fetch_notification_status_for_service_for_day(convert_utc_to_est(now), service_id=service_id)
+        todays_deltas = fetch_notification_status_for_service_for_day(convert_utc_to_local_timezone(now), service_id=service_id)
         statistics.add_monthly_notification_status_stats(data, todays_deltas)
 
     return jsonify(data=data)

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -611,6 +611,7 @@ def get_monthly_template_usage(service_id):
             end_date=end_date,
             service_id=service_id
         )
+        print(data)
         stats = list()
         for i in data:
             stats.append(

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -613,7 +613,6 @@ def get_monthly_template_usage(service_id):
             end_date=end_date,
             service_id=service_id
         )
-        print(data)
         stats = list()
         for i in data:
             stats.append(

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -472,7 +472,9 @@ def get_monthly_notification_stats(service_id):
 
     now = datetime.utcnow()
     if end_date > now:
-        todays_deltas = fetch_notification_status_for_service_for_day(convert_utc_to_local_timezone(now), service_id=service_id)
+        todays_deltas = fetch_notification_status_for_service_for_day(
+            convert_utc_to_local_timezone(now),
+            service_id=service_id)
         statistics.add_monthly_notification_status_stats(data, todays_deltas)
 
     return jsonify(data=data)

--- a/app/service/statistics.py
+++ b/app/service/statistics.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from datetime import datetime
 
-from notifications_utils.timezones import convert_utc_to_est
+from notifications_utils.timezones import convert_utc_to_local_timezone
 
 from app.models import NOTIFICATION_STATUS_TYPES, TEMPLATE_TYPES
 from app.dao.date_util import get_months_for_financial_year
@@ -98,7 +98,7 @@ def create_empty_monthly_notification_status_stats_dict(year):
     utc_month_starts = get_months_for_financial_year(year)
     # nested dicts - data[month][template type][status] = count
     return {
-        convert_utc_to_est(start).strftime('%Y-%m'): {
+        convert_utc_to_local_timezone(start).strftime('%Y-%m'): {
             template_type: defaultdict(int)
             for template_type in TEMPLATE_TYPES
         }

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,3 +1,5 @@
+import os
+
 from datetime import datetime, timedelta
 
 import pytz
@@ -5,7 +7,7 @@ from flask import url_for
 from sqlalchemy import func
 from notifications_utils.template import SMSMessageTemplate, WithSubjectTemplate, get_html_email_body
 
-local_timezone = pytz.timezone("America/Toronto")
+local_timezone = pytz.timezone(os.getenv("TIMEZONE", "America/Toronto"))
 
 
 def pagination_links(pagination, endpoint, **kwargs):
@@ -46,7 +48,7 @@ def get_html_email_body_from_template(template_instance):
     )
 
 
-def get_toronto_midnight_in_utc(date):
+def get_local_timezone_midnight_in_utc(date):
     """
      This function converts date to midnight as BST (British Standard Time) to UTC,
      the tzinfo is lastly removed from the datetime because the database stores the timestamps without timezone.
@@ -60,7 +62,7 @@ def get_toronto_midnight_in_utc(date):
 
 def get_midnight_for_day_before(date):
     day_before = date - timedelta(1)
-    return get_toronto_midnight_in_utc(day_before)
+    return get_local_timezone_midnight_in_utc(day_before)
 
 
 def get_london_month_from_utc_column(column):
@@ -96,7 +98,7 @@ def midnight_n_days_ago(number_of_days):
     """
     Returns midnight a number of days ago. Takes care of daylight savings etc.
     """
-    return get_toronto_midnight_in_utc(datetime.utcnow() - timedelta(days=number_of_days))
+    return get_local_timezone_midnight_in_utc(datetime.utcnow() - timedelta(days=number_of_days))
 
 
 def escape_special_characters(string):

--- a/app/utils.py
+++ b/app/utils.py
@@ -65,7 +65,7 @@ def get_midnight_for_day_before(date):
     return get_local_timezone_midnight_in_utc(day_before)
 
 
-def get_london_month_from_utc_column(column):
+def get_local_timezone_month_from_utc_column(column):
     """
      Where queries need to count notifications by month it needs to be
      the month in BST (British Summer Time).
@@ -77,7 +77,7 @@ def get_london_month_from_utc_column(column):
     """
     return func.date_trunc(
         "month",
-        func.timezone("America/Toronto", func.timezone("UTC", column))
+        func.timezone(os.getenv("TIMEZONE", "America/Toronto"), func.timezone("UTC", column))
     )
 
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -32,6 +32,6 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@34.0.9#egg=notifications-utils==34.0.9
+git+https://github.com/cds-snc/notifier-utils.git@34.0.10#egg=notifications-utils==34.0.10
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@34.0.9#egg=notifications-utils==34.0.9
+git+https://github.com/cds-snc/notifier-utils.git@34.0.10#egg=notifications-utils==34.0.10
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
 
@@ -44,13 +44,13 @@ amqp==1.4.9
 anyjson==0.3.3
 asn1crypto==0.24.0
 attrs==19.1.0
-awscli==1.16.211
+awscli==1.16.212
 bcrypt==3.1.7
 billiard==3.3.0.23
 bleach==3.1.0
 blinker==1.4
 boto3==1.6.16
-botocore==1.12.201
+botocore==1.12.202
 certifi==2019.6.16
 chardet==3.0.4
 Click==7.0
@@ -80,7 +80,7 @@ python-editor==1.0.4
 python-json-logger==0.1.11
 pytz==2019.2
 PyYAML==4.2b1
-redis==3.3.5
+redis==3.3.6
 requests==2.22.0
 rsa==3.4.2
 s3transfer==0.2.1

--- a/tests/app/billing/test_billing.py
+++ b/tests/app/billing/test_billing.py
@@ -177,7 +177,6 @@ def test_get_yearly_usage_by_monthly_from_ft_billing_populates_deltas(client, no
     assert fact_billing[0].notification_type == 'sms'
 
 
-@pytest.mark.skip(reason="Date math needs to be revisited")
 def test_get_yearly_usage_by_monthly_from_ft_billing(client, notify_db_session):
     service = create_service()
     sms_template = create_template(service=service, template_type="sms")
@@ -187,18 +186,18 @@ def test_get_yearly_usage_by_monthly_from_ft_billing(client, notify_db_session):
         mon = str(month).zfill(2)
         for day in range(1, monthrange(2016, month)[1] + 1):
             d = str(day).zfill(2)
-            create_ft_billing(bst_date='2016-{}-{}'.format(mon, d),
+            create_ft_billing(utc_date='2016-{}-{}'.format(mon, d),
                               service=service,
                               template=sms_template,
                               notification_type='sms',
                               billable_unit=1,
                               rate=0.162)
-            create_ft_billing(bst_date='2016-{}-{}'.format(mon, d),
+            create_ft_billing(utc_date='2016-{}-{}'.format(mon, d),
                               service=service,
                               template=email_template,
                               notification_type='email',
                               rate=0)
-            create_ft_billing(bst_date='2016-{}-{}'.format(mon, d),
+            create_ft_billing(utc_date='2016-{}-{}'.format(mon, d),
                               service=service,
                               template=letter_template,
                               notification_type='letter',
@@ -242,24 +241,24 @@ def set_up_yearly_data():
         mon = str(month).zfill(2)
         for day in range(1, monthrange(2016, month)[1] + 1):
             d = str(day).zfill(2)
-            create_ft_billing(bst_date='2016-{}-{}'.format(mon, d),
+            create_ft_billing(utc_date='2016-{}-{}'.format(mon, d),
                               service=service,
                               template=sms_template,
                               notification_type='sms',
                               rate=0.0162)
-            create_ft_billing(bst_date='2016-{}-{}'.format(mon, d),
+            create_ft_billing(utc_date='2016-{}-{}'.format(mon, d),
                               service=service,
                               template=sms_template,
                               notification_type='sms',
                               rate_multiplier=2,
                               rate=0.0162)
-            create_ft_billing(bst_date='2016-{}-{}'.format(mon, d),
+            create_ft_billing(utc_date='2016-{}-{}'.format(mon, d),
                               service=service,
                               template=email_template,
                               notification_type='email',
                               billable_unit=0,
                               rate=0)
-            create_ft_billing(bst_date='2016-{}-{}'.format(mon, d),
+            create_ft_billing(utc_date='2016-{}-{}'.format(mon, d),
                               service=service,
                               template=letter_template,
                               notification_type='letter',
@@ -291,7 +290,6 @@ def test_get_yearly_billing_usage_summary_from_ft_billing_returns_empty_list_if_
     assert json.loads(response.get_data(as_text=True)) == []
 
 
-@pytest.mark.skip(reason="Date math needs to be revisited")
 def test_get_yearly_billing_usage_summary_from_ft_billing(client, notify_db_session):
     service = set_up_yearly_data()
 
@@ -398,7 +396,7 @@ def set_up_data_for_all_cases():
     sms_template = create_template(service=service, template_type="sms")
     email_template = create_template(service=service, template_type="email")
     letter_template = create_template(service=service, template_type="letter")
-    create_ft_billing(bst_date='2018-05-16',
+    create_ft_billing(utc_date='2018-05-16',
                       notification_type='sms',
                       template=sms_template,
                       service=service,
@@ -407,7 +405,7 @@ def set_up_data_for_all_cases():
                       rate=0.162,
                       billable_unit=1,
                       notifications_sent=1)
-    create_ft_billing(bst_date='2018-05-17',
+    create_ft_billing(utc_date='2018-05-17',
                       notification_type='sms',
                       template=sms_template,
                       service=service,
@@ -416,7 +414,7 @@ def set_up_data_for_all_cases():
                       rate=0.162,
                       billable_unit=2,
                       notifications_sent=1)
-    create_ft_billing(bst_date='2018-05-16',
+    create_ft_billing(utc_date='2018-05-16',
                       notification_type='sms',
                       template=sms_template,
                       service=service,
@@ -425,7 +423,7 @@ def set_up_data_for_all_cases():
                       rate=0.0150,
                       billable_unit=2,
                       notifications_sent=1)
-    create_ft_billing(bst_date='2018-05-16',
+    create_ft_billing(utc_date='2018-05-16',
                       notification_type='email',
                       template=email_template,
                       service=service,
@@ -434,7 +432,7 @@ def set_up_data_for_all_cases():
                       rate=0,
                       billable_unit=0,
                       notifications_sent=1)
-    create_ft_billing(bst_date='2018-05-16',
+    create_ft_billing(utc_date='2018-05-16',
                       notification_type='letter',
                       template=letter_template,
                       service=service,
@@ -444,7 +442,7 @@ def set_up_data_for_all_cases():
                       billable_unit=1,
                       notifications_sent=1,
                       postage='second')
-    create_ft_billing(bst_date='2018-05-17',
+    create_ft_billing(utc_date='2018-05-17',
                       notification_type='letter',
                       template=letter_template,
                       service=service,
@@ -454,7 +452,7 @@ def set_up_data_for_all_cases():
                       billable_unit=2,
                       notifications_sent=1,
                       postage='second')
-    create_ft_billing(bst_date='2018-05-18',
+    create_ft_billing(utc_date='2018-05-18',
                       notification_type='letter',
                       template=letter_template,
                       service=service,

--- a/tests/app/celery/test_ftp_update_tasks.py
+++ b/tests/app/celery/test_ftp_update_tasks.py
@@ -229,7 +229,6 @@ def test_check_billable_units_when_billable_units_does_not_match_page_count(
     ('20170820230000', date(2017, 8, 20)),
     ('20170120230000', date(2017, 1, 20))
 ])
-@pytest.mark.skip(reason="Figure out hard coded BST")
 def test_get_billing_date_in_est_from_filename(filename_date, billing_date):
     filename = 'NOTIFY-{}-RSP.TXT'.format(filename_date)
     result = get_billing_date_in_est_from_filename(filename)

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -393,7 +393,7 @@ def test_letter_in_created_state_fails_if_notification_doesnt_exist(sample_notif
 @freeze_time('2018-01-01 18:00')
 @mock_s3
 @pytest.mark.parametrize('key_type,noti_status,bucket_config_name,destination_folder', [
-    (KEY_TYPE_NORMAL, NOTIFICATION_CREATED, 'LETTERS_PDF_BUCKET_NAME', '2018-01-02/'),
+    (KEY_TYPE_NORMAL, NOTIFICATION_CREATED, 'LETTERS_PDF_BUCKET_NAME', '2018-01-01/'),
     (KEY_TYPE_TEST, NOTIFICATION_DELIVERED, 'TEST_LETTERS_BUCKET_NAME', '')
 ])
 def test_process_letter_task_check_virus_scan_passed(

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -396,7 +396,6 @@ def test_letter_in_created_state_fails_if_notification_doesnt_exist(sample_notif
     (KEY_TYPE_NORMAL, NOTIFICATION_CREATED, 'LETTERS_PDF_BUCKET_NAME', '2018-01-02/'),
     (KEY_TYPE_TEST, NOTIFICATION_DELIVERED, 'TEST_LETTERS_BUCKET_NAME', '')
 ])
-@pytest.mark.skip(reason="Figure out hard coded BST")
 def test_process_letter_task_check_virus_scan_passed(
     sample_letter_template, mocker, key_type, noti_status, bucket_config_name, destination_folder
 ):

--- a/tests/app/celery/test_nightly_tasks.py
+++ b/tests/app/celery/test_nightly_tasks.py
@@ -252,7 +252,7 @@ def test_send_daily_performance_stats_calls_does_not_send_if_inactive(client, mo
 
 
 @freeze_time("2016-06-11 02:00:00")
-@pytest.mark.skip(reason="Date math needs to be revisited")
+# @pytest.mark.skip(reason="Date math needs to be revisited")
 def test_send_total_sent_notifications_to_performance_platform_calls_with_correct_totals(
         notify_db_session,
         sample_template,
@@ -263,13 +263,13 @@ def test_send_total_sent_notifications_to_performance_platform_calls_with_correc
         'app.celery.nightly_tasks.total_sent_notifications.send_total_notifications_sent_for_day_stats')  # noqa
 
     today = date(2016, 6, 11)
-    create_ft_notification_status(bst_date=today, template=sample_template)
-    create_ft_notification_status(bst_date=today, template=sample_email_template)
+    create_ft_notification_status(utc_date=today, template=sample_template)
+    create_ft_notification_status(utc_date=today, template=sample_email_template)
 
     # Create some notifications for the day before
     yesterday = date(2016, 6, 10)
-    create_ft_notification_status(bst_date=yesterday, template=sample_template, count=2)
-    create_ft_notification_status(bst_date=yesterday, template=sample_email_template, count=3)
+    create_ft_notification_status(utc_date=yesterday, template=sample_template, count=2)
+    create_ft_notification_status(utc_date=yesterday, template=sample_email_template, count=3)
 
     with patch.object(
             PerformancePlatformClient,
@@ -280,9 +280,9 @@ def test_send_total_sent_notifications_to_performance_platform_calls_with_correc
         send_total_sent_notifications_to_performance_platform(yesterday)
 
         perf_mock.assert_has_calls([
-            call(datetime(2016, 6, 9, 23, 0), 'sms', 2),
-            call(datetime(2016, 6, 9, 23, 0), 'email', 3),
-            call(datetime(2016, 6, 9, 23, 0), 'letter', 0)
+            call("2016-06-10", 'sms', 2),
+            call("2016-06-10", 'email', 3),
+            call("2016-06-10", 'letter', 0)
         ])
 
 

--- a/tests/app/celery/test_nightly_tasks.py
+++ b/tests/app/celery/test_nightly_tasks.py
@@ -252,7 +252,6 @@ def test_send_daily_performance_stats_calls_does_not_send_if_inactive(client, mo
 
 
 @freeze_time("2016-06-11 02:00:00")
-# @pytest.mark.skip(reason="Date math needs to be revisited")
 def test_send_total_sent_notifications_to_performance_platform_calls_with_correct_totals(
         notify_db_session,
         sample_template,

--- a/tests/app/celery/test_reporting_tasks.py
+++ b/tests/app/celery/test_reporting_tasks.py
@@ -285,7 +285,7 @@ def test_create_nightly_billing_null_sent_by_sms(
 
 
 @freeze_time('2018-01-15T03:30:00')
-@pytest.mark.skip(reason="Figure out hard coded BST")
+# This test assumes the local timezone is EST
 def test_create_nightly_billing_consolidate_from_3_days_delta(
         sample_template,
         mocker):
@@ -314,8 +314,8 @@ def test_create_nightly_billing_consolidate_from_3_days_delta(
     records = FactBilling.query.order_by(FactBilling.bst_date).all()
 
     assert len(records) == 4
-    assert records[0].bst_date == date(2018, 1, 11)
-    assert records[-1].bst_date == date(2018, 1, 14)
+    assert records[0].bst_date == date(2018, 1, 10)
+    assert records[-1].bst_date == date(2018, 1, 13)
 
 
 def test_get_rate_for_letter_latest(notify_db_session):
@@ -342,9 +342,8 @@ def test_get_rate_for_sms_and_email(notify_db_session):
     assert rate == Decimal(0)
 
 
-@freeze_time('2018-03-26T23:30:00')
-# summer time starts on 2018-03-25
-@pytest.mark.skip(reason="Figure out hard coded BST")
+@freeze_time('2018-03-27T04:30:00')
+# This test assumes the local timezone is EST
 def test_create_nightly_billing_use_BST(
         sample_service,
         sample_template,
@@ -363,7 +362,7 @@ def test_create_nightly_billing_use_BST(
     )
 
     create_notification(
-        created_at=datetime(2018, 3, 25, 23, 5),
+        created_at=datetime(2018, 3, 26, 4, 30),
         template=sample_template,
         status='delivered',
         sent_by=None,
@@ -386,7 +385,7 @@ def test_create_nightly_billing_use_BST(
 
 
 @freeze_time('2018-01-15T03:30:00')
-@pytest.mark.skip(reason="Figure out hard coded BST")
+# This test assumes the local timezone is EST
 def test_create_nightly_billing_update_when_record_exists(
         sample_service,
         sample_template,
@@ -411,7 +410,7 @@ def test_create_nightly_billing_update_when_record_exists(
     records = FactBilling.query.order_by(FactBilling.bst_date).all()
 
     assert len(records) == 1
-    assert records[0].bst_date == date(2018, 1, 14)
+    assert records[0].bst_date == date(2018, 1, 13)
     assert records[0].billable_units == 1
     assert not records[0].updated_at
 
@@ -475,25 +474,25 @@ def test_create_nightly_notification_status(notify_db_session):
     assert str(new_data[6].bst_date) == datetime.strftime(datetime.utcnow() - timedelta(days=1), "%Y-%m-%d")
 
 
-# the job runs at 12:30am London time. 04/01 is in BST.
-@freeze_time('2019-04-01T23:30')
-@pytest.mark.skip(reason="Figure out hard coded BST")
+@freeze_time('2019-04-02T04:30')
+# This test assumes the local timezone is EST
 def test_create_nightly_notification_status_respects_bst(sample_template):
-    create_notification(sample_template, status='delivered', created_at=datetime(2019, 4, 1, 23, 0))  # too new
+    create_notification(sample_template, status='delivered', created_at=datetime(2019, 4, 2, 5, 0))  # too new
 
-    create_notification(sample_template, status='created', created_at=datetime(2019, 4, 1, 22, 59))
-    create_notification(sample_template, status='created', created_at=datetime(2019, 3, 31, 23, 0))
+    create_notification(sample_template, status='created', created_at=datetime(2019, 4, 2, 5, 59))
+    create_notification(sample_template, status='created', created_at=datetime(2019, 4, 1, 4, 59))
 
-    create_notification(sample_template, status='temporary-failure', created_at=datetime(2019, 3, 31, 22, 59))
+    create_notification(sample_template, status='temporary-failure', created_at=datetime(2019, 4, 1, 2, 59))
 
     # we create records for last ten days
-    create_notification(sample_template, status='sending', created_at=datetime(2019, 3, 29, 0, 0))
+    create_notification(sample_template, status='sending', created_at=datetime(2019, 3, 29, 5, 0))
 
-    create_notification(sample_template, status='delivered', created_at=datetime(2019, 3, 22, 23, 59))  # too old
+    create_notification(sample_template, status='delivered', created_at=datetime(2019, 3, 21, 17, 59))  # too old
 
     create_nightly_notification_status()
 
     noti_status = FactNotificationStatus.query.order_by(FactNotificationStatus.bst_date).all()
+    print(noti_status)
     assert len(noti_status) == 3
 
     assert noti_status[0].bst_date == date(2019, 3, 29)

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -372,7 +372,7 @@ def test_check_precompiled_letter_state(mocker, sample_letter_template):
 
 
 @freeze_time("2019-05-30 14:00:00")
-@pytest.mark.skip(reason="Figure out hard coded BST")
+@pytest.mark.skip(reason="Letter feature")
 def test_check_templated_letter_state_during_bst(mocker, sample_letter_template):
     mock_logger = mocker.patch('app.celery.tasks.current_app.logger.exception')
     mock_create_ticket = mocker.patch('app.celery.nightly_tasks.zendesk_client.create_ticket')
@@ -398,7 +398,7 @@ def test_check_templated_letter_state_during_bst(mocker, sample_letter_template)
 
 
 @freeze_time("2019-01-30 14:00:00")
-@pytest.mark.skip(reason="Figure out hard coded BST")
+@pytest.mark.skip(reason="Letter feature")
 def test_check_templated_letter_state_during_utc(mocker, sample_letter_template):
     mock_logger = mocker.patch('app.celery.tasks.current_app.logger.exception')
     mock_create_ticket = mocker.patch('app.celery.nightly_tasks.zendesk_client.create_ticket')

--- a/tests/app/commands/test_performance_platform_commands.py
+++ b/tests/app/commands/test_performance_platform_commands.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-import pytest
 
 from app.commands import backfill_performance_platform_totals, backfill_processing_time
 

--- a/tests/app/commands/test_performance_platform_commands.py
+++ b/tests/app/commands/test_performance_platform_commands.py
@@ -4,7 +4,7 @@ import pytest
 from app.commands import backfill_performance_platform_totals, backfill_processing_time
 
 
-@pytest.mark.skip(reason="Date math needs to be revisited")
+# This test assumes the local timezone is EST
 def test_backfill_processing_time_works_for_correct_dates(mocker, notify_api):
     send_mock = mocker.patch('app.commands.send_processing_time_for_start_and_end')
 
@@ -13,9 +13,9 @@ def test_backfill_processing_time_works_for_correct_dates(mocker, notify_api):
     backfill_processing_time.callback.__wrapped__(datetime(2017, 8, 1), datetime(2017, 8, 3))
 
     assert send_mock.call_count == 3
-    send_mock.assert_any_call(datetime(2017, 7, 31, 23, 0), datetime(2017, 8, 1, 23, 0))
-    send_mock.assert_any_call(datetime(2017, 8, 1, 23, 0), datetime(2017, 8, 2, 23, 0))
-    send_mock.assert_any_call(datetime(2017, 8, 2, 23, 0), datetime(2017, 8, 3, 23, 0))
+    send_mock.assert_any_call(datetime(2017, 8, 3, 4, 0), datetime(2017, 8, 4, 4, 0))
+    send_mock.assert_any_call(datetime(2017, 8, 3, 4, 0), datetime(2017, 8, 4, 4, 0))
+    send_mock.assert_any_call(datetime(2017, 8, 3, 4, 0), datetime(2017, 8, 4, 4, 0))
 
 
 def test_backfill_totals_works_for_correct_dates(mocker, notify_api):

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -563,13 +563,13 @@ def test_update_notification_sets_status(sample_notification):
 
 
 @freeze_time("2016-01-10")
-@pytest.mark.skip(reason="Date math needs to be revisited")
+# This test assumes the local timezone is EST
 def test_should_limit_notifications_return_by_day_limit_plus_one(sample_template):
     assert len(Notification.query.all()) == 0
 
     # create one notification a day between 1st and 9th
     for i in range(1, 11):
-        past_date = '2016-01-{0:02d}'.format(i)
+        past_date = '2016-01-{0:02d} 12:00:00'.format(i)
         with freeze_time(past_date):
             create_notification(sample_template, created_at=datetime.utcnow(), status="failed")
 

--- a/tests/app/dao/test_fact_notification_status_dao.py
+++ b/tests/app/dao/test_fact_notification_status_dao.py
@@ -253,7 +253,7 @@ def test_fetch_notification_status_for_service_for_today_and_7_previous_days(not
 
 
 @freeze_time('2018-10-31T18:00:00')
-@pytest.mark.skip(reason="Date math needs to be revisited")
+# This test assumes the local timezone is EST
 def test_fetch_notification_status_by_template_for_service_for_today_and_7_previous_days(notify_db_session):
     service_1 = create_service(service_name='service_1')
     sms_template = create_template(template_name='sms Template 1', service=service_1, template_type=SMS_TYPE)
@@ -288,9 +288,9 @@ def test_fetch_notification_status_by_template_for_service_for_today_and_7_previ
         ('sms Template Name', False, mock.ANY, 'sms', 'created', 1),
         ('sms Template 1', False, mock.ANY, 'sms', 'delivered', 1),
         ('sms Template 2', False, mock.ANY, 'sms', 'delivered', 1),
-        ('sms Template Name', False, mock.ANY, 'sms', 'delivered', 8),
         ('sms Template Name', False, mock.ANY, 'sms', 'delivered', 10),
         ('sms Template Name', False, mock.ANY, 'sms', 'delivered', 11),
+
     ] == sorted(results, key=lambda x: (x.notification_type, x.status, x.template_name, x.count))
 
 
@@ -449,21 +449,21 @@ def test_fetch_monthly_template_usage_for_service(sample_service):
     template_two = create_template(service=sample_service, template_type='email', template_name='b')
     template_three = create_template(service=sample_service, template_type='letter', template_name='c')
 
-    create_ft_notification_status(bst_date=date(2017, 12, 10),
+    create_ft_notification_status(utc_date=date(2017, 12, 10),
                                   service=sample_service,
                                   template=template_two,
                                   count=3)
-    create_ft_notification_status(bst_date=date(2017, 12, 10),
+    create_ft_notification_status(utc_date=date(2017, 12, 10),
                                   service=sample_service,
                                   template=template_one,
                                   count=6)
 
-    create_ft_notification_status(bst_date=date(2018, 1, 1),
+    create_ft_notification_status(utc_date=date(2018, 1, 1),
                                   service=sample_service,
                                   template=template_one,
                                   count=4)
 
-    create_ft_notification_status(bst_date=date(2018, 3, 1),
+    create_ft_notification_status(utc_date=date(2018, 3, 1),
                                   service=sample_service,
                                   template=template_three,
                                   count=5)
@@ -513,15 +513,15 @@ def test_fetch_monthly_template_usage_for_service_does_join_to_notifications_if_
 ):
     template_one = create_template(service=sample_service, template_type='sms', template_name='a')
     template_two = create_template(service=sample_service, template_type='email', template_name='b')
-    create_ft_notification_status(bst_date=date(2018, 2, 1),
+    create_ft_notification_status(utc_date=date(2018, 2, 1),
                                   service=template_two.service,
                                   template=template_two,
                                   count=15)
-    create_ft_notification_status(bst_date=date(2018, 2, 2),
+    create_ft_notification_status(utc_date=date(2018, 2, 2),
                                   service=template_one.service,
                                   template=template_one,
                                   count=20)
-    create_ft_notification_status(bst_date=date(2018, 3, 1),
+    create_ft_notification_status(utc_date=date(2018, 3, 1),
                                   service=template_one.service,
                                   template=template_one,
                                   count=3)
@@ -552,7 +552,7 @@ def test_fetch_monthly_template_usage_for_service_does_join_to_notifications_if_
 def test_fetch_monthly_template_usage_for_service_does_not_include_cancelled_status(
         sample_template
 ):
-    create_ft_notification_status(bst_date=date(2018, 3, 1),
+    create_ft_notification_status(utc_date=date(2018, 3, 1),
                                   service=sample_template.service,
                                   template=sample_template,
                                   notification_status='cancelled',
@@ -569,7 +569,7 @@ def test_fetch_monthly_template_usage_for_service_does_not_include_cancelled_sta
 def test_fetch_monthly_template_usage_for_service_does_not_include_test_notifications(
         sample_template
 ):
-    create_ft_notification_status(bst_date=date(2018, 3, 1),
+    create_ft_notification_status(utc_date=date(2018, 3, 1),
                                   service=sample_template.service,
                                   template=sample_template,
                                   notification_status='delivered',
@@ -593,11 +593,11 @@ def test_fetch_monthly_template_usage_for_service_does_not_include_test_notifica
 def test_get_total_sent_notifications_for_day_and_type_returns_right_notification_type(
         notification_type, count, sample_template, sample_email_template, sample_letter_template
 ):
-    create_ft_notification_status(bst_date="2019-03-27", service=sample_template.service, template=sample_template,
+    create_ft_notification_status(utc_date="2019-03-27", service=sample_template.service, template=sample_template,
                                   count=3)
-    create_ft_notification_status(bst_date="2019-03-27", service=sample_email_template.service,
+    create_ft_notification_status(utc_date="2019-03-27", service=sample_email_template.service,
                                   template=sample_email_template, count=5)
-    create_ft_notification_status(bst_date="2019-03-27", service=sample_letter_template.service,
+    create_ft_notification_status(utc_date="2019-03-27", service=sample_letter_template.service,
                                   template=sample_letter_template, count=7)
 
     result = get_total_sent_notifications_for_day_and_type(day='2019-03-27', notification_type=notification_type)
@@ -611,11 +611,11 @@ def test_get_total_sent_notifications_for_day_and_type_returns_total_for_right_d
     day, sample_template
 ):
     date = datetime.strptime(day, "%Y-%m-%d")
-    create_ft_notification_status(bst_date=date - timedelta(days=1), notification_type=sample_template.template_type,
+    create_ft_notification_status(utc_date=date - timedelta(days=1), notification_type=sample_template.template_type,
                                   service=sample_template.service, template=sample_template, count=1)
-    create_ft_notification_status(bst_date=date, notification_type=sample_template.template_type,
+    create_ft_notification_status(utc_date=date, notification_type=sample_template.template_type,
                                   service=sample_template.service, template=sample_template, count=2)
-    create_ft_notification_status(bst_date=date + timedelta(days=1), notification_type=sample_template.template_type,
+    create_ft_notification_status(utc_date=date + timedelta(days=1), notification_type=sample_template.template_type,
                                   service=sample_template.service, template=sample_template, count=3)
 
     total = get_total_sent_notifications_for_day_and_type(day, sample_template.template_type)

--- a/tests/app/dao/test_ft_billing_dao.py
+++ b/tests/app/dao/test_ft_billing_dao.py
@@ -43,23 +43,23 @@ def set_up_yearly_data():
             mon = str(month).zfill(2)
             for day in range(1, monthrange(year, month)[1] + 1):
                 d = str(day).zfill(2)
-                create_ft_billing(bst_date='{}-{}-{}'.format(year, mon, d),
+                create_ft_billing(utc_date='{}-{}-{}'.format(year, mon, d),
                                   service=service,
                                   template=sms_template,
                                   notification_type='sms',
                                   rate=0.162)
-                create_ft_billing(bst_date='{}-{}-{}'.format(year, mon, d),
+                create_ft_billing(utc_date='{}-{}-{}'.format(year, mon, d),
                                   service=service,
                                   template=email_template,
                                   notification_type='email',
                                   rate=0)
-                create_ft_billing(bst_date='{}-{}-{}'.format(year, mon, d),
+                create_ft_billing(utc_date='{}-{}-{}'.format(year, mon, d),
                                   service=service,
                                   template=letter_template,
                                   notification_type='letter',
                                   rate=0.33,
                                   postage='second')
-                create_ft_billing(bst_date='{}-{}-{}'.format(year, mon, d),
+                create_ft_billing(utc_date='{}-{}-{}'.format(year, mon, d),
                                   service=service,
                                   template=letter_template,
                                   notification_type='letter',
@@ -96,14 +96,14 @@ def test_fetch_billing_data_for_today_includes_data_with_the_right_key_type(noti
     assert results[0].notifications_sent == 2
 
 
-@freeze_time('2018-04-02 01:20:00')
-@pytest.mark.skip(reason="Date math needs to be revisited")
+@freeze_time('2018-04-02 06:20:00')
+# This test assumes the local timezone is EST
 def test_fetch_billing_data_for_today_includes_data_with_the_right_date(notify_db_session):
     process_day = datetime(2018, 4, 1, 13, 30, 0)
     service = create_service()
     template = create_template(service=service, template_type="email")
     create_notification(template=template, status='delivered', created_at=process_day)
-    create_notification(template=template, status='delivered', created_at=datetime(2018, 3, 31, 23, 23, 23))
+    create_notification(template=template, status='delivered', created_at=datetime(2018, 4, 1, 4, 23, 23))
 
     create_notification(template=template, status='delivered', created_at=datetime(2018, 3, 31, 20, 23, 23))
     create_notification(template=template, status='sending', created_at=process_day + timedelta(days=1))
@@ -351,14 +351,14 @@ def test_fetch_monthly_billing_for_year(notify_db_session):
     service = create_service()
     template = create_template(service=service, template_type="sms")
     for i in range(1, 31):
-        create_ft_billing(bst_date='2018-06-{}'.format(i),
+        create_ft_billing(utc_date='2018-06-{}'.format(i),
                           service=service,
                           template=template,
                           notification_type='sms',
                           rate_multiplier=2,
                           rate=0.162)
     for i in range(1, 32):
-        create_ft_billing(bst_date='2018-07-{}'.format(i),
+        create_ft_billing(utc_date='2018-07-{}'.format(i),
                           service=service,
                           template=template,
                           notification_type='sms',
@@ -387,7 +387,7 @@ def test_fetch_monthly_billing_for_year_adds_data_for_today(notify_db_session):
     service = create_service()
     template = create_template(service=service, template_type="email")
     for i in range(1, 32):
-        create_ft_billing(bst_date='2018-07-{}'.format(i),
+        create_ft_billing(utc_date='2018-07-{}'.format(i),
                           service=service,
                           template=template,
                           notification_type='email',
@@ -401,7 +401,7 @@ def test_fetch_monthly_billing_for_year_adds_data_for_today(notify_db_session):
     assert len(results) == 2
 
 
-@pytest.mark.skip(reason="Date math needs to be revisited")
+# This test assumes the local timezone is EST
 def test_fetch_monthly_billing_for_year_return_financial_year(notify_db_session):
     service = set_up_yearly_data()
 
@@ -409,7 +409,7 @@ def test_fetch_monthly_billing_for_year_return_financial_year(notify_db_session)
     # returns 3 rows, per month, returns financial year april to end of march
     # Orders by Month
 
-    assert len(results) == 48
+    assert len(results) == 52
     assert str(results[0].month) == "2016-04-01"
     assert results[0].notification_type == 'email'
     assert results[0].notifications_sent == 30

--- a/tests/app/dao/test_ft_billing_dao.py
+++ b/tests/app/dao/test_ft_billing_dao.py
@@ -6,7 +6,7 @@ from freezegun import freeze_time
 
 import pytest
 
-from notifications_utils.timezones import convert_utc_to_est
+from notifications_utils.timezones import convert_utc_to_local_timezone
 
 from app import db
 from app.dao.fact_billing_dao import (
@@ -74,7 +74,7 @@ def test_fetch_billing_data_for_today_includes_data_with_the_right_status(notify
     for status in ['created', 'technical-failure']:
         create_notification(template=template, status=status)
 
-    today = convert_utc_to_est(datetime.utcnow())
+    today = convert_utc_to_local_timezone(datetime.utcnow())
     results = fetch_billing_data_for_day(today)
     assert results == []
     for status in ['delivered', 'sending', 'temporary-failure']:
@@ -90,7 +90,7 @@ def test_fetch_billing_data_for_today_includes_data_with_the_right_key_type(noti
     for key_type in ['normal', 'test', 'team']:
         create_notification(template=template, status='delivered', key_type=key_type)
 
-    today = convert_utc_to_est(datetime.utcnow())
+    today = convert_utc_to_local_timezone(datetime.utcnow())
     results = fetch_billing_data_for_day(today)
     assert len(results) == 1
     assert results[0].notifications_sent == 2
@@ -108,7 +108,7 @@ def test_fetch_billing_data_for_today_includes_data_with_the_right_date(notify_d
     create_notification(template=template, status='delivered', created_at=datetime(2018, 3, 31, 20, 23, 23))
     create_notification(template=template, status='sending', created_at=process_day + timedelta(days=1))
 
-    day_under_test = convert_utc_to_est(process_day)
+    day_under_test = convert_utc_to_local_timezone(process_day)
     results = fetch_billing_data_for_day(day_under_test)
     assert len(results) == 1
     assert results[0].notifications_sent == 2
@@ -121,7 +121,7 @@ def test_fetch_billing_data_for_day_is_grouped_by_template_and_notification_type
     create_notification(template=email_template, status='delivered')
     create_notification(template=sms_template, status='delivered')
 
-    today = convert_utc_to_est(datetime.utcnow())
+    today = convert_utc_to_local_timezone(datetime.utcnow())
     results = fetch_billing_data_for_day(today)
     assert len(results) == 2
     assert results[0].notifications_sent == 1
@@ -136,7 +136,7 @@ def test_fetch_billing_data_for_day_is_grouped_by_service(notify_db_session):
     create_notification(template=email_template, status='delivered')
     create_notification(template=sms_template, status='delivered')
 
-    today = convert_utc_to_est(datetime.utcnow())
+    today = convert_utc_to_local_timezone(datetime.utcnow())
     results = fetch_billing_data_for_day(today)
     assert len(results) == 2
     assert results[0].notifications_sent == 1
@@ -149,7 +149,7 @@ def test_fetch_billing_data_for_day_is_grouped_by_provider(notify_db_session):
     create_notification(template=template, status='delivered', sent_by='mmg')
     create_notification(template=template, status='delivered', sent_by='firetext')
 
-    today = convert_utc_to_est(datetime.utcnow())
+    today = convert_utc_to_local_timezone(datetime.utcnow())
     results = fetch_billing_data_for_day(today)
     assert len(results) == 2
     assert results[0].notifications_sent == 1
@@ -162,7 +162,7 @@ def test_fetch_billing_data_for_day_is_grouped_by_rate_mulitplier(notify_db_sess
     create_notification(template=template, status='delivered', rate_multiplier=1)
     create_notification(template=template, status='delivered', rate_multiplier=2)
 
-    today = convert_utc_to_est(datetime.utcnow())
+    today = convert_utc_to_local_timezone(datetime.utcnow())
     results = fetch_billing_data_for_day(today)
     assert len(results) == 2
     assert results[0].notifications_sent == 1
@@ -175,7 +175,7 @@ def test_fetch_billing_data_for_day_is_grouped_by_international(notify_db_sessio
     create_notification(template=template, status='delivered', international=True)
     create_notification(template=template, status='delivered', international=False)
 
-    today = convert_utc_to_est(datetime.utcnow())
+    today = convert_utc_to_local_timezone(datetime.utcnow())
     results = fetch_billing_data_for_day(today)
     assert len(results) == 2
     assert results[0].notifications_sent == 1
@@ -194,7 +194,7 @@ def test_fetch_billing_data_for_day_is_grouped_by_notification_type(notify_db_se
     create_notification(template=email_template, status='delivered')
     create_notification(template=letter_template, status='delivered')
 
-    today = convert_utc_to_est(datetime.utcnow())
+    today = convert_utc_to_local_timezone(datetime.utcnow())
     results = fetch_billing_data_for_day(today)
     assert len(results) == 3
     notification_types = [x[2] for x in results if x[2] in ['email', 'sms', 'letter']]
@@ -210,7 +210,7 @@ def test_fetch_billing_data_for_day_groups_by_postage(notify_db_session):
     create_notification(template=letter_template, status='delivered', postage='second')
     create_notification(template=email_template, status='delivered')
 
-    today = convert_utc_to_est(datetime.utcnow())
+    today = convert_utc_to_local_timezone(datetime.utcnow())
     results = fetch_billing_data_for_day(today)
     assert len(results) == 3
 
@@ -222,7 +222,7 @@ def test_fetch_billing_data_for_day_sets_postage_for_emails_and_sms_to_none(noti
     create_notification(template=sms_template, status='delivered')
     create_notification(template=email_template, status='delivered')
 
-    today = convert_utc_to_est(datetime.utcnow())
+    today = convert_utc_to_local_timezone(datetime.utcnow())
     results = fetch_billing_data_for_day(today)
     assert len(results) == 2
     assert results[0].postage == 'none'
@@ -230,7 +230,7 @@ def test_fetch_billing_data_for_day_sets_postage_for_emails_and_sms_to_none(noti
 
 
 def test_fetch_billing_data_for_day_returns_empty_list(notify_db_session):
-    today = convert_utc_to_est(datetime.utcnow())
+    today = convert_utc_to_local_timezone(datetime.utcnow())
     results = fetch_billing_data_for_day(today)
     assert results == []
 
@@ -258,7 +258,7 @@ def test_fetch_billing_data_for_day_returns_list_for_given_service(notify_db_ses
     create_notification(template=template, status='delivered')
     create_notification(template=template_2, status='delivered')
 
-    today = convert_utc_to_est(datetime.utcnow())
+    today = convert_utc_to_local_timezone(datetime.utcnow())
     results = fetch_billing_data_for_day(process_day=today, service_id=service.id)
     assert len(results) == 1
     assert results[0].service_id == service.id
@@ -273,7 +273,7 @@ def test_fetch_billing_data_for_day_bills_correctly_for_status(notify_db_session
         create_notification(template=sms_template, status=status)
         create_notification(template=email_template, status=status)
         create_notification(template=letter_template, status=status)
-    today = convert_utc_to_est(datetime.utcnow())
+    today = convert_utc_to_local_timezone(datetime.utcnow())
     results = fetch_billing_data_for_day(process_day=today, service_id=service.id)
 
     sms_results = [x for x in results if x[2] == 'sms']

--- a/tests/app/dao/test_inbound_sms_dao.py
+++ b/tests/app/dao/test_inbound_sms_dao.py
@@ -57,10 +57,10 @@ def test_get_all_inbound_sms_filters_on_service(notify_db_session):
     assert res[0] == sms_one
 
 
-@pytest.mark.skip(reason="Date math needs to be revisited")
+# This test assumes the local timezone is EST
 def test_get_all_inbound_sms_filters_on_time(sample_service, notify_db_session):
-    create_inbound_sms(sample_service, created_at=datetime(2017, 8, 6, 22, 59))  # sunday evening
-    sms_two = create_inbound_sms(sample_service, created_at=datetime(2017, 8, 6, 23, 0))  # monday (7th) morning
+    create_inbound_sms(sample_service, created_at=datetime(2017, 8, 7, 3, 59))  # sunday evening
+    sms_two = create_inbound_sms(sample_service, created_at=datetime(2017, 8, 7, 4, 0))  # monday (7th) morning
 
     with freeze_time('2017-08-14 12:00'):
         res = dao_get_inbound_sms_for_service(sample_service.id, limit_days=7)
@@ -80,19 +80,19 @@ def test_count_inbound_sms_for_service(notify_db_session):
     assert dao_count_inbound_sms_for_service(service_one.id, limit_days=1) == 2
 
 
-@pytest.mark.skip(reason="Date math needs to be revisited")
+# This test assumes the local timezone is EST
 def test_count_inbound_sms_for_service_filters_messages_older_than_n_days(sample_service):
     # test between evening sunday 2nd of june and morning of monday 3rd
-    create_inbound_sms(sample_service, created_at=datetime(2019, 6, 2, 22, 59))
-    create_inbound_sms(sample_service, created_at=datetime(2019, 6, 2, 22, 59))
-    create_inbound_sms(sample_service, created_at=datetime(2019, 6, 2, 23, 1))
+    create_inbound_sms(sample_service, created_at=datetime(2019, 6, 3, 3, 59))
+    create_inbound_sms(sample_service, created_at=datetime(2019, 6, 3, 3, 59))
+    create_inbound_sms(sample_service, created_at=datetime(2019, 6, 3, 4, 1))
 
     with freeze_time('Monday 10th June 2019 12:00'):
         assert dao_count_inbound_sms_for_service(sample_service.id, limit_days=7) == 1
 
 
 @freeze_time("2017-06-08 12:00:00")
-@pytest.mark.skip(reason="Date math needs to be revisited")
+# This test assumes the local timezone is EST
 def test_should_delete_inbound_sms_according_to_data_retention(notify_db_session):
     no_retention_service = create_service(service_name='no retention')
     short_retention_service = create_service(service_name='three days')
@@ -106,10 +106,10 @@ def test_should_delete_inbound_sms_according_to_data_retention(notify_db_session
     create_service_data_retention(short_retention_service, notification_type='email', days_of_retention=4)
 
     dates = [
-        datetime(2017, 6, 4, 23, 00),  # just before three days
-        datetime(2017, 6, 4, 22, 59),  # older than three days
-        datetime(2017, 5, 31, 23, 00),  # just before seven days
-        datetime(2017, 5, 31, 22, 59),  # older than seven days
+        datetime(2017, 6, 5, 4, 00),  # just before three days
+        datetime(2017, 6, 5, 3, 59),  # older than three days
+        datetime(2017, 6, 1, 4, 00),  # just before seven days
+        datetime(2017, 6, 1, 3, 59),  # older than seven days
         datetime(2017, 5, 1, 0, 0),  # older than thirty days
     ]
 
@@ -264,12 +264,12 @@ def test_most_recent_inbound_sms_paginates_properly(notify_api, sample_service):
             assert res.items[1].content == '111 2'
 
 
-@pytest.mark.skip(reason="Date math needs to be revisited")
+# This test assumes the local timezone is EST
 def test_most_recent_inbound_sms_only_returns_values_within_7_days(sample_service):
     # just out of bounds
-    create_inbound_sms(sample_service, user_number='1', content='old', created_at=datetime(2017, 4, 2, 22, 59, 59))
+    create_inbound_sms(sample_service, user_number='1', content='old', created_at=datetime(2017, 4, 3, 3, 59, 59))
     # just in bounds
-    create_inbound_sms(sample_service, user_number='2', content='new', created_at=datetime(2017, 4, 2, 23, 0, 0))
+    create_inbound_sms(sample_service, user_number='2', content='new', created_at=datetime(2017, 4, 3, 4, 0, 0))
 
     with freeze_time('Monday 10th April 2017 12:00:00'):
         res = dao_get_paginated_most_recent_inbound_sms_by_user_number_for_service(sample_service.id, limit_days=7, page=1)  # noqa

--- a/tests/app/dao/test_inbound_sms_dao.py
+++ b/tests/app/dao/test_inbound_sms_dao.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from itertools import product
-import pytest
 from freezegun import freeze_time
 
 from app.dao.inbound_sms_dao import (

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -134,11 +134,11 @@ def test_get_jobs_for_service_with_limit_days_param(sample_template):
 
 
 @freeze_time('2017-06-10')
-@pytest.mark.skip(reason="Date math needs to be revisited")
+# This test assumes the local timezone is EST
 def test_get_jobs_for_service_with_limit_days_edge_case(sample_template):
     one_job = create_job(sample_template)
-    just_after_midnight_job = create_job(sample_template, created_at=datetime(2017, 6, 2, 23, 0, 1))
-    just_before_midnight_job = create_job(sample_template, created_at=datetime(2017, 6, 2, 22, 59, 0))
+    just_after_midnight_job = create_job(sample_template, created_at=datetime(2017, 6, 3, 4, 0, 1))
+    just_before_midnight_job = create_job(sample_template, created_at=datetime(2017, 6, 3, 3, 59, 0))
 
     jobs_limit_days = dao_get_jobs_by_service_id(one_job.service_id, limit_days=7).items
     assert len(jobs_limit_days) == 2
@@ -346,7 +346,7 @@ def test_can_letter_job_be_cancelled_returns_false_and_error_message_if_notifica
     assert errors == "It’s too late to cancel sending, these letters have already been sent."
 
 
-@pytest.mark.skip(reason="Date math needs to be revisited")
+@pytest.mark.skip(reason="Letter feature")
 def test_can_letter_job_be_cancelled_returns_false_and_error_message_if_letters_already_sent_to_dvla(
     sample_letter_template, admin_request
 ):

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -720,7 +720,7 @@ def create_ft_notification_status(
         template = create_template(service=service, template_type=notification_type)
 
     data = FactNotificationStatus(
-        utc_date=utc_date,
+        bst_date=utc_date,
         template_id=template.id,
         service_id=service.id,
         job_id=job.id if job else uuid.UUID(int=0),

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -666,7 +666,7 @@ def create_daily_sorted_letter(billing_day=date(2018, 1, 18),
     return daily_sorted_letter
 
 
-def create_ft_billing(bst_date,
+def create_ft_billing(utc_date,
                       notification_type,
                       template=None,
                       service=None,
@@ -683,7 +683,7 @@ def create_ft_billing(bst_date,
     if not template:
         template = create_template(service=service, template_type=notification_type)
 
-    data = FactBilling(bst_date=bst_date,
+    data = FactBilling(bst_date=utc_date,
                        service_id=service.id,
                        template_id=template.id,
                        notification_type=notification_type,
@@ -700,7 +700,7 @@ def create_ft_billing(bst_date,
 
 
 def create_ft_notification_status(
-    bst_date,
+    utc_date,
     notification_type='sms',
     service=None,
     template=None,
@@ -720,7 +720,7 @@ def create_ft_notification_status(
         template = create_template(service=service, template_type=notification_type)
 
     data = FactNotificationStatus(
-        bst_date=bst_date,
+        utc_date=utc_date,
         template_id=template.id,
         service_id=service.id,
         job_id=job.id if job else uuid.UUID(int=0),

--- a/tests/app/inbound_sms/test_rest.py
+++ b/tests/app/inbound_sms/test_rest.py
@@ -91,10 +91,10 @@ def test_post_to_get_inbound_sms_allows_badly_formatted_number(admin_request, sa
 
 
 @freeze_time('Monday 10th April 2017 12:00')
-@pytest.mark.skip(reason="Date math needs to be revisited")
+# This test assumes the local timezone is EST
 def test_post_to_get_most_recent_inbound_sms_for_service_limits_to_a_week(admin_request, sample_service):
-    create_inbound_sms(sample_service, created_at=datetime(2017, 4, 2, 22, 59))
-    returned_inbound = create_inbound_sms(sample_service, created_at=datetime(2017, 4, 2, 23, 30))
+    create_inbound_sms(sample_service, created_at=datetime(2017, 4, 3, 3, 59))
+    returned_inbound = create_inbound_sms(sample_service, created_at=datetime(2017, 4, 3, 4, 30))
 
     sms = admin_request.post('inbound_sms.post_inbound_sms_for_service', service_id=sample_service.id, _data={})
 

--- a/tests/app/job/test_rest.py
+++ b/tests/app/job/test_rest.py
@@ -745,11 +745,11 @@ def test_get_all_notifications_for_job_returns_csv_format(admin_request, sample_
     }
 
 
-@freeze_time('2017-06-10 12:00')
-@pytest.mark.skip(reason="Date math needs to be revisited")
+@freeze_time('2017-06-10 4:00')
+# This test assumes the local timezone is EST
 def test_get_jobs_should_retrieve_from_ft_notification_status_for_old_jobs(admin_request, sample_template):
     # it's the 10th today, so 3 days should include all of 7th, 8th, 9th, and some of 10th.
-    just_three_days_ago = datetime(2017, 6, 6, 22, 59, 59)
+    just_three_days_ago = datetime(2017, 6, 7, 3, 59, 59)
     not_quite_three_days_ago = just_three_days_ago + timedelta(seconds=1)
 
     job_1 = create_job(sample_template, created_at=just_three_days_ago, processing_started=just_three_days_ago)

--- a/tests/app/letters/test_letter_utils.py
+++ b/tests/app/letters/test_letter_utils.py
@@ -40,7 +40,7 @@ def _sample_precompiled_letter_notification_using_test_key(sample_precompiled_le
     (datetime(2017, 1, 1, 17, 29), '2017-01-01'),
     (datetime(2017, 1, 1, 17, 31), '2017-01-02'),
 ])
-@pytest.mark.skip(reason="Date math needs to be revisited")
+@pytest.mark.skip(reason="Letter feature")
 def test_get_bucket_name_and_prefix_for_notification_valid_notification(sample_notification, created_at, folder):
     sample_notification.created_at = created_at
 
@@ -127,7 +127,7 @@ def test_get_letter_pdf_filename_returns_correct_filename_for_test_letters(
 
 
 @freeze_time("2017-12-04 17:31:00")
-@pytest.mark.skip(reason="Date math needs to be revisited")
+@pytest.mark.skip(reason="Letter feature")
 def test_get_letter_pdf_filename_returns_tomorrows_filename(notify_api, mocker):
     filename = get_letter_pdf_filename(reference='foo', crown=True)
 
@@ -268,7 +268,7 @@ def test_move_failed_pdf_scan_failed(notify_api):
                           ("2018-01-02 23:30:00", "2018-01-03/"),
                           ("2018-01-03 00:30:00", "2018-01-03/"),
                           ])
-@pytest.mark.skip(reason="Date math needs to be revisited")
+@pytest.mark.skip(reason="Letter feature")
 def test_get_folder_name_in_british_summer_time(notify_api, freeze_date, expected_folder_name):
     with freeze_time(freeze_date):
         now = datetime.utcnow()
@@ -281,7 +281,7 @@ def test_get_folder_name_returns_empty_string_for_test_letter():
 
 
 @freeze_time('2017-07-07 20:00:00')
-@pytest.mark.skip(reason="Date math needs to be revisited")
+@pytest.mark.skip(reason="Letter feature")
 def test_letter_print_day_returns_today_if_letter_was_printed_after_1730_yesterday():
     created_at = datetime(2017, 7, 6, 17, 30)
     assert letter_print_day(created_at) == 'today'
@@ -301,6 +301,6 @@ def test_letter_print_day_returns_today_if_letter_was_printed_today():
     (datetime(2016, 12, 12, 17, 30), 'on 13 December'),
 ])
 @freeze_time('2017-07-07 16:30:00')
-@pytest.mark.skip(reason="Date math needs to be revisited")
+@pytest.mark.skip(reason="Letter feature")
 def test_letter_print_day_returns_formatted_date_if_letter_printed_before_1730_yesterday(created_at, formatted_date):
     assert letter_print_day(created_at) == formatted_date

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -386,13 +386,13 @@ def test_persist_notification_with_international_info_does_not_store_for_email(
     assert persisted_notification.rate_multiplier is None
 
 
-@pytest.mark.skip(reason="Date math needs to be revisited")
+# This test assumes the local timezone is EST
 def test_persist_scheduled_notification(sample_notification):
     persist_scheduled_notification(sample_notification.id, '2017-05-12 14:15')
     scheduled_notification = ScheduledNotification.query.all()
     assert len(scheduled_notification) == 1
     assert scheduled_notification[0].notification_id == sample_notification.id
-    assert scheduled_notification[0].scheduled_for == datetime.datetime(2017, 5, 12, 13, 15)
+    assert scheduled_notification[0].scheduled_for == datetime.datetime(2017, 5, 12, 18, 15)
 
 
 @pytest.mark.parametrize('recipient, expected_recipient_normalised', [

--- a/tests/app/notifications/test_receive_notification.py
+++ b/tests/app/notifications/test_receive_notification.py
@@ -211,20 +211,20 @@ def test_unescape_string(raw, expected):
 
 
 @pytest.mark.parametrize('provider_date, expected_output', [
-    ('2017-01-21+11%3A56%3A11', datetime(2017, 1, 21, 11, 56, 11)),
-    ('2017-05-21+11%3A56%3A11', datetime(2017, 5, 21, 10, 56, 11))
+    ('2017-01-21+11%3A56%3A11', datetime(2017, 1, 21, 16, 56, 11)),
+    ('2017-05-21+11%3A56%3A11', datetime(2017, 5, 21, 15, 56, 11))
 ])
-@pytest.mark.skip(reason="Date math needs to be revisited")
+# This test assumes the local timezone is EST
 def test_format_mmg_datetime(provider_date, expected_output):
     assert format_mmg_datetime(provider_date) == expected_output
 
 
-@pytest.mark.skip(reason="Date math needs to be revisited")
+# This test assumes the local timezone is EST
 def test_create_inbound_mmg_sms_object(sample_service_full_permissions):
     data = {
         'Message': 'hello+there+%F0%9F%93%A9',
         'Number': sample_service_full_permissions.get_inbound_number(),
-        'MSISDN': '07700 900 001',
+        'MSISDN': '447700900001',
         'DateRecieved': '2017-01-02+03%3A04%3A05',
         'ID': 'bar',
     }
@@ -235,7 +235,7 @@ def test_create_inbound_mmg_sms_object(sample_service_full_permissions):
     assert inbound_sms.service_id == sample_service_full_permissions.id
     assert inbound_sms.notify_number == sample_service_full_permissions.get_inbound_number()
     assert inbound_sms.user_number == '447700900001'
-    assert inbound_sms.provider_date == datetime(2017, 1, 2, 3, 4, 5)
+    assert inbound_sms.provider_date == datetime(2017, 1, 2, 8, 4, 5)
     assert inbound_sms.provider_reference == 'bar'
     assert inbound_sms._content != 'hello there 📩'
     assert inbound_sms.content == 'hello there 📩'
@@ -316,7 +316,7 @@ def test_receive_notification_returns_received_to_firetext(notify_db_session, cl
     mocked.assert_called_once_with([str(inbound_sms_id), str(service.id)], queue="notify-internal-tasks")
 
 
-@pytest.mark.skip(reason="Date math needs to be revisited")
+# This test assumes the local timezone is EST
 def test_receive_notification_from_firetext_persists_message(notify_db_session, client, mocker):
     mocked = mocker.patch("app.notifications.receive_notifications.tasks.send_inbound_sms_to_service.apply_async")
     mocker.patch('app.notifications.receive_notifications.statsd_client.incr')
@@ -326,7 +326,7 @@ def test_receive_notification_from_firetext_persists_message(notify_db_session, 
         service_name='b',
         service_permissions=[EMAIL_TYPE, SMS_TYPE, INBOUND_SMS_TYPE])
 
-    data = "source=07999999999&destination=07111111111&message=this is a message&time=2017-01-01 12:00:00"
+    data = "source=447999999999&destination=07111111111&message=this is a message&time=2017-01-01 12:00:00"
 
     response = firetext_post(client, data)
 
@@ -340,7 +340,7 @@ def test_receive_notification_from_firetext_persists_message(notify_db_session, 
     assert persisted.service == service
     assert persisted.content == 'this is a message'
     assert persisted.provider == 'firetext'
-    assert persisted.provider_date == datetime(2017, 1, 1, 12, 0, 0, 0)
+    assert persisted.provider_date == datetime(2017, 1, 1, 17, 0, 0, 0)
     mocked.assert_called_once_with([str(persisted.id), str(service.id)], queue="notify-internal-tasks")
 
 

--- a/tests/app/performance_platform/test_processing_time.py
+++ b/tests/app/performance_platform/test_processing_time.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta, date
 
 from freezegun import freeze_time
-import pytest
 from tests.app.db import create_notification
 from app.performance_platform.processing_time import (
     send_processing_time_to_performance_platform,

--- a/tests/app/performance_platform/test_processing_time.py
+++ b/tests/app/performance_platform/test_processing_time.py
@@ -9,8 +9,8 @@ from app.performance_platform.processing_time import (
 )
 
 
-@freeze_time('2016-10-18T02:00')
-@pytest.mark.skip(reason="Date math needs to be revisited")
+@freeze_time('2016-10-18T06:00')
+# This test assumes the local timezone is EST
 def test_send_processing_time_to_performance_platform_generates_correct_calls(mocker, sample_template):
     send_mock = mocker.patch('app.performance_platform.processing_time.send_processing_time_data')
 
@@ -22,16 +22,16 @@ def test_send_processing_time_to_performance_platform_generates_correct_calls(mo
 
     send_processing_time_to_performance_platform(date(2016, 10, 17))
 
-    send_mock.assert_any_call(datetime(2016, 10, 16, 23, 0), 'messages-total', 2)
-    send_mock.assert_any_call(datetime(2016, 10, 16, 23, 0), 'messages-within-10-secs', 1)
+    send_mock.assert_any_call(datetime(2016, 10, 17, 4, 0), 'messages-total', 2)
+    send_mock.assert_any_call(datetime(2016, 10, 17, 4, 0), 'messages-within-10-secs', 1)
 
 
-@pytest.mark.skip(reason="Date math needs to be revisited")
+# This test assumes the local timezone is EST
 def test_send_processing_time_to_performance_platform_creates_correct_call_to_perf_platform(mocker):
     send_stats = mocker.patch('app.performance_platform.total_sent_notifications.performance_platform_client.send_stats_to_performance_platform')  # noqa
 
     send_processing_time_data(
-        start_time=datetime(2016, 10, 15, 23, 0, 0),
+        start_time=datetime(2016, 10, 16, 4, 0, 0),
         status='foo',
         count=142
     )

--- a/tests/app/performance_platform/test_total_sent_notifications.py
+++ b/tests/app/performance_platform/test_total_sent_notifications.py
@@ -1,5 +1,4 @@
 from datetime import datetime, date
-import pytest
 from freezegun import freeze_time
 
 from app.performance_platform.total_sent_notifications import (

--- a/tests/app/performance_platform/test_total_sent_notifications.py
+++ b/tests/app/performance_platform/test_total_sent_notifications.py
@@ -10,12 +10,12 @@ from app.performance_platform.total_sent_notifications import (
 from tests.app.db import create_template, create_ft_notification_status
 
 
-@pytest.mark.skip(reason="Date math needs to be revisited")
+# This test assumes the local timezone is EST
 def test_send_total_notifications_sent_for_day_stats_stats_creates_correct_call(mocker, client):
     send_stats = mocker.patch('app.performance_platform.total_sent_notifications.performance_platform_client.send_stats_to_performance_platform')  # noqa
 
     send_total_notifications_sent_for_day_stats(
-        start_time=datetime(2016, 10, 15, 23, 0, 0),
+        start_time=datetime(2016, 10, 16, 4, 0, 0),
         notification_type='sms',
         count=142
     )
@@ -43,14 +43,14 @@ def test_get_total_sent_notifications_yesterday_returns_expected_totals_dict(sam
     yesterday = date(2018, 6, 9)
 
     # todays is excluded
-    create_ft_notification_status(bst_date=today, template=sms)
-    create_ft_notification_status(bst_date=today, template=email)
-    create_ft_notification_status(bst_date=today, template=letter)
+    create_ft_notification_status(utc_date=today, template=sms)
+    create_ft_notification_status(utc_date=today, template=email)
+    create_ft_notification_status(utc_date=today, template=letter)
 
     # yesterdays is included
-    create_ft_notification_status(bst_date=yesterday, template=sms, count=2)
-    create_ft_notification_status(bst_date=yesterday, template=email, count=3)
-    create_ft_notification_status(bst_date=yesterday, template=letter, count=1)
+    create_ft_notification_status(utc_date=yesterday, template=sms, count=2)
+    create_ft_notification_status(utc_date=yesterday, template=email, count=3)
+    create_ft_notification_status(utc_date=yesterday, template=letter, count=1)
 
     total_count_dict = get_total_sent_notifications_for_day(yesterday)
 

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -147,8 +147,8 @@ def test_get_live_services_data(sample_user, admin_request):
     template = create_template(service=service)
     template2 = create_template(service=service, template_type='email')
     dao_add_service_to_organisation(service=service, organisation_id=org.id)
-    create_ft_billing(bst_date='2019-04-20', notification_type='sms', template=template, service=service)
-    create_ft_billing(bst_date='2019-04-20', notification_type='email', template=template2, service=service)
+    create_ft_billing(utc_date='2019-04-20', notification_type='sms', template=template, service=service)
+    create_ft_billing(utc_date='2019-04-20', notification_type='email', template=template2, service=service)
 
     create_annual_billing(service.id, 1, 2019)
     create_annual_billing(service_2.id, 2, 2018)
@@ -1953,14 +1953,14 @@ def test_get_detailed_services_includes_services_with_no_notifications(notify_db
     }
 
 
-@pytest.mark.skip(reason="Date math needs to be revisited")
+# This test assumes the local timezone is EST
 def test_get_detailed_services_only_includes_todays_notifications(notify_db, notify_db_session):
     from app.service.rest import get_detailed_services
 
-    create_sample_notification(notify_db, notify_db_session, created_at=datetime(2015, 10, 9, 23, 59))
-    create_sample_notification(notify_db, notify_db_session, created_at=datetime(2015, 10, 10, 0, 0))
+    create_sample_notification(notify_db, notify_db_session, created_at=datetime(2015, 10, 10, 3, 59))
+    create_sample_notification(notify_db, notify_db_session, created_at=datetime(2015, 10, 10, 4, 0))
     create_sample_notification(notify_db, notify_db_session, created_at=datetime(2015, 10, 10, 12, 0))
-    create_sample_notification(notify_db, notify_db_session, created_at=datetime(2015, 10, 10, 23, 0))
+    create_sample_notification(notify_db, notify_db_session, created_at=datetime(2015, 10, 11, 3, 0))
 
     with freeze_time('2015-10-10T12:00:00'):
         data = get_detailed_services(start_date=datetime.utcnow().date(), end_date=datetime.utcnow().date())
@@ -1983,13 +1983,13 @@ def test_get_detailed_services_only_includes_todays_notifications(notify_db, not
 def test_get_detailed_services_for_date_range(sample_template, start_date_delta, end_date_delta):
     from app.service.rest import get_detailed_services
 
-    create_ft_notification_status(bst_date=(datetime.utcnow() - timedelta(days=3)).date(),
+    create_ft_notification_status(utc_date=(datetime.utcnow() - timedelta(days=3)).date(),
                                   service=sample_template.service,
                                   notification_type='sms')
-    create_ft_notification_status(bst_date=(datetime.utcnow() - timedelta(days=2)).date(),
+    create_ft_notification_status(utc_date=(datetime.utcnow() - timedelta(days=2)).date(),
                                   service=sample_template.service,
                                   notification_type='sms')
-    create_ft_notification_status(bst_date=(datetime.utcnow() - timedelta(days=1)).date(),
+    create_ft_notification_status(utc_date=(datetime.utcnow() - timedelta(days=1)).date(),
                                   service=sample_template.service,
                                   notification_type='sms')
 

--- a/tests/app/service/test_statistics.py
+++ b/tests/app/service/test_statistics.py
@@ -175,8 +175,8 @@ def _stats(requested, delivered, failed):
         ]
     )
 ])
-@freeze_time('2018-05-31 23:59:59')
-@pytest.mark.skip(reason="Date math needs to be revisited")
+@freeze_time('2018-06-01 04:59:59')
+# This test assumes the local timezone is EST
 def test_create_empty_monthly_notification_status_stats_dict(year, expected_years):
     output = create_empty_monthly_notification_status_stats_dict(year)
     assert sorted(output.keys()) == expected_years
@@ -184,8 +184,8 @@ def test_create_empty_monthly_notification_status_stats_dict(year, expected_year
         assert v == {'sms': {}, 'email': {}, 'letter': {}}
 
 
-@freeze_time('2018-05-31 23:59:59')
-@pytest.mark.skip(reason="Date math needs to be revisited")
+@freeze_time('2018-06-01 04:59:59')
+# This test assumes the local timezone is EST
 def test_add_monthly_notification_status_stats():
     row_data = [
         {'month': datetime(2018, 4, 1), 'notification_type': 'sms', 'notification_status': 'sending', 'count': 1},

--- a/tests/app/service/test_statistics_rest.py
+++ b/tests/app/service/test_statistics_rest.py
@@ -22,13 +22,13 @@ from tests.app.db import (
 )
 
 
-@freeze_time('2017-11-11 02:00')
-@pytest.mark.skip(reason="Date math needs to be revisited")
+@freeze_time('2017-11-11 06:00')
+# This test assumes the local timezone is EST
 def test_get_template_usage_by_month_returns_correct_data(
         admin_request,
         sample_template
 ):
-    create_ft_notification_status(bst_date=date(2017, 4, 2), template=sample_template, count=3)
+    create_ft_notification_status(utc_date=date(2017, 4, 2), template=sample_template, count=3)
     create_notification(sample_template, created_at=datetime.utcnow())
 
     resp_json = admin_request.get(
@@ -55,8 +55,8 @@ def test_get_template_usage_by_month_returns_correct_data(
     assert resp_json[1]["count"] == 1
 
 
-@freeze_time('2017-11-11 02:00')
-@pytest.mark.skip(reason="Date math needs to be revisited")
+@freeze_time('2017-11-11 06:00')
+# This test assumes the local timezone is EST
 def test_get_template_usage_by_month_returns_two_templates(admin_request, sample_template, sample_service):
     template_one = create_template(
         sample_service,
@@ -64,8 +64,8 @@ def test_get_template_usage_by_month_returns_two_templates(admin_request, sample
         template_name=PRECOMPILED_TEMPLATE_NAME,
         hidden=True
     )
-    create_ft_notification_status(bst_date=datetime(2017, 4, 1), template=template_one, count=1)
-    create_ft_notification_status(bst_date=datetime(2017, 4, 1), template=sample_template, count=3)
+    create_ft_notification_status(utc_date=datetime(2017, 4, 1), template=template_one, count=1)
+    create_ft_notification_status(utc_date=datetime(2017, 4, 1), template=sample_template, count=3)
     create_notification(sample_template, created_at=datetime.utcnow())
 
     resp_json = admin_request.get(
@@ -214,8 +214,8 @@ def test_get_monthly_notification_stats_returns_stats(admin_request, sample_serv
     }
 
 
-@freeze_time('2016-06-05 12:00:00')
-@pytest.mark.skip(reason="Date math needs to be revisited")
+@freeze_time('2016-06-05 00:00:00')
+# This test assumes the local timezone is EST
 def test_get_monthly_notification_stats_combines_todays_data_and_historic_stats(admin_request, sample_template):
     create_ft_notification_status(datetime(2016, 5, 1), template=sample_template, count=1)
     create_ft_notification_status(datetime(2016, 6, 1), template=sample_template, notification_status='created', count=2)  # noqa
@@ -251,7 +251,7 @@ def test_get_monthly_notification_stats_combines_todays_data_and_historic_stats(
     }
 
 
-@pytest.mark.skip(reason="Date math needs to be revisited")
+# This test assumes the local timezone is EST
 def test_get_monthly_notification_stats_ignores_test_keys(admin_request, sample_service):
     create_ft_notification_status(datetime(2016, 6, 1), service=sample_service, key_type=KEY_TYPE_NORMAL, count=1)
     create_ft_notification_status(datetime(2016, 6, 1), service=sample_service, key_type=KEY_TYPE_TEAM, count=2)
@@ -262,7 +262,7 @@ def test_get_monthly_notification_stats_ignores_test_keys(admin_request, sample_
     assert response['data']['2016-06']['sms'] == {'delivered': 3}
 
 
-@pytest.mark.skip(reason="Date math needs to be revisited")
+# This test assumes the local timezone is EST
 def test_get_monthly_notification_stats_checks_dates(admin_request, sample_service):
     t = create_template(sample_service)
     create_ft_notification_status(datetime(2016, 3, 31), template=t, notification_status='created')

--- a/tests/app/service/test_utils.py
+++ b/tests/app/service/test_utils.py
@@ -1,6 +1,5 @@
 from app.dao.date_util import get_current_financial_year_start_year
 from freezegun import freeze_time
-import pytest
 
 
 # see get_financial_year for conversion of financial years.
@@ -10,8 +9,8 @@ def test_get_current_financial_year_start_year_before_march():
     assert current_fy == 2016
 
 
-@freeze_time("2017-03-31 23:00:00.000000")
-@pytest.mark.skip(reason="Date math needs to be revisited")
+@freeze_time("2017-04-01 4:00:00.000000")
+# This test assumes the local timezone is EST
 def test_get_current_financial_year_start_year_after_april():
     current_fy = get_current_financial_year_start_year()
     assert current_fy == 2017

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -4,7 +4,7 @@ import pytest
 from freezegun import freeze_time
 
 from app.utils import (
-    get_toronto_midnight_in_utc,
+    get_local_timezone_midnight_in_utc,
     get_midnight_for_day_before,
     midnight_n_days_ago,
 )
@@ -18,8 +18,8 @@ from app.utils import (
     (date(2016, 1, 15), datetime(2016, 1, 15, 5, 0)),
     (date(2016, 6, 15), datetime(2016, 6, 15, 4, 0)),
 ])
-def test_get_toronto_midnight_in_utc_returns_expected_date(date, expected_date):
-    assert get_toronto_midnight_in_utc(date) == expected_date
+def test_get_local_timezone_midnight_in_utc_returns_expected_date(date, expected_date):
+    assert get_local_timezone_midnight_in_utc(date) == expected_date
 
 
 @pytest.mark.parametrize('date, expected_date', [

--- a/tests/app/v2/notifications/test_get_notifications.py
+++ b/tests/app/v2/notifications/test_get_notifications.py
@@ -15,7 +15,7 @@ from tests.app.db import (
     (0, 'mmg'),
     (1, None)
 ])
-@pytest.mark.skip(reason="Date math needs to be revisited")
+# This test assumes the local timezone is EST
 def test_get_notification_by_id_returns_200(
         client, billable_units, provider, sample_template
 ):
@@ -71,7 +71,7 @@ def test_get_notification_by_id_returns_200(
         "subject": None,
         'sent_at': sample_notification.sent_at,
         'completed_at': sample_notification.completed_at(),
-        'scheduled_for': '2017-05-12T14:15:00.000000Z',
+        'scheduled_for': '2017-05-12T19:15:00.000000Z',
         'postage': None,
     }
 
@@ -167,7 +167,7 @@ def test_get_notification_by_id_returns_created_by_name_if_notification_created_
     assert json_response['created_by_name'] == 'Test User'
 
 
-@pytest.mark.skip(reason="Date math needs to be revisited")
+# This test assumes the local timezone is EST
 def test_get_notifications_returns_scheduled_for(client, sample_template):
     sample_notification_with_reference = create_notification(template=sample_template,
                                                              client_reference='some-client-reference',
@@ -185,7 +185,7 @@ def test_get_notifications_returns_scheduled_for(client, sample_template):
     assert len(json_response['notifications']) == 1
 
     assert json_response['notifications'][0]['id'] == str(sample_notification_with_reference.id)
-    assert json_response['notifications'][0]['scheduled_for'] == "2017-05-23T16:15:00.000000Z"
+    assert json_response['notifications'][0]['scheduled_for'] == "2017-05-23T21:15:00.000000Z"
 
 
 def test_get_notification_by_reference_nonexistent_reference_returns_no_notifications(client, sample_service):
@@ -247,7 +247,7 @@ def test_get_notification_by_id_invalid_id(client, sample_notification, id):
     (12, 'first', '2000-12-05T16:00:00.000000Z'),  # 4pm GMT in winter
     (6, 'first', '2000-06-03T15:00:00.000000Z'),  # 4pm BST in summer (two days before 2nd class due to weekends)
 ])
-@pytest.mark.skip(reason="Date math needs to be revisited")
+@pytest.mark.skip(reason="Letter feature")
 def test_get_notification_adds_delivery_estimate_for_letters(
     client,
     sample_letter_notification,


### PR DESCRIPTION
Closes https://github.com/cds-snc/notification-api/issues/199. You can now use the `TIMEZONE` env to set a timezone for the server. It currently defaults to `America/Toronto`. The tests have been changed to reflect an EST timezone. 

The problem currently is that there is a a column in one of the tables called `bst_date` which holds the date for when a report is run and the aggregate statistics. This will cause some confusion and will need to be removed in a next iteration. However, we need more validation of this product before doing so.