### PR TITLE
Increase keepalive between Gunicorn and LB

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -10,6 +10,14 @@ worker_connections = 256
 bind = "0.0.0.0:{}".format(os.getenv("PORT"))
 accesslog = '-'
 
+# See AWS doc
+# > We also recommend that you configure the idle timeout of your application
+# to be larger than the idle timeout configured for the load balancer.
+# > By default, Elastic Load Balancing sets the idle timeout value for your load balancer to 60 seconds.
+# https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#connection-idle-timeout
+if os.environ.get("NOTIFY_ENVIRONMENT", "") == "production":
+    keepalive = 75
+
 
 def on_starting(server):
     server.log.info("Starting Notifications API")

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -15,7 +15,9 @@ accesslog = '-'
 # to be larger than the idle timeout configured for the load balancer.
 # > By default, Elastic Load Balancing sets the idle timeout value for your load balancer to 60 seconds.
 # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#connection-idle-timeout
-if os.environ.get("NOTIFY_ENVIRONMENT", "") == "production":
+in_production = os.environ.get("NOTIFY_ENVIRONMENT", "") == "production"
+feature_increased_keepalive = os.environ.get("FEATURE_INCREASED_KEEPALIVE", "") == "true"
+if in_production and feature_increased_keepalive:
     keepalive = 75
 
 


### PR DESCRIPTION
In production only, in order to stop the 502 alarms we're seeing.

Long Slack thread explaining the rationale https://gcdigital.slack.com/archives/CNWA63606/p1607417483005100

Same as https://github.com/cds-snc/notification-admin/pull/852