### PR TITLE
Adjust rate limit for SMS

### DIFF
--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -14,32 +14,25 @@ from app.models import NOTIFICATION_TECHNICAL_FAILURE
 
 @notify_celery.task(
     bind=True,
+    name="deliver_throttled_sms",
+    max_retries=48,
+    default_retry_delay=300,
+    rate_limit="1/s",
+)
+@statsd(namespace="tasks")
+def deliver_throttled_sms(self, notification_id):
+    _deliver_sms(self, notification_id)
+
+
+@notify_celery.task(
+    bind=True,
     name="deliver_sms",
     max_retries=48,
     default_retry_delay=300,
-    rate_limit="1/s")
+)
 @statsd(namespace="tasks")
 def deliver_sms(self, notification_id):
-    try:
-        current_app.logger.info("Start sending SMS for notification id: {}".format(notification_id))
-        notification = notifications_dao.get_notification_by_id(notification_id)
-        if not notification:
-            raise NoResultFound()
-        send_to_providers.send_sms_to_provider(notification)
-    except Exception:
-        try:
-            current_app.logger.exception(
-                "SMS notification delivery for id: {} failed".format(notification_id)
-            )
-            if self.request.retries == 0:
-                self.retry(queue=QueueNames.RETRY, countdown=0)
-            else:
-                self.retry(queue=QueueNames.RETRY)
-        except self.MaxRetriesExceededError:
-            message = "RETRY FAILED: Max retries reached. The task send_sms_to_provider failed for notification {}. " \
-                      "Notification has been updated to technical-failure".format(notification_id)
-            update_notification_status_by_id(notification_id, NOTIFICATION_TECHNICAL_FAILURE)
-            raise NotificationTechnicalFailureException(message)
+    _deliver_sms(self, notification_id)
 
 
 @notify_celery.task(bind=True, name="deliver_email", max_retries=48, default_retry_delay=300)
@@ -67,6 +60,29 @@ def deliver_email(self, notification_id):
         except self.MaxRetriesExceededError:
             message = "RETRY FAILED: Max retries reached. " \
                       "The task send_email_to_provider failed for notification {}. " \
+                      "Notification has been updated to technical-failure".format(notification_id)
+            update_notification_status_by_id(notification_id, NOTIFICATION_TECHNICAL_FAILURE)
+            raise NotificationTechnicalFailureException(message)
+
+
+def _deliver_sms(self, notification_id):
+    try:
+        current_app.logger.info("Start sending SMS for notification id: {}".format(notification_id))
+        notification = notifications_dao.get_notification_by_id(notification_id)
+        if not notification:
+            raise NoResultFound()
+        send_to_providers.send_sms_to_provider(notification)
+    except Exception:
+        try:
+            current_app.logger.exception(
+                "SMS notification delivery for id: {} failed".format(notification_id)
+            )
+            if self.request.retries == 0:
+                self.retry(queue=QueueNames.RETRY, countdown=0)
+            else:
+                self.retry(queue=QueueNames.RETRY)
+        except self.MaxRetriesExceededError:
+            message = "RETRY FAILED: Max retries reached. The task send_sms_to_provider failed for notification {}. " \
                       "Notification has been updated to technical-failure".format(notification_id)
             update_notification_status_by_id(notification_id, NOTIFICATION_TECHNICAL_FAILURE)
             raise NotificationTechnicalFailureException(message)

--- a/app/config.py
+++ b/app/config.py
@@ -24,6 +24,7 @@ class QueueNames(object):
     PRIORITY = 'priority-tasks'
     DATABASE = 'database-tasks'
     SEND_SMS = 'send-sms-tasks'
+    SEND_THROTTLED_SMS = 'send-throttled-sms-tasks'
     SEND_EMAIL = 'send-email-tasks'
     RESEARCH_MODE = 'research-mode-tasks'
     REPORTING = 'reporting-tasks'
@@ -43,6 +44,7 @@ class QueueNames(object):
             QueueNames.PERIODIC,
             QueueNames.DATABASE,
             QueueNames.SEND_SMS,
