### PR TITLE
Update Flask app name

### DIFF
--- a/application.py
+++ b/application.py
@@ -29,7 +29,7 @@ sentry_sdk.init(
     release="notify-api@" + os.environ.get('GIT_SHA', '')
 )
 
-application = Flask('app')
+application = Flask('api')
 application.wsgi_app = ProxyFix(application.wsgi_app)
 create_app(application)
 

--- a/run_celery.py
+++ b/run_celery.py
@@ -9,6 +9,6 @@ from app import notify_celery, create_app  # noqa
 
 load_dotenv()
 
-application = Flask('delivery')
+application = Flask('celery')
 create_app(application)
 application.app_context().push()


### PR DESCRIPTION
Update Flask app names to have consistent StatsD prefixes.

The `NOTIFY_APP_NAME` is overridden to be set to the Flask app name here
https://github.com/cds-snc/notification-api/blob/8a1de76bd92ac20c08a2e1d953f2c8fba84d5c26/app/__init__.py#L75

This is then used by the StatsD client to create a namespace according to the environment and the application name
https://github.com/cds-snc/notification-utils/blob/72dea8e0bfe470a254655aef81d257d75a1f4b1d/notifications_utils/clients/statsd/statsd_client.py#L55-L58

Currently, this is a bit messy
![Screen Shot 2020-11-27 at 14 24 37](https://user-images.githubusercontent.com/295709/100479565-94996d80-30bc-11eb-97e3-6adeafbaf66c.png)

- the `production` env is logged as `live` for the admin
- the app name is set to `app` instead of `api` for the API

Celery uses a different app name to distinguish API/Celery (this is the same codebase)
https://github.com/cds-snc/notification-api/blob/8a1de76bd92ac20c08a2e1d953f2c8fba84d5c26/run_celery.py#L12

My final goal is to have the following prefixes
- production_notifications_admin
- production_notifications_api
- production_notifications_celery

**Note:** I've got an admin PR + a Terraform PR following this that I have referenced