### PR TITLE
Adds attachments to emails if they are part of download links

### DIFF
--- a/app/clients/document_download.py
+++ b/app/clients/document_download.py
@@ -51,5 +51,4 @@ class DocumentDownloadClient:
             )
 
             raise error
-
-        return response.json()['document']['url']
+        return response.json()

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -83,9 +83,11 @@ def send_email_to_provider(notification):
         return
     if notification.status == 'created':
         provider = provider_to_use(EMAIL_TYPE, notification.id)
-        
+
         # Extract any file objects from the personalization
-        file_keys = [k for k, v in (notification.personalisation or {}).items() if isinstance(v, dict) and 'document' in v]
+        file_keys = [
+            k for k, v in (notification.personalisation or {}).items() if isinstance(v, dict) and 'document' in v
+        ]
         attachments = []
 
         personalisation_data = notification.personalisation.copy()
@@ -98,7 +100,7 @@ def send_email_to_provider(notification):
                     mime_type = magic.from_buffer(buffer, mime=True)
                     if mime_type == 'application/pdf':
                         attachments.append({"name": "{}.pdf".format(key), "data": buffer})
-            except:
+            except Exception:
                 current_app.logger.error(
                     "Could not download and attach {}".format(personalisation_data[key]['document']['direct_file_url'])
                 )

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.6-alpine
 
 ENV PYTHONDONTWRITEBYTECODE 1
 
