### PR TITLE
Update some error messages for translation

### DIFF
--- a/app/dao/users_dao.py
+++ b/app/dao/users_dao.py
@@ -157,7 +157,8 @@ def get_user_and_accounts(user_id):
 @transactional
 def dao_archive_user(user):
     if not user_can_be_archived(user):
-        msg = "User cannot be removed from service. Check that all services have another team member who can manage settings"
+        msg = "User cannot be removed from service. "\
+            "Check that all services have another team member who can manage settings"
         raise InvalidRequest(msg, 400)
 
     permission_dao.remove_user_service_permissions_for_all_services(user)

--- a/app/dao/users_dao.py
+++ b/app/dao/users_dao.py
@@ -157,7 +157,7 @@ def get_user_and_accounts(user_id):
 @transactional
 def dao_archive_user(user):
     if not user_can_be_archived(user):
-        msg = "User can’t be removed from a service - check all services have another team member with manage_settings"
+        msg = "User cannot be removed from service. Check that all services have another team member who can manage settings"
         raise InvalidRequest(msg, 400)
 
     permission_dao.remove_user_service_permissions_for_all_services(user)

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -994,8 +994,8 @@ def check_if_reply_to_address_already_in_use(service_id, email_address):
     if email_address in [i.email_address for i in existing_reply_to_addresses]:
         raise InvalidRequest(
             {
-                "0":"Your service already uses ",
+                "0": "Your service already uses ",
                 "1": "‘{}’ ".format(email_address),
-                "2":"as an email reply-to address."
+                "2": "as an email reply-to address."
             }, status_code=400
         )

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -993,5 +993,9 @@ def check_if_reply_to_address_already_in_use(service_id, email_address):
     existing_reply_to_addresses = dao_get_reply_to_by_service_id(service_id)
     if email_address in [i.email_address for i in existing_reply_to_addresses]:
         raise InvalidRequest(
-            "Your service already uses ‘{}’ as an email reply-to address.".format(email_address), status_code=400
+            {
+                "0":"Your service already uses ",
+                "1": "‘{}’ ".format(email_address),
+                "2":"as an email reply-to address."
+            }, status_code=400
         )

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -2620,10 +2620,10 @@ def test_verify_reply_to_email_address_doesnt_allow_duplicates(admin_request, no
         _expected_status=400
     )
     assert response["message"] == {
-                "0": "Your service already uses ",
-                "1": "‘reply-here@example.gov.uk’ ",
-                "2": "as an email reply-to address."
-            }
+        "0": "Your service already uses ",
+        "1": "‘reply-here@example.gov.uk’ ",
+        "2": "as an email reply-to address."
+    }
 
 
 def test_add_service_reply_to_email_address(admin_request, sample_service):
@@ -2653,10 +2653,10 @@ def test_add_service_reply_to_email_address_doesnt_allow_duplicates(
         _expected_status=400
     )
     assert response["message"] == {
-                "0": "Your service already uses ",
-                "1": "‘reply-here@example.gov.uk’ ",
-                "2": "as an email reply-to address."
-            }
+        "0": "Your service already uses ",
+        "1": "‘reply-here@example.gov.uk’ ",
+        "2": "as an email reply-to address."
+    }
 
 
 def test_add_service_reply_to_email_address_can_add_multiple_addresses(admin_request, sample_service):

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -2619,7 +2619,11 @@ def test_verify_reply_to_email_address_doesnt_allow_duplicates(admin_request, no
         _data=data,
         _expected_status=400
     )
-    assert response["message"] == "Your service already uses ‘reply-here@example.gov.uk’ as an email reply-to address."
+    assert response["message"] == {
+                "0": "Your service already uses ",
+                "1": "‘reply-here@example.gov.uk’ ",
+                "2": "as an email reply-to address."
+            }
 
 
 def test_add_service_reply_to_email_address(admin_request, sample_service):
@@ -2648,7 +2652,11 @@ def test_add_service_reply_to_email_address_doesnt_allow_duplicates(
         _data=data,
         _expected_status=400
     )
-    assert response["message"] == "Your service already uses ‘reply-here@example.gov.uk’ as an email reply-to address."
+    assert response["message"] == {
+                "0": "Your service already uses ",
+                "1": "‘reply-here@example.gov.uk’ ",
+                "2": "as an email reply-to address."
+            }
 
 
 def test_add_service_reply_to_email_address_can_add_multiple_addresses(admin_request, sample_service):

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -410,7 +410,8 @@ def test_archive_user_when_user_cannot_be_archived(mocker, client, sample_user):
     )
     json_resp = json.loads(response.get_data(as_text=True))
 
-    msg = "User can’t be removed from a service - check all services have another team member with manage_settings"
+    msg = "User cannot be removed from service. "\
+          "Check that all services have another team member who can manage settings"
 
     assert response.status_code == 400
     assert json_resp['message'] == msg


### PR DESCRIPTION
Just updating a couple error strings.

I split an error message into multiple keys to be strung back together on the admin side to account for a variable in the middle.

Closes #953 