### PR TITLE
Avoid hard termination of API pods

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -19,6 +19,15 @@ in_production = os.environ.get("NOTIFY_ENVIRONMENT", "") == "production"
 if in_production:
     keepalive = 75
 
+# The default graceful timeout period for Kubernetes is 30 seconds, so
+# want a lower graceful timeout value for gunicorn so that proper instance
+# shutdowns.
+#
+# Gunicorn config:
+# https://docs.gunicorn.org/en/stable/settings.html#graceful-timeout
+#
+# Kubernetes config:
+# https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
 if in_production:
     graceful_timeout = 20
 

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -16,8 +16,7 @@ accesslog = '-'
 # > By default, Elastic Load Balancing sets the idle timeout value for your load balancer to 60 seconds.
 # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#connection-idle-timeout
 in_production = os.environ.get("NOTIFY_ENVIRONMENT", "") == "production"
-if in_production:
-    keepalive = 75
+if in_production: keepalive = 75
 
 # The default graceful timeout period for Kubernetes is 30 seconds, so
 # want a lower graceful timeout value for gunicorn so that proper instance
@@ -28,8 +27,7 @@ if in_production:
 #
 # Kubernetes config:
 # https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
-if in_production:
-    graceful_timeout = 20
+if in_production: graceful_timeout = 20
 
 
 def on_starting(server):

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -16,7 +16,8 @@ accesslog = '-'
 # > By default, Elastic Load Balancing sets the idle timeout value for your load balancer to 60 seconds.
 # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#connection-idle-timeout
 in_production = os.environ.get("NOTIFY_ENVIRONMENT", "") == "production"
-if in_production: keepalive = 75
+if in_production:
+    keepalive = 75
 
 # The default graceful timeout period for Kubernetes is 30 seconds, so
 # want a lower graceful timeout value for gunicorn so that proper instance
@@ -27,7 +28,8 @@ if in_production: keepalive = 75
 #
 # Kubernetes config:
 # https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
-if in_production: graceful_timeout = 20
+if in_production:
+    graceful_timeout = 20
 
 
 def on_starting(server):

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -10,14 +10,17 @@ worker_connections = 256
 bind = "0.0.0.0:{}".format(os.getenv("PORT"))
 accesslog = '-'
 
-# See AWS doc
+# To avoid load balancers reporting errors on shutdown instances, see AWS doc
 # > We also recommend that you configure the idle timeout of your application
-# to be larger than the idle timeout configured for the load balancer.
+# > to be larger than the idle timeout configured for the load balancer.
 # > By default, Elastic Load Balancing sets the idle timeout value for your load balancer to 60 seconds.
 # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#connection-idle-timeout
 in_production = os.environ.get("NOTIFY_ENVIRONMENT", "") == "production"
 if in_production:
     keepalive = 75
+
+if in_production:
+    graceful_timeout = 20
 
 
 def on_starting(server):

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -10,25 +10,24 @@ worker_connections = 256
 bind = "0.0.0.0:{}".format(os.getenv("PORT"))
 accesslog = '-'
 
-# To avoid load balancers reporting errors on shutdown instances, see AWS doc
-# > We also recommend that you configure the idle timeout of your application
-# > to be larger than the idle timeout configured for the load balancer.
-# > By default, Elastic Load Balancing sets the idle timeout value for your load balancer to 60 seconds.
-# https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#connection-idle-timeout
 in_production = os.environ.get("NOTIFY_ENVIRONMENT", "") == "production"
 if in_production:
+    # To avoid load balancers reporting errors on shutdown instances, see AWS doc
+    # > We also recommend that you configure the idle timeout of your application
+    # > to be larger than the idle timeout configured for the load balancer.
+    # > By default, Elastic Load Balancing sets the idle timeout value for your load balancer to 60 seconds.
+    # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#connection-idle-timeout
     keepalive = 75
 
