### PR TITLE
feat: remove reply-to for Notify no reply emails

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -646,7 +646,11 @@ def send_notify_no_reply(self, data):
             notification_type=template.template_type,
             api_key_id=None,
             key_type=KEY_TYPE_NORMAL,
-            reply_to_text=service.get_default_reply_to_email_address(),
+            # Ensure that the reply to is not set, if people reply
+            # to these emails, they will go to the GC Notify service
+            # email address, and we handle those on the SES inbound
+            # Lambda
+            reply_to_text=None,
         )
 
         send_notification_to_queue(saved_notification, False, queue=QueueNames.NOTIFY)

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -1628,6 +1628,7 @@ def test_send_notify_no_reply(mocker, no_reply_template):
     assert persist_call['personalisation'] == {
         'sending_email_address': 'service@notify.ca',
     }
+    assert persist_call["reply_to_text"] is None
 
     assert len(queue_mock.call_args_list) == 1
     queue_call = queue_mock.call_args_list[0][1]


### PR DESCRIPTION
## Steps to Reproduce
1) Reply to No-reply email from Notify
2) Check Freshdesk

## Expected Behaviour
- Email goes to the void

## Actual Behaviour
- People sending us their personal information

## Notes
We worked recently on providing feedback for people replying to emails sent by Notify where services did not put a reply-to email address (see linked Trello card). This "no reply" email is sent by the GC Notify service and uses the default reply-to email address of this service, which goes to Freshdesk.

We've seen that some people reply to these emails and provide personal information, which is a privacy concern for us. **Make sure that we don't get these emails by changing the reply-to email address of these notifications only.** We can do this by setting the reply-to email address to the Notify service email address, [this is handled by our Lambda](https://github.com/cds-snc/notification-terraform/blob/a6c08a9a7f9a69f70c700a3475af5591af0e93ba/aws/common/lambdas/ses_receiving_emails.py#L120-L126).

Trello card: https://trello.com/c/XKdRjDY9/430-block-replies-to-no-reply-emails-from-gc-notify