### PR TITLE
rename service.whitelist property

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -674,7 +674,7 @@ class ServiceSafelist(db.Model):
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     service_id = db.Column(UUID(as_uuid=True), db.ForeignKey('services.id'), index=True, nullable=False)
-    service = db.relationship('Service', backref='whitelist')
+    service = db.relationship('Service', backref='safelist')
     recipient_type = db.Column(safelist_recipient_types, nullable=False)
     recipient = db.Column(db.String(255), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.datetime.utcnow)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -288,7 +288,7 @@ class DetailedServiceSchema(BaseSchema):
             'message_limit',
             'email_from',
             'inbound_api',
-            'whitelist',
+            'safelist',
             'reply_to_email_address',
             'sms_sender',
             'permissions',

--- a/app/service/utils.py
+++ b/app/service/utils.py
@@ -37,7 +37,7 @@ def service_allowed_to_send_to(recipient, service, key_type, allow_safelisted_re
         [user.mobile_number, user.email_address] for user in service.users
     )
     safelist_members = [
-        member.recipient for member in service.whitelist
+        member.recipient for member in service.safelist
         if allow_safelisted_recipients
     ]
 

--- a/tests/app/dao/test_service_whitelist_dao.py
+++ b/tests/app/dao/test_service_whitelist_dao.py
@@ -44,8 +44,8 @@ def test_remove_service_safelist_only_removes_for_my_service(notify_db, notify_d
 
     dao_remove_service_safelist(service_1.id)
 
-    assert service_1.whitelist == []
-    assert len(service_2.whitelist) == 1
+    assert service_1.safelist == []
+    assert len(service_2.safelist) == 1
 
 
 def test_remove_service_safelist_does_not_commit(notify_db, sample_service_safelist):

--- a/tests/app/notifications/rest/test_send_notification.py
+++ b/tests/app/notifications/rest/test_send_notification.py
@@ -871,7 +871,7 @@ def test_should_not_send_notification_to_non_safelist_recipient_in_trial_mode(
     apply_async = mocker.patch('app.celery.provider_tasks.deliver_{}.apply_async'.format(notification_type))
     template = _create_sample_template(notify_db, notify_db_session, service=service)
     assert service_safelist.service_id == service.id
-    assert to not in [member.recipient for member in service.whitelist]
+    assert to not in [member.recipient for member in service.safelist]
 
     create_sample_notification(notify_db, notify_db_session, template=template, service=service)
 
@@ -932,7 +932,7 @@ def test_should_send_notification_to_safelist_recipient(
                                                           service=service, email_address=to)
 
     assert service_safelist.service_id == service.id
-    assert to in [member.recipient for member in service.whitelist]
+    assert to in [member.recipient for member in service.safelist]
 
     create_sample_notification(notify_db, notify_db_session, template=template, service=service)
 


### PR DESCRIPTION
re https://github.com/cds-snc/notification-api/issues/962

change property service.whitelist to service.safelist
should have been part of https://github.com/cds-snc/notification-api/pull/1040 🤷 