### PR TITLE
feat: increment statsd counter when services reach daily limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,15 @@ source  ~/.pyenv/versions/3.6.9/bin/virtualenvwrapper.sh
 
 `createdb --user=postgres notification_api`
 
-11. Decrypt our existing set of environment variables
+11. Install the required environment variables via our LastPast Vault
 
-`gcloud kms decrypt --project=[PROJECT_NAME] --plaintext-file=.env --ciphertext-file=.env.enc --location=global --keyring=[KEY_RING] --key=[KEY_NAME]`
+Within the team's *LastPass Vault*, you should find corresponding folders for this
+project containing the `.env` content that you should copy in your root folder. This
+will grant the application necessary access to our internal infrastructure. 
 
-A sane set of defaults exists in `.env.example`
+If you don't have access to our *LastPass Vault* (as you evaluate our notification
+platform for example), you will find a sane set of defaults exists in the `.env.example`
+file. Copy that file to `.env` and customize it to your needs.
 
 12. Install all dependencies
 

--- a/README.md
+++ b/README.md
@@ -188,3 +188,4 @@ __Solution__: Do not specify a database in your `.env`
 __Problem__: Messages are in the queue but not sending
 
 __Solution__: Check that `celery` is running. 
+

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -34,7 +34,7 @@ def check_service_over_api_rate_limit(service, api_key):
             raise RateLimitError(rate_limit, interval, api_key.key_type)
 
 
-@statsd_catch(namespace="validators", counter_name="rate.limit.daily", exception=TooManyRequestsError)
+@statsd_catch(namespace="validators", counter_name="rate_limit.service_daily", exception=TooManyRequestsError)
 def check_service_over_daily_message_limit(key_type, service):
     if key_type != KEY_TYPE_TEST and current_app.config['REDIS_ENABLED']:
         cache_key = daily_limit_cache_key(service.id)

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -7,6 +7,7 @@ from notifications_utils.recipients import (
     get_international_phone_info
 )
 from notifications_utils.clients.redis import rate_limit_cache_key, daily_limit_cache_key
+from notifications_utils.statsd_decorators import statsd_catch
 
 from app.dao import services_dao, templates_dao
 from app.dao.service_sms_sender_dao import dao_get_service_sms_senders_by_id
@@ -33,6 +34,7 @@ def check_service_over_api_rate_limit(service, api_key):
             raise RateLimitError(rate_limit, interval, api_key.key_type)
 
 
+@statsd_catch(namespace="validators", counter_name="rate.limit.daily", exception=TooManyRequestsError)
 def check_service_over_daily_message_limit(key_type, service):
     if key_type != KEY_TYPE_TEST and current_app.config['REDIS_ENABLED']:
         cache_key = daily_limit_cache_key(service.id)

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -14,6 +14,7 @@ click-datetime==0.2
 eventlet==0.28.0
 gunicorn==20.0.4  # pyup: ignore, >19.8 breaks eventlet patching
 iso8601==0.1.13
+idna==2.8 # pinned to align with test moto dependency requirements
 jsonschema==3.2.0
 marshmallow-sqlalchemy==0.23.1
 marshmallow==2.21.0
@@ -53,6 +54,3 @@ pycryptodome
 git+https://bitbucket.org/cse-assemblyline/assemblyline_client.git@v3.7.3#egg=assemblyline_client==v3.7.3
 
 rsa>=4.1 # not directly required, pinned by Snyk to avoid a vulnerability
-
-# Pinned down for moto 1.3.14 test dependency
-idna==2.8

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -53,3 +53,6 @@ pycryptodome
 git+https://bitbucket.org/cse-assemblyline/assemblyline_client.git@v3.7.3#egg=assemblyline_client==v3.7.3
 
 rsa>=4.1 # not directly required, pinned by Snyk to avoid a vulnerability
+
+# Pinned down for moto 1.3.14 test dependency
+idna==2.8

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -42,7 +42,7 @@ awscli-cwlogs>=1.4.6,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@43.2.2#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@43.3.0#egg=notifications-utils
 
 # MLWR
 socketio-client==0.5.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,8 +44,7 @@ awscli-cwlogs>=1.4.6,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-#git+https://github.com/cds-snc/notifier-utils.git@43.3.0#egg=notifications-utils
-file:///Users/jimmyroyer/Projects/notification-utils#egg=notifications-utils==43.0.0
+git+https://github.com/cds-snc/notifier-utils.git@43.3.0#egg=notifications-utils
 
 # MLWR
 socketio-client==0.5.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -74,7 +74,7 @@ certifi==2020.12.5
 chardet==3.0.4
 click==7.1.2
 colorama==0.4.3
-cryptography==3.3
+cryptography==3.3.1
 dnspython==1.16.0
 docutils==0.15.2
 flask-redis==0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ click-datetime==0.2
 eventlet==0.28.0
 gunicorn==20.0.4  # pyup: ignore, >19.8 breaks eventlet patching
 iso8601==0.1.13
+idna==2.8 # pinned to align with test moto dependency requirements
 jsonschema==3.2.0
 marshmallow-sqlalchemy==0.23.1
 marshmallow==2.21.0
