### PR TITLE
Change AWS region for Pinpoint

### DIFF
--- a/app/clients/sms/aws_pinpoint.py
+++ b/app/clients/sms/aws_pinpoint.py
@@ -11,7 +11,10 @@ class AwsPinpointClient(SmsClient):
     '''
 
     def init_app(self, current_app, statsd_client, *args, **kwargs):
-        self._client = boto3.client('pinpoint', region_name="us-west-2")
+        self._client = boto3.client(
+            'pinpoint',
+            region_name=current_app.config['AWS_REGION']
+        )
         super(SmsClient, self).__init__(*args, **kwargs)
         self.current_app = current_app
         self.name = 'pinpoint'


### PR DESCRIPTION
Our production is in `us-east-1` for now. We also need to change the `AWS_PINPOINT_APP_ID` env variable