### PR TITLE
feat: catch other exceptions for base64 decode

### DIFF
--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -1,5 +1,4 @@
 import base64
-import binascii
 
 from sqlalchemy.orm.exc import NoResultFound
 from flask import current_app
@@ -200,7 +199,7 @@ def decode_personalisation_files(personalisation_data):
     for key in file_keys:
         try:
             personalisation_data[key]['file'] = base64.b64decode(personalisation_data[key]['file'])
-        except binascii.Error as e:
+        except Exception as e:
             errors.append({
                 "error": "ValidationError",
                 "message": f"{key} : {str(e)} : Error decoding base64 field"

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -1203,16 +1203,15 @@ def test_post_notification_with_document_upload_bad_sending_method(
     )
 
 
-@pytest.mark.parametrize(
-    "file_data",
-    [
-        ("abc"),
-    ],
-)
+@pytest.mark.parametrize("file_data, message", [
+    ("abc", "Incorrect padding"),
+    ("🤡", "string argument should contain only ASCII characters"),
+])
 def test_post_notification_with_document_upload_not_base64_file(
     client,
     notify_db_session,
     file_data,
+    message,
 ):
     service = create_service(service_permissions=[EMAIL_TYPE, UPLOAD_DOCUMENT])
     content = "See attached file."
@@ -1238,7 +1237,7 @@ def test_post_notification_with_document_upload_not_base64_file(
 
     assert response.status_code == 400
     resp_json = json.loads(response.get_data(as_text=True))
-    assert "Incorrect padding" in resp_json["errors"][0]["message"]
+    assert f"{message} : Error decoding base64 field" in resp_json["errors"][0]["message"]
 
 
 def test_post_notification_with_document_upload_simulated(


### PR DESCRIPTION
Fixing this because we had 500 errors in production.

According to the documentation, https://docs.python.org/3/library/base64.html

> A binascii.Error exception is raised if s is incorrectly padded.

Catching other exceptions as well.