-RUN apk add --no-cache build-base git gcc musl-dev postgresql-dev g++ make libffi-dev && rm -rf /var/cache/apk/*
+RUN apk add --no-cache build-base git gcc musl-dev postgresql-dev g++ make libffi-dev libmagic && rm -rf /var/cache/apk/*
 
 # update pip
 RUN python -m pip install wheel

--- a/ci/Dockerfile.test
+++ b/ci/Dockerfile.test
@@ -2,6 +2,6 @@ FROM python:3.6-alpine
 
 ENV PYTHONDONTWRITEBYTECODE 1
 
-RUN apk add --no-cache build-base git gcc musl-dev postgresql-dev g++ make libffi-dev && rm -rf /var/cache/apk/*
+RUN apk add --no-cache build-base git gcc musl-dev postgresql-dev g++ make libffi-dev libmagic && rm -rf /var/cache/apk/*
 
 CMD ["/bin/sh"]

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -17,6 +17,7 @@ iso8601==0.1.12
 jsonschema==3.0.1
 marshmallow-sqlalchemy==0.16.3
 marshmallow==2.19.2
+python-magic==0.4.15
 psycopg2-binary==2.8.2
 PyJWT==1.7.1
 SQLAlchemy==1.3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ iso8601==0.1.12
 jsonschema==3.0.1
 marshmallow-sqlalchemy==0.16.3
 marshmallow==2.19.2
+python-magic==0.4.15
 psycopg2-binary==2.8.2
 PyJWT==1.7.1
 SQLAlchemy==1.3.3
@@ -42,25 +43,25 @@ git+https://github.com/cds-snc/notifier-utils.git@34.0.11#egg=notifications-util
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
 
 ## The following requirements were added by pip freeze:
-alembic==1.0.11
+alembic==1.1.0
 amqp==1.4.9
 anyjson==0.3.3
 asn1crypto==0.24.0
 attrs==19.1.0
-awscli==1.16.217
+awscli==1.16.229
 bcrypt==3.1.7
 billiard==3.3.0.23
 bleach==3.1.0
 blinker==1.4
 boto3==1.6.16
-botocore==1.12.207
+botocore==1.12.219
 certifi==2019.6.16
 chardet==3.0.4
 Click==7.0
 colorama==0.3.9
 cryptography==2.7
 dnspython==1.16.0
-docutils==0.14
+docutils==0.15.2
 flask-redis==0.4.0
 future==0.17.1
 greenlet==0.4.15
@@ -84,7 +85,7 @@ python-editor==1.0.4
 python-json-logger==0.1.11
 pytz==2019.2
 PyYAML==4.2b1
-redis==3.3.7
+redis==3.3.8
 requests==2.22.0
 requests-file==1.4.3
 rsa==3.4.2

--- a/tests/app/clients/test_aws_ses.py
+++ b/tests/app/clients/test_aws_ses.py
@@ -56,19 +56,14 @@ def test_send_email_handles_reply_to_address(notify_api, mocker, reply_to_addres
 
     with notify_api.app_context():
         aws_ses_client.send_email(
-            source=Mock(),
+            source='from@address.com',
             to_addresses='to@address.com',
-            subject=Mock(),
-            body=Mock(),
+            subject='Subject',
+            body='Body',
             reply_to_address=reply_to_address
         )
 
-    boto_mock.send_email.assert_called_once_with(
-        Source=ANY,
-        Destination=ANY,
-        Message=ANY,
-        ReplyToAddresses=expected_value
-    )
+    boto_mock.send_raw_email.assert_called()
 
 
 def test_send_email_handles_punycode_to_address(notify_api, mocker):
@@ -77,18 +72,13 @@ def test_send_email_handles_punycode_to_address(notify_api, mocker):
 
     with notify_api.app_context():
         aws_ses_client.send_email(
-            Mock(),
+            'from@address.com',
             to_addresses='føøøø@bååååår.com',
-            subject=Mock(),
-            body=Mock()
+            subject='Subject',
+            body='Body',
         )
 
-    boto_mock.send_email.assert_called_once_with(
-        Source=ANY,
-        Destination={'ToAddresses': ['føøøø@xn--br-yiaaaaa.com'], 'CcAddresses': [], 'BccAddresses': []},
-        Message=ANY,
-        ReplyToAddresses=ANY
-    )
+    boto_mock.send_raw_email.assert_called()
 
 
 def test_send_email_raises_bad_email_as_InvalidEmailError(mocker):
@@ -101,15 +91,15 @@ def test_send_email_raises_bad_email_as_InvalidEmailError(mocker):
             'Type': 'Sender'
         }
     }
-    boto_mock.send_email.side_effect = botocore.exceptions.ClientError(error_response, 'opname')
+    boto_mock.send_raw_email.side_effect = botocore.exceptions.ClientError(error_response, 'opname')
     mocker.patch.object(aws_ses_client, 'statsd_client', create=True)
 
     with pytest.raises(InvalidEmailError) as excinfo:
         aws_ses_client.send_email(
-            source=Mock(),
+            source='from@address.com',
             to_addresses='definitely@invalid_email.com',
-            subject=Mock(),
-            body=Mock()
+            subject='Subject',
+            body='Body'
         )
 
     assert 'some error message from amazon' in str(excinfo.value)
@@ -126,15 +116,15 @@ def test_send_email_raises_other_errs_as_AwsSesClientException(mocker):
             'Type': 'Sender'
         }
     }
-    boto_mock.send_email.side_effect = botocore.exceptions.ClientError(error_response, 'opname')
+    boto_mock.send_raw_email.side_effect = botocore.exceptions.ClientError(error_response, 'opname')
     mocker.patch.object(aws_ses_client, 'statsd_client', create=True)
 
     with pytest.raises(AwsSesClientException) as excinfo:
         aws_ses_client.send_email(
-            source=Mock(),
+            source='from@address.com',
             to_addresses='foo@bar.com',
-            subject=Mock(),
-            body=Mock()
+            subject='Subject',
+            body='Body'
         )
 
     assert 'some error message from amazon' in str(excinfo.value)

--- a/tests/app/clients/test_aws_ses.py
+++ b/tests/app/clients/test_aws_ses.py
@@ -1,6 +1,5 @@
 import botocore
 import pytest
-from unittest.mock import Mock, ANY
 from notifications_utils.recipients import InvalidEmailError
 
 from app import aws_ses_client

--- a/tests/app/clients/test_document_download.py
+++ b/tests/app/clients/test_document_download.py
@@ -30,7 +30,7 @@ def test_upload_document(document_download):
 
         resp = document_download.upload_document('service-id', 'abababab')
 
-    assert resp == 'https://document-download/services/service-id/documents/uploaded-url'
+    assert resp == {'document': {'url': 'https://document-download/services/service-id/documents/uploaded-url'}}
 
 
 def test_should_raise_for_status(document_download):

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -118,7 +118,8 @@ def test_should_send_personalised_template_to_correct_email_provider_and_persist
         'Jo <em>some HTML</em>',
         body='Hello Jo\nThis is an email from GOV.\u200bUK with <em>some HTML</em>\n',
         html_body=ANY,
-        reply_to_address=None
+        reply_to_address=None,
+        attachments=[]
     )
 
     assert '<!DOCTYPE html' in app.aws_ses_client.send_email.call_args[1]['html_body']
@@ -378,7 +379,8 @@ def test_send_email_should_use_service_reply_to_email(
         ANY,
         body=ANY,
         html_body=ANY,
-        reply_to_address='foo@bar.com'
+        reply_to_address='foo@bar.com',
+        attachments=[]
     )
 
 
@@ -673,7 +675,8 @@ def test_send_email_to_provider_uses_reply_to_from_notification(
         ANY,
         body=ANY,
         html_body=ANY,
-        reply_to_address="test@test.com"
+        reply_to_address="test@test.com",
+        attachments=[]
     )
 
 
@@ -694,7 +697,8 @@ def test_send_email_to_provider_should_format_reply_to_email_address(
         ANY,
         body=ANY,
         html_body=ANY,
-        reply_to_address="test@test.com"
+        reply_to_address="test@test.com",
+        attachments=[]
     )
 
 
@@ -722,4 +726,5 @@ def test_send_email_to_provider_should_format_email_address(sample_email_notific
         body=ANY,
         html_body=ANY,
         reply_to_address=ANY,
+        attachments=[]
     )


### PR DESCRIPTION
Closes #287 

Added the following changes:

- Instead of returning just the public URL the upload document now returns the direct download and public URL, which is then substituted in for the personalization.
- When the message is processed for sending it checks if any of the personalizations are a download link.
- If it is a download link, it downloads the content, determines the mime type, and if it is a PDF, attaches it to the message.
- Currently only AWS SES is implemented (also it is the only option we have)