### PR TITLE
fix: repaired the docker-compose up setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,96 +1,107 @@
-version: '2'
+version: '3'
 
 services:
-  postgres:
+  db:
     image: postgres:11.2
     volumes:
-      - ./data:/docker-entrypoint-initdb.d
+      - ./local/initdb:/docker-entrypoint-initdb.d
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: chummy
     ports:
       - "5432:5432"
+    expose:
+      - "5432"
+    command:
+      - "postgres"
+      - "-c"
+      - "listen_addresses=*"
+    restart: always
   redis:
     image: redis:latest
   web:
     image: notification-api
-    restart: on-failure
+    restart: always
     build:
-      context: ./
-      dockerfile: ci/Dockerfile
+      context: .
+      dockerfile: local/Dockerfile
     environment:
       - REDIS_URL=redis://redis:6379/0
-      - SQLALCHEMY_DATABASE_URI=postgres://postgres:postgres@postgres:5432/postgres
+      - SQLALCHEMY_DATABASE_URI=postgres://postgres:chummy@db:5432/notification_api
+    entrypoint: local/scripts/notify-web-entrypoint.sh
     command: >
       bash -c "make generate-version-file && flask run -p 6011 --host=0.0.0.0"
     volumes:
       - .:/app
     ports:
         - "6011:6011"
-    depends_on:
-      - postgres
+    links:
+      - db
       - redis
   beat:
     image: notification-api
     restart: on-failure
     build:
-      context: ./
-      dockerfile: ci/Dockerfile
+      context: .
+      dockerfile: local/Dockerfile
     environment:
       - REDIS_URL=redis://redis:6379/0
-      - SQLALCHEMY_DATABASE_URI=postgres://postgres:postgres@postgres:5432/postgres
+      - SQLALCHEMY_DATABASE_URI=postgres://postgres:chummy@db:5432/notification_api
     command: >
       bash -c "sh scripts/run_celery_beat.sh"
     volumes:
       - .:/app
     depends_on:
-      - postgres
+      - db
       - redis
       - web
   worker:
     image: notification-api
     restart: on-failure
     build:
-      context: ./
-      dockerfile: ci/Dockerfile
+      context: .
+      dockerfile: local/Dockerfile
     environment:
       - REDIS_URL=redis://redis:6379/0
-      - SQLALCHEMY_DATABASE_URI=postgres://postgres:postgres@postgres:5432/postgres
+      - SQLALCHEMY_DATABASE_URI=postgres://postgres:chummy@db:5432/notification_api
     command: >
       bash -c "rm /tmp/celery.pid; sh scripts/run_celery.sh"
     volumes:
       - .:/app
     depends_on:
-      - postgres
+      - db
       - redis
       - web
   worker_sms:
     image: notification-api
     restart: on-failure
     build:
-      context: ./
-      dockerfile: ci/Dockerfile
+      context: .
+      dockerfile: local/Dockerfile
     environment:
       - REDIS_URL=redis://redis:6379/0
-      - SQLALCHEMY_DATABASE_URI=postgres://postgres:postgres@postgres:5432/postgres
+      - SQLALCHEMY_DATABASE_URI=postgres://postgres:chummy@db:5432/notification_api
     command: >
       bash -c "sh scripts/run_celery_sms.sh"
     volumes:
       - .:/app
     depends_on:
-      - postgres
+      - db
       - redis
       - web
   tests:
     image: notification-api-tests
     restart: "no"
     build:
-      context: ./
+      context: .
       dockerfile: ci/Dockerfile.test
     environment:
       - REDIS_URL=redis://redis:6379/1
-      - SQLALCHEMY_DATABASE_URI=postgres://postgres:postgres@postgres:5432/test_notification_api
+      - SQLALCHEMY_DATABASE_URI=postgres://postgres:chummy@db:5432/test_notification_api
     command: >
       bash -c "./scripts/run_tests.sh"
     volumes:
       - .:/app
     depends_on:
-      - postgres
+      - db
       - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - .:/app
     ports:
         - "6011:6011"
-    links:
+    depends_on:
       - db
       - redis
   beat:

--- a/local/Dockerfile
+++ b/local/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.6-alpine
+
+ENV PYTHONDONTWRITEBYTECODE 1
+
+RUN apk add --no-cache bash build-base git gcc musl-dev postgresql-dev g++ make libffi-dev libmagic && rm -rf /var/cache/apk/*
+
+# update pip
+RUN python -m pip install wheel
+
+RUN set -ex && mkdir /app
+
+WORKDIR /app
+
+COPY . /app
+
+ENV PORT=6011
+
+ARG GIT_SHA
+ENV GIT_SHA ${GIT_SHA}
+
+CMD ["sh", "-c", "gunicorn -c gunicorn_config.py application"]

--- a/local/initdb/notify-db-entrypoint.sh
+++ b/local/initdb/notify-db-entrypoint.sh
@@ -1,0 +1,15 @@
+set -ex
+
+###################################################################
+# This script will get executed *once* the Docker container has 
+# been built. Commands that need to be executed with all available
+# tools and the filesystem mount enabled should be located here. 
+#
+# The PostgreSQL Docker image has an extension mechanism that does 
+# not necessitate to override the entrypoint or main command. One
+# simply has to copy a shell script into the 
+# /docker-entrypoint-initdb.d/ initialization folder. 
+###################################################################
+
+# Notify database setup.
+createdb --user=postgres notification_api

--- a/local/scripts/notify-web-entrypoint.sh
+++ b/local/scripts/notify-web-entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -x
+
+###################################################################
+# This script will get executed *once* the Docker container has 
+# been built. Commands that need to be executed with all available
+# tools and the filesystem mount enabled should be located here. 
+###################################################################
+
+cd /app 
+
+# We need to override the default database URI to provide the database
+# container hostname in the URI string.
+#cp .env.example .env
+
+make generate-version-file
+pip3 install -r requirements.txt
+
+# Upgrade schema of the notification_api database.
+flask db upgrade
+
+# Bubble up the main Docker command to container.
+exec "$@"


### PR DESCRIPTION
## Description

The `docker-compose up` series of commands did not work from a fresh installation. The database especially was missing creation and the `flask db upgrade` command. This should fix it.

I created new files in the `/local` folder. I didn't want to touch the existing Docker files in `/ci` as at least one is used by the GitHub workflows. 

So now a command such as `docker-compose up web` should bring the necessary ecosystem to work in tandem with the notification-admin project for example. 