### PR TITLE
Adjust Celery rate limit for deliver_sms

### DIFF
--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -14,9 +14,10 @@ from app.models import NOTIFICATION_TECHNICAL_FAILURE
 
 # Celery rate limits are per worker instance and not a global rate limit.
 # https://docs.celeryproject.org/en/stable/userguide/tasks.html#Task.rate_limit
-# This task is dispatched through the `send-throttled-sms-tasks`
-# queue. This queue is consumed by 1 Celery instance
-# with 1 worker, the SMS Celery pod.
+# This task is dispatched through the `send-throttled-sms-tasks` queue.
+# This queue is consumed by 1 Celery instance with 1 worker, the SMS Celery pod.
+# The maximum throughput is therefore 1 instance * 1 worker = 1 task per second
+# if we set rate_limit="1/s" on the Celery task
 @notify_celery.task(
     bind=True,
     name="deliver_throttled_sms",
@@ -31,11 +32,10 @@ def deliver_throttled_sms(self, notification_id):
 
 # Celery rate limits are per worker instance and not a global rate limit.
 # https://docs.celeryproject.org/en/stable/userguide/tasks.html#Task.rate_limit
-# This task is dispatched through the `send-sms-tasks`
-# queue. This queue is consumed by 6 Celery instances
-# with 4 workers in production.
-# The maximum throughput is therefore 6*4 = 24 tasks per second
-# with a rate limit of 1/s
+# This task is dispatched through the `send-sms-tasks` queue.
+# This queue is consumed by 6 Celery instances with 4 workers in production.
+# The maximum throughput is therefore 6 instances * 4 workers = 24 tasks per second
+# if we set rate_limit="1/s" on the Celery task
 @notify_celery.task(
     bind=True,
     name="deliver_sms",


### PR DESCRIPTION
The SNS rate limit is set at 20 messages per second but we asked AWS for a limit increase.

As we run 6 Celery instances with 4 workers, we need to set a rate limit at the task level if
we want to avoid hitting rate limits per second on AWS, even with increased limits.

Follow up of https://github.com/cds-snc/notification-api/pull/1185
Slack thread for more details https://gcdigital.slack.com/archives/CNWA63606/p1607979769008500