### PR TITLE
Fix DNS bug with SMTP

### DIFF
--- a/app/smtp/aws.py
+++ b/app/smtp/aws.py
@@ -106,12 +106,13 @@ def smtp_remove(name):
         ses_client.delete_identity(Identity=domain)
         records = r53_client.list_resource_record_sets(
             HostedZoneId=current_app.config["AWS_ROUTE53_ZONE"],
-            MaxItems="6",
+            MaxItems="6",  # Change this if # records per domain are changed
             StartRecordName=domain
         )["ResourceRecordSets"]
 
         for record in records:
-            delete_record(r53_client, record)
+            if domain in record["Name"]:
+                delete_record(r53_client, record)
 
         return True
 

--- a/app/smtp/aws.py
+++ b/app/smtp/aws.py
@@ -106,6 +106,7 @@ def smtp_remove(name):
         ses_client.delete_identity(Identity=domain)
         records = r53_client.list_resource_record_sets(
             HostedZoneId=current_app.config["AWS_ROUTE53_ZONE"],
+            MaxItems="6",
             StartRecordName=domain
         )["ResourceRecordSets"]
 


### PR DESCRIPTION
When removing an SMTP integration it would delete DNS records for other integrations that were alphabetically behind. Each integration has six records, so it should only remove those six.