### PR TITLE
Remove HTTP callbacks for SES

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -125,7 +125,6 @@ def register_blueprint(application):
     from app.api_key.rest import api_key_blueprint
     from app.inbound_number.rest import inbound_number_blueprint
     from app.inbound_sms.rest import inbound_sms as inbound_sms_blueprint
-    from app.celery.process_ses_receipts_tasks import ses_callback_blueprint, ses_smtp_callback_blueprint
     from app.notifications.notifications_letter_callback import letter_callback_blueprint
     from app.notifications.notifications_email_callback import email_callback_blueprint
     from app.authentication.auth import requires_admin_auth, requires_auth, requires_no_auth
@@ -149,13 +148,6 @@ def register_blueprint(application):
 
     status_blueprint.before_request(requires_no_auth)
     application.register_blueprint(status_blueprint)
-
-    # delivery receipts
-    ses_callback_blueprint.before_request(requires_no_auth)
-    application.register_blueprint(ses_callback_blueprint)
-
-    ses_smtp_callback_blueprint.before_request(requires_no_auth)
-    application.register_blueprint(ses_smtp_callback_blueprint)
 
     email_callback_blueprint.before_request(requires_no_auth)
     application.register_blueprint(email_callback_blueprint)

--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -3,22 +3,17 @@ from datetime import datetime, timedelta
 import iso8601
 from celery.exceptions import Retry
 from flask import (
-    Blueprint,
-    request,
     current_app,
     json,
-    jsonify,
 )
 from notifications_utils.statsd_decorators import statsd
 from sqlalchemy.orm.exc import NoResultFound
-import enum
-import requests
+
 from app import notify_celery, statsd_client
 from app.config import QueueNames
 from app.clients.email.aws_ses import get_aws_responses
 from app.dao import notifications_dao, services_dao, templates_dao
 from app.models import NOTIFICATION_SENDING, NOTIFICATION_PENDING, EMAIL_TYPE, KEY_TYPE_NORMAL
-from json import decoder
 from app.notifications import process_notifications
 from app.notifications.callbacks import _check_and_queue_callback_task
 from app.notifications.notifications_ses_callback import (
@@ -27,130 +22,6 @@ from app.notifications.notifications_ses_callback import (
     handle_smtp_complaint,
     _check_and_queue_complaint_callback_task,
 )
-
-from app.errors import (
-    register_errors,
-    InvalidRequest
-)
-from cachelib import SimpleCache
-import validatesns
-
-ses_callback_blueprint = Blueprint('notifications_ses_callback', __name__)
-ses_smtp_callback_blueprint = Blueprint('notifications_ses_smtp_callback', __name__)
-
-register_errors(ses_callback_blueprint)
-register_errors(ses_smtp_callback_blueprint)
-
-
-class SNSMessageType(enum.Enum):
-    SubscriptionConfirmation = 'SubscriptionConfirmation'
-    Notification = 'Notification'
-    UnsubscribeConfirmation = 'UnsubscribeConfirmation'
-
-
-class InvalidMessageTypeException(Exception):
-    pass
-
-
-def verify_message_type(message_type: str):
-    try:
-        SNSMessageType(message_type)
-    except ValueError:
-        raise InvalidMessageTypeException(f'{message_type} is not a valid message type.')
-
-
-certificate_cache = SimpleCache()
-
-
-def get_certificate(url):
-    res = certificate_cache.get(url)
-    if res is not None:
-        return res
-    res = requests.get(url).content
-    certificate_cache.set(url, res, timeout=60 * 60)  # 60 minutes
-    return res
-
-
-# 400 counts as a permanent failure so SNS will not retry.
-# 500 counts as a failed delivery attempt so SNS will retry.
-# See https://docs.aws.amazon.com/sns/latest/dg/DeliveryPolicies.html#DeliveryPolicies
-# This should not be here, it used to be in notifications/notifications_ses_callback. It then
-# got refactored into a task, which is fine, but it created a circular dependency. Will need
-# to investigate why GDS extracted this into a lambda
-@ses_callback_blueprint.route('/notifications/email/ses', methods=['POST'])
-def sns_callback_handler():
-    message_type = request.headers.get('x-amz-sns-message-type')
-    try:
-        verify_message_type(message_type)
-    except InvalidMessageTypeException:
-        raise InvalidRequest("SES-SNS callback failed: invalid message type", 400)
-
-    try:
-        message = json.loads(request.data)
-    except decoder.JSONDecodeError:
-        raise InvalidRequest("SES-SNS callback failed: invalid JSON given", 400)
-
-    try:
-        validatesns.validate(message, get_certificate=get_certificate)
-    except validatesns.ValidationError:
-        raise InvalidRequest("SES-SNS callback failed: validation failed", 400)
-
-    if message.get('Type') == 'SubscriptionConfirmation':
-        url = message.get('SubscribeURL')
-        response = requests.get(url)
-        try:
-            response.raise_for_status()
-        except Exception as e:
-            current_app.logger.warning("Response: {}".format(response.text))
-            raise e
-
-        return jsonify(
-            result="success", message="SES-SNS auto-confirm callback succeeded"
-        ), 200
-
-    process_ses_results.apply_async([{"Message": message.get("Message")}], queue=QueueNames.NOTIFY)
-
-    return jsonify(
-        result="success", message="SES-SNS callback succeeded"
-    ), 200
-
-
-@ses_smtp_callback_blueprint.route('/notifications/email/ses-smtp', methods=['POST'])
-def sns_smtp_callback_handler():
-    message_type = request.headers.get('x-amz-sns-message-type')
-    try:
-        verify_message_type(message_type)
-    except InvalidMessageTypeException:
-        raise InvalidRequest("SES-SNS SMTP callback failed: invalid message type", 400)
-
-    try:
-        message = json.loads(request.data)
-    except decoder.JSONDecodeError:
-        raise InvalidRequest("SES-SNS SMTP callback failed: invalid JSON given", 400)
-
-    try:
-        validatesns.validate(message, get_certificate=get_certificate)
-    except validatesns.ValidationError:
-        raise InvalidRequest("SES-SNS SMTP callback failed: validation failed", 400)
-
-    if message.get('Type') == 'SubscriptionConfirmation':
-        url = message.get('SubscribeURL')
-        response = requests.get(url)
-        try:
-            response.raise_for_status()
-        except Exception as e:
-            current_app.logger.warning("Response: {}".format(response.text))
-            raise e
-
-        return jsonify(
-            result="success", message="SES-SNS auto-confirm callback succeeded"
-        ), 200
-
-    process_ses_smtp_results.apply_async([{"Message": message.get("Message")}], queue=QueueNames.NOTIFY)
-
-    return jsonify(
-        result="success", message="SES-SNS callback succeeded"
-    ), 200
 
 
 @notify_celery.task(bind=True, name="process-ses-result", max_retries=5, default_retry_delay=300)

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -23,7 +23,6 @@ PyJWT==1.7.1
 PyYAML==5.3.1
 SQLAlchemy==1.3.20
 sentry-sdk[flask]==0.19.2
-validatesns==0.1.1
 cachelib==0.1.1
 
 newrelic==5.22.1.152

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,6 @@ PyJWT==1.7.1
 PyYAML==5.3.1
 SQLAlchemy==1.3.20
 sentry-sdk[flask]==0.19.2
-validatesns==0.1.1
 cachelib==0.1.1
 
 newrelic==5.22.1.152


### PR DESCRIPTION
Callbacks go through SNS and not HTTP anymore. Delete these HTTP endpoints and clean out unused code 🧹