### PR TITLE
fix: The celery dependency should be in the docker-compose workers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,7 @@ services:
     environment:
       - REDIS_URL=redis://redis:6379/0
       - SQLALCHEMY_DATABASE_URI=postgres://postgres:chummy@db:5432/notification_api
+    entrypoint: local/scripts/notify-worker-entrypoint.sh
     command: >
       bash -c "sh scripts/run_celery_beat.sh"
     volumes:
@@ -64,8 +65,9 @@ services:
     environment:
       - REDIS_URL=redis://redis:6379/0
       - SQLALCHEMY_DATABASE_URI=postgres://postgres:chummy@db:5432/notification_api
+    entrypoint: local/scripts/notify-worker-entrypoint.sh
     command: >
-      bash -c "rm /tmp/celery.pid; sh scripts/run_celery.sh"
+      bash -c "[[ -f /tmp/celery.pid ]] && rm /tmp/celery.pid; sh /app/scripts/run_celery.sh"
     volumes:
       - .:/app
     depends_on:
@@ -81,8 +83,9 @@ services:
     environment:
       - REDIS_URL=redis://redis:6379/0
       - SQLALCHEMY_DATABASE_URI=postgres://postgres:chummy@db:5432/notification_api
+    entrypoint: local/scripts/notify-worker-entrypoint.sh
     command: >
-      bash -c "sh scripts/run_celery_sms.sh"
+      bash -c "sh /app/scripts/run_celery_sms.sh"
     volumes:
       - .:/app
     depends_on:
@@ -98,8 +101,9 @@ services:
     environment:
       - REDIS_URL=redis://redis:6379/1
       - SQLALCHEMY_DATABASE_URI=postgres://postgres:chummy@db:5432/test_notification_api
+    entrypoint: local/scripts/notify-worker-entrypoint.sh
     command: >
-      bash -c "./scripts/run_tests.sh"
+      bash -c "/app/scripts/run_celery.sh"
     volumes:
       - .:/app
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,7 +103,7 @@ services:
       - SQLALCHEMY_DATABASE_URI=postgres://postgres:chummy@db:5432/test_notification_api
     entrypoint: local/scripts/notify-worker-entrypoint.sh
     command: >
-      bash -c "/app/scripts/run_celery.sh"
+      bash -c "/app/scripts/run_tests.sh"
     volumes:
       - .:/app
     depends_on:

--- a/local/scripts/notify-worker-entrypoint.sh
+++ b/local/scripts/notify-worker-entrypoint.sh
@@ -9,11 +9,7 @@ set -x
 
 cd /app 
 
-make generate-version-file
 pip3 install -r requirements.txt
-
-# Upgrade schema of the notification_api database.
-flask db upgrade
 
 # Bubble up the main Docker command to container.
 exec "$@"


### PR DESCRIPTION
## Changes

The celery binary was not installed anymore in the workers defined in the docker-compose.yml file. This might have been provoked by the latest changes I did, as I moved the pip install upon containers startup via entrypoint shell scripts. Hence simply adding entrypoint shell script for the workers was sufficient to fix this minor issue. 

## Test

Manually tested in my setup. Having the workers up and running allowed me to register locally in the setup as I received the expected registration emails.