### PR TITLE
Move pinpoint region to us-west-2

### DIFF
--- a/app/clients/sms/aws_pinpoint.py
+++ b/app/clients/sms/aws_pinpoint.py
@@ -11,7 +11,7 @@ class AwsPinpointClient(SmsClient):
     '''
 
     def init_app(self, current_app, statsd_client, *args, **kwargs):
-        self._client = boto3.client('pinpoint', region_name="us-east-1")
+        self._client = boto3.client('pinpoint', region_name="us-west-2")
         super(SmsClient, self).__init__(*args, **kwargs)
         self.current_app = current_app
         self.name = 'pinpoint'


### PR DESCRIPTION
This is to make pinpoint and sns behave more like independent services. 

Here is the test I did to arrive at this:
- spun up my local admin and connected it to the api running  locally
- sent myself an SMS from a service with no longcode attached
- observed that I received an SMS from one of our longcodes in us-east-1
- deleted all our longcodes in us-east-1 (on staging)
- send myself a 4 texts from the same service
- observed that I received them from 4 different US longcodes (none were sent from the deleted pinpoint longcodes, hooray)
- created a new Pinpoint project in us-west-2, provisioned a Canadian long code there
- locally switched my pinpoint client region and AWS_PINPOINT_APP_ID (an env variable) over to the new project in us-west-2
- added the new longcode to my local db, then assigned it to the service
- sent myself another text
- observed that it came from the new longcode in us-west-2!
