### PR TITLE
feat: new StatsD metrics to compute SLOs

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -25,6 +25,7 @@ from app import (
     DATETIME_FORMAT,
     encryption,
     notify_celery,
+    statsd_client,
 )
 from app.aws import s3
 from app.celery import (  # noqa: F401
@@ -104,6 +105,9 @@ def process_job(job_id, sender_id=None):
     job.job_status = JOB_STATUS_IN_PROGRESS
     job.processing_started = start
     dao_update_job(job)
+
+    # Record StatsD stats to compute SLOs
+    statsd_client.timing_with_dates('job.processing-start-delay', job.processing_started, job.scheduled_for)
 
     db_template = dao_get_template_by_id(job.template_id, job.template_version)
 


### PR DESCRIPTION
Add new StatsD metrics to help compute SLOs. Some SLOs were only computable using the Notify database, make sure that those metrics are available on CloudWatch to make it easy for us to consolidate metrics and create a CloudWatch dashboards for SLOs.

Adds:
- Delay to send emails (multiple categories with/without attachments are according to process type (normal/bulk/priority)
- Delay to send SMS (multiple categories according to process type)
- Delay for processed jobs (do those start on time)

[See SLOs](https://docs.google.com/spreadsheets/d/1fU-FJ7THfWEqNhbpQ4r22MQipFwC7SP851ZQnOf68cM/edit)

Trello: https://trello.com/c/GFHzZGgz/453-measure-slos-for-the-first-time