### PR TITLE
feat: delete daily limit cache when updating limits

### DIFF
--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -252,7 +252,9 @@ def update_service(service_id):
     fetched_service = dao_fetch_service_by_id(service_id)
     # Capture the status change here as Marshmallow changes this later
     service_going_live = fetched_service.restricted and not req_json.get('restricted', True)
-    message_limit_changed = fetched_service.message_limit != req_json.get('message_limit', None)
+    message_limit_changed = (
+        fetched_service.message_limit != req_json.get('message_limit', fetched_service.message_limit)
+    )
     current_data = dict(service_schema.dump(fetched_service).data.items())
 
     current_data.update(request.get_json())

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -7,12 +7,14 @@ from flask import (
     current_app,
     Blueprint
 )
+from notifications_utils.clients.redis import daily_limit_cache_key
 from notifications_utils.letter_timings import letter_can_be_cancelled
 from notifications_utils.timezones import convert_utc_to_local_timezone
 from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 
+from app import redis_store
 from app.clients.zendesk_sell import ZenDeskSell
 from app.config import QueueNames
 from app.dao import fact_notification_status_dao, notifications_dao
@@ -262,10 +264,11 @@ def update_service(service_id):
     if 'letter_branding' in req_json:
         letter_branding_id = req_json['letter_branding']
         service.letter_branding = None if not letter_branding_id else LetterBranding.query.get(letter_branding_id)
-    dao_update_service(service)
 
-    if 'default_email_is_french' in req_json:
-        service.default_email_is_french = req_json['default_email_is_french']
+    if 'message_limit' in req_json:
+        redis_store.delete(daily_limit_cache_key(service_id))
+
+    dao_update_service(service)
 
     if service_going_live:
         send_notification_to_service_users(

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -252,6 +252,7 @@ def update_service(service_id):
     fetched_service = dao_fetch_service_by_id(service_id)
     # Capture the status change here as Marshmallow changes this later
     service_going_live = fetched_service.restricted and not req_json.get('restricted', True)
+    message_limit_changed = fetched_service.message_limit != req_json.get('message_limit', None)
     current_data = dict(service_schema.dump(fetched_service).data.items())
 
     current_data.update(request.get_json())
@@ -265,7 +266,7 @@ def update_service(service_id):
         letter_branding_id = req_json['letter_branding']
         service.letter_branding = None if not letter_branding_id else LetterBranding.query.get(letter_branding_id)
 
-    if 'message_limit' in req_json:
+    if message_limit_changed:
         redis_store.delete(daily_limit_cache_key(service_id))
 
     dao_update_service(service)

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -7,6 +7,7 @@ from unittest.mock import ANY
 import pytest
 from flask import url_for, current_app
 from freezegun import freeze_time
+from notifications_utils.clients.redis import daily_limit_cache_key
 
 from app.dao.organisation_dao import dao_add_service_to_organisation
 from app.dao.service_sms_sender_dao import dao_get_sms_senders_by_service_id
@@ -2161,6 +2162,23 @@ def test_update_service_calls_send_notification_as_service_becomes_live(notify_d
         },
         include_user_fields=['name']
     )
+
+
+def test_update_service_updating_daily_limit_clears_redis_cache(
+    admin_request,
+    sample_service,
+    mocker
+):
+    redis_delete = mocker.patch('app.service.rest.redis_store.delete')
+
+    admin_request.post(
+        'service.update_service',
+        service_id=sample_service.id,
+        _data={"message_limit": 1_000},
+        _expected_status=200
+    )
+
+    redis_delete.assert_called_once_with(daily_limit_cache_key(sample_service.id))
 
 
 def test_update_service_does_not_call_send_notification_for_live_service(sample_service, client, mocker):

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -2168,6 +2168,7 @@ def test_update_service_calls_send_notification_as_service_becomes_live(notify_d
     (1_000, 1_000, False),
     (1_000, 2_000, True),
     (1_000, 50, True),
+    (1_000, None, False),
 ])
 def test_update_service_updating_daily_limit_clears_redis_cache(
     notify_db,
@@ -2185,7 +2186,7 @@ def test_update_service_updating_daily_limit_clears_redis_cache(
     admin_request.post(
         'service.update_service',
         service_id=service.id,
-        _data={"message_limit": new_limit},
+        _data={"message_limit": new_limit} if new_limit else {},
         _expected_status=200
     )
 


### PR DESCRIPTION
Remove the daily limit cache key from Redis when a service's message limit value is updated.

At the moment, if a service goes above its message limit and we update the message limit value, the cache may be used for up to 1h before expiring. This is not a great experience because if we change limits we want that to be reflected right rather than telling clients to wait for up to 1h.

https://github.com/cds-snc/notification-api/blob/3db95eb950de58faeecefe0818c95c7872863d1f/app/notifications/validators.py#L38-L44

You can check for other places where `daily_limit_cache_key` is used in this codebase to understand how it works.

Trello: https://trello.com/c/7VIM7U6r/419-delete-daily-limit-cache-when-updating-a-services-message-limit