### PR TITLE
Remove mention of Travis on healthcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ help:
 
 .PHONY: generate-version-file
 generate-version-file: ## Generates the app version file
-	@printf "__travis_commit__ = \"${GIT_COMMIT}\"\n__time__ = \"${DATE}\"\n__travis_job_number__ = \"0\"\n__travis_job_url__ = \"\"\n" > ${APP_VERSION_FILE}
+	@printf "__commit_sha__ = \"${GIT_COMMIT}\"\n__time__ = \"${DATE}\"\n" > ${APP_VERSION_FILE}
 
 .PHONY: test
 test: generate-version-file ## Run tests

--- a/app/status/healthcheck.py
+++ b/app/status/healthcheck.py
@@ -19,8 +19,7 @@ def show_status():
     else:
         return jsonify(
             status="ok",  # This should be considered part of the public API
-            travis_commit=version.__travis_commit__,
-            travis_build_number=version.__travis_job_number__,
+            commit_sha=version.__commit_sha__,
             build_time=version.__time__,
             db_version=get_db_version()), 200
 

--- a/tests/app/status/test_status.py
+++ b/tests/app/status/test_status.py
@@ -11,8 +11,7 @@ def test_get_status_all_ok(client, notify_db_session, path):
     resp_json = json.loads(response.get_data(as_text=True))
     assert resp_json['status'] == 'ok'
     assert resp_json['db_version']
-    assert resp_json['travis_commit']
-    assert resp_json['travis_build_number']
+    assert resp_json['commit_sha']
     assert resp_json['build_time']
 
 


### PR DESCRIPTION
We do not use Travis, remove those fields from the Makefile and the healthcheck page https://api.notification.alpha.canada.ca.

They are creating confusion for developers.