### PR TITLE
feat: run get_api_key_by_secret on reader instances

### DIFF
--- a/app/dao/api_key_dao.py
+++ b/app/dao/api_key_dao.py
@@ -31,7 +31,7 @@ def expire_api_key(service_id, api_key_id):
 
 
 def get_api_key_by_secret(secret):
-    return ApiKey.query.filter_by(
+    return db.on_reader().query(ApiKey).filter_by(
         _secret=encryption.encrypt(str(secret))
     ).options(joinedload('service')).one()
 


### PR DESCRIPTION
Run the method `get_api_key_by_secret` on reader instances as introduced in #1219 