### PR TITLE
feat: revert cryptography to 3.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -77,7 +77,7 @@ click-didyoumean==0.0.3
 click-plugins==1.1.1
 click-repl==0.1.6
 colorama==0.4.3
-cryptography==3.4.2
+cryptography==3.3.1
 dnspython==1.16.0
 docutils==0.15.2
 filelock==3.0.12


### PR DESCRIPTION
Revert the bump introduced in https://github.com/cds-snc/notification-api/pull/1229