### PR TITLE
Don't allow blocked users to reset password

### DIFF
--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -562,6 +562,9 @@ def send_user_reset_password():
 
     user_to_send_to = get_user_by_email(email['email'])
 
+    if user_to_send_to.blocked:
+        return jsonify({}), 400
+
     template = dao_get_template_by_id(current_app.config['PASSWORD_RESET_TEMPLATE_ID'])
     service = Service.query.get(current_app.config['NOTIFY_SERVICE_ID'])
     saved_notification = persist_notification(

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -563,7 +563,7 @@ def send_user_reset_password():
     user_to_send_to = get_user_by_email(email['email'])
 
     if user_to_send_to.blocked:
-        return jsonify({}), 400
+        return jsonify({'message': 'cannot reset password: user blocked'}), 400
 
     template = dao_get_template_by_id(current_app.config['PASSWORD_RESET_TEMPLATE_ID'])
     service = Service.query.get(current_app.config['NOTIFY_SERVICE_ID'])

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -670,17 +670,17 @@ def test_send_user_reset_password_should_send_reset_password_link(client,
 def test_send_user_reset_password_should_send_400_if_user_blocked(client,
                                                                   mocker,
                                                                   password_reset_email_template):
-    blocked_user = create_user(blocked=True, email="blocked@cds-snc.ca")                                                             
+    blocked_user = create_user(blocked=True, email="blocked@cds-snc.ca")
     mocked = mocker.patch('app.celery.provider_tasks.deliver_email.apply_async')
     data = json.dumps({'email': blocked_user.email_address})
     auth_header = create_authorization_header()
-    notify_service = password_reset_email_template.service
     resp = client.post(
         url_for('user.send_user_reset_password'),
         data=data,
         headers=[('Content-Type', 'application/json'), auth_header])
     assert resp.status_code == 400
     assert 'user blocked' in json.loads(resp.get_data(as_text=True))['message']
+    assert mocked.call_count == 0
 
 
 def test_send_user_reset_password_should_return_400_when_email_is_missing(client, mocker):


### PR DESCRIPTION
Return an error if a blocked user attempts to reset password.

Corresponding admin PR: https://github.com/cds-snc/notification-admin/pull/657