### PR TITLE
Store the provider's ID when sending SMS

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -68,7 +68,7 @@ def send_sms_to_provider(notification):
 
         else:
             try:
-                provider.send_sms(
+                reference = provider.send_sms(
                     to=validate_and_format_phone_number(notification.to, international=notification.international),
                     content=str(template),
                     reference=str(notification.id),
@@ -80,6 +80,7 @@ def send_sms_to_provider(notification):
                 dao_toggle_sms_provider(provider.name)
                 raise e
             else:
+                notification.reference = reference
                 notification.billable_units = template.fragment_count
                 update_notification_to_sending(notification, provider)
 
@@ -192,8 +193,8 @@ def send_email_to_provider(notification):
 def update_notification_to_sending(notification, provider):
     notification.sent_at = datetime.utcnow()
     notification.sent_by = provider.get_name()
-    # We currently have no callback method for SNS
-    # notification.status = NOTIFICATION_SENT if notification.international else NOTIFICATION_SENDING
+    # We currently have no callback method for SMS (SNS and Pinpoint)
+    # notification.status = NOTIFICATION_SENT if it's a text else NOTIFICATION_SENDING
     notification.status = NOTIFICATION_SENT if notification.notification_type == "sms" else NOTIFICATION_SENDING
     dao_update_notification(notification)
 


### PR DESCRIPTION
If we want to track delivery statuses for SNS and Pinpoint, we should store the AWS ID in the `Notification` model, in the `reference` column. AWS will include this ID in the callback later and we'll use this information to update the notification status.

SNS and Pinpoint clients already return this ID, we need to store it.
https://github.com/cds-snc/notification-api/blob/6781341dfe03a26ac145228265517ab8b62d5f15/app/clients/sms/aws_sns.py#L53
https://github.com/cds-snc/notification-api/blob/6781341dfe03a26ac145228265517ab8b62d5f15/app/clients/sms/aws_pinpoint.py#L96

The code is very similar to the email part
https://github.com/cds-snc/notification-api/blob/6781341dfe03a26ac145228265517ab8b62d5f15/app/delivery/send_to_providers.py#L176-L186