### PR TITLE
fix: appropriate start date when recording stats for jobs

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -107,7 +107,8 @@ def process_job(job_id, sender_id=None):
     dao_update_job(job)
 
     # Record StatsD stats to compute SLOs
-    statsd_client.timing_with_dates('job.processing-start-delay', job.processing_started, job.scheduled_for)
+    job_start = job.scheduled_for or job.created_at
+    statsd_client.timing_with_dates('job.processing-start-delay', job.processing_started, job_start)
 
     db_template = dao_get_template_by_id(job.template_id, job.template_version)
 

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -124,7 +124,9 @@ def test_should_process_sms_job(sample_job, mocker):
     )
     job = jobs_dao.dao_get_job_by_id(sample_job.id)
     assert job.job_status == 'finished'
-    redis_mock.assert_called_once_with('job.processing-start-delay', job.processing_started, job.scheduled_for)
+    assert job.processing_started is not None
+    assert job.created_at is not None
+    redis_mock.assert_called_once_with('job.processing-start-delay', job.processing_started, job.created_at)
 
 
 def test_should_process_sms_job_with_sender_id(sample_job, mocker, fake_uuid):
@@ -289,7 +291,9 @@ def test_should_process_email_job(email_job_with_placeholders, mocker):
     )
     job = jobs_dao.dao_get_job_by_id(email_job_with_placeholders.id)
     assert job.job_status == 'finished'
-    redis_mock.assert_called_once_with('job.processing-start-delay', job.processing_started, job.scheduled_for)
+    assert job.processing_started is not None
+    assert job.created_at is not None
+    redis_mock.assert_called_once_with('job.processing-start-delay', job.processing_started, job.created_at)
 
 
 def test_should_process_email_job_with_sender_id(email_job_with_placeholders, mocker, fake_uuid):


### PR DESCRIPTION
Fix a bug introduced in #1269, `scheduled_for` can be null if a job is not scheduled, which happens often.