### PR TITLE
Dependency upgrade

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -1,6 +1,7 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
+boto==2.49.0
 cffi==1.14.4
 celery[sqs]==5.0.5
 docopt==0.6.2

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -20,7 +20,7 @@ marshmallow-sqlalchemy==0.23.1
 marshmallow==2.21.0
 python-magic==0.4.18
 psycopg2-binary==2.8.6
-PyJWT==1.7.1
+PyJWT==2.0.1
 PyYAML==5.3.1
 SQLAlchemy==1.3.23
 sentry-sdk[flask]==0.19.5

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -21,7 +21,7 @@ marshmallow-sqlalchemy==0.23.1
 marshmallow==2.21.0
 python-magic==0.4.18
 psycopg2-binary==2.8.6
-PyJWT==2.0.1
+PyJWT==1.7.1
 PyYAML==5.3.1
 SQLAlchemy==1.3.23
 sentry-sdk[flask]==0.19.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ marshmallow-sqlalchemy==0.23.1
 marshmallow==2.21.0
 python-magic==0.4.18
 psycopg2-binary==2.8.6
-PyJWT==1.7.1
+PyJWT==2.0.1
 PyYAML==5.3.1
 SQLAlchemy==1.3.23
 sentry-sdk[flask]==0.19.5
@@ -76,14 +76,13 @@ click-didyoumean==0.0.3
 click-plugins==1.1.1
 click-repl==0.1.6
 colorama==0.4.3
-cryptography==3.3.1
+cryptography==3.4.2
 dnspython==1.16.0
 docutils==0.15.2
 filelock==3.0.12
 flask-redis==0.4.0
 future==0.18.2
 greenlet==1.0.0
-importlib-metadata==3.4.0
 Jinja2==2.11.3
 jmespath==0.10.0
 kombu==5.0.2
@@ -114,11 +113,9 @@ six==1.15.0
 smartypants==2.0.1
 starkbank-ecdsa==1.1.0
 statsd==3.3.0
-typing-extensions==3.7.4.3
 urllib3==1.26.3
 vine==5.0.0
 wcwidth==0.2.5
 webencodings==0.5.1
 websocket-client==0.57.0
 Werkzeug==1.0.1
-zipp==3.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
+boto==2.49.0
 cffi==1.14.4
 celery[sqs]==5.0.5
 docopt==0.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ marshmallow-sqlalchemy==0.23.1
 marshmallow==2.21.0
 python-magic==0.4.18
 psycopg2-binary==2.8.6
-PyJWT==2.0.1
+PyJWT==1.7.1
 PyYAML==5.3.1
 SQLAlchemy==1.3.23
 sentry-sdk[flask]==0.19.5


### PR DESCRIPTION
# Summary | Résumé

Reinstating boto dependency to address issues with Celery Pods in Staging