### PR TITLE
More API key stats

### DIFF
--- a/app/api_key/rest.py
+++ b/app/api_key/rest.py
@@ -1,13 +1,29 @@
-from flask import Blueprint, jsonify
-from app.dao.fact_notification_status_dao import get_total_notifications_sent_for_api_key
+import datetime
 
+from flask import Blueprint, jsonify
+from app.dao.fact_notification_status_dao import get_total_notifications_sent_for_api_key, get_last_send_for_api_key
+from app import DATETIME_FORMAT
 from app.errors import register_errors
 
 api_key_blueprint = Blueprint('api_key', __name__)
 register_errors(api_key_blueprint)
 
 
-@api_key_blueprint.route('/<uuid:api_key_id>/total-sends', methods=['GET'])
+@api_key_blueprint.route('/<uuid:api_key_id>/summary-statistics', methods=['GET'])
 def get_api_key_stats(api_key_id):
-    total_sends = get_total_notifications_sent_for_api_key(api_key_id)[0]
-    return jsonify(data={"total_sends": total_sends, "api_key_id": api_key_id})
+    result_array_totals = get_total_notifications_sent_for_api_key(api_key_id)
+    result_array_last_send = get_last_send_for_api_key(api_key_id)
+    try:
+        last_send = result_array_last_send[0][0].strftime(DATETIME_FORMAT)
+    except:
+        last_send = None
+    
+    result_dict_totals = dict(result_array_totals)
+    data = {
+        "api_key_id": api_key_id,
+        "email_sends": 0 if "email" not in result_dict_totals else result_dict_totals["email"],
+        "sms_sends": 0 if "sms" not in result_dict_totals else result_dict_totals["sms"],
+        "last_send": last_send
+    }
+    data["total_sends"] = data["email_sends"] + data["sms_sends"]
+    return jsonify(data=data)

--- a/app/api_key/rest.py
+++ b/app/api_key/rest.py
@@ -1,8 +1,8 @@
 import datetime
 
 from flask import Blueprint, jsonify
-from app.dao.fact_notification_status_dao import get_total_notifications_sent_for_api_key, get_last_send_for_api_key
 from app import DATETIME_FORMAT
+from app.dao.fact_notification_status_dao import get_total_notifications_sent_for_api_key, get_last_send_for_api_key
 from app.errors import register_errors
 
 api_key_blueprint = Blueprint('api_key', __name__)

--- a/app/api_key/rest.py
+++ b/app/api_key/rest.py
@@ -1,5 +1,3 @@
-import datetime
-
 from flask import Blueprint, jsonify
 from app import DATETIME_FORMAT
 from app.dao.fact_notification_status_dao import get_total_notifications_sent_for_api_key, get_last_send_for_api_key
@@ -15,9 +13,9 @@ def get_api_key_stats(api_key_id):
     result_array_last_send = get_last_send_for_api_key(api_key_id)
     try:
         last_send = result_array_last_send[0][0].strftime(DATETIME_FORMAT)
-    except:
+    except IndexError:
         last_send = None
-    
+
     result_dict_totals = dict(result_array_totals)
     data = {
         "api_key_id": api_key_id,

--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -216,12 +216,12 @@ def get_total_notifications_sent_for_api_key(api_key_id):
     """
 
     return db.session.query(
-        FactNotificationStatus.notification_type.label('notification_type'),
+        Notification.notification_type.label('notification_type'),
         func.count(Notification.id).label('total_send_attempts')
     ).filter(
         Notification.api_key_id == api_key_id,
     ).group_by(
-        FactNotificationStatus.notification_type
+        Notification.notification_type
     ).all()
 
 
@@ -234,7 +234,7 @@ def get_last_send_for_api_key(api_key_id):
     """
 
     return db.session.query(
-        func.max(FactNotificationStatus.created_at).label('last_notification_created')
+        func.max(Notification.created_at).label('last_notification_created')
     ).filter(
         Notification.api_key_id == api_key_id
     ).group_by(

--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -209,16 +209,37 @@ def fetch_notification_status_for_service_for_today_and_7_previous_days(service_
 
 def get_total_notifications_sent_for_api_key(api_key_id):
     """
-    SELECT count(*) as total_send_attempts
+    SELECT count(*) as total_send_attempts, notification_type
     FROM notifications
-    WHERE api_key_id = 'api_key_id';
+    WHERE api_key_id = 'api_key_id'
+    GROUP BY notification_type;
     """
 
     return db.session.query(
+        FactNotificationStatus.notification_type.label('notification_type'),
         func.count(Notification.id).label('total_send_attempts')
     ).filter(
         Notification.api_key_id == api_key_id,
-    ).one()
+    ).group_by(
+        FactNotificationStatus.notification_type
+    ).all()
+
+
+def get_last_send_for_api_key(api_key_id):
+    """
+    SELECT max(created_at) as last_notification_created
+    FROM notifications
+    WHERE api_key_id = 'api_key_id'
+    GROUP BY api_key_id;
+    """
+
+    return db.session.query(
+        func.max(FactNotificationStatus.created_at).label('last_notification_created')
+    ).filter(
+        Notification.api_key_id == api_key_id
+    ).group_by(
+        Notification.api_key_id
+    ).all()
 
 
 def fetch_notification_status_totals_for_all_services(start_date, end_date):

--- a/tests/app/api_key/test_rest.py
+++ b/tests/app/api_key/test_rest.py
@@ -29,7 +29,7 @@ def test_get_api_key_stats_with_sends(admin_request, notify_db, notify_db_sessio
     assert api_key_stats["email_sends"] == total_sends
     assert api_key_stats["sms_sends"] == 0
     assert api_key_stats["total_sends"] == total_sends
-    
+
     # the following lines test that a send has occurred within the last second
     last_send_dt = datetime.strptime(api_key_stats["last_send"], DATETIME_FORMAT)
     now = datetime.utcnow()

--- a/tests/app/api_key/test_rest.py
+++ b/tests/app/api_key/test_rest.py
@@ -1,3 +1,7 @@
+from datetime import datetime
+
+from app import DATETIME_FORMAT
+
 from tests.app.db import (
     create_api_key,
     create_service,
@@ -13,11 +17,9 @@ def test_get_api_key_stats_with_sends(admin_request, notify_db, notify_db_sessio
     service = create_service(service_name='Service 1')
     api_key = create_api_key(service)
     template = create_template(service=service, template_type='email')
-    # template_sms = create_template(service=service, template_type='sms')
     total_sends = 10
 
     for x in range(total_sends):
-        # create_sample_notification(notify_db, notify_db_session, api_key=api_key, service=service)
         create_notification(template=template, api_key=api_key)
 
     api_key_stats = admin_request.get(
@@ -29,6 +31,12 @@ def test_get_api_key_stats_with_sends(admin_request, notify_db, notify_db_sessio
     assert api_key_stats["email_sends"] == total_sends
     assert api_key_stats["sms_sends"] == 0
     assert api_key_stats["total_sends"] == total_sends
+
+    last_send_dt = datetime.strptime(api_key_stats["last_send"], DATETIME_FORMAT)
+    now = datetime.utcnow()
+    timedelta = now - last_send_dt
+    assert abs(timedelta.total_seconds()) < 1
+
 
 def test_get_api_key_stats_no_sends(admin_request, notify_db, notify_db_session):
 
@@ -44,3 +52,4 @@ def test_get_api_key_stats_no_sends(admin_request, notify_db, notify_db_session)
     assert api_key_stats["email_sends"] == 0
     assert api_key_stats["sms_sends"] == 0
     assert api_key_stats["total_sends"] == 0
+    assert api_key_stats["last_send"] == None

--- a/tests/app/api_key/test_rest.py
+++ b/tests/app/api_key/test_rest.py
@@ -9,8 +9,6 @@ from tests.app.db import (
     create_template
 )
 
-from tests.app.conftest import sample_notification as create_sample_notification
-
 
 def test_get_api_key_stats_with_sends(admin_request, notify_db, notify_db_session):
 
@@ -52,4 +50,4 @@ def test_get_api_key_stats_no_sends(admin_request, notify_db, notify_db_session)
     assert api_key_stats["email_sends"] == 0
     assert api_key_stats["sms_sends"] == 0
     assert api_key_stats["total_sends"] == 0
-    assert api_key_stats["last_send"] == None
+    assert api_key_stats["last_send"] is None

--- a/tests/app/api_key/test_rest.py
+++ b/tests/app/api_key/test_rest.py
@@ -29,7 +29,8 @@ def test_get_api_key_stats_with_sends(admin_request, notify_db, notify_db_sessio
     assert api_key_stats["email_sends"] == total_sends
     assert api_key_stats["sms_sends"] == 0
     assert api_key_stats["total_sends"] == total_sends
-
+    
+    # the following lines test that a send has occurred within the last second
     last_send_dt = datetime.strptime(api_key_stats["last_send"], DATETIME_FORMAT)
     now = datetime.utcnow()
     time_delta = now - last_send_dt

--- a/tests/app/api_key/test_rest.py
+++ b/tests/app/api_key/test_rest.py
@@ -24,7 +24,7 @@ def test_get_api_key_stats_with_sends(admin_request, notify_db, notify_db_sessio
         'api_key.get_api_key_stats',
         api_key_id=api_key.id
     )['data']
-    print("api_key_stats", api_key_stats)
+
     assert api_key_stats["api_key_id"] == str(api_key.id)
     assert api_key_stats["email_sends"] == total_sends
     assert api_key_stats["sms_sends"] == 0
@@ -32,8 +32,8 @@ def test_get_api_key_stats_with_sends(admin_request, notify_db, notify_db_sessio
 
     last_send_dt = datetime.strptime(api_key_stats["last_send"], DATETIME_FORMAT)
     now = datetime.utcnow()
-    timedelta = now - last_send_dt
-    assert abs(timedelta.total_seconds()) < 1
+    time_delta = now - last_send_dt
+    assert abs(time_delta.total_seconds()) < 1
 
 
 def test_get_api_key_stats_no_sends(admin_request, notify_db, notify_db_session):

--- a/tests/app/api_key/test_rest.py
+++ b/tests/app/api_key/test_rest.py
@@ -1,19 +1,39 @@
 from tests.app.db import (
     create_api_key,
-    create_service
+    create_service,
+    create_notification,
+    create_template
 )
 
 from tests.app.conftest import sample_notification as create_sample_notification
 
 
-def test_get_api_key_stats(admin_request, notify_db, notify_db_session):
+def test_get_api_key_stats_with_sends(admin_request, notify_db, notify_db_session):
 
-    service = create_service(check_if_service_exists=True)
+    service = create_service(service_name='Service 1')
     api_key = create_api_key(service)
+    template = create_template(service=service, template_type='email')
+    # template_sms = create_template(service=service, template_type='sms')
     total_sends = 10
 
     for x in range(total_sends):
-        create_sample_notification(notify_db, notify_db_session, api_key=api_key, service=service)
+        # create_sample_notification(notify_db, notify_db_session, api_key=api_key, service=service)
+        create_notification(template=template, api_key=api_key)
+
+    api_key_stats = admin_request.get(
+        'api_key.get_api_key_stats',
+        api_key_id=api_key.id
+    )['data']
+    print("api_key_stats", api_key_stats)
+    assert api_key_stats["api_key_id"] == str(api_key.id)
+    assert api_key_stats["email_sends"] == total_sends
+    assert api_key_stats["sms_sends"] == 0
+    assert api_key_stats["total_sends"] == total_sends
+
+def test_get_api_key_stats_no_sends(admin_request, notify_db, notify_db_session):
+
+    service = create_service(service_name='Service 2')
+    api_key = create_api_key(service)
 
     api_key_stats = admin_request.get(
         'api_key.get_api_key_stats',
@@ -21,4 +41,6 @@ def test_get_api_key_stats(admin_request, notify_db, notify_db_session):
     )['data']
 
     assert api_key_stats["api_key_id"] == str(api_key.id)
-    assert api_key_stats["total_sends"] == total_sends
+    assert api_key_stats["email_sends"] == 0
+    assert api_key_stats["sms_sends"] == 0
+    assert api_key_stats["total_sends"] == 0

--- a/tests/app/dao/test_fact_notification_status_dao.py
+++ b/tests/app/dao/test_fact_notification_status_dao.py
@@ -363,7 +363,7 @@ def test_fetch_notification_status_totals_for_all_services(
             start_date=date(2018, 10, start_date), end_date=date(2018, 10, end_date)),
         key=lambda x: (x.notification_type, x.status)
     )
-    print("other results", results)
+
     assert len(results) == 4
 
     assert results[0].notification_type == 'email'

--- a/tests/app/dao/test_fact_notification_status_dao.py
+++ b/tests/app/dao/test_fact_notification_status_dao.py
@@ -299,14 +299,20 @@ def test_get_total_notifications_sent_for_api_key(notify_db_session):
     service = create_service(service_name='First Service')
     api_key = create_api_key(service)
     template = create_template(service=service)
+    template_email = create_template(service=service, template_type=EMAIL_TYPE)
+    template_sms = create_template(service=service, template_type=SMS_TYPE)
     total_sends = 10
-
+    print("str(api_key.id)" , str(api_key.id))
     for x in range(total_sends):
         create_notification(template=template, api_key=api_key)
+    # create_ft_notification_status(date(2018, 1, 1), 'email', service, count=total_sends)
 
-    api_key_stats = get_total_notifications_sent_for_api_key(api_key.id)
+        # create_notification(template=template_email, api_key=api_key)
+        # create_notification(template=template_sms, api_key=api_key)
 
-    assert api_key_stats[0] == total_sends
+    api_key_stats = get_total_notifications_sent_for_api_key(str(api_key.id))
+
+    assert api_key_stats == [(EMAIL_TYPE, total_sends), (SMS_TYPE, 0)]
 
 
 @pytest.mark.parametrize(
@@ -335,7 +341,7 @@ def test_fetch_notification_status_totals_for_all_services(
             start_date=date(2018, 10, start_date), end_date=date(2018, 10, end_date)),
         key=lambda x: (x.notification_type, x.status)
     )
-
+    print("other results", results)
     assert len(results) == 4
 
     assert results[0].notification_type == 'email'

--- a/tests/app/dao/test_fact_notification_status_dao.py
+++ b/tests/app/dao/test_fact_notification_status_dao.py
@@ -333,8 +333,8 @@ def test_get_last_send_for_api_key(notify_db_session):
 
     last_send = get_last_send_for_api_key(str(api_key.id))[0][0]
     now = datetime.utcnow()
-    timedelta = now - last_send
-    assert abs(timedelta.total_seconds()) < 1
+    time_delta = now - last_send
+    assert abs(time_delta.total_seconds()) < 1
 
 
 @pytest.mark.parametrize(

--- a/tests/app/dao/test_fact_notification_status_dao.py
+++ b/tests/app/dao/test_fact_notification_status_dao.py
@@ -311,7 +311,7 @@ def test_get_total_notifications_sent_for_api_key(notify_db_session):
 
     api_key_stats_2 = get_total_notifications_sent_for_api_key(str(api_key.id))
     assert api_key_stats_2 == [(EMAIL_TYPE, total_sends), ]
-    
+
     for x in range(total_sends):
         create_notification(template=template_sms, api_key=api_key)
 

--- a/tests/app/dao/test_fact_notification_status_dao.py
+++ b/tests/app/dao/test_fact_notification_status_dao.py
@@ -331,6 +331,7 @@ def test_get_last_send_for_api_key(notify_db_session):
     for x in range(total_sends):
         create_notification(template=template_email, api_key=api_key)
 
+    # the following lines test that a send has occurred within the last second
     last_send = get_last_send_for_api_key(str(api_key.id))[0][0]
     now = datetime.utcnow()
     time_delta = now - last_send


### PR DESCRIPTION
Working on addressing @timarney's [comment](https://github.com/cds-snc/notification-admin/pull/411#issuecomment-601642344).

This PR:
- changes the endpoint name from "total-sends" to "summary-statistics" since we are now returning more data
- fixed an error where I was querying the wrong table 😓 
- added a new query to get the last time the api key was used, added that to the data returned from the endpoint
- tests