### PR TITLE
Auth with API key only

### DIFF
--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -8,9 +8,11 @@ from sqlalchemy.orm.exc import NoResultFound
 from app.dao.api_key_dao import get_api_key_by_secret
 from app.dao.services_dao import dao_fetch_service_by_id_with_api_keys
 
+JWT_AUTH_TYPE = 'jwt'
+API_KEY_V1_AUTH_TYPE = 'api_key_v1'
 AUTH_TYPES = [
-    ('Bearer', 'jwt'),
-    ('ApiKey-v1', 'api_key_v1'),  # TODO decide if ApiKey-v1 scheme is a good scheme name
+    ('Bearer', JWT_AUTH_TYPE),
+    ('ApiKey-v1', API_KEY_V1_AUTH_TYPE),
 ]
 
 
@@ -61,7 +63,7 @@ def requires_admin_auth():
     request_helper.check_proxy_header_before_request()
 
     auth_type, auth_token = get_auth_token(request)
-    if auth_type != 'jwt':
+    if auth_type != JWT_AUTH_TYPE:
         raise AuthError("Invalid scheme: can only use JWT for admin authentication", 401)
     client = __get_token_issuer(auth_token)
 
@@ -76,7 +78,7 @@ def requires_auth():
     request_helper.check_proxy_header_before_request()
 
     auth_type, auth_token = get_auth_token(request)
-    if auth_type == 'api_key_v1':
+    if auth_type == API_KEY_V1_AUTH_TYPE:
         _auth_by_api_key(auth_token)
         return
     client = __get_token_issuer(auth_token)

--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -5,7 +5,13 @@ from notifications_utils import request_helper
 from sqlalchemy.exc import DataError
 from sqlalchemy.orm.exc import NoResultFound
 
+from app.dao.api_key_dao import get_api_key_by_secret
 from app.dao.services_dao import dao_fetch_service_by_id_with_api_keys
+
+AUTH_TYPES = [
+    ('Bearer', 'jwt'),
+    ('ApiKey-v1', 'api_key_v1'),  # TODO decide if ApiKey-v1 scheme is a good scheme name
+]
 
 
 class AuthError(Exception):
@@ -36,12 +42,15 @@ def get_auth_token(req):
     if not auth_header:
         raise AuthError('Unauthorized, authentication token must be provided', 401)
 
-    auth_scheme = auth_header[:7].title()
+    for el in AUTH_TYPES:
+        scheme, auth_type = el
+        if auth_header.lower().startswith(scheme.lower()):
+            token = auth_header[len(scheme) + 1:]
+            return auth_type, token
 
-    if auth_scheme != 'Bearer ':
-        raise AuthError('Unauthorized, authentication bearer scheme must be used', 401)
-
-    return auth_header[7:]
+    # TODO: decide if error message stays the same.
+    # In fact we support another auth method than Bearer
+    raise AuthError('Unauthorized, authentication bearer scheme must be used', 401)
 
 
 def requires_no_auth():
@@ -51,7 +60,9 @@ def requires_no_auth():
 def requires_admin_auth():
     request_helper.check_proxy_header_before_request()
 
-    auth_token = get_auth_token(request)
+    auth_type, auth_token = get_auth_token(request)
+    if auth_type != 'jwt':
+        raise AuthError("Invalid scheme: can only use JWT for admin authentication", 401)
     client = __get_token_issuer(auth_token)
 
     if client == current_app.config.get('ADMIN_CLIENT_USER_NAME'):
@@ -64,7 +75,9 @@ def requires_admin_auth():
 def requires_auth():
     request_helper.check_proxy_header_before_request()
 
-    auth_token = get_auth_token(request)
+    auth_type, auth_token = get_auth_token(request)
+    if auth_type == 'api_key_v1':
+        return _auth_by_api_key(auth_token)
     client = __get_token_issuer(auth_token)
 
     try:
@@ -91,21 +104,32 @@ def requires_auth():
             )
             raise AuthError(err_msg, 403, service_id=service.id, api_key_id=api_key.id)
 
-        if api_key.expiry_date:
-            raise AuthError("Invalid token: API key revoked", 403, service_id=service.id, api_key_id=api_key.id)
-
-        g.service_id = api_key.service_id
-        _request_ctx_stack.top.authenticated_service = service
-        _request_ctx_stack.top.api_user = api_key
-        current_app.logger.info('API authorised for service {} with api key {}, using client {}'.format(
-            service.id,
-            api_key.id,
-            request.headers.get('User-Agent')
-        ))
+        _auth_with_api_key(api_key, service)
         return
     else:
         # service has API keys, but none matching the one the user provided
         raise AuthError("Invalid token: signature, api token not found", 403, service_id=service.id)
+
+
+def _auth_by_api_key(auth_token):
+    try:
+        api_key = get_api_key_by_secret(auth_token)
+    except NoResultFound:
+        raise AuthError("Invalid token: API key not found", 403)
+    _auth_with_api_key(api_key, api_key.service)
+
+
+def _auth_with_api_key(api_key, service):
+    if api_key.expiry_date:
+        raise AuthError("Invalid token: API key revoked", 403, service_id=service.id, api_key_id=api_key.id)
+    g.service_id = api_key.service_id
+    _request_ctx_stack.top.authenticated_service = service
+    _request_ctx_stack.top.api_user = api_key
+    current_app.logger.info('API authorised for service {} with api key {}, using client {}'.format(
+        service.id,
+        api_key.id,
+        request.headers.get('User-Agent')
+    ))
 
 
 def __get_token_issuer(auth_token):

--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -77,7 +77,8 @@ def requires_auth():
 
     auth_type, auth_token = get_auth_token(request)
     if auth_type == 'api_key_v1':
-        return _auth_by_api_key(auth_token)
+        _auth_by_api_key(auth_token)
+        return
     client = __get_token_issuer(auth_token)
 
     try:

--- a/app/dao/api_key_dao.py
+++ b/app/dao/api_key_dao.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime, timedelta
 
-from app import db
+from app import db, encryption
 from app.models import ApiKey
 
 from app.dao.dao_utils import (
@@ -10,6 +10,7 @@ from app.dao.dao_utils import (
 )
 
 from sqlalchemy import or_, func
+from sqlalchemy.orm import joinedload
 
 
 @transactional
@@ -27,6 +28,13 @@ def expire_api_key(service_id, api_key_id):
     api_key = ApiKey.query.filter_by(id=api_key_id, service_id=service_id).one()
     api_key.expiry_date = datetime.utcnow()
     db.session.add(api_key)
+
+
+def get_api_key_by_secret(secret):
+    # TODO add index to the secret column in the DB
+    return ApiKey.query.filter_by(
+        _secret=encryption.encrypt(str(secret))
+    ).options(joinedload('service')).one()
 
 
 def get_model_api_keys(service_id, id=None):

--- a/app/dao/api_key_dao.py
+++ b/app/dao/api_key_dao.py
@@ -31,7 +31,6 @@ def expire_api_key(service_id, api_key_id):
 
 
 def get_api_key_by_secret(secret):
-    # TODO add index to the secret column in the DB
     return ApiKey.query.filter_by(
         _secret=encryption.encrypt(str(secret))
     ).options(joinedload('service')).one()

--- a/tests/app/dao/test_api_key_dao.py
+++ b/tests/app/dao/test_api_key_dao.py
@@ -9,7 +9,8 @@ from app.dao.api_key_dao import (
     get_model_api_keys,
     get_unsigned_secrets,
     get_unsigned_secret,
-    expire_api_key
+    expire_api_key,
+    get_api_key_by_secret
 )
 from app.models import ApiKey, KEY_TYPE_NORMAL
 
@@ -72,6 +73,14 @@ def test_get_unsigned_secret_returns_key(sample_api_key):
     unsigned_api_key = get_unsigned_secret(sample_api_key.id)
     assert sample_api_key._secret != unsigned_api_key
     assert unsigned_api_key == sample_api_key.secret
+
+
+def test_get_api_key_by_secret(sample_api_key):
+    unsigned_secret = get_unsigned_secret(sample_api_key.id)
+    assert get_api_key_by_secret(unsigned_secret).id == sample_api_key.id
+
+    with pytest.raises(NoResultFound):
+        get_api_key_by_secret("nope")
 
 
 def test_should_not_allow_duplicate_key_names_per_service(sample_api_key, fake_uuid):


### PR DESCRIPTION
This PR adds an alternative authentication mechanism to JWT tokens: API keys only. It's limited in scope for now:
- we don't advertise it so we don't change error messages for now
- it's backend only, no UI changes
- it's not straightforward to get only your API key from the UI for now (as we display key name + service ID + key)

To test it locally:
- create an API key, keep only the API key part (the displayed key is `key_name-service_id-api_key`
- hit an endpoint where you need an API key, for example, `curl -H 'Authorization: ApiKey-v1 $api_key' http://localhost:6011/notifications`

Authentication is well covered by tests. `pytest -k 'test_authentication.py' --maxfail=1 --ff -v` reports 40 tests executed.

Trello card: https://trello.com/c/xXoa6LwD/83-spike-what-is-needed-to-remove-jwt-from-api-auth