### PR TITLE
Fixed the bugs in setting max rows

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -108,7 +108,7 @@ def process_job(job_id, sender_id=None):
             s3.get_job_from_s3(str(service.id), str(job_id)),
             template_type=template.template_type,
             placeholders=template.placeholders,
-            max_rows=get_csv_max_rows(service.id)
+            max_rows=get_csv_max_rows(service.id),
     ).get_rows():
         process_row(row, template, job, service, sender_id=sender_id)
 

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -108,7 +108,7 @@ def process_job(job_id, sender_id=None):
             s3.get_job_from_s3(str(service.id), str(job_id)),
             template_type=template.template_type,
             placeholders=template.placeholders,
-            max_rows=get_csv_max_rows(job.service_id),
+            max_rows=get_csv_max_rows(service.id)
     ).get_rows():
         process_row(row, template, job, service, sender_id=sender_id)
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -141,6 +141,6 @@ def get_csv_max_rows(service_id):
         current_app.config['HC_FR_SERVICE_ID'],
     ]
 
-    if service_id in bulk_sending_services:
-        return current_app.config['CSV_MAX_ROWS_BULK_SEND']
-    return current_app.config['CSV_MAX_ROWS']
+    if str(service_id) in bulk_sending_services:
+        return int(current_app.config['CSV_MAX_ROWS_BULK_SEND'])
+    return int(current_app.config['CSV_MAX_ROWS'])


### PR DESCRIPTION
I found these by running a csv send through my local api, with `CSV_MAX_ROWS` and `CSV_MAX_ROWS_BULK_SEND` set to low numbers. Also had to implement a mock email client to do it. Wow that was a lot of work to fix 4 lines.