### PR TITLE
rename service_whitelist table

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -670,7 +670,7 @@ safelist_recipient_types = db.Enum(*SAFELIST_RECIPIENT_TYPE, name='recipient_typ
 
 
 class ServiceSafelist(db.Model):
-    __tablename__ = 'service_whitelist'
+    __tablename__ = 'service_safelist'
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     service_id = db.Column(UUID(as_uuid=True), db.ForeignKey('services.id'), index=True, nullable=False)

--- a/migrations/versions/0308_rename_service_whitelist_table.py
+++ b/migrations/versions/0308_rename_service_whitelist_table.py
@@ -1,0 +1,19 @@
+"""
+
+Revision ID: 0308_rename_service_whitelist
+Revises: 0307_update_email_2fa_template
+Create Date: 2020-08-04 12:50:00
+
+"""
+from alembic import op
+
+
+revision = '0308_rename_service_whitelist'
+down_revision = '0307_update_email_2fa_template'
+
+
+def upgrade():
+    op.execute('ALTER TABLE service_whitelist RENAME TO service_safelist')
+
+def downgrade():
+    op.execute('ALTER TABLE service_safelist RENAME TO service_whitelist')


### PR DESCRIPTION
re https://github.com/cds-snc/notification-api/issues/962

rename database table `service_whitelist` to `service_safelist`. This requires a database migration as well as updating the place we join in the table.

To test:
- run everything locally
- use service / api integration / safelist to add add some more email address to a service's safelist
- look at the stuff in the `service_whitelist` table in the database
- run migration
- verify that local table `service_whitelist` was renamed to `service_safelist` and still has the same content as before
- restart api
verify via service / api integration / safelist that you can see the email addresses added to the service
