### PR TITLE
Update simulated email addresses

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -323,9 +323,9 @@ class Config(object):
     SENDING_NOTIFICATIONS_TIMEOUT_PERIOD = 259200  # 3 days
 
     SIMULATED_EMAIL_ADDRESSES = (
-        'simulate-delivered@notifications.service.gov.uk',
-        'simulate-delivered-2@notifications.service.gov.uk',
-        'simulate-delivered-3@notifications.service.gov.uk',
+        'simulate-delivered@notification.canada.ca',
+        'simulate-delivered-2@notification.canada.ca',
+        'simulate-delivered-3@notification.canada.ca',
     )
 
     SIMULATED_SMS_NUMBERS = ('+16132532222', '+16132532223', '+16132532224')

--- a/tests/app/notifications/rest/test_send_notification.py
+++ b/tests/app/notifications/rest/test_send_notification.py
@@ -791,9 +791,9 @@ def test_should_delete_notification_and_return_error_if_sqs_fails(
 
 
 @pytest.mark.parametrize('to_email', [
-    'simulate-delivered@notifications.service.gov.uk',
-    'simulate-delivered-2@notifications.service.gov.uk',
-    'simulate-delivered-3@notifications.service.gov.uk'
+    'simulate-delivered@notification.canada.ca',
+    'simulate-delivered-2@notification.canada.ca',
+    'simulate-delivered-3@notification.canada.ca'
 ])
 def test_should_not_persist_notification_or_send_email_if_simulated_email(
         client,

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -307,9 +307,9 @@ def test_send_notification_to_queue_throws_exception_deletes_notification(sample
     ("+16132532222", "sms", True),
     ("+16132532223", "sms", True),
     ("6132532222", "sms", True),
-    ("simulate-delivered@notifications.service.gov.uk", "email", True),
-    ("simulate-delivered-2@notifications.service.gov.uk", "email", True),
-    ("simulate-delivered-3@notifications.service.gov.uk", "email", True),
+    ("simulate-delivered@notification.canada.ca", "email", True),
+    ("simulate-delivered-2@notification.canada.ca", "email", True),
+    ("simulate-delivered-3@notification.canada.ca", "email", True),
     ("6132532225", "sms", False),
     ("valid_email@test.com", "email", False)
 ])
@@ -318,9 +318,9 @@ def test_simulated_recipient(notify_api, to_address, notification_type, expected
     The values where the expected = 'research-mode' are listed in the config['SIMULATED_EMAIL_ADDRESSES']
     and config['SIMULATED_SMS_NUMBERS']. These values should result in using the research mode queue.
     SIMULATED_EMAIL_ADDRESSES = (
-        'simulate-delivered@notifications.service.gov.uk',
-        'simulate-delivered-2@notifications.service.gov.uk',
-        'simulate-delivered-2@notifications.service.gov.uk'
+        'simulate-delivered@notification.canada.ca',
+        'simulate-delivered-2@notification.canada.ca',
+        'simulate-delivered-2@notification.canada.ca'
     )
     SIMULATED_SMS_NUMBERS = ('6132532222', '+16132532222', '+16132532223')
     """

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -328,9 +328,9 @@ def test_post_email_notification_returns_201(client, sample_email_template_with_
 
 
 @pytest.mark.parametrize('recipient, notification_type', [
-    ('simulate-delivered@notifications.service.gov.uk', EMAIL_TYPE),
-    ('simulate-delivered-2@notifications.service.gov.uk', EMAIL_TYPE),
-    ('simulate-delivered-3@notifications.service.gov.uk', EMAIL_TYPE),
+    ('simulate-delivered@notification.canada.ca', EMAIL_TYPE),
+    ('simulate-delivered-2@notification.canada.ca', EMAIL_TYPE),
+    ('simulate-delivered-3@notification.canada.ca', EMAIL_TYPE),
     ('6132532222', 'sms'),
     ('6132532223', 'sms'),
     ('6132532224', 'sms')
@@ -819,7 +819,7 @@ def test_post_notification_with_document_upload_simulated(client, notify_db_sess
     document_download_mock.get_upload_url.return_value = 'https://document-url'
 
     data = {
-        "email_address": 'simulate-delivered@notifications.service.gov.uk',
+        "email_address": 'simulate-delivered@notification.canada.ca',
         "template_id": template.id,
         "personalisation": {"document": {"file": "abababab"}}
     }


### PR DESCRIPTION
Use a canada.ca domain and not a gov.uk one. Aligns with [the documentation](https://github.com/cds-snc/notification-documentation/commit/7509df47cf00c161b2c2af037b27b91f82ce17f4).

We don't know anyone using these fake email addresses to perform tests at the moment (we never communicated these were available) so the change should not be a problem.