### PR TITLE
Fix overnight tests tz failure

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,8 +1,8 @@
 on:
   push:
   schedule:
-    - cron: '0 0-6,23 * * 1-4'
-    - cron: '0 0-6 * * 5'
+    - cron: '1 0-12,20-23 * * 1-5'
+    - cron: '1 * * * 0,6'
 name: Continuous Integration Testing
 jobs:
   test:

--- a/app/utils.py
+++ b/app/utils.py
@@ -48,7 +48,7 @@ def get_html_email_body_from_template(template_instance):
     )
 
 
-def get_local_timezone_midnight(date):
+def get_local_timezone_midnight(date: datetime):
     """
      Gets the local timezones midnight
     """

--- a/tests/app/dao/test_ft_billing_dao.py
+++ b/tests/app/dao/test_ft_billing_dao.py
@@ -247,9 +247,9 @@ def test_fetch_billing_data_for_day_uses_notification_history(notify_db_session)
     service = create_service()
     sms_template = create_template(service=service, template_type='sms')
     create_notification_history(template=sms_template, status='delivered',
-                                created_at=local_now - timedelta(days=8))
+                                created_at=datetime.utcnow() - timedelta(days=8))
     create_notification_history(template=sms_template, status='delivered',
-                                created_at=local_now - timedelta(days=8))
+                                created_at=datetime.utcnow() - timedelta(days=8))
 
     Notification.query.delete()
     db.session.commit()


### PR DESCRIPTION
# Summary | Résumé
[Trello](https://trello.com/c/hOCUVQRc)
fix: localized naive time to GMT so that test would pass on Ubuntu and Mac OS
refactor: update cron timing
refactor: added typing information
refactor: split out the tests, date was both date and datetime type
refactor: renamed date to date_val because it was shadowing a parent date, worried about naming colision

# Test instructions | Instructions pour tester la modification
1) With a Mac run `test_utils.py` manually and validate that the tests pass
2) Was able to copy and paste the code below into https://www.programiz.com/python-programming/online-compiler/ and validate that both on Mac (tested locally) and this platform (which I assume is a flavour of *nix) both give the right datetime for `local`

`local_timezone = pytz.timezone("America/Toronto")`
`val = datetime(2016, 1, 15, 0, 30, tzinfo=timezone.utc)`
`local = val.astimezone(local_timezone)`


# Help requested | Aide requise
Please pay close attention to the comment within the tests and make sure that they make sense and why we are seeing different behaviour on different platforms

# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their review | Voici une suggestion de liste de vérification comprenant des questions que les réviseurs pourraient poser pendant leur examen :


- [ ] Does this meet a user need? | Est-ce que ça répond à un besoin utilisateur?
- [ ] Is it accessible? | Est-ce que c’est accessible?
- [ ] Is it translated between both offical languages? | Est-ce dans les deux langues officielles?
- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une fonctionnalité existante?
- [ ] Should this be split into smaller PRs to decrease change risk? | Est-ce que ça devrait être divisé en de plus petites demandes de tirage (« pull requests ») afin de réduire le risque lié aux modifications?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce changement (fichier README, etc.)?
