### PR TITLE
feat: add queue for delivery receipts

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -36,6 +36,7 @@ class QueueNames(object):
     CALLBACKS = 'service-callbacks'
     LETTERS = 'letter-tasks'
     ANTIVIRUS = 'antivirus-tasks'
+    DELIVERY_RECEIPTS = 'delivery-receipts'
 
     @staticmethod
     def all_queues():
@@ -54,6 +55,7 @@ class QueueNames(object):
             # QueueNames.CREATE_LETTERS_PDF,
             QueueNames.CALLBACKS,
             # QueueNames.LETTERS,
+            QueueNames.DELIVERY_RECEIPTS,
         ]
 
 

--- a/scripts/run_celery.sh
+++ b/scripts/run_celery.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency=4 -Q database-tasks,job-tasks,notify-internal-tasks,periodic-tasks,priority-tasks,reporting-tasks,research-mode-tasks,retry-tasks,send-sms-tasks,send-email-tasks,service-callbacks
+celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency=4 -Q database-tasks,job-tasks,notify-internal-tasks,periodic-tasks,priority-tasks,reporting-tasks,research-mode-tasks,retry-tasks,send-sms-tasks,send-email-tasks,service-callbacks,delivery-receipts

--- a/tests/app/test_config.py
+++ b/tests/app/test_config.py
@@ -58,7 +58,7 @@ def test_load_config_if_cloudfoundry_not_available(monkeypatch, reload_config):
 def test_queue_names_all_queues_correct():
     # Need to ensure that all_queues() only returns queue names used in API
     queues = QueueNames.all_queues()
-    assert len(queues) == 12
+    assert len(queues) == 13
     assert set([
         QueueNames.PRIORITY,
         QueueNames.PERIODIC,
@@ -74,4 +74,5 @@ def test_queue_names_all_queues_correct():
         # QueueNames.CREATE_LETTERS_PDF,
         QueueNames.CALLBACKS,
         # QueueNames.LETTERS,
+        QueueNames.DELIVERY_RECEIPTS,
     ]) == set(queues)


### PR DESCRIPTION
At the moment, SES and SNS delivery receipts are routed to the `notify-internal-tasks` SQS queue. This queue is used by Notify to send Notify notifications (inception) and some Notify specific tasks.

Delivery receipts should not clog up this queue and should be prioritized accordlingly.

This PR introduces a new queue on the API, we will need to update our Terraform code afterwards to route messages to this new queue.

Terraform code:
- SES: https://github.com/cds-snc/notification-terraform/blob/517400d0c7513486530576c5f400cc3a22a360b3/aws/common/lambdas/ses_to_sqs_email_callbacks.py#L10
- SNS: https://github.com/cds-snc/notification-terraform/blob/517400d0c7513486530576c5f400cc3a22a360b3/aws/common/lambdas/sns_to_sqs_sms_callbacks.py#L64

Trello card: https://trello.com/c/sJZip602/341-delivery-receipts-should-not-clog-the-notify-queue