### PR TITLE
Fill the requester's email in a branding request

### DIFF
--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -478,7 +478,7 @@ def send_branding_request(user_id):
         recipient=to['email'],
         service=service,
         personalisation={
-            'email': to['email'],
+            'email': get_user_by_id(user_id=user_id).email_address,
             'serviceID': to['serviceID'],
             'service_name': to['service_name'],
             'filename': to['filename']


### PR DESCRIPTION
**Story**
When users upload branding images we need to have the email address included so we know who to respond to.

**What?**
Branding requests currently come in like this https://assistance.cds-snc.ca/a/tickets/901 They need an email.

**Done When**
A branding Request has email in it.

Demo: (note the different recipient/request address - Freshdesk is the recipient in prod)
![Screen Shot 2020-09-29 at 15 21 53](https://user-images.githubusercontent.com/295709/94605764-90410780-0267-11eb-90b1-711e34c0c872.png)

https://trello.com/c/0fGhyLwF/45-include-users-email-in-a-branding-request-notification