### PR TITLE
Temporary rate limit Celery process-ses-result task

### DIFF
--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -24,7 +24,18 @@ from app.notifications.notifications_ses_callback import (
 )
 
 
-@notify_celery.task(bind=True, name="process-ses-result", max_retries=5, default_retry_delay=300)
+# Celery rate limits are per worker instance and not a global rate limit.
+# https://docs.celeryproject.org/en/stable/userguide/tasks.html#Task.rate_limit
+# This queue is consumed by 6 Celery instances with 4 workers in production.
+# The maximum throughput is therefore 6 instances * 4 workers * 30 tasks = 720 tasks / minute
+# if we set rate_limit="30/m" on the Celery task
+@notify_celery.task(
+    bind=True,
+    name="process-ses-result",
+    max_retries=5,
+    default_retry_delay=300,
+    rate_limit="30/m",
+)
 @statsd(namespace="tasks")
 def process_ses_results(self, response):
     try:


### PR DESCRIPTION
Put a temporary rate limit on the process-ses-result Celery task, in charge of dealing with delivery receipts from SES.

We saw that with the current production settings we can execute 10k/5 minutes of deliver_email and process-ses-result in parallel. If we reduce the rate of process-ses-result from 10k/5 minutes = 33.33 tasks/s to 12 tasks/s, we would have more ressources to deliver emails faster. The tradeoff is that delivery receipts will be delayed.

This is a temporary measure before putting horizontal scaling/database improvements in place in January 2021.