### PR TITLE
Email two-factor now sends a 5 digit code instead of a clickable link

### DIFF
--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -726,17 +726,6 @@ def _create_confirmation_url(user, email_address):
     return url_with_token(data, url, current_app.config)
 
 
-"""
-def _create_2fa_url(user, secret_code, next_redir, email_auth_link_host):
-    data = json.dumps({'user_id': str(user.id), 'secret_code': secret_code})
-    url = '/email-auth/'
-    ret = url_with_token(data, url, current_app.config, base_url=email_auth_link_host)
-    if next_redir:
-        ret += '?{}'.format(urlencode({'next': next_redir}))
-    return ret
-"""
-
-
 def get_orgs_and_services(user):
     return {
         'organisations': [

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -305,7 +305,7 @@ def send_user_email_code(user_to_send_to, data):
 
     personalisation = {
         'name': user_to_send_to.name,
-        'url': secret_code
+        'verify_code': secret_code
     }
 
     create_2fa_code(
@@ -327,6 +327,7 @@ def create_2fa_code(template_id, user_to_send_to, secret_code, recipient, person
         reply_to = template.service.get_default_sms_sender()
     elif template.template_type == EMAIL_TYPE:
         reply_to = template.service.get_default_reply_to_email_address()
+
     saved_notification = persist_notification(
         template_id=template.id,
         template_version=template.version,

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -1,7 +1,6 @@
 import json
 import uuid
 from datetime import (datetime, timedelta)
-from urllib.parse import urlencode
 import base64
 import pickle
 import requests
@@ -302,10 +301,11 @@ def send_user_sms_code(user_to_send_to, data):
 def send_user_email_code(user_to_send_to, data):
     recipient = user_to_send_to.email_address
 
-    secret_code = str(uuid.uuid4())
+    secret_code = create_secret_code()
+
     personalisation = {
         'name': user_to_send_to.name,
-        'url': _create_2fa_url(user_to_send_to, secret_code, data.get('next'), data.get('email_auth_link_host'))
+        'url': secret_code
     }
 
     create_2fa_code(
@@ -726,6 +726,7 @@ def _create_confirmation_url(user, email_address):
     return url_with_token(data, url, current_app.config)
 
 
+"""
 def _create_2fa_url(user, secret_code, next_redir, email_auth_link_host):
     data = json.dumps({'user_id': str(user.id), 'secret_code': secret_code})
     url = '/email-auth/'
@@ -733,6 +734,7 @@ def _create_2fa_url(user, secret_code, next_redir, email_auth_link_host):
     if next_redir:
         ret += '?{}'.format(urlencode({'next': next_redir}))
     return ret
+"""
 
 
 def get_orgs_and_services(user):

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -290,7 +290,6 @@ def send_user_sms_code(user_to_send_to, data):
 
     secret_code = create_secret_code()
     personalisation = {'verify_code': secret_code}
-    print(secret_code)
 
     create_2fa_code(
         current_app.config['SMS_CODE_TEMPLATE_ID'],

--- a/migrations/versions/0307_update_email_2fa_template.py
+++ b/migrations/versions/0307_update_email_2fa_template.py
@@ -8,7 +8,6 @@ Create Date: 2020-06-10 08:08:00
 from datetime import datetime
 
 from alembic import op
-from flask import current_app
 
 
 revision = '0307_update_email_2fa_template'

--- a/migrations/versions/0307_update_email_2fa_template.py
+++ b/migrations/versions/0307_update_email_2fa_template.py
@@ -1,0 +1,54 @@
+"""
+
+Revision ID: 0307_update_email_2fa_template
+Revises: 0306c_branding_organisation
+Create Date: 2020-06-10 08:08:00
+
+"""
+from datetime import datetime
+
+from alembic import op
+from flask import current_app
+
+
+revision = '0307_update_email_2fa_template'
+down_revision = '0306c_branding_organisation'
+
+template_id = '299726d2-dba6-42b8-8209-30e1d66ea164'
+
+
+def upgrade():
+    template_content = '\n'.join([
+        'Hi ((name)),',
+        '',
+        '((verify_code)) is your security code to log in to Notify.',
+        '',
+        '-------',
+        '',
+        '',
+        'Bonjour ((name)),',
+        '',
+        '((verify_code)) est votre code de sécurité pour vous connecter à Notification.',
+    ])
+    template_subject = 'Sign in to Notify  |  Inscrivez-vous dans Notification'
+    op.execute("UPDATE templates SET content = '{}', subject = '{}' WHERE id = '{}'".format(template_content, template_subject, template_id))
+    op.execute("UPDATE templates_history SET content = '{}', subject = '{}' WHERE id = '{}'".format(template_content, template_subject, template_id))
+
+
+def downgrade():
+    template_content = '\n'.join([
+        'Hi ((name)),',
+        '\n',
+        'To sign in to Notify please open this link:',
+        '((url))',
+        '\n',
+        '-------',
+        '\n',
+        '\n',
+        'Bonjour ((name)),',
+        '\n',
+        'Pour vous connecter à Notification, veuillez ouvrir ce lien: ((url))',
+    ])
+
+    op.execute("UPDATE templates SET content = '{}' WHERE id = '{}'".format(template_content, template_id))
+    op.execute("UPDATE templates_history SET content = '{}' WHERE id = '{}'".format(template_content, template_id))

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -847,10 +847,10 @@ def email_2fa_code_template(notify_db, notify_db_session):
         content=(
             'Hi ((name)),'
             ''
-            'To sign in to GOV.​UK Notify please open this link:'
+            'To sign in to Notify please open this link:'
             '((url))'
         ),
-        subject='Sign in to GOV.UK Notify',
+        subject='Sign in to Notify',
         template_type='email'
     )
 

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -847,8 +847,7 @@ def email_2fa_code_template(notify_db, notify_db_session):
         content=(
             'Hi ((name)),'
             ''
-            'To sign in to Notify please open this link:'
-            '((url))'
+            '((verify_code)) is your security code to log in to Notify.'
         ),
         subject='Sign in to Notify',
         template_type='email'

--- a/tests/app/user/test_rest_verify.py
+++ b/tests/app/user/test_rest_verify.py
@@ -425,7 +425,7 @@ def test_send_user_email_code(
     assert str(noti.template_id) == current_app.config['EMAIL_2FA_TEMPLATE_ID']
     assert mocked.call_count == 1
     assert noti.personalisation['name'] == 'Test User'
-    assert noti.personalisation['url'] == '11111'
+    assert noti.personalisation['verify_code'] == '11111'
     deliver_email.assert_called_once_with(
         [str(noti.id)],
         queue='notify-internal-tasks'
@@ -449,7 +449,7 @@ def test_send_user_email_code_with_urlencoded_next_param(admin_request, mocker, 
     )
     noti = Notification.query.one()
     assert mocked.call_count == 1
-    assert noti.personalisation['url'] == '11111'
+    assert noti.personalisation['verify_code'] == '11111'
 
 
 def test_send_email_code_returns_404_for_bad_input_data(admin_request):


### PR DESCRIPTION
Closes #895 
Most of the changes were on the admin side. All I had to do here was switch the email 2fa to use the existing code generation that we use for SMS, and remove the old code.

Also added a new DB migration to update the email 2fa template. I did this as a migration to ensure the new variables / content filter through to staging / local dev environments etc. I did not add this as a new version, but the content will replace whatever the current version is on each of these systems. I did this to account for there possibly being different version numbers on staging vs prod, and not knowing what version the template will have anytime this migration is run.
A consequence of this is that all old versions of this template will also have the new content written into them, so we will effectively lose all older versions of the email 2fa template. I did archive the current prod content in the db migration, so if we downgrade, it will return to that. But anything before this will be lost.

If this is a dealbreaker, I will do more work to try and find a better way, but this seemed an acceptable loss to me.