### PR TITLE
Bump notification-utils to 43.6.0

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -44,7 +44,7 @@ awscli-cwlogs>=1.4.6,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@43.5.0#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@43.6.0#egg=notifications-utils
 
 # MLWR
 socketio-client==0.5.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ awscli-cwlogs>=1.4.6,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@43.5.0#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@43.6.0#egg=notifications-utils
 
 # MLWR
 socketio-client==0.5.6


### PR DESCRIPTION
Adds:
- https://github.com/cds-snc/notification-utils/pull/77
- https://github.com/cds-snc/notification-utils/pull/78