### PR TITLE
Upgrade Python 3.9.1 plus celery 5x

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.9
 
 ARG USERNAME=vscode
 ARG USER_UID=1000

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"name": "Python 3.6 & PostgreSQL",
+	"name": "Python 3.9 & PostgreSQL",
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "dev",
 	"workspaceFolder": "/workspace",

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image:  python:3.6-stretch
+      image:  python:3.9-alpine
     services:
       postgres:
         image: postgres:10.8

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ jobs:
       image:  python:3.9-buster
     services:
       postgres:
-        image: postgres:10.8
+        image: postgres:11.8
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -17,13 +17,20 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-    - uses: actions/checkout@v1     
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Upgrade pip
+      run: python -m pip install --upgrade pip
     - uses: actions/cache@v2
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('requirements_for_test.txt') }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
-    - run: /bin/bash -c "pip3 install -r requirements_for_test.txt --no-cache-dir && make test"
+    - name: Run tests
+      run: /bin/bash -c "pip install -r requirements_for_test.txt && make test"
       env:
-        SQLALCHEMY_DATABASE_URI: postgresql://postgres:postgres@postgres:5432/test_notification_api
+        SQLALCHEMY_DATABASE_URI: postgresql://postgres:postgres@localhost:5432/test_notification_api

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image:  python:3.9-alpine
+      image:  python:3.9-buster
     services:
       postgres:
         image: postgres:10.8

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,6 +18,8 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
+    - uses: Install libcurl
+      run: apt-get install libssl-dev libcurl4-openssl-dev
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-    - uses: Install libcurl
+    - name: Install libcurl
       run: apt-get install libssl-dev libcurl4-openssl-dev
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,9 +3,6 @@ name: Continuous Integration Testing
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [ 3.9 ]
     services:
       postgres:
         image: postgres:11.8
@@ -21,10 +18,10 @@ jobs:
     - name: Install libcurl
       run: sudo apt-get install libssl-dev libcurl4-openssl-dev
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.9
     - name: Upgrade pip
       run: python -m pip install --upgrade pip
     - uses: actions/cache@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,8 +3,9 @@ name: Continuous Integration Testing
 jobs:
   test:
     runs-on: ubuntu-latest
-    container:
-      image:  python:3.9-buster
+    strategy:
+      matrix:
+        python-version: [ 3.9 ]
     services:
       postgres:
         image: postgres:11.8
@@ -18,10 +19,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.9
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: ${{ matrix.python-version }}
     - name: Upgrade pip
       run: python -m pip install --upgrade pip
     - uses: actions/cache@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Install libcurl
-      run: apt-get install libssl-dev libcurl4-openssl-dev
+      run: sudo apt-get install libssl-dev libcurl4-openssl-dev
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ test: generate-version-file ## Run tests
 .PHONY: freeze-requirements
 freeze-requirements:
 	rm -rf venv-freeze
-	virtualenv -p python3 venv-freeze
+	python -m venv venv-freeze
 	# Make sure we are using the latest pip prior to requirements installation.
 	$$(pwd)/venv-freeze/bin/python3 -m pip install --upgrade pip
 	$$(pwd)/venv-freeze/bin/pip install -r requirements-app.txt --no-cache-dir

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ test: generate-version-file ## Run tests
 .PHONY: freeze-requirements
 freeze-requirements:
 	rm -rf venv-freeze
-	python -m venv venv-freeze
+	virtualenv -p python3 venv-freeze
 	# Make sure we are using the latest pip prior to requirements installation.
 	$$(pwd)/venv-freeze/bin/python3 -m pip install --upgrade pip
 	$$(pwd)/venv-freeze/bin/pip install -r requirements-app.txt --no-cache-dir

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ scripts/run_celery_beat.sh
 
 ### Python version
 
-This codebase is Python 3 only. At the moment we run 3.9.1 in production. You will run into problems if you try to use Python 3.4 or older, or Python 3.7 or newer.
+This codebase is Python 3 only. At the moment we run 3.9.1 in production. You will run into problems if you try to use Python 3.4 or older.
 
 ## To update application dependencies
 
@@ -158,7 +158,7 @@ createuser -l -s postgres
 
 __Problem__ : `E999 SyntaxError: invalid syntax` when running `flake8`
 
-__Solution__ : Check that you are in your correct virtualenv, with python 3.5 or 3.9
+__Solution__ : Check that you are in your correct virtualenv, with python 3.9
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ On OS X:
 
 `brew install pyenv`
 
-2. Install Python 3.6.9 or whatever is the latest
+2. Install Python 3.9.1 or whatever is the latest
 
-`pyenv install 3.6.9`
+`pyenv install 3.9.1`
 
-3. If you expect no conflicts, set `3.6.9` as you default
+3. If you expect no conflicts, set `3.9.1` as you default
 
-`pyenv global 3.6.9`
+`pyenv global 3.9.1`
 
 4. Ensure it installed by running
 
@@ -46,12 +46,12 @@ if it did not, take a look here: https://github.com/pyenv/pyenv/issues/660
 6. Add the following to your shell rc file. ex: `.bashrc` or `.zshrc`
 
 ```
-source  ~/.pyenv/versions/3.6.9/bin/virtualenvwrapper.sh
+source  ~/.pyenv/versions/3.9.1/bin/virtualenvwrapper.sh
 ```
 
 7. Restart your terminal and make your virtual environtment:
 
-`mkvirtualenv -p ~/.pyenv/versions/3.6.9/bin/python notifications-api`
+`mkvirtualenv -p ~/.pyenv/versions/3.9.1/bin/python notifications-api`
 
 8. You can now return to your environment any time by entering
 
@@ -112,7 +112,7 @@ scripts/run_celery_beat.sh
 
 ### Python version
 
-This codebase is Python 3 only. At the moment we run 3.6.9 in production. You will run into problems if you try to use Python 3.4 or older, or Python 3.7 or newer.
+This codebase is Python 3 only. At the moment we run 3.9.1 in production. You will run into problems if you try to use Python 3.4 or older, or Python 3.7 or newer.
 
 ## To update application dependencies
 
@@ -158,7 +158,7 @@ createuser -l -s postgres
 
 __Problem__ : `E999 SyntaxError: invalid syntax` when running `flake8`
 
-__Solution__ : Check that you are in your correct virtualenv, with python 3.5 or 3.6
+__Solution__ : Check that you are in your correct virtualenv, with python 3.5 or 3.9
 
 ---
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,8 +1,8 @@
-FROM python:3.6-alpine
+FROM python:3.9-alpine
 
 ENV PYTHONDONTWRITEBYTECODE 1
 
-RUN apk add --no-cache bash build-base git gcc musl-dev postgresql-dev g++ make libffi-dev libmagic && rm -rf /var/cache/apk/*
+RUN apk add --no-cache bash build-base git gcc musl-dev postgresql-dev g++ make libffi-dev libmagic libcurl curl-dev && rm -rf /var/cache/apk/*
 
 # update pip
 RUN python -m pip install wheel

--- a/ci/Dockerfile.test
+++ b/ci/Dockerfile.test
@@ -1,10 +1,10 @@
 # Heavily inspired from Dockerfile, this one also install requirements_for_test.txt
 
-FROM python:3.6-alpine
+FROM python:3.9-alpine
 
 ENV PYTHONDONTWRITEBYTECODE 1
 
-RUN apk add --no-cache bash build-base git gcc musl-dev postgresql-dev g++ make libffi-dev libmagic && rm -rf /var/cache/apk/*
+RUN apk add --no-cache bash build-base git gcc musl-dev postgresql-dev g++ make libffi-dev libmagic libcurl curl-dev && rm -rf /var/cache/apk/*
 
 # update pip
 RUN python -m pip install wheel

--- a/local/Dockerfile
+++ b/local/Dockerfile
@@ -1,8 +1,8 @@
-FROM python:3.6-alpine
+FROM python:3.9-alpine
 
 ENV PYTHONDONTWRITEBYTECODE 1
 
-RUN apk add --no-cache bash build-base git gcc musl-dev postgresql-dev g++ make libffi-dev libmagic && rm -rf /var/cache/apk/*
+RUN apk add --no-cache bash build-base git gcc musl-dev postgresql-dev g++ make libffi-dev libmagic libcurl curl-dev && rm -rf /var/cache/apk/*
 
 # update pip
 RUN python -m pip install wheel

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -2,7 +2,7 @@
 # with package version changes made in requirements-app.txt
 
 cffi==1.14.3
-celery[sqs]==3.1.26.post2 # pyup: <4
+celery[sqs]==5.0.5
 docopt==0.6.2
 fido2==0.8.1
 Flask-Bcrypt==0.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 # with package version changes made in requirements-app.txt
 
 cffi==1.14.3
-celery[sqs]==3.1.26.post2 # pyup: <4
+celery[sqs]==5.0.5
 docopt==0.6.2
 fido2==0.8.1
 Flask-Bcrypt==0.7.1
@@ -59,12 +59,12 @@ rsa>=4.1 # not directly required, pinned by Snyk to avoid a vulnerability
 
 ## The following requirements were added by pip freeze:
 alembic==1.4.3
-amqp==1.4.9
+amqp==5.0.3
 anyjson==0.3.3
 attrs==20.3.0
 awscli==1.18.188
 bcrypt==3.2.0
-billiard==3.3.0.23
+billiard==3.6.3.0
 bleach==3.2.1
 blinker==1.4
 boto==2.49.0
@@ -84,7 +84,7 @@ greenlet==0.4.17
 importlib-metadata==3.1.1
 Jinja2==2.11.2
 jmespath==0.10.0
-kombu==3.0.37
+kombu==5.0.2
 Mako==1.1.3
 MarkupSafe==1.1.1
 mistune==0.8.4

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.5.x
+python-3.9.1


### PR DESCRIPTION
Trello
https://trello.com/c/POlbTAih/238-prepare-the-upgrade-to-python-39

Upgrading app to python 3.9.1
This upgrade requires Kombu 5 which requires Celery 4+, we are opting to upgrade to celery 5x and some small dependency bumps.
Dockerfiles, CI and docs updated.

@AntoineAugusti suggesting to load test partly influenced from GDS decision to revert from Celery 4 to Celery 3: https://github.com/alphagov/notifications-api/pull/2142

Test plan:

Local:
* Tested API locally with ad-hoc and scheduled jobs OK
* Tested API locally with built Docker image with ad-hoc and scheduled jobs OK
* Local minor load testing OK

Staging:
* Gather baseline load testing data with various sustained loads (done, some data linked in Trello card)
* Other testing:  https://github.com/cds-snc/notification-api/pull/1192

Staging: (todo post merge)
* Test API with ad-hoc and scheduled jobs
* Perform load test and compare with baseline data for acceptability to continue to production or reversion.