-# The default graceful timeout period for Kubernetes is 30 seconds, so
-# want a lower graceful timeout value for gunicorn so that proper instance
-# shutdowns.
-#
-# Gunicorn config:
-# https://docs.gunicorn.org/en/stable/settings.html#graceful-timeout
-#
-# Kubernetes config:
-# https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
-if in_production:
+    # The default graceful timeout period for Kubernetes is 30 seconds, so
+    # want a lower graceful timeout value for gunicorn so that proper instance
+    # shutdowns.
+    #
+    # Gunicorn config:
+    # https://docs.gunicorn.org/en/stable/settings.html#graceful-timeout
+    #
+    # Kubernetes config:
+    # https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
     graceful_timeout = 20
 
 


### PR DESCRIPTION
# Summary | Résumé

Lowered the value for `graceful_timeout` within gunicorn configuration. The default is `30` seconds but we set it at `20` seconds.

# Rationale

Following our recent incident which caused an increase of database connections to get past the RDS instance limit, our current theory is that as the kubernetes pods kept restarting the instances, these did not clean up resources including their database connections in a clean manner.

Lowering the gunicorn configuration value for `graceful_timeout` might provide a better heads up to the gunicorn workers to properly work out the clean up of resources. Because the previous default value of 30 seconds matched the exact value for kubernetes graceful pod timeout as well (i.e. `terminationGracePeriodSeconds`), which might not give the proper time for gunicorn to gracefully shut down.

## A minor rebuttal

This all depends on how gunicorn treats its `graceful_timeout` value internally. From the documentation, we can read:

> After receiving a restart signal, workers have this much time to finish serving requests. Workers still alive after the timeout (starting from the receipt of the restart signal) are force killed.

I have the impression that it might not help, as a force kill will not help clean up the resources properly anyway. I hope I am wrong and that this will help though. 🤞  

# Test instructions and some investigation

I loaded gunicorn locally with the following command, which enabled the DEBUG level of logging:

```
gunicorn -c gunicorn_config.py application -b 127.0.0.1:6011 -p ./gunicorn.pid --access-logfile ./gunicorn.log --log-level debug
```

Right there, I could confirm the changed configuration value deviating from the default due to the newest changes:

```
...
timeout: 30
graceful_timeout: 20
keepalive: 2
...
```

Yay! But then, I wanted to actually test a pseudo scenario of what happened during the incident by sending a SIGTERM signal to the gunicorn instances while it was hanging on the database table(s). For that, I setup the following...

1. Run a SQL statement that locks on the `alembic_version` table:

```
begin;
lock table alembic_version in ACCESS exclusive mode;
-- commit;
```

The commit instruction should be discarded until we need to free the table out of the lock; so no run for now.

2. As we locked on the `alembic_version` table, this is the one that will get called by the health check endpoint. I opened a few windows tab with the local URL...

http://localhost:6011/_status

...and confirmed that the HTTP call was ongoing and could not get delivered due to the database lock.

