### PR TITLE
Remove rate limit for process-ses-result

### DIFF
--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -34,7 +34,6 @@ from app.notifications.notifications_ses_callback import (
     name="process-ses-result",
     max_retries=5,
     default_retry_delay=300,
-    rate_limit="30/m",
 )
 @statsd(namespace="tasks")
 def process_ses_results(self, response):


### PR DESCRIPTION
Remove rate limit introduced today for the process-ses-result task