@@ -56,8 +57,6 @@ git+https://bitbucket.org/cse-assemblyline/assemblyline_client.git@v3.7.3#egg=as
 
 rsa>=4.1 # not directly required, pinned by Snyk to avoid a vulnerability
 
-# Pinned down for moto 1.3.14 test dependency
-idna==2.8
 ## The following requirements were added by pip freeze:
 alembic==1.4.3
 amqp==1.4.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,6 +56,8 @@ git+https://bitbucket.org/cse-assemblyline/assemblyline_client.git@v3.7.3#egg=as
 
 rsa>=4.1 # not directly required, pinned by Snyk to avoid a vulnerability
 
+# Pinned down for moto 1.3.14 test dependency
+idna==2.8
 ## The following requirements were added by pip freeze:
 alembic==1.4.3
 amqp==1.4.9
@@ -80,7 +82,6 @@ docutils==0.15.2
 flask-redis==0.4.0
 future==0.18.2
 greenlet==0.4.17
-idna==2.10
 importlib-metadata==3.1.1
 Jinja2==2.11.2
 jmespath==0.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,8 @@ awscli-cwlogs>=1.4.6,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@43.2.2#egg=notifications-utils
+#git+https://github.com/cds-snc/notifier-utils.git@43.3.0#egg=notifications-utils
+file:///Users/jimmyroyer/Projects/notification-utils#egg=notifications-utils==43.0.0
 
 # MLWR
 socketio-client==0.5.6
@@ -70,17 +71,17 @@ boto==2.49.0
 boto3==1.16.28
 botocore==1.19.28
 cachetools==4.1.1
-certifi==2020.11.8
+certifi==2020.12.5
 chardet==3.0.4
 click==7.1.2
 colorama==0.4.3
-cryptography==3.2.1
+cryptography==3.3
 dnspython==1.16.0
 docutils==0.15.2
 flask-redis==0.4.0
 future==0.18.2
 greenlet==0.4.17
-idna==2.8
+idna==2.10
 importlib-metadata==3.1.1
 Jinja2==2.11.2
 jmespath==0.10.0

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -5,7 +5,6 @@ from datetime import datetime, timedelta
 import pytest
 import pytz
 import requests_mock
-from unittest.mock import Mock
 
 from flask import current_app, url_for
 from sqlalchemy import asc
@@ -1222,13 +1221,13 @@ def admin_request(client):
 
 
 @pytest.fixture(scope='function')
-def app_statsd():
+def app_statsd(mocker):
     current_app.config['NOTIFY_ENVIRONMENT'] = "test"
     current_app.config['NOTIFY_APP_NAME'] = "api"
     current_app.config['STATSD_HOST'] = "localhost"
     current_app.config['STATSD_PORT'] = "8000"
     current_app.config['STATSD_PREFIX'] = "prefix"
-    current_app.statsd_client = Mock()
+    current_app.statsd_client = mocker.Mock()
     return current_app
 
 

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -5,6 +5,8 @@ from datetime import datetime, timedelta
 import pytest
 import pytz
 import requests_mock
+from unittest.mock import Mock
+
 from flask import current_app, url_for
 from sqlalchemy import asc
 from sqlalchemy.orm.session import make_transient
@@ -1217,6 +1219,17 @@ def admin_request(client):
             return json_resp
 
     return AdminRequest
+
+
+@pytest.fixture(scope='function')
+def app_statsd():
+    current_app.config['NOTIFY_ENVIRONMENT'] = "test"
+    current_app.config['NOTIFY_APP_NAME'] = "api"
+    current_app.config['STATSD_HOST'] = "localhost"
+    current_app.config['STATSD_PORT'] = "8000"
+    current_app.config['STATSD_PREFIX'] = "prefix"
+    current_app.statsd_client = Mock()
+    return current_app
 
 
 def datetime_in_past(days=0, seconds=0):

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -156,7 +156,7 @@ def test_check_service_message_limit_sends_statsd_over_message_limit_fails(
         check_service_over_daily_message_limit("normal", service)
 
     # Then
-    app_statsd.statsd_client.incr.assert_called_once_with("validators.rate.limit.daily")
+    app_statsd.statsd_client.incr.assert_called_once_with("validators.rate_limit.service_daily")
 
 
 def test_check_service_message_limit_skip_statsd_over_message_no_limit_fails(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,6 @@ def client(notify_api):
 
 
 def create_test_db(database_uri):
-    # get the
     db_uri_parts = database_uri.split('/')
     postgres_db_uri = '/'.join(db_uri_parts[:-1] + ['postgres'])
 


### PR DESCRIPTION
## Before

Review this PR in notification-utils as this PR relies on it:
https://github.com/cds-snc/notification-utils/pull/72

## Issue

https://trello.com/c/62gscLJH/169-graph-the-services-going-over-the-daily-rate-limit

## Changes

Added a statsd metric when daily rate usage of services have been reached.

## Testing 

* Added two tests covering the two scenarios of when the service rate is within and outside the limit.