### PR TITLE
Add ability to use local jinja template for html emails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,5 @@ celerybeat-schedule
 
 /scripts/run_my_tests.sh
 .vscode
+
+jinja_templates/

--- a/README.md
+++ b/README.md
@@ -118,6 +118,22 @@ make freeze-requirements
 
 `requirements.txt` should be committed alongside `requirements-app.txt` changes.
 
+## Using Local Jinja for template changes
+
+HTML Email Templates (`email_template.jinja2`) are pulled in from the [notification-utils](https://github.com/cds-snc/notification-utils) repo. To test jinja changes locally (without needing to update the upstream), follow this procedure:
+
+1. Create a `jinja_templates` folder in the project root directory, and put a .gitignore in it so nothing is tracked or pushed to this repo.
+
+2. Copy `./notification-utils/jinja_templates/email_template.jinja2` from [notification-utils](https://github.com/cds-snc/notification-utils) into the `jinja_templates` folder created in step 1
+
+3. Set a new .ENV variable: `USE_LOCAL_JINJA_TEMPLATES=True`
+
+4. Make markup changes, and see them locally!
+
+5. When finished, copy `email_template.jinja2` back to notification-utils, and push up the PR for your changes in that repo.
+
+6. Remove `USE_LOCAL_JINJA_TEMPLATES=True` from your .env file, and delete any jinja in `jinja_templates`. Deleting the folder and jinja files is not required, but recommended. Make sure you're pulling up-to-date jinja from notification-utils the next time you need to make changes.
+
 ## Frequent problems
 
 __Problem__ : `E999 SyntaxError: invalid syntax` when running `flake8`

--- a/README.md
+++ b/README.md
@@ -118,19 +118,21 @@ make freeze-requirements
 
 `requirements.txt` should be committed alongside `requirements-app.txt` changes.
 
-## Using Local Jinja for template changes
+## Using Local Jinja for testing template changes
 
-HTML Email Templates (`email_template.jinja2`) are pulled in from the [notification-utils](https://github.com/cds-snc/notification-utils) repo. To test jinja changes locally (without needing to update the upstream), follow this procedure:
+Jinja templates used in this repo: `email_template.jinja2`
 
-1. Create a `jinja_templates` folder in the project root directory, and put a .gitignore in it so nothing is tracked or pushed to this repo.
+Jinja templates are pulled in from the [notification-utils](https://github.com/cds-snc/notification-utils) repo. To test jinja changes locally (without needing to update the upstream), follow this procedure:
 
-2. Copy `./notification-utils/jinja_templates/email_template.jinja2` from [notification-utils](https://github.com/cds-snc/notification-utils) into the `jinja_templates` folder created in step 1
+1. Create a `jinja_templates` folder in the project root directory. This folder name is already gitignored and won't be tracked.
+
+2. Copy the jinja template files from [notification-utils](https://github.com/cds-snc/notification-utils) into the `jinja_templates` folder created in step 1
 
 3. Set a new .ENV variable: `USE_LOCAL_JINJA_TEMPLATES=True`
 
 4. Make markup changes, and see them locally!
 
-5. When finished, copy `email_template.jinja2` back to notification-utils, and push up the PR for your changes in that repo.
+5. When finished, copy any changed jinja files back to notification-utils, and push up the PR for your changes in that repo.
 
 6. Remove `USE_LOCAL_JINJA_TEMPLATES=True` from your .env file, and delete any jinja in `jinja_templates`. Deleting the folder and jinja files is not required, but recommended. Make sure you're pulling up-to-date jinja from notification-utils the next time you need to make changes.
 

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -132,8 +132,10 @@ def send_email_to_provider(notification):
         template_dict = dao_get_template_by_id(notification.template_id, notification.template_version).__dict__
 
         # Local Jinja support - Add USE_LOCAL_JINJA_TEMPLATES=True to .env
-        # Add a folder to the project root called 'jinja_templates' with a copy of 'email_template.jinja2' from notification-utils repo
-        debug_template_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__))) if os.environ.get('USE_LOCAL_JINJA_TEMPLATES') is not None else None
+        # Add a folder to the project root called 'jinja_templates'
+        # with a copy of 'email_template.jinja2' from notification-utils repo
+        debug_template_path = (os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+                               if os.environ.get('USE_LOCAL_JINJA_TEMPLATES') is not None else None)
 
         html_email = HTMLEmailTemplate(
             template_dict,

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -135,7 +135,7 @@ def send_email_to_provider(notification):
         # Add a folder to the project root called 'jinja_templates'
         # with a copy of 'email_template.jinja2' from notification-utils repo
         debug_template_path = (os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-                               if os.environ.get('USE_LOCAL_JINJA_TEMPLATES') is 'True' else None)
+                               if os.environ.get('USE_LOCAL_JINJA_TEMPLATES') == 'True' else None)
 
         html_email = HTMLEmailTemplate(
             template_dict,

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import os
 import urllib.request
 import magic
 import re
@@ -130,9 +131,14 @@ def send_email_to_provider(notification):
 
         template_dict = dao_get_template_by_id(notification.template_id, notification.template_version).__dict__
 
+        # Local Jinja support - Add USE_LOCAL_JINJA_TEMPLATES=True to .env
+        # Add a folder to the project root called 'jinja_templates' with a copy of 'email_template.jinja2' from notification-utils repo
+        debug_template_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__))) if os.environ.get('USE_LOCAL_JINJA_TEMPLATES') is not None else None
+
         html_email = HTMLEmailTemplate(
             template_dict,
             values=personalisation_data,
+            jinja_path=debug_template_path,
             **get_html_email_options(service)
         )
 

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -135,7 +135,7 @@ def send_email_to_provider(notification):
         # Add a folder to the project root called 'jinja_templates'
         # with a copy of 'email_template.jinja2' from notification-utils repo
         debug_template_path = (os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-                               if os.environ.get('USE_LOCAL_JINJA_TEMPLATES') is not None else None)
+                               if os.environ.get('USE_LOCAL_JINJA_TEMPLATES') is 'True' else None)
 
         html_email = HTMLEmailTemplate(
             template_dict,

--- a/application.py
+++ b/application.py
@@ -39,6 +39,7 @@ if os.environ.get('USE_LOCAL_JINJA_TEMPLATES') == 'True':
     print('========================================================')
     print('')
     print('WARNING: USING LOCAL JINJA from /jinja_templates FOLDER!')
+    print('.env USE_LOCAL_JINJA_TEMPLATES=True')
     print('')
     print('========================================================')
     print('')

--- a/application.py
+++ b/application.py
@@ -22,3 +22,12 @@ sentry_sdk.init(
 application = Flask('app')
 application.wsgi_app = ProxyFix(application.wsgi_app)
 create_app(application)
+
+if os.environ.get('USE_LOCAL_JINJA_TEMPLATES') == 'True':
+    print('')
+    print('========================================================')
+    print('')
+    print('WARNING: USING LOCAL JINJA from /jinja_templates FOLDER!')
+    print('')
+    print('========================================================')
+    print('')

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -43,7 +43,7 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@40.0.2#egg=notifications-utils==40.0.2
+git+https://github.com/cds-snc/notifier-utils.git@41.0.0#egg=notifications-utils==41.0.0
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,7 +66,7 @@ attrs==19.3.0
 awscli==1.18.45
 bcrypt==3.1.7
 billiard==3.3.0.23
-bleach==3.1.1
+bleach==3.1.4
 blinker==1.4
 boto3==1.12.13
 botocore==1.15.45

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@40.0.2#egg=notifications-utils==40.0.2
+git+https://github.com/cds-snc/notifier-utils.git@41.0.0#egg=notifications-utils==41.0.0
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
 
@@ -63,18 +63,18 @@ amqp==1.4.9
 anyjson==0.3.3
 asn1crypto==1.3.0
 attrs==19.3.0
-awscli==1.18.40
+awscli==1.18.45
 bcrypt==3.1.7
 billiard==3.3.0.23
-bleach==3.1.4
+bleach==3.1.1
 blinker==1.4
 boto3==1.12.13
-botocore==1.15.40
+botocore==1.15.45
 certifi==2020.4.5.1
 chardet==3.0.4
 click==7.1.1
 colorama==0.4.3
-cryptography==2.9
+cryptography==2.9.2
 dnspython==1.16.0
 docutils==0.15.2
 flask-redis==0.4.0
@@ -104,7 +104,7 @@ python-json-logger==0.1.11
 pytz==2019.3
 PyYAML==5.3
 redis==3.4.1
-requests-file==1.4.3
+requests-file==1.5.0
 rsa==3.4.2
 s3transfer==0.3.3
 six==1.14.0


### PR DESCRIPTION
Closes #759 and possibly #763 

This PR, in tandem with the matching PRs in notification-utils and notification-admin, allows devs to use local in-project jinja for sending emails. This allows us to easily preview our markup changes without having to have first pushed them through the notification-utils repo.

Tests will fail until notification-utils has been updated