### PR TITLE
Change AWS region for SNS

### DIFF
--- a/app/clients/sms/aws_sns.py
+++ b/app/clients/sms/aws_sns.py
@@ -11,7 +11,7 @@ class AwsSnsClient(SmsClient):
     '''
 
     def init_app(self, current_app, statsd_client, *args, **kwargs):
-        self._client = boto3.client('sns', region_name="us-east-1")
+        self._client = boto3.client('sns', region_name=current_app.config['AWS_REGION'])
         super(SmsClient, self).__init__(*args, **kwargs)
         self.current_app = current_app
         self.name = 'sns'


### PR DESCRIPTION
This will only affect staging as production is on `us-east-1` at the moment.

Checked that pods in staging and production have the expected value for this env variable