### PR TITLE
Remove hardcoded domain from branding request

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -136,7 +136,7 @@ class Config(object):
     AWS_PINPOINT_KEYWORD = os.getenv('AWS_PINPOINT_KEYWORD')
     CSV_UPLOAD_BUCKET_NAME = os.getenv('CSV_UPLOAD_BUCKET_NAME', 'notification-alpha-canada-ca-csv-upload')
     ASSET_UPLOAD_BUCKET_NAME = os.getenv('ASSET_UPLOAD_BUCKET_NAME', 'notification-alpha-canada-ca-asset-upload')
-    ASSET_DOMAIN = os.getenv('ASSET_DOMAIN', 's3.amazonaws.com')
+    ASSET_DOMAIN = os.getenv('ASSET_DOMAIN', 'assets.notification.canada.ca')
     INVITATION_EXPIRATION_DAYS = 2
     NOTIFY_APP_NAME = 'api'
     SQLALCHEMY_RECORD_QUERIES = False

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -36,6 +36,7 @@ from app.models import (
     NOTIFICATION_SENDING
 )
 from app.clients.mlwr.mlwr import check_mlwr_score
+from app.utils import get_logo_url
 
 
 def send_sms_to_provider(notification):
@@ -216,12 +217,6 @@ def provider_to_use(notification_type, notification_id, international=False, sen
     return clients.get_client_by_name_and_type(active_providers_in_order[0].identifier, notification_type)
 
 
-def get_logo_url(base_url, logo_file):
-    bucket = current_app.config['ASSET_UPLOAD_BUCKET_NAME']
-    domain = current_app.config['ASSET_DOMAIN']
-    return "https://{}.{}/{}".format(bucket, domain, logo_file)
-
-
 def get_html_email_options(service):
     if service.email_branding is None:
         if service.default_branding_is_french is True:
@@ -238,7 +233,6 @@ def get_html_email_options(service):
             }
 
     logo_url = get_logo_url(
-        current_app.config['ADMIN_BASE_URL'],
         service.email_branding.logo
     ) if service.email_branding.logo else None
 

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -69,9 +69,11 @@ from app.errors import (
     InvalidRequest
 )
 
-from app.utils import (update_dct_to_str)
-
-from app.utils import url_with_token
+from app.utils import (
+    url_with_token,
+    update_dct_to_str,
+    get_logo_url,
+)
 from app.user.users_schema import (
     post_verify_code_schema,
     post_send_user_sms_code_schema,
@@ -479,9 +481,9 @@ def send_branding_request(user_id):
         service=service,
         personalisation={
             'email': get_user_by_id(user_id=user_id).email_address,
-            'serviceID': to['serviceID'],
+            'service_id': to['serviceID'],
             'service_name': to['service_name'],
-            'filename': to['filename']
+            'url': get_logo_url(to['filename']),
         },
         notification_type=template.template_type,
         api_key_id=None,

--- a/app/utils.py
+++ b/app/utils.py
@@ -173,3 +173,7 @@ def get_csv_max_rows(service_id):
     if str(service_id) in bulk_sending_services:
         return int(current_app.config['CSV_MAX_ROWS_BULK_SEND'])
     return int(current_app.config['CSV_MAX_ROWS'])
+
+
+def get_logo_url(logo_file):
+    return f"https://{current_app.config['ASSET_DOMAIN']}/{logo_file}"

--- a/migrations/versions/0312_update_branding_request.py
+++ b/migrations/versions/0312_update_branding_request.py
@@ -1,0 +1,42 @@
+"""
+
+Revision ID: 0312_update_branding_request
+Revises: 0311_disable_old_providers
+Create Date: 2020-11-23 15:00:00
+
+"""
+from alembic import op
+from flask import current_app
+
+revision = '0312_update_branding_request'
+down_revision = '0311_disable_old_providers'
+
+template_id = current_app.config['BRANDING_REQUEST_TEMPLATE_ID']
+
+
+def upgrade():
+    template_content = '\n'.join([
+        'A new logo has been uploaded by ((email)) for the following service:',
+        '',
+        "Service id: ((service_id))",
+        "Service name: ((service_name))",
+        '',
+        "Logo filename: ((url))",
+        '',
+        '___',
+        '',
+        "Un nouveau logo a été téléchargé par ((email)) pour le service suivant :",
+        '',
+        "Identifiant du service : ((service_id))",
+        "Nom du service : ((service_name))",
+        '',
+        "Nom du fichier du logo : ((url))",
+    ])
+    template_subject = "Branding change request for ((service_name)) | Demande de changement d''image de marque pour ((service_name))"
+
+    op.execute("UPDATE templates SET content = '{}', subject = '{}' WHERE id = '{}'".format(template_content, template_subject, template_id))
+    op.execute("UPDATE templates_history SET content = '{}', subject = '{}' WHERE id = '{}'".format(template_content, template_subject, template_id))
+
+
+def downgrade():
+    pass

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -505,7 +505,7 @@ def test_get_html_email_renderer_prepends_logo_path(notify_api):
     )
 
     renderer = send_to_providers.get_html_email_options(service)
-    domain = "https://notification-alpha-canada-ca-asset-upload.s3.amazonaws.com"
+    domain = "https://assets.notification.canada.ca"
     assert renderer['brand_logo'] == "{}{}".format(domain, '/justice-league.png')
 
 

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -534,19 +534,6 @@ def test_get_html_email_renderer_handles_email_branding_without_logo(notify_api)
     assert renderer['brand_name'] == 'Justice League'
 
 
-@pytest.mark.parametrize('base_url, expected_url', [
-    # don't change localhost to prevent errors when testing locally
-    ('http://localhost:6012', 'filename.png'),
-    ('https://www.notifications.service.gov.uk', 'filename.png'),
-])
-def test_get_logo_url_works_for_different_environments(base_url, expected_url):
-    logo_file = 'filename.png'
-
-    logo_url = send_to_providers.get_logo_url(base_url, logo_file)
-    domain = "notification-alpha-canada-ca-asset-upload.s3.amazonaws.com"
-    assert logo_url == "https://{}/{}".format(domain, expected_url)
-
-
 def test_should_not_update_notification_if_research_mode_on_exception(
         sample_service, sample_notification, mocker
 ):

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -8,7 +8,8 @@ from app.utils import (
     get_local_timezone_midnight_in_utc,
     get_midnight_for_day_before,
     midnight_n_days_ago,
-    update_dct_to_str
+    update_dct_to_str,
+    get_logo_url,
 )
 
 
@@ -86,3 +87,8 @@ def test_update_dct_to_str():
     expected = ' '.join(expected)
 
     assert result == expected
+
+
+def test_get_logo_url(notify_api):
+    with notify_api.app_context():
+        assert get_logo_url('foo.png') == "https://assets.notification.canada.ca/foo.png"


### PR DESCRIPTION
Edit the [branding request template](https://notification.alpha.canada.ca/services/d6aa2c68-a2d9-4437-ab19-3ae8eb202553/templates/7d423d9e-e94e-4118-879d-d52f383206ae) to remove the hardcoded S3 domain. Cleans up the `get_logo_url` method at the same time

Trello card: https://trello.com/c/5wylvewO/122-review-notify-templates-for-hardcoded-domains