### PR TITLE
Un-fixes the SES sending region

### DIFF
--- a/app/clients/email/aws_ses.py
+++ b/app/clients/email/aws_ses.py
@@ -53,7 +53,7 @@ class AwsSesClient(EmailClient):
     '''
 
     def init_app(self, region, statsd_client, *args, **kwargs):
-        self._client = boto3.client('ses', region_name=current_app.config['AWS_REGION'])
+        self._client = boto3.client('ses', region_name=region)
         super(AwsSesClient, self).__init__(*args, **kwargs)
         self.name = 'ses'
         self.statsd_client = statsd_client

--- a/app/clients/email/aws_ses.py
+++ b/app/clients/email/aws_ses.py
@@ -53,7 +53,7 @@ class AwsSesClient(EmailClient):
     '''
 
     def init_app(self, region, statsd_client, *args, **kwargs):
-        self._client = boto3.client('ses', region_name="us-east-1")
+        self._client = boto3.client('ses', region_name=current_app.config['AWS_REGION'])
         super(AwsSesClient, self).__init__(*args, **kwargs)
         self.name = 'ses'
         self.statsd_client = statsd_client


### PR DESCRIPTION
This reverts a previous fixing of the SES region to us-east-1 because the staging cluster is in ca-central-1 and there was no SES in ca-central-1 (See https://github.com/cds-snc/notification-api/pull/671). Now that ca-central-1 has SES we can use SES in the region that the cluster is in. The production cluster will default to us-east-1 and staging will default to ca-central-1.