### PR TITLE
feat: log iat value to ease debugging with JWT tokens

### DIFF
--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -1,5 +1,10 @@
 from flask import request, _request_ctx_stack, current_app, g
-from notifications_python_client.authentication import decode_jwt_token, get_token_issuer
+from notifications_python_client.authentication import (
+    decode_jwt_token,
+    decode_token,
+    epoch_seconds,
+    get_token_issuer,
+)
 from notifications_python_client.errors import TokenDecodeError, TokenExpiredError, TokenIssuerError
 from notifications_utils import request_helper
 from sqlalchemy.exc import DataError
@@ -102,6 +107,10 @@ def requires_auth():
         except TokenDecodeError:
             continue
         except TokenExpiredError:
+            decoded_token = decode_token(auth_token)
+            current_app.logger.info(
+                f'JWT: iat value was {decoded_token["iat"]} while server clock is {epoch_seconds()}'
+            )
             err_msg = (
                 "Error: Your system clock must be accurate to within 30 seconds"
             )

--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -107,7 +107,10 @@ def requires_auth():
         except TokenDecodeError:
             continue
         except TokenExpiredError:
-            decoded_token = decode_token(auth_token)
+            try:
+                decoded_token = decode_token(auth_token)
+            except TokenDecodeError:
+                continue
             current_app.logger.info(
                 f'JWT: iat value was {decoded_token["iat"]} while server clock is {epoch_seconds()}'
             )

--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -7,6 +7,7 @@ from notifications_python_client.authentication import (
 )
 from notifications_python_client.errors import TokenDecodeError, TokenExpiredError, TokenIssuerError
 from notifications_utils import request_helper
+from jwt import PyJWTError
 from sqlalchemy.exc import DataError
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -109,7 +110,7 @@ def requires_auth():
         except TokenExpiredError:
             try:
                 decoded_token = decode_token(auth_token)
-            except TokenDecodeError:
+            except PyJWTError:
                 continue
             current_app.logger.info(
                 f'JWT: iat value was {decoded_token["iat"]} while server clock is {epoch_seconds()}'

--- a/tests/app/authentication/test_authentication.py
+++ b/tests/app/authentication/test_authentication.py
@@ -348,17 +348,26 @@ def test_should_attach_the_current_api_key_to_current_app(notify_api, sample_ser
         assert api_user == sample_api_key
 
 
-def test_should_return_403_when_token_is_expired(client,
-                                                 sample_api_key):
+def test_should_return_403_when_token_is_expired(
+    client,
+    sample_api_key,
+    mocker,
+):
+    mock_logger = mocker.patch('app.authentication.auth.current_app.logger.info')
     with freeze_time('2001-01-01T12:00:00'):
         token = __create_token(sample_api_key.service_id)
     with freeze_time('2001-01-01T12:00:40'):
         with pytest.raises(AuthError) as exc:
             request.headers = {'Authorization': 'Bearer {}'.format(token)}
             requires_auth()
+
     assert exc.value.short_message == 'Error: Your system clock must be accurate to within 30 seconds'
     assert exc.value.service_id == sample_api_key.service_id
     assert exc.value.api_key_id == sample_api_key.id
+
+    mock_logger.assert_called_with(
+        'JWT: iat value was 978350400 while server clock is 978350440'
+    )
 
 
 def __create_token(service_id):


### PR DESCRIPTION
JWT tokens are only valid for 30 seconds. When clients send requests to the Notify API, they can get a clock error, but it's a bit too generic to be helpful.

> Error: Your system clock must be accurate to within 30 seconds

This PR adds some logging, to be able to hunt down specific values in AWS log groups to have more evidence to help clients.

Trello card: https://trello.com/c/Mbkumte7/376-log-jwt-iat-field-value-to-ease-debugging-with-clock-errors