### PR TITLE
Revert "Put in an aggressive rate limit for test keys"

### DIFF
--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -26,8 +26,7 @@ from app.dao.service_letter_contact_dao import dao_get_letter_contact_by_id
 def check_service_over_api_rate_limit(service, api_key):
     if current_app.config['API_RATE_LIMIT_ENABLED'] and current_app.config['REDIS_ENABLED']:
         cache_key = rate_limit_cache_key(service.id, api_key.key_type)
-
-        rate_limit = service.rate_limit if api_key.key_type != KEY_TYPE_TEST else 500
+        rate_limit = service.rate_limit
         interval = 60
         if redis_store.exceeded_rate_limit(cache_key, rate_limit, interval):
             current_app.logger.info("service {} has been rate limited for throughput".format(service.id))

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -301,16 +301,14 @@ def test_that_when_exceed_rate_limit_request_fails(
         with pytest.raises(RateLimitError) as e:
             check_service_over_api_rate_limit(service, api_key)
 
-        test_rate_limit = 500 if key_type == "test" else service.rate_limit
-
         assert app.redis_store.exceeded_rate_limit.called_with(
             "{}-{}".format(str(service.id), api_key.key_type),
-            test_rate_limit,
+            service.rate_limit,
             60
         )
         assert e.value.status_code == 429
         assert e.value.message == 'Exceeded rate limit for key type {} of {} requests per {} seconds'.format(
-            key_type.upper(), test_rate_limit, 60
+            key_type.upper(), service.rate_limit, 60
         )
         assert e.value.fields == []
 


### PR DESCRIPTION
Reverts cds-snc/notification-api#1038

Since this didn't seem to do anything, and since our problems seem to be related to other things, figured it was best to remove this.