### PR TITLE
feat: update contact page URL

### DIFF
--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -369,7 +369,7 @@ def send_user_confirm_new_email(user_id):
         personalisation={
             'name': user_to_send_to.name,
             'url': _create_confirmation_url(user=user_to_send_to, email_address=email['email']),
-            'feedback_url': current_app.config['ADMIN_BASE_URL'] + '/support/ask-question-give-feedback'
+            'feedback_url': f"{current_app.config['ADMIN_BASE_URL']}/contact",
         },
         notification_type=template.template_type,
         api_key_id=None,
@@ -421,9 +421,9 @@ def send_already_registered_email(user_id):
         recipient=to['email'],
         service=service,
         personalisation={
-            'signin_url': current_app.config['ADMIN_BASE_URL'] + '/sign-in',
-            'forgot_password_url': current_app.config['ADMIN_BASE_URL'] + '/forgot-password',
-            'feedback_url': current_app.config['ADMIN_BASE_URL'] + '/support/ask-question-give-feedback'
+            'signin_url': f"{current_app.config['ADMIN_BASE_URL']}/sign-in",
+            'forgot_password_url': f"{current_app.config['ADMIN_BASE_URL']}/forgot-password",
+            'feedback_url': f"{current_app.config['ADMIN_BASE_URL']}/contact",
         },
         notification_type=template.template_type,
         api_key_id=None,
@@ -777,7 +777,7 @@ def _update_alert(user_to_update, changes=None):
         service=service,
         personalisation={
             'base_url': Config.ADMIN_BASE_URL,
-            'contact_us_url': f'{Config.ADMIN_BASE_URL}/support/ask-question-give-feedback',
+            'contact_us_url': f'{Config.ADMIN_BASE_URL}/contact',
             'change_type_en': change_type_en,
             'change_type_fr': change_type_fr,
         },


### PR DESCRIPTION
The contact page is not available at the URL `/support/ask-question-give-feedback` anymore for several months.

There is a redirection in place so the current link is not broken, fortunately.
https://github.com/cds-snc/notification-admin/blob/0237926c01c58d72a927e85aba58bb5b80dd20e9/app/main/views/contact.py#L155-L157

This PR is a small clean up.

Note that we don't have a clean and reliable way to link to the admin from the API as these are 2 different codebases. Maybe we'll move some URLs to the utils repo at some point? Food for thoughts.