### PR TITLE
feat: add content-type header for direct attachments

### DIFF
--- a/app/clients/email/aws_ses.py
+++ b/app/clients/email/aws_ses.py
@@ -119,7 +119,10 @@ class AwsSesClient(EmailClient):
                 attach_html(msg, html_body)
 
             for attachment in attachments:
+                # See https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-raw.html#send-email-raw-mime
                 attachment_part = MIMEApplication(attachment["data"])
+                if attachment.get('mime_type'):
+                    attachment_part.add_header('Content-Type', attachment["mime_type"], name=attachment["name"])
                 attachment_part.add_header('Content-Disposition', 'attachment', filename=attachment["name"])
                 msg.attach(attachment_part)
 

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -130,9 +130,11 @@ def send_email_to_provider(notification):
                     with urllib.request.urlopen(req) as response:
                         buffer = response.read()
                         filename = personalisation_data[key]['document'].get('filename')
+                        mime_type = personalisation_data[key]['document'].get('mime_type')
                         attachments.append({
                             "name": filename,
-                            "data": buffer
+                            "data": buffer,
+                            "mime_type": mime_type,
                         })
                 except Exception:
                     current_app.logger.error(

--- a/tests/app/clients/test_aws_ses.py
+++ b/tests/app/clients/test_aws_ses.py
@@ -137,7 +137,7 @@ def test_send_email_txt_and_html_email_with_attachment(notify_api, mocker):
             subject='Subject',
             body='email body',
             html_body='<p>email body</p>',
-            attachments=[{'data': 'Canada', 'name': 'file.txt'}],
+            attachments=[{'data': 'Canada', 'name': 'file.txt', 'mime_type': 'text/plain'}],
             reply_to_address='reply@example.com',
         )
 
@@ -174,6 +174,7 @@ def test_send_email_txt_and_html_email_with_attachment(notify_api, mocker):
         Content-Type: application/octet-stream
         MIME-Version: 1\.0
         Content-Transfer-Encoding: base64
+        Content-Type: text/plain; name="file\.txt"
         Content-Disposition: attachment; filename="file\.txt"
 
         Q2FuYWRh

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -1246,3 +1246,24 @@ def app_statsd(mocker):
 
 def datetime_in_past(days=0, seconds=0):
     return datetime.now(tz=pytz.utc) - timedelta(days=days, seconds=seconds)
+
+
+def document_download_response(override={}):
+    # See response from
+    # https://github.com/cds-snc/notification-document-download-api/blob/master/app/upload/views.py
+    base = {
+        'id': 'document-id',
+        'direct_file_url': 'http://direct-file-url.localdomain',
+        'url': 'http://frontend-url.localdomain',
+        'mlwr_sid': 'mlwr-sid',
+        'filename': 'filename',
+        'sending_method': 'sending_method',
+        'mime_type': 'mime_type',
+        'file_size': 42,
+        'file_extension': 'pdf',
+    }
+
+    return {
+        'status': 'ok',
+        'document': base | override
+    }

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -27,6 +27,7 @@ from app.v2.notifications.notification_schemas import (
 )
 from tests import create_authorization_header
 
+from tests.app.conftest import document_download_response
 from tests.app.db import (
     create_service,
     create_template,
@@ -35,27 +36,6 @@ from tests.app.db import (
     create_service_with_inbound_number,
     create_api_key,
 )
-
-
-def document_download_response(override={}):
-    # See response from
-    # https://github.com/cds-snc/notification-document-download-api/blob/master/app/upload/views.py
-    base = {
-        'id': 'document-id',
-        'direct_file_url': 'http://direct-file-url.localdomain',
-        'url': 'http://frontend-url.localdomain',
-        'mlwr_sid': 'mlwr-sid',
-        'filename': 'filename',
-        'sending_method': 'sending_method',
-        'mime_type': 'mime_type',
-        'file_size': 42,
-        'file_extension': 'pdf',
-    }
-
-    return {
-        'status': 'ok',
-        'document': base | override
-    }
 
 
 @pytest.mark.parametrize("reference", [None, "reference_from_client"])


### PR DESCRIPTION
Add a `Content-Type` header when sending direct attachments with AWS SES.

It's recommend in [the documentation](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-raw.html#send-email-raw-mime) ("File attachments" section). Previously it was not set or AWS SES added a generic header like `Content-Type: application/octet-stream`.

Trello: https://trello.com/c/XzhQ42Jx/440-specify-content-type-when-sending-direct-attachments