3. It was then time to send the `SIGTERM` by retrieving the main gunicorn process (lowest ID out of `ps -ax | grep gun` and then send the signal:

```
kill -s TERM 25890
```

4. This produced the following logs where the timestamps of the SIGTERM  report +20 seconds matched the forced process kill:

```
[2021-02-18 22:44:55 -0500] [25901] [DEBUG] GET /_status
[2021-02-18 22:45:24 -0500] [25890] [INFO] Handling signal: term
[2021-02-18 22:45:25 -0500] [25900] [INFO] Worker exiting (pid: 25900)
[2021-02-18 22:45:44 -0500] [25901] [INFO] Worker exiting (pid: 25901)
[2021-02-18 22:45:44 -0500] [25890] [INFO] Shutting down: Master
[2021-02-18 22:45:44 -0500] [25890] [INFO] Stopping Notifications API
```

So we know that the graceful termination timeout took effect with the new updated gunicorn configuration value.

5. Let's test the database connections number before and after the SIGTERM signal now. First, I execute the following SQL query to get all active connections to my local postgresql database:

```
select pid as process_id, 
       usename as username, 
       datname as database_name, 
       client_addr as client_address, 
       application_name,
       backend_start,
       state,
       state_change
from pg_stat_activity
order by process_id;
```

I get these results which provide me the active connections prior to start the gunicorn workers:

|process_id|username|database_name|client_address|application_name|backend_start|state|state_change|
|----------|--------|-------------|--------------|----------------|-------------|-----|------------|
|26|||||2021-02-15 11:16:47|||
|27|||||2021-02-15 11:16:47|||
|28|||||2021-02-15 11:16:47|||
|29|||||2021-02-15 11:16:47|||
|31|postgres||||2021-02-15 11:16:47|||
|1987|postgres|notification_api|172.22.0.1|DBeaver 7.3.5 - Main <notification_api>|2021-02-18 22:16:40|idle|2021-02-18 22:21:22|
|1988|postgres|notification_api|172.22.0.1|DBeaver 7.3.5 - Metadata <notification_api>|2021-02-18 22:16:41|idle|2021-02-18 23:30:44|
|1989|postgres|notification_api|172.22.0.1|DBeaver 7.3.5 - SQLEditor <Script-1.sql>|2021-02-18 22:16:41|active|2021-02-18 23:31:40|
|1990|postgres|postgres|172.22.0.1|DBeaver 7.3.5 - Main <postgres>|2021-02-18 22:16:45|idle|2021-02-18 22:16:45|
|1991|postgres|postgres|172.22.0.1|DBeaver 7.3.5 - Metadata <postgres>|2021-02-18 22:16:45|idle|2021-02-18 22:16:45|

So we should discard the connections above to know the ones used by the workers. I started gunicorn, hit the health check endpoint a few times to activate database connections and re-executed the SQL query. I get the same connections as above along with these two new ones:

|process_id|username|database_name|client_address|application_name|backend_start|state|state_change|
|----------|--------|-------------|--------------|----------------|-------------|-----|------------|
|2151|postgres|notification_api|172.22.0.1||2021-02-18 23:31:06|idle|2021-02-18 23:31:06|
|2152|postgres|notification_api|172.22.0.1||2021-02-18 23:31:06|idle|2021-02-18 23:31:39|

I proceed afterward to lock the `alembic_version` table, hit the health check, send the SIGTERM signal to the gunicorn master process. All along, I was executing the SQL query to know if our database connections were dropped. **After** the 20 seconds of graceful period timeout, the SQL results still return our database connections, living after the workers has been killed.

It's only **when I released the lock on the table that the connections get dropped**.

### Interesting notes

a) The 2 connections owned by the workers were only released once the lock was released. 
b) Once the lock was released, there was absolutely no problem to let go of the connections. The connections did not linger at all behind.

I can't correlate and explain why we reached the connection limit on RDS during the incident. I don't know enough and the context might be different, hence different results. But it's good stuff to know and ponder about.

# Help requested | Aide requise

> Things that you (the submitter) want reviewers to pay very close attention to when they review this.

---

> Éléments auxquels vous (le demandeur) souhaitez que les réviseurs prêtent attention lorsqu’ils examineront votre demande.

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

> Are there any related issues or tangent features you consider out of scope for this issue that could be addressed in the future?

---

> Y a-t-il des questions connexes que vous considérez hors sujet et qui pourraient être abordées plus tard?

# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their review | Voici une suggestion de liste de vérification comprenant des questions que les réviseurs pourraient poser pendant leur examen :


- [ ] Does this meet a user need? | Est-ce que ça répond à un besoin utilisateur?
- [ ] Is it accessible? | Est-ce que c’est accessible?
- [ ] Is it translated between both offical languages? | Est-ce dans les deux langues officielles?
- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une fonctionnalité existante?
- [ ] Should this be split into smaller PRs to decrease change risk? | Est-ce que ça devrait être divisé en de plus petites demandes de tirage (« pull requests ») afin de réduire le risque lié aux modifications?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce changement (fichier README, etc.)?
