### PR TITLE
Send methods stats by service endpoint

### DIFF
--- a/app/platform_stats/rest.py
+++ b/app/platform_stats/rest.py
@@ -11,6 +11,7 @@ from app.dao.fact_notification_status_dao import (
     fetch_notification_stats_for_trial_services,
     fetch_notification_status_totals_for_all_services,
 )
+from app.dao.notifications_dao import send_method_stats_by_service
 from app.errors import register_errors, InvalidRequest
 from app.platform_stats.platform_stats_schema import platform_stats_request
 from app.service.statistics import format_admin_stats
@@ -114,3 +115,11 @@ def get_usage_for_all_services():
         x['organisation_name'],
         x['service_name']
     )))
+
+
+@platform_stats_blueprint.route('send-method-stats-by-service')
+def get_send_methods_stats_by_service():
+    start_date = datetime.strptime(request.args.get('start_date'), '%Y-%m-%d').date()
+    end_date = datetime.strptime(request.args.get('end_date'), '%Y-%m-%d').date()
+
+    return jsonify(send_method_stats_by_service(start_date, end_date))

--- a/tests/app/dao/test_fact_notification_status_dao.py
+++ b/tests/app/dao/test_fact_notification_status_dao.py
@@ -674,10 +674,12 @@ def test_fetch_delivered_notification_stats_by_month_empty():
     assert fetch_delivered_notification_stats_by_month() == []
 
 
-@freeze_time('2020-11-02 14:00')
 def test_fetch_notification_stats_for_trial_services(sample_service):
-    trial_service = create_service(service_name='restricted', restricted=True)
-    trial_service_2 = create_service(service_name='restricted_2', restricted=True)
+    with freeze_time('2020-11-02 14:00'):
+        trial_service = create_service(service_name='restricted', restricted=True)
+
+    with freeze_time('2020-11-01 14:00'):
+        trial_service_2 = create_service(service_name='restricted_2', restricted=True)
 
     sms_template = create_template(
         service=trial_service_2,
@@ -727,7 +729,7 @@ def test_fetch_notification_stats_for_trial_services(sample_service):
 
     assert results[0].service_id == trial_service_2.id
     assert results[0].service_name == trial_service_2.name
-    assert results[0].creation_date == '2020-11-02 00:00:00'
+    assert results[0].creation_date == '2020-11-01 00:00:00'
     assert results[0].user_name == trial_service_2.created_by.name
     assert results[0].user_email == trial_service_2.created_by.email_address
     assert results[0].notification_type == 'sms'

--- a/tests/app/platform_stats/test_rest.py
+++ b/tests/app/platform_stats/test_rest.py
@@ -158,7 +158,31 @@ def test_get_usage_for_all_services(notify_db_session, admin_request):
 
 def test_get_usage_for_trial_services(mocker, notify_db, admin_request):
     # The DAO method is already covered by tests
-    mocker.patch('app.dao.fact_notification_status_dao.fetch_notification_stats_for_trial_services', return_value=[])
+    mock = mocker.patch(
+        'app.platform_stats.rest.fetch_notification_stats_for_trial_services',
+        return_value=[]
+    )
     response = admin_request.get('platform_stats.get_usage_for_trial_services')
 
     assert len(response) == 0
+    mock.assert_called_once()
+
+
+def test_get_send_methods_stats_by_service(mocker, notify_db, admin_request):
+    # The DAO method is already covered by tests
+    mock = mocker.patch(
+        'app.platform_stats.rest.send_method_stats_by_service',
+        return_value=[]
+    )
+    response = admin_request.get(
+        'platform_stats.get_send_methods_stats_by_service',
+        start_date='2020-12-01',
+        end_date='2020-12-07',
+    )
+
+    assert len(response) == 0
+
+    mock.assert_called_once_with(
+        date(2020, 12, 1),
+        date(2020, 12, 7),
+    )

--- a/tests/app/platform_stats/test_rest.py
+++ b/tests/app/platform_stats/test_rest.py
@@ -156,7 +156,7 @@ def test_get_usage_for_all_services(notify_db_session, admin_request):
     assert response[3]["letter_breakdown"] == "15 second class letters at 55p\n"
 
 
-def test_get_usage_for_trial_services(mocker, notify_db, admin_request):
+def test_get_usage_for_trial_services(mocker, admin_request):
     # The DAO method is already covered by tests
     mock = mocker.patch(
         'app.platform_stats.rest.fetch_notification_stats_for_trial_services',
@@ -168,7 +168,7 @@ def test_get_usage_for_trial_services(mocker, notify_db, admin_request):
     mock.assert_called_once()
 
 
-def test_get_send_methods_stats_by_service(mocker, notify_db, admin_request):
+def test_get_send_methods_stats_by_service(mocker, admin_request):
     # The DAO method is already covered by tests
     mock = mocker.patch(
         'app.platform_stats.rest.send_method_stats_by_service',


### PR DESCRIPTION
New API endpoint to build API keys report (know which services use the admin VS the API).

Trello card: https://trello.com/c/dFATfrV6/114-new-report-api-key-send-vs-ui-send