### PR TITLE
Change max CSV row limit for bulk sending services

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -69,7 +69,7 @@ from app.models import (
 )
 from app.notifications.process_notifications import persist_notification
 from app.service.utils import service_allowed_to_send_to
-from app.utils import service_can_bulk_send
+from app.utils import get_csv_max_rows
 
 
 @notify_celery.task(name="process-job")
@@ -108,7 +108,7 @@ def process_job(job_id, sender_id=None):
             s3.get_job_from_s3(str(service.id), str(job_id)),
             template_type=template.template_type,
             placeholders=template.placeholders,
-            max_rows=100000 if service_can_bulk_send(service_id) else 50000,
+            max_rows=get_csv_max_rows(job.service_id),
     ).get_rows():
         process_row(row, template, job, service, sender_id=sender_id)
 
@@ -604,7 +604,7 @@ def process_incomplete_job(job_id):
             s3.get_job_from_s3(str(job.service_id), str(job.id)),
             template_type=template.template_type,
             placeholders=template.placeholders,
-            max_rows=100000 if service_can_bulk_send(service_id) else 50000,
+            max_rows=get_csv_max_rows(job.service_id),
     ).get_rows():
         if row.index > resume_from_row:
             process_row(row, template, job, job.service)

--- a/app/config.py
+++ b/app/config.py
@@ -371,8 +371,8 @@ class Config(object):
         RelyingParty(os.getenv('FIDO2_DOMAIN', 'localhost'), 'Notification'),
         verify_origin=lambda x: True)
 
-    HC_EN_SERVICE_ID = os.getenv('HC_EN_SERVICE_ID')
-    HC_FR_SERVICE_ID = os.getenv('HC_FR_SERVICE_ID')
+    HC_EN_SERVICE_ID = os.getenv('HC_EN_SERVICE_ID', '9d7eb35c-e15f-46d0-b7a4-6859b843fedb')
+    HC_FR_SERVICE_ID = os.getenv('HC_FR_SERVICE_ID', '3e2589c4-a0d7-4592-9eb9-c178cddf2b1f')
     CSV_MAX_ROWS = os.getenv('CSV_MAX_ROWS', 50000)
     CSV_MAX_ROWS_BULK_SEND = os.getenv('CSV_MAX_ROWS_BULK_SEND', 100000)
 

--- a/app/config.py
+++ b/app/config.py
@@ -371,6 +371,8 @@ class Config(object):
         RelyingParty(os.getenv('FIDO2_DOMAIN', 'localhost'), 'Notification'),
         verify_origin=lambda x: True)
 
+    HC_EN_SERVICE_ID = os.getenv('HC_EN_SERVICE_ID')
+    HC_FR_SERVICE_ID = os.getenv('HC_FR_SERVICE_ID')
 
 ######################
 # Config overrides ###

--- a/app/config.py
+++ b/app/config.py
@@ -371,8 +371,8 @@ class Config(object):
         RelyingParty(os.getenv('FIDO2_DOMAIN', 'localhost'), 'Notification'),
         verify_origin=lambda x: True)
 
-    HC_EN_SERVICE_ID = os.getenv('HC_EN_SERVICE_ID', '9d7eb35c-e15f-46d0-b7a4-6859b843fedb')
-    HC_FR_SERVICE_ID = os.getenv('HC_FR_SERVICE_ID', '3e2589c4-a0d7-4592-9eb9-c178cddf2b1f')
+    HC_EN_SERVICE_ID = os.getenv('HC_EN_SERVICE_ID', '')
+    HC_FR_SERVICE_ID = os.getenv('HC_FR_SERVICE_ID', '')
     CSV_MAX_ROWS = os.getenv('CSV_MAX_ROWS', 50000)
     CSV_MAX_ROWS_BULK_SEND = os.getenv('CSV_MAX_ROWS_BULK_SEND', 100000)
 

--- a/app/config.py
+++ b/app/config.py
@@ -373,6 +373,9 @@ class Config(object):
 
     HC_EN_SERVICE_ID = os.getenv('HC_EN_SERVICE_ID')
     HC_FR_SERVICE_ID = os.getenv('HC_FR_SERVICE_ID')
+    CSV_MAX_ROWS = os.getenv('CSV_MAX_ROWS', 50000)
+    CSV_MAX_ROWS_BULK_SEND = os.getenv('CSV_MAX_ROWS_BULK_SEND', 100000)
+
 
 ######################
 # Config overrides ###

--- a/app/utils.py
+++ b/app/utils.py
@@ -3,7 +3,7 @@ import os
 from datetime import datetime, timedelta
 
 import pytz
-from flask import url_for
+from flask import current_app, url_for
 from sqlalchemy import func
 from notifications_utils.template import SMSMessageTemplate, WithSubjectTemplate, get_html_email_body
 
@@ -135,9 +135,12 @@ def update_dct_to_str(update_dct):
     return str
 
 
-def service_can_bulk_send(service_id):
+def get_csv_max_rows(service_id):
     bulk_sending_services = [
         current_app.config['HC_EN_SERVICE_ID'],
         current_app.config['HC_FR_SERVICE_ID'],
     ]
-    return service_id in bulk_sending_services    
+
+    if service_id in bulk_sending_services:
+        return current_app.config['CSV_MAX_ROWS_BULK_SEND']
+    return current_app.config['CSV_MAX_ROWS']

--- a/app/utils.py
+++ b/app/utils.py
@@ -133,3 +133,11 @@ def update_dct_to_str(update_dct):
         str += "- {}".format(key.replace("_", " "))
         str += "\n"
     return str
+
+
+def service_can_bulk_send(service_id):
+    bulk_sending_services = [
+        current_app.config['HC_EN_SERVICE_ID'],
+        current_app.config['HC_FR_SERVICE_ID'],
+    ]
+    return service_id in bulk_sending_services    

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -44,7 +44,7 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@42.1.3#egg=notifications-utils==42.1.3
+git+https://github.com/cds-snc/notifier-utils.git@42.1.4#egg=notifications-utils==42.1.4
 
 # MLWR
 socketio-client==0.5.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ awscli-cwlogs>=1.4,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@42.1.3#egg=notifications-utils==42.1.3
+git+https://github.com/cds-snc/notifier-utils.git@42.1.4#egg=notifications-utils==42.1.4
 
 # MLWR
 socketio-client==0.5.6
@@ -62,14 +62,14 @@ amqp==1.4.9
 anyjson==0.3.3
 asn1crypto==1.3.0
 attrs==19.3.0
-awscli==1.18.66
+awscli==1.18.67
 bcrypt==3.1.7
 billiard==3.3.0.23
 bleach==3.1.4
 blinker==1.4
 boto==2.49.0
 boto3==1.12.13
-botocore==1.16.16
+botocore==1.16.17
 certifi==2020.4.5.1
 chardet==3.0.4
 click==7.1.2


### PR DESCRIPTION
I can't actually test this locally because csv jobs don't seem to work locally - they are just stuck in pending. Not sure why. So I'll need to test this on staging instead. I have verified that the API behaves as before - nothing will change until the env variables `HC_EN_SERVICE_ID` and `HC_FR_SERVICE_ID` are set. 