### PR TITLE
Add "default_branding_is_french" column to organisations as well

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -373,6 +373,7 @@ class Organisation(db.Model):
     agreement_signed_on_behalf_of_email_address = db.Column(db.String(255), nullable=True)
     agreement_signed_version = db.Column(db.Float, nullable=True)
     crown = db.Column(db.Boolean, nullable=True)
+    default_branding_is_french = db.Column(db.Boolean, index=False, unique=False, nullable=False, default=False)
     organisation_type = db.Column(
         db.String(255),
         db.ForeignKey('organisation_types.name'),
@@ -418,6 +419,7 @@ class Organisation(db.Model):
             "name": self.name,
             "active": self.active,
             "crown": self.crown,
+            "default_branding_is_french": self.default_branding_is_french,
             "organisation_type": self.organisation_type,
             "letter_branding_id": self.letter_branding_id,
             "email_branding_id": self.email_branding_id,

--- a/migrations/versions/0306c_branding_organisation.py
+++ b/migrations/versions/0306c_branding_organisation.py
@@ -1,0 +1,19 @@
+"""
+
+Revision ID: 0306c_branding_organisation
+Revises: 0306b_branding_french_fip
+Create Date: 2020-05-19 09:30:00
+
+"""
+from alembic import op
+
+
+revision = '0306c_branding_organisation'
+down_revision = '0306b_branding_french_fip'
+
+
+def upgrade():
+    op.execute('ALTER TABLE organisation ADD COLUMN default_branding_is_french boolean DEFAULT false')
+
+def downgrade():
+    op.execute('ALTER TABLE organisation DROP COLUMN default_branding_is_french')

--- a/tests/app/organisation/test_rest.py
+++ b/tests/app/organisation/test_rest.py
@@ -58,6 +58,7 @@ def test_get_organisation_by_id(admin_request, notify_db_session):
         'name',
         'active',
         'crown',
+        'default_branding_is_french',
         'organisation_type',
         'agreement_signed',
         'agreement_signed_at',
@@ -349,6 +350,16 @@ def test_update_organisation_default_branding(
 
     assert org.email_branding == email_branding
     assert org.letter_branding == letter_branding
+
+def test_update_organisation_change_default_branding_language(admin_request, notify_db, sample_service):
+    resp = admin_request.post(
+        'organisation.update_organisation',
+        _data={'default_branding_is_french': True},
+        organisation_id=org.id,
+        _expected_status=204
+    )
+
+    assert org.default_branding_is_french is True
 
 
 def test_post_update_organisation_raises_400_on_existing_org_name(

--- a/tests/app/organisation/test_rest.py
+++ b/tests/app/organisation/test_rest.py
@@ -351,8 +351,13 @@ def test_update_organisation_default_branding(
     assert org.email_branding == email_branding
     assert org.letter_branding == letter_branding
 
-def test_update_organisation_change_default_branding_language(admin_request, notify_db, sample_service):
-    resp = admin_request.post(
+
+def test_update_organisation_change_default_branding_language(admin_request, notify_db):
+    org = create_organisation(name='Test Organisation')
+
+    assert org.default_branding_is_french is False
+
+    admin_request.post(
         'organisation.update_organisation',
         _data={'default_branding_is_french': True},
         organisation_id=org.id,


### PR DESCRIPTION
Closes #875 
Adds the 'default_branding_is_french' column to the organisation table in the DB as well, similarly to my last PR for services.