### PR TITLE
feat: use Celery lowercase settings

### DIFF
--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -46,4 +46,13 @@ class NotifyCelery(Celery):
             task_cls=make_task(app),
         )
 
-        self.conf.update(app.config)
+        # See https://docs.celeryproject.org/en/stable/userguide/configuration.html
+        self.conf.update({
+            'beat_schedule': app.config['CELERYBEAT_SCHEDULE'],
+            'imports': app.config['CELERY_IMPORTS'],
+            'task_serializer': app.config['CELERY_TASK_SERIALIZER'],
+            'timezone': app.config['CELERY_TIMEZONE'],
+            'broker_transport_options': app.config['BROKER_TRANSPORT_OPTIONS'],
+            'task_queues': app.config['CELERY_QUEUES'],
+            'accept_content': app.config['CELERY_ACCEPT_CONTENT'],
+        })


### PR DESCRIPTION
Follow up of https://github.com/cds-snc/notification-api/pull/1209

Changed Celery settings name because those are going to be deprecated in 6.0. Config values stay in `app/config.py` but keys are remapped when passed to the Celery app.

Followed the documentation at https://docs.celeryproject.org/en/stable/userguide/configuration.html#new-lowercase-settings and warning messages when running Celery locally.