### PR TITLE
Fix research mode error

### DIFF
--- a/app/notifications/notifications_sms_callback.py
+++ b/app/notifications/notifications_sms_callback.py
@@ -59,11 +59,15 @@ def process_firetext_response():
 
 @sms_callback_blueprint.route('/sns', methods=['POST'])
 def process_sns_response():
+    # setting provider_reference = 'send-sms-code' mocks a successful response
+    success, errors = process_sms_client_response(None, 'send-sms-code', 'sns')
     return jsonify(result='success', message=success), 200
 
 
 @sms_callback_blueprint.route('/pinpoint', methods=['POST'])
 def process_pinpoint_response():
+    # setting provider_reference = 'send-sms-code' mocks a successful response
+    success, errors = process_sms_client_response(None, 'send-sms-code', 'pinpoint')
     return jsonify(result='success', message=success), 200
 
 

--- a/app/notifications/notifications_sms_callback.py
+++ b/app/notifications/notifications_sms_callback.py
@@ -57,6 +57,16 @@ def process_firetext_response():
         return jsonify(result='success', message=success), 200
 
 
+@sms_callback_blueprint.route('/sns', methods=['POST'])
+def process_sns_response():
+    return jsonify(result='success', message=success), 200
+
+
+@sms_callback_blueprint.route('/pinpoint', methods=['POST'])
+def process_pinpoint_response():
+    return jsonify(result='success', message=success), 200
+
+
 @sms_callback_blueprint.route('/twilio/<notification_id>', methods=['POST'])
 def process_twilio_response(notification_id):
     client_name = 'Twilio'

--- a/tests/app/celery/test_research_mode_tasks.py
+++ b/tests/app/celery/test_research_mode_tasks.py
@@ -55,6 +55,36 @@ def test_make_firetext_callback(notify_api, rmock, phone_number):
     assert 'mobile={}'.format(phone_number) in rmock.request_history[0].text
 
 
+def test_make_sns_callback(notify_api, rmock):
+    phone_number = "07700900001"
+    endpoint = "http://localhost:6011/notifications/sms/sns"
+    rmock.request(
+        "POST",
+        endpoint,
+        json="some data",
+        status_code=200)
+    send_sms_response("sns", "1234", phone_number)
+
+    assert rmock.called
+    assert rmock.request_history[0].url == endpoint
+    assert 'mobile={}'.format(phone_number) in rmock.request_history[0].text
+
+
+def test_make_pinpoint_callback(notify_api, rmock):
+    phone_number = "07700900001"
+    endpoint = "http://localhost:6011/notifications/sms/pinpoint"
+    rmock.request(
+        "POST",
+        endpoint,
+        json="some data",
+        status_code=200)
+    send_sms_response("pinpoint", "1234", phone_number)
+
+    assert rmock.called
+    assert rmock.request_history[0].url == endpoint
+    assert 'mobile={}'.format(phone_number) in rmock.request_history[0].text
+
+
 def test_make_ses_callback(notify_api, mocker):
     mock_task = mocker.patch('app.celery.research_mode_tasks.process_ses_results')
     some_ref = str(uuid.uuid4())


### PR DESCRIPTION
Add success callbacks for sns and pinpoint that get used by research mode/test api key sends

This is to fix the error we are seeing in prod when someone uses a test api key:
```API POST request on http://api.notification-canada-ca.svc.cluster.local:6011/notifications/sms/sns failed with None```

Thanks to @maxneuvians for the fix!

I tested locally using a test api key to make calls to send sms to the api running locally. I verified that this code resolved the error.