### PR TITLE
fix: handle hand crafted Notify user agents

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -278,7 +278,7 @@ def process_user_agent(user_agent_string):
         return 'unknown'
 
     m = re.search(
-        r'(?P<name>notify.*)/(?P<version>\d+.\d+.\d+)',
+        r'^(?P<name>notify.*)/(?P<version>\d+.\d+.\d+)$',
         user_agent_string,
         re.IGNORECASE
     )

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -275,9 +275,12 @@ def create_random_identifier():
 def process_user_agent(user_agent_string):
     if user_agent_string and user_agent_string.lower().startswith("notify"):
         components = user_agent_string.split("/")
-        client_name = components[0].lower()
-        client_version = components[1].replace(".", "-")
-        return "{}.{}".format(client_name, client_version)
+        try:
+            client_name = components[0].lower()
+            client_version = components[1].replace(".", "-")
+            return "{}.{}".format(client_name, client_version)
+        except IndexError:
+            return "unknown"
     elif user_agent_string and not user_agent_string.lower().startswith("notify"):
         return "non-notify-user-agent"
     else:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,6 +2,7 @@ import os
 import random
 import string
 import uuid
+import re
 from dotenv import load_dotenv
 
 from flask import _request_ctx_stack, request, g, jsonify, make_response
@@ -273,15 +274,14 @@ def create_random_identifier():
 
 
 def process_user_agent(user_agent_string):
-    if user_agent_string and user_agent_string.lower().startswith("notify"):
-        components = user_agent_string.split("/")
-        try:
-            client_name = components[0].lower()
-            client_version = components[1].replace(".", "-")
-            return "{}.{}".format(client_name, client_version)
-        except IndexError:
-            return "unknown"
-    elif user_agent_string and not user_agent_string.lower().startswith("notify"):
-        return "non-notify-user-agent"
-    else:
-        return "unknown"
+    if user_agent_string is None:
+        return 'unknown'
+
+    m = re.search(
+        r'(?P<name>notify.*)/(?P<version>\d+.\d+.\d+)',
+        user_agent_string,
+        re.IGNORECASE
+    )
+    if m:
+        return f'{m.group("name").lower()}.{m.group("version").replace(".", "-")}'
+    return 'non-notify-user-agent'

--- a/tests/app/test_user_agent_processing.py
+++ b/tests/app/test_user_agent_processing.py
@@ -13,6 +13,8 @@ import pytest
         ("NOTIFY-API-PYTHON-CLIENT/3.0.0", "notify-api-python-client.3-0-0"),
         (None, "unknown"),
         ("NotifyApiKeyClient", "non-notify-user-agent"),
+        ("nearlyNOTIFY-API-PYTHON-CLIENT/3.0.0", "non-notify-user-agent"),
+        ("NOTIFY-API-PYTHON-CLIENT/3.0.0almost", "non-notify-user-agent"),
     ],
 )
 def test_process_user_agent(input, expected):

--- a/tests/app/test_user_agent_processing.py
+++ b/tests/app/test_user_agent_processing.py
@@ -11,3 +11,7 @@ def test_can_handle_non_notify_api_user_agent():
 
 def test_handles_null_user_agent():
     assert "unknown" == process_user_agent(None)
+
+
+def test_handles_invalid_notify_user_agent():
+    assert "unknown" == process_user_agent("NotifyApiKeyClient")

--- a/tests/app/test_user_agent_processing.py
+++ b/tests/app/test_user_agent_processing.py
@@ -1,17 +1,19 @@
 from app import process_user_agent
 
-
-def test_can_process_notify_api_user_agent():
-    assert "notify-api-python-client.3-0-0" == process_user_agent("NOTIFY-API-PYTHON-CLIENT/3.0.0")
+import pytest
 
 
-def test_can_handle_non_notify_api_user_agent():
-    assert "non-notify-user-agent" == process_user_agent("Mozilla/5.0 (iPad; U; CPU OS 3_2_1 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Mobile/7B405")  # noqa
-
-
-def test_handles_null_user_agent():
-    assert "unknown" == process_user_agent(None)
-
-
-def test_handles_invalid_notify_user_agent():
-    assert "unknown" == process_user_agent("NotifyApiKeyClient")
+@pytest.mark.parametrize(
+    "input, expected",
+    [
+        (
+            "Mozilla/5.0 (iPad; U; CPU like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Mobile/7B405",
+            "non-notify-user-agent",
+        ),
+        ("NOTIFY-API-PYTHON-CLIENT/3.0.0", "notify-api-python-client.3-0-0"),
+        (None, "unknown"),
+        ("NotifyApiKeyClient", "non-notify-user-agent"),
+    ],
+)
+def test_process_user_agent(input, expected):
+    assert expected == process_user_agent(input)


### PR DESCRIPTION
Fix a possible 500 error when people submit a custom user agent, starting with `notify` but with an unexpected format.

See occurence on Slack: https://gcdigital.slack.com/archives/CNWA63606/p1617214953097200