### PR TITLE
send invite error codes for admin to translate

### DIFF
--- a/app/accept_invite/rest.py
+++ b/app/accept_invite/rest.py
@@ -27,6 +27,7 @@ register_errors(accept_invite)
 def validate_invitation_token(invitation_type, token):
 
     max_age_seconds = 60 * 60 * 24 * current_app.config['INVITATION_EXPIRATION_DAYS']
+
     try:
         invited_user_id = check_token(token,
                                       current_app.config['SECRET_KEY'],

--- a/app/accept_invite/rest.py
+++ b/app/accept_invite/rest.py
@@ -35,12 +35,9 @@ def validate_invitation_token(invitation_type, token):
                                       max_age_seconds)
     except SignatureExpired:
         errors = {'invitation': 'invitation expired'}
-                #   ['Your invitation to GOV.UK Notify has expired. '
-                #    'Please ask the person that invited you to send you another one']}
         raise InvalidRequest(errors, status_code=400)
     except BadData:
         errors = {'invitation': 'bad invitation link'}
-        # errors = {'invitation': 'Something’s wrong with this link. Make sure you’ve copied the whole thing.'}
         raise InvalidRequest(errors, status_code=400)
 
     if invitation_type == 'service':

--- a/app/accept_invite/rest.py
+++ b/app/accept_invite/rest.py
@@ -27,19 +27,20 @@ register_errors(accept_invite)
 def validate_invitation_token(invitation_type, token):
 
     max_age_seconds = 60 * 60 * 24 * current_app.config['INVITATION_EXPIRATION_DAYS']
-
+    max_age_seconds = 1
     try:
         invited_user_id = check_token(token,
                                       current_app.config['SECRET_KEY'],
                                       current_app.config['DANGEROUS_SALT'],
                                       max_age_seconds)
     except SignatureExpired:
-        errors = {'invitation':
-                  ['Your invitation to GOV.UK Notify has expired. '
-                   'Please ask the person that invited you to send you another one']}
+        errors = {'invitation': 'invitation expired'}
+                #   ['Your invitation to GOV.UK Notify has expired. '
+                #    'Please ask the person that invited you to send you another one']}
         raise InvalidRequest(errors, status_code=400)
     except BadData:
-        errors = {'invitation': 'Something’s wrong with this link. Make sure you’ve copied the whole thing.'}
+        errors = {'invitation': 'bad invitation link'}
+        # errors = {'invitation': 'Something’s wrong with this link. Make sure you’ve copied the whole thing.'}
         raise InvalidRequest(errors, status_code=400)
 
     if invitation_type == 'service':

--- a/app/accept_invite/rest.py
+++ b/app/accept_invite/rest.py
@@ -27,7 +27,6 @@ register_errors(accept_invite)
 def validate_invitation_token(invitation_type, token):
 
     max_age_seconds = 60 * 60 * 24 * current_app.config['INVITATION_EXPIRATION_DAYS']
-    max_age_seconds = 1
     try:
         invited_user_id = check_token(token,
                                       current_app.config['SECRET_KEY'],

--- a/tests/app/accept_invite/test_accept_invite_rest.py
+++ b/tests/app/accept_invite/test_accept_invite_rest.py
@@ -19,9 +19,7 @@ def test_validate_invitation_token_for_expired_token_returns_400(client, invitat
     assert response.status_code == 400
     json_resp = json.loads(response.get_data(as_text=True))
     assert json_resp['result'] == 'error'
-    assert json_resp['message'] == {'invitation': [
-        'Your invitation to GOV.UK Notify has expired. '
-        'Please ask the person that invited you to send you another one']}
+    assert json_resp['message'] == {'invitation': 'invitation expired'}
 
 
 @pytest.mark.parametrize('invitation_type', ['service', 'organisation'])
@@ -80,5 +78,5 @@ def test_validate_invitation_token_returns_400_when_token_is_malformed(client, i
     json_resp = json.loads(response.get_data(as_text=True))
     assert json_resp['result'] == 'error'
     assert json_resp['message'] == {
-        'invitation': 'Something’s wrong with this link. Make sure you’ve copied the whole thing.'
+        'invitation': 'bad invitation link'
     }


### PR DESCRIPTION
fixes https://github.com/cds-snc/notification-api/issues/784

Rather than having the content here I've changed to simple error messages, the idea being that admin will handle both the English and French content to display to the user.

corresponding admin PR: https://github.com/cds-snc/notification-admin/pull/565