### PR TITLE
Endpoint to get delivered notifications stats by month

### DIFF
--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -139,6 +139,24 @@ def fetch_notification_status_for_service_by_month(start_date, end_date, service
     ).all()
 
 
+def fetch_delivered_notification_stats_by_month():
+    return db.session.query(
+        func.date_trunc('month', FactNotificationStatus.bst_date).cast(db.Text).label('month'),
+        FactNotificationStatus.notification_type,
+        func.sum(FactNotificationStatus.notification_count).label('count')
+    ).filter(
+        FactNotificationStatus.key_type != KEY_TYPE_TEST,
+        FactNotificationStatus.notification_status.in_([NOTIFICATION_DELIVERED, NOTIFICATION_SENT]),
+        FactNotificationStatus.bst_date >= '2019-11-01',  # GC Notify start date
+    ).group_by(
+        func.date_trunc('month', FactNotificationStatus.bst_date),
+        FactNotificationStatus.notification_type,
+    ).order_by(
+        func.date_trunc('month', FactNotificationStatus.bst_date).desc(),
+        FactNotificationStatus.notification_type,
+    ).all()
+
+
 def fetch_notification_status_for_service_for_day(bst_day, service_id):
     return db.session.query(
         # return current month as a datetime so the data has the same shape as the ft_notification_status query

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -25,7 +25,9 @@ from app.dao.fact_notification_status_dao import (
     fetch_notification_status_for_service_by_month,
     fetch_notification_status_for_service_for_day,
     fetch_notification_status_for_service_for_today_and_7_previous_days,
-    fetch_stats_for_all_services_by_date_range, fetch_monthly_template_usage_for_service
+    fetch_stats_for_all_services_by_date_range,
+    fetch_monthly_template_usage_for_service,
+    fetch_delivered_notification_stats_by_month,
 )
 from app.dao.inbound_numbers_dao import dao_allocate_number_for_service
 from app.dao.organisation_dao import dao_get_organisation_by_service_id
@@ -185,6 +187,11 @@ def find_services_by_name():
 def get_live_services_data():
     data = dao_fetch_live_services_data()
     return jsonify(data=data)
+
+
+@service_blueprint.route('/delivered-notifications-stats-by-month-data', methods=['GET'])
+def get_delivered_notification_stats_by_month_data():
+    return jsonify(data=fetch_delivered_notification_stats_by_month())
 
 
 @service_blueprint.route('/<uuid:service_id>', methods=['GET'])


### PR DESCRIPTION
Needed by the new activity dashboard.

Would be good to ship before https://github.com/cds-snc/notification-admin/pull/810 so that the review app could call the new endpoint