### PR TITLE
downgrade dnspython to 1.16.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -77,7 +77,7 @@ chardet==3.0.4
 click==7.1.2
 colorama==0.4.3
 cryptography==3.0
-dnspython==2.0.0
+dnspython==1.16.0
 docutils==0.15.2
 flask-redis==0.4.0
 future==0.18.2


### PR DESCRIPTION
new pods are crashing with `dnspython` 2.0.0 (introduced in https://github.com/cds-snc/notification-api/pull/1051). Fix this for now, and investigate how to adapt our code later.