+            QueueNames.SEND_THROTTLED_SMS,
             QueueNames.SEND_EMAIL,
             QueueNames.RESEARCH_MODE,
             QueueNames.REPORTING,

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -33,7 +33,8 @@ from app.models import (
     NOTIFICATION_VIRUS_SCAN_FAILED,
     NOTIFICATION_CONTAINS_PII,
     NOTIFICATION_SENT,
-    NOTIFICATION_SENDING
+    NOTIFICATION_SENDING,
+    PINPOINT_PROVIDER,
 )
 from app.clients.mlwr.mlwr import check_mlwr_score
 from app.utils import get_logo_url
@@ -211,10 +212,14 @@ def provider_to_use(notification_type, notification_id, international=False, sen
         )
         raise Exception("No active {} providers".format(notification_type))
 
-    if sender is not None and notification_type == SMS_TYPE and sender[0] == "+":
-        return clients.get_client_by_name_and_type("pinpoint", notification_type)
+    if _sms_send_on_pinpoint(notification_type, sender):
+        return clients.get_client_by_name_and_type(PINPOINT_PROVIDER, notification_type)
 
     return clients.get_client_by_name_and_type(active_providers_in_order[0].identifier, notification_type)
+
+
+def _sms_send_on_pinpoint(notification_type, sender):
+    return notification_type == SMS_TYPE and sender and sender[0] == "+"
 
 
 def get_html_email_options(service):

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -30,7 +30,7 @@ from app.dao.notifications_dao import (
     dao_delete_notifications_by_id,
     dao_created_scheduled_notification
 )
-
+from app.delivery import send_to_providers
 from app.v2.errors import BadRequestError
 from app.utils import get_template_instance
 
@@ -130,6 +130,11 @@ def send_notification_to_queue(notification, research_mode, queue=None):
         if not queue:
             queue = QueueNames.SEND_SMS
         deliver_task = provider_tasks.deliver_sms
+        if send_to_providers._sms_send_on_pinpoint(
+            notification.notification_type,
+            notification.reply_to_text
+        ):
+            deliver_task = provider_tasks.deliver_throttled_sms
     if notification.notification_type == EMAIL_TYPE:
         if not queue:
             queue = QueueNames.SEND_EMAIL

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -127,14 +127,16 @@ def send_notification_to_queue(notification, research_mode, queue=None):
         queue = QueueNames.RESEARCH_MODE
 
     if notification.notification_type == SMS_TYPE:
-        if not queue:
-            queue = QueueNames.SEND_SMS
         deliver_task = provider_tasks.deliver_sms
         if send_to_providers._sms_send_on_pinpoint(
             notification.notification_type,
             notification.reply_to_text
         ):
             deliver_task = provider_tasks.deliver_throttled_sms
+            if not queue:
+                queue = QueueNames.SEND_THROTTLED_SMS
+        if not queue:
+            queue = QueueNames.SEND_SMS
     if notification.notification_type == EMAIL_TYPE:
         if not queue:
             queue = QueueNames.SEND_EMAIL

--- a/scripts/run_celery.sh
+++ b/scripts/run_celery.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency=4 -Q database-tasks,job-tasks,notify-internal-tasks,periodic-tasks,priority-tasks,reporting-tasks,research-mode-tasks,retry-tasks,send-email-tasks,service-callbacks
+celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency=4 -Q database-tasks,job-tasks,notify-internal-tasks,periodic-tasks,priority-tasks,reporting-tasks,research-mode-tasks,retry-tasks,send-sms-tasks,send-email-tasks,service-callbacks

--- a/scripts/run_celery_sms.sh
+++ b/scripts/run_celery_sms.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=1 -Q send-sms-tasks
+celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=1 -Q send-throttled-sms-tasks

--- a/tests/app/celery/test_provider_tasks.py
+++ b/tests/app/celery/test_provider_tasks.py
@@ -10,50 +10,69 @@ from app.clients.email.aws_ses import AwsSesClientException
 from app.exceptions import NotificationTechnicalFailureException
 
 
+sms_methods = [
+    (deliver_sms, 'deliver_sms'),
+    (deliver_throttled_sms, 'deliver_throttled_sms'),
+]
+
+
 def test_should_have_decorated_tasks_functions():
     assert deliver_sms.__wrapped__.__name__ == 'deliver_sms'
     assert deliver_throttled_sms.__wrapped__.__name__ == 'deliver_throttled_sms'
     assert deliver_email.__wrapped__.__name__ == 'deliver_email'
 
 
+@pytest.mark.parametrize("sms_method,sms_method_name", sms_methods)
 def test_should_call_send_sms_to_provider_from_deliver_sms_task(
-        sample_notification,
-        mocker):
+    sample_notification,
+    mocker,
+    sms_method,
+    sms_method_name,
+):
     mocker.patch('app.delivery.send_to_providers.send_sms_to_provider')
 
-    deliver_sms(sample_notification.id)
+    sms_method(sample_notification.id)
     app.delivery.send_to_providers.send_sms_to_provider.assert_called_with(sample_notification)
 
 
+@pytest.mark.parametrize("sms_method,sms_method_name", sms_methods)
 def test_sms_tasks_should_call_same_method(
     sample_notification,
     mocker,
+    sms_method,
+    sms_method_name,
 ):
     private_task = mocker.patch('app.celery.provider_tasks._deliver_sms')
 
-    deliver_sms(sample_notification.id)
-    assert private_task.call_count == 1
-
-    deliver_throttled_sms(sample_notification.id)
-    assert private_task.call_count == 2
+    sms_method(sample_notification.id)
+    private_task.assert_called_once()
 
 
+@pytest.mark.parametrize("sms_method,sms_method_name", sms_methods)
 def test_should_add_to_retry_queue_if_notification_not_found_in_deliver_sms_task(
-        notify_db_session,
-        mocker):
+    notify_db_session,
+    mocker,
+    sms_method,
+    sms_method_name,
+):
     mocker.patch('app.delivery.send_to_providers.send_sms_to_provider')
-    mocker.patch('app.celery.provider_tasks.deliver_sms.retry')
+    mocker.patch(f'app.celery.provider_tasks.{sms_method_name}.retry')
 
     notification_id = app.create_uuid()
 
-    deliver_sms(notification_id)
+    sms_method(notification_id)
     app.delivery.send_to_providers.send_sms_to_provider.assert_not_called()
-    app.celery.provider_tasks.deliver_sms.retry.assert_called_with(queue="retry-tasks", countdown=0)
+
+    getattr(app.celery.provider_tasks, sms_method_name).retry.assert_called_with(
+        queue="retry-tasks",
+        countdown=0
+    )
 
 
 def test_should_call_send_email_to_provider_from_deliver_email_task(
-        sample_notification,
-        mocker):
+    sample_notification,
+    mocker,
+):
     mocker.patch('app.delivery.send_to_providers.send_email_to_provider')
 
     deliver_email(sample_notification.id)
@@ -73,15 +92,21 @@ def test_should_add_to_retry_queue_if_notification_not_found_in_deliver_email_ta
 
 # DO THESE FOR THE 4 TYPES OF TASK
 
-def test_should_go_into_technical_error_if_exceeds_retries_on_deliver_sms_task(sample_notification, mocker):
+@pytest.mark.parametrize("sms_method,sms_method_name", sms_methods)
+def test_should_go_into_technical_error_if_exceeds_retries_on_deliver_sms_task(
+    sample_notification,
+    mocker,
+    sms_method,
+    sms_method_name,
+):
     mocker.patch('app.delivery.send_to_providers.send_sms_to_provider', side_effect=Exception("EXPECTED"))
-    mocker.patch('app.celery.provider_tasks.deliver_sms.retry', side_effect=MaxRetriesExceededError())
+    mocker.patch(f'app.celery.provider_tasks.{sms_method_name}.retry', side_effect=MaxRetriesExceededError())
 
     with pytest.raises(NotificationTechnicalFailureException) as e:
-        deliver_sms(sample_notification.id)
+        sms_method(sample_notification.id)
     assert str(sample_notification.id) in str(e.value)
 
-    provider_tasks.deliver_sms.retry.assert_called_with(queue="retry-tasks", countdown=0)
+    getattr(provider_tasks, sms_method_name).retry.assert_called_with(queue="retry-tasks", countdown=0)
 
     assert sample_notification.status == 'technical-failure'
 
@@ -126,17 +151,20 @@ def test_should_retry_and_log_exception(sample_notification, mocker):
     assert sample_notification.status == 'created'
 
 
+@pytest.mark.parametrize("sms_method,sms_method_name", sms_methods)
 def test_send_sms_should_not_switch_providers_on_non_provider_failure(
     sample_notification,
-    mocker
+    mocker,
+    sms_method,
+    sms_method_name,
 ):
     mocker.patch(
         'app.delivery.send_to_providers.send_sms_to_provider',
         side_effect=Exception("Non Provider Exception")
     )
     switch_provider_mock = mocker.patch('app.delivery.send_to_providers.dao_toggle_sms_provider')
-    mocker.patch('app.celery.provider_tasks.deliver_sms.retry')
+    mocker.patch(f'app.celery.provider_tasks.{sms_method_name}.retry')
 
-    deliver_sms(sample_notification.id)
+    sms_method(sample_notification.id)
 
     assert switch_provider_mock.called is False

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -1106,7 +1106,7 @@ def test_save_sms_uses_sms_sender_reply_to_text(mocker, notify_db_session):
     template = create_template(service=service)
 
     notification = _notification_json(template, to="6502532222")
-    mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
+    mocker.patch('app.celery.provider_tasks.deliver_throttled_sms.apply_async')
 
     notification_id = uuid.uuid4()
     save_sms(

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -254,7 +254,7 @@ def test_persist_notification_increments_cache_if_key_exists(sample_template, sa
     (False, None, 'sms', 'team', None, 'send-sms-tasks', 'deliver_sms'),
     (False, None, 'letter', 'normal', None, 'create-letters-pdf-tasks', 'letters_pdf_tasks.create_letters_pdf'),
     (False, None, 'sms', 'test', None, 'research-mode-tasks', 'deliver_sms'),
-    (False, None, 'sms', 'normal', '+14383898585', 'send-sms-tasks', 'deliver_throttled_sms'),
+    (False, None, 'sms', 'normal', '+14383898585', 'send-throttled-sms-tasks', 'deliver_throttled_sms'),
     (True, 'notify-internal-tasks', 'email', 'normal', None, 'research-mode-tasks', 'deliver_email'),
     (False, 'notify-internal-tasks', 'sms', 'normal', None, 'notify-internal-tasks', 'deliver_sms'),
     (False, 'notify-internal-tasks', 'email', 'normal', None, 'notify-internal-tasks', 'deliver_email'),

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -244,22 +244,22 @@ def test_persist_notification_increments_cache_if_key_exists(sample_template, sa
 @pytest.mark.parametrize((
     'research_mode, requested_queue, notification_type, key_type, reply_to_text, expected_queue, expected_task'
 ), [
-    (True, None, 'sms', 'normal', None, 'research-mode-tasks', 'provider_tasks.deliver_sms'),
-    (True, None, 'email', 'normal', None, 'research-mode-tasks', 'provider_tasks.deliver_email'),
-    (True, None, 'email', 'team', None, 'research-mode-tasks', 'provider_tasks.deliver_email'),
+    (True, None, 'sms', 'normal', None, 'research-mode-tasks', 'deliver_sms'),
+    (True, None, 'email', 'normal', None, 'research-mode-tasks', 'deliver_email'),
+    (True, None, 'email', 'team', None, 'research-mode-tasks', 'deliver_email'),
     (True, None, 'letter', 'normal', None, 'research-mode-tasks', 'letters_pdf_tasks.create_letters_pdf'),
-    (True, None, 'sms', 'normal', '+14383898585', 'research-mode-tasks', 'provider_tasks.deliver_throttled_sms'),
-    (False, None, 'sms', 'normal', None, 'send-sms-tasks', 'provider_tasks.deliver_sms'),
-    (False, None, 'email', 'normal', None, 'send-email-tasks', 'provider_tasks.deliver_email'),
-    (False, None, 'sms', 'team', None, 'send-sms-tasks', 'provider_tasks.deliver_sms'),
+    (True, None, 'sms', 'normal', '+14383898585', 'research-mode-tasks', 'deliver_throttled_sms'),
+    (False, None, 'sms', 'normal', None, 'send-sms-tasks', 'deliver_sms'),
+    (False, None, 'email', 'normal', None, 'send-email-tasks', 'deliver_email'),
+    (False, None, 'sms', 'team', None, 'send-sms-tasks', 'deliver_sms'),
     (False, None, 'letter', 'normal', None, 'create-letters-pdf-tasks', 'letters_pdf_tasks.create_letters_pdf'),
-    (False, None, 'sms', 'test', None, 'research-mode-tasks', 'provider_tasks.deliver_sms'),
-    (False, None, 'sms', 'normal', '+14383898585', 'send-sms-tasks', 'provider_tasks.deliver_throttled_sms'),
-    (True, 'notify-internal-tasks', 'email', 'normal', None, 'research-mode-tasks', 'provider_tasks.deliver_email'),
-    (False, 'notify-internal-tasks', 'sms', 'normal', None, 'notify-internal-tasks', 'provider_tasks.deliver_sms'),
-    (False, 'notify-internal-tasks', 'email', 'normal', None, 'notify-internal-tasks', 'provider_tasks.deliver_email'),
-    (False, 'notify-internal-tasks', 'sms', 'test', None, 'research-mode-tasks', 'provider_tasks.deliver_sms'),
-    (False, 'notify-internal-tasks', 'sms', 'normal', '+14383898585', 'notify-internal-tasks', 'provider_tasks.deliver_throttled_sms'),
+    (False, None, 'sms', 'test', None, 'research-mode-tasks', 'deliver_sms'),
+    (False, None, 'sms', 'normal', '+14383898585', 'send-sms-tasks', 'deliver_throttled_sms'),
+    (True, 'notify-internal-tasks', 'email', 'normal', None, 'research-mode-tasks', 'deliver_email'),
+    (False, 'notify-internal-tasks', 'sms', 'normal', None, 'notify-internal-tasks', 'deliver_sms'),
+    (False, 'notify-internal-tasks', 'email', 'normal', None, 'notify-internal-tasks', 'deliver_email'),
+    (False, 'notify-internal-tasks', 'sms', 'test', None, 'research-mode-tasks', 'deliver_sms'),
+    (False, 'notify-internal-tasks', 'sms', 'normal', '+14383898585', 'notify-internal-tasks', 'deliver_throttled_sms'),
 ])
 def test_send_notification_to_queue(
     notify_db,
@@ -273,7 +273,9 @@ def test_send_notification_to_queue(
     expected_task,
     mocker,
 ):
-    mocked = mocker.patch('app.celery.{}.apply_async'.format(expected_task))
+    if '.' not in expected_task:
+        expected_task = f'provider_tasks.{expected_task}'
+    mocked = mocker.patch(f'app.celery.{expected_task}.apply_async')
     Notification = namedtuple(
         'Notification',
         ['id', 'key_type', 'notification_type', 'reply_to_text', 'created_at']

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -242,21 +242,24 @@ def test_persist_notification_increments_cache_if_key_exists(sample_template, sa
 
 
 @pytest.mark.parametrize((
-    'research_mode, requested_queue, notification_type, key_type, expected_queue, expected_task'
+    'research_mode, requested_queue, notification_type, key_type, reply_to_text, expected_queue, expected_task'
 ), [
-    (True, None, 'sms', 'normal', 'research-mode-tasks', 'provider_tasks.deliver_sms'),
-    (True, None, 'email', 'normal', 'research-mode-tasks', 'provider_tasks.deliver_email'),
-    (True, None, 'email', 'team', 'research-mode-tasks', 'provider_tasks.deliver_email'),
-    (True, None, 'letter', 'normal', 'research-mode-tasks', 'letters_pdf_tasks.create_letters_pdf'),
-    (False, None, 'sms', 'normal', 'send-sms-tasks', 'provider_tasks.deliver_sms'),
-    (False, None, 'email', 'normal', 'send-email-tasks', 'provider_tasks.deliver_email'),
-    (False, None, 'sms', 'team', 'send-sms-tasks', 'provider_tasks.deliver_sms'),
-    (False, None, 'letter', 'normal', 'create-letters-pdf-tasks', 'letters_pdf_tasks.create_letters_pdf'),
-    (False, None, 'sms', 'test', 'research-mode-tasks', 'provider_tasks.deliver_sms'),
-    (True, 'notify-internal-tasks', 'email', 'normal', 'research-mode-tasks', 'provider_tasks.deliver_email'),
-    (False, 'notify-internal-tasks', 'sms', 'normal', 'notify-internal-tasks', 'provider_tasks.deliver_sms'),
-    (False, 'notify-internal-tasks', 'email', 'normal', 'notify-internal-tasks', 'provider_tasks.deliver_email'),
-    (False, 'notify-internal-tasks', 'sms', 'test', 'research-mode-tasks', 'provider_tasks.deliver_sms'),
+    (True, None, 'sms', 'normal', None, 'research-mode-tasks', 'provider_tasks.deliver_sms'),
+    (True, None, 'email', 'normal', None, 'research-mode-tasks', 'provider_tasks.deliver_email'),
+    (True, None, 'email', 'team', None, 'research-mode-tasks', 'provider_tasks.deliver_email'),
+    (True, None, 'letter', 'normal', None, 'research-mode-tasks', 'letters_pdf_tasks.create_letters_pdf'),
+    (True, None, 'sms', 'normal', '+14383898585', 'research-mode-tasks', 'provider_tasks.deliver_throttled_sms'),
+    (False, None, 'sms', 'normal', None, 'send-sms-tasks', 'provider_tasks.deliver_sms'),
+    (False, None, 'email', 'normal', None, 'send-email-tasks', 'provider_tasks.deliver_email'),
+    (False, None, 'sms', 'team', None, 'send-sms-tasks', 'provider_tasks.deliver_sms'),
+    (False, None, 'letter', 'normal', None, 'create-letters-pdf-tasks', 'letters_pdf_tasks.create_letters_pdf'),
+    (False, None, 'sms', 'test', None, 'research-mode-tasks', 'provider_tasks.deliver_sms'),
+    (False, None, 'sms', 'normal', '+14383898585', 'send-sms-tasks', 'provider_tasks.deliver_throttled_sms'),
+    (True, 'notify-internal-tasks', 'email', 'normal', None, 'research-mode-tasks', 'provider_tasks.deliver_email'),
+    (False, 'notify-internal-tasks', 'sms', 'normal', None, 'notify-internal-tasks', 'provider_tasks.deliver_sms'),
+    (False, 'notify-internal-tasks', 'email', 'normal', None, 'notify-internal-tasks', 'provider_tasks.deliver_email'),
+    (False, 'notify-internal-tasks', 'sms', 'test', None, 'research-mode-tasks', 'provider_tasks.deliver_sms'),
+    (False, 'notify-internal-tasks', 'sms', 'normal', '+14383898585', 'notify-internal-tasks', 'provider_tasks.deliver_throttled_sms'),
 ])
 def test_send_notification_to_queue(
     notify_db,
@@ -265,17 +268,22 @@ def test_send_notification_to_queue(
     requested_queue,
     notification_type,
     key_type,
+    reply_to_text,
     expected_queue,
     expected_task,
     mocker,
 ):
     mocked = mocker.patch('app.celery.{}.apply_async'.format(expected_task))
-    Notification = namedtuple('Notification', ['id', 'key_type', 'notification_type', 'created_at'])
+    Notification = namedtuple(
+        'Notification',
+        ['id', 'key_type', 'notification_type', 'reply_to_text', 'created_at']
+    )
     notification = Notification(
         id=uuid.uuid4(),
         key_type=key_type,
         notification_type=notification_type,
         created_at=datetime.datetime(2016, 11, 11, 16, 8, 18),
+        reply_to_text=reply_to_text,
     )
 
     send_notification_to_queue(notification=notification, research_mode=research_mode, queue=requested_queue)

--- a/tests/app/test_config.py
+++ b/tests/app/test_config.py
@@ -58,12 +58,13 @@ def test_load_config_if_cloudfoundry_not_available(monkeypatch, reload_config):
 def test_queue_names_all_queues_correct():
     # Need to ensure that all_queues() only returns queue names used in API
     queues = QueueNames.all_queues()
-    assert len(queues) == 11
+    assert len(queues) == 12
     assert set([
         QueueNames.PRIORITY,
         QueueNames.PERIODIC,
         QueueNames.DATABASE,
         QueueNames.SEND_SMS,
+        QueueNames.SEND_THROTTLED_SMS,
         QueueNames.SEND_EMAIL,
         QueueNames.RESEARCH_MODE,
         QueueNames.REPORTING,

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -122,7 +122,7 @@ def test_post_sms_notification_uses_inbound_number_reply_to_as_sender(client, no
     assert resp_json['id'] == str(notification_id)
     assert resp_json['content']['from_number'] == '+16502532222'
     assert notifications[0].reply_to_text == '+16502532222'
-    mocked.assert_called_once_with([str(notification_id)], queue='send-sms-tasks')
+    mocked.assert_called_once_with([str(notification_id)], queue='send-throttled-sms-tasks')
 
 
 def test_post_sms_notification_returns_201_with_sms_sender_id(
@@ -176,7 +176,7 @@ def test_post_sms_notification_uses_sms_sender_id_reply_to(
     notifications = Notification.query.all()
     assert len(notifications) == 1
     assert notifications[0].reply_to_text == '+16502532222'
-    mocked.assert_called_once_with([resp_json['id']], queue='send-sms-tasks')
+    mocked.assert_called_once_with([resp_json['id']], queue='send-throttled-sms-tasks')
 
 
 def test_notification_reply_to_text_is_original_value_if_sender_is_changed_after_post_notification(

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -101,7 +101,7 @@ def test_post_sms_notification_uses_inbound_number_reply_to_as_sender(client, no
     service = create_service_with_inbound_number(inbound_number='6502532222')
 
     template = create_template(service=service, content="Hello (( Name))\nYour thing is due soon")
-    mocked = mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
+    mocked = mocker.patch('app.celery.provider_tasks.deliver_throttled_sms.apply_async')
     data = {
         'phone_number': '+16502532222',
         'template_id': str(template.id),
@@ -156,7 +156,7 @@ def test_post_sms_notification_uses_sms_sender_id_reply_to(
         client, sample_template_with_placeholders, mocker
 ):
     sms_sender = create_service_sms_sender(service=sample_template_with_placeholders.service, sms_sender='6502532222')
-    mocked = mocker.patch('app.celery.provider_tasks.deliver_sms.apply_async')
+    mocked = mocker.patch('app.celery.provider_tasks.deliver_throttled_sms.apply_async')
     data = {
         'phone_number': '+16502532222',
         'template_id': str(sample_template_with_placeholders.id),


### PR DESCRIPTION
Added a new SMS task, SMS will now be:
- unthrottled and handled by Celery workers if they are not sent using a specific phone number
- throttled system-wide at 1 SMS/s by a single SMS Celery worker if they are sent using a dedicated long code phone number

This introduces a new Celery task and a new queue but doesn't require Kubernetes changes.

The code changes aren't too bad but I really want to test this extensively in staging as it is critical.