### PR TITLE
feat: add new error messages for SES

### DIFF
--- a/app/celery/process_sns_receipts_tasks.py
+++ b/app/celery/process_sns_receipts_tasks.py
@@ -66,7 +66,7 @@ def process_sns_results(self, response):
         notifications_dao._update_notification_status(
             notification=notification,
             status=notification_status,
-            provider_response=provider_response
+            provider_response=provider_response if notification_status == NOTIFICATION_TECHNICAL_FAILURE else None
         )
 
         if notification_status != NOTIFICATION_DELIVERED:

--- a/app/celery/research_mode_tasks.py
+++ b/app/celery/research_mode_tasks.py
@@ -205,18 +205,18 @@ def ses_notification_callback(reference):
     }
 
 
-def ses_hard_bounce_callback(reference):
-    return _ses_bounce_callback(reference, 'Permanent')
+def ses_hard_bounce_callback(reference, bounce_subtype=None):
+    return _ses_bounce_callback(reference, 'Permanent', bounce_subtype)
 
 
-def ses_soft_bounce_callback(reference):
-    return _ses_bounce_callback(reference, 'Temporary')
+def ses_soft_bounce_callback(reference, bounce_subtype=None):
+    return _ses_bounce_callback(reference, 'Transient', bounce_subtype)
 
 
-def _ses_bounce_callback(reference, bounce_type):
+def _ses_bounce_callback(reference, bounce_type, bounce_subtype=None):
     ses_message_body = {
         'bounce': {
-            'bounceSubType': 'General',
+            'bounceSubType': bounce_subtype or 'General',
             'bounceType': bounce_type,
             'bouncedRecipients': [{
                 'action': 'failed',

--- a/app/clients/__init__.py
+++ b/app/clients/__init__.py
@@ -12,11 +12,6 @@ class Client(object):
     pass
 
 
-STATISTICS_REQUESTED = 'requested'
-STATISTICS_DELIVERED = 'delivered'
-STATISTICS_FAILURE = 'failure'
-
-
 class Clients(object):
     sms_clients = {}
     email_clients = {}

--- a/app/clients/email/aws_ses.py
+++ b/app/clients/email/aws_ses.py
@@ -5,42 +5,10 @@ from time import monotonic
 from notifications_utils.recipients import InvalidEmailError
 from unidecode import unidecode
 
-from app.clients import STATISTICS_DELIVERED, STATISTICS_FAILURE
 from app.clients.email import (EmailClientException, EmailClient)
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.mime.application import MIMEApplication
-
-ses_response_map = {
-    'Permanent': {
-        "message": 'Hard bounced',
-        "success": False,
-        "notification_status": 'permanent-failure',
-        "notification_statistics_status": STATISTICS_FAILURE
-    },
-    'Temporary': {
-        "message": 'Soft bounced',
-        "success": False,
-        "notification_status": 'temporary-failure',
-        "notification_statistics_status": STATISTICS_FAILURE
-    },
-    'Delivery': {
-        "message": 'Delivered',
-        "success": True,
-        "notification_status": 'delivered',
-        "notification_statistics_status": STATISTICS_DELIVERED
-    },
-    'Complaint': {
-        "message": 'Complaint',
-        "success": True,
-        "notification_status": 'delivered',
-        "notification_statistics_status": STATISTICS_DELIVERED
-    }
-}
-
-
-def get_aws_responses(status):
-    return ses_response_map[status]
 
 
 class AwsSesClientException(EmailClientException):

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -96,7 +96,7 @@ def country_records_delivery(phone_prefix):
 def _update_notification_status(notification, status, provider_response=None):
     status = _decide_permanent_temporary_failure(current_status=notification.status, status=status)
     notification.status = status
-    if status == NOTIFICATION_TECHNICAL_FAILURE and provider_response:
+    if provider_response:
         notification.provider_response = provider_response
     dao_update_notification(notification)
     return notification

--- a/app/notifications/notifications_ses_callback.py
+++ b/app/notifications/notifications_ses_callback.py
@@ -40,7 +40,7 @@ def _determine_provider_response(ses_message):
 
     # See https://docs.aws.amazon.com/ses/latest/DeveloperGuide/event-publishing-retrieving-sns-contents.html
     if bounce_type == 'Permanent' and bounce_subtype == 'Suppressed':
-        return 'Email address is on the Amazon suppression list'
+        return 'Email address is on our email provider suppression list'
     elif bounce_type == 'Permanent' and bounce_subtype == 'OnAccountSuppressionList':
         return 'Email address is on the GC Notify suppression list'
     elif bounce_type == 'Transient' and bounce_subtype == 'AttachmentRejected':

--- a/app/notifications/notifications_ses_callback.py
+++ b/app/notifications/notifications_ses_callback.py
@@ -40,11 +40,11 @@ def _determine_provider_response(ses_message):
 
     # See https://docs.aws.amazon.com/ses/latest/DeveloperGuide/event-publishing-retrieving-sns-contents.html
     if bounce_type == 'Permanent' and bounce_subtype == 'Suppressed':
-        return 'Email address is on our email provider suppression list'
+        return 'The email address is on our email provider suppression list'
     elif bounce_type == 'Permanent' and bounce_subtype == 'OnAccountSuppressionList':
-        return 'Email address is on the GC Notify suppression list'
+        return 'The email address is on the GC Notify suppression list'
     elif bounce_type == 'Transient' and bounce_subtype == 'AttachmentRejected':
-        return 'Email was rejected because of its attachments'
+        return 'The email was rejected because of its attachments'
 
     return None
 

--- a/tests/app/celery/test_process_ses_receipts_tasks.py
+++ b/tests/app/celery/test_process_ses_receipts_tasks.py
@@ -212,7 +212,7 @@ def test_ses_callback_should_update_multiple_notification_status_sent(
 
 @pytest.mark.parametrize('bounce_subtype, provider_response', [
     ['General', None],
-    ['AttachmentRejected', 'Email was rejected because of its attachments'],
+    ['AttachmentRejected', 'The email was rejected because of its attachments'],
 ])
 def test_ses_callback_should_set_status_to_temporary_failure(
     notify_db,
@@ -245,8 +245,8 @@ def test_ses_callback_should_set_status_to_temporary_failure(
 
 @pytest.mark.parametrize('bounce_subtype, provider_response', [
     ['General', None],
-    ['Suppressed', 'Email address is on our email provider suppression list'],
-    ['OnAccountSuppressionList', 'Email address is on the GC Notify suppression list'],
+    ['Suppressed', 'The email address is on our email provider suppression list'],
+    ['OnAccountSuppressionList', 'The email address is on the GC Notify suppression list'],
 ])
 def test_ses_callback_should_set_status_to_permanent_failure(
     notify_db,

--- a/tests/app/celery/test_process_ses_receipts_tasks.py
+++ b/tests/app/celery/test_process_ses_receipts_tasks.py
@@ -245,7 +245,7 @@ def test_ses_callback_should_set_status_to_temporary_failure(
 
 @pytest.mark.parametrize('bounce_subtype, provider_response', [
     ['General', None],
-    ['Suppressed', 'Email address is on the Amazon suppression list'],
+    ['Suppressed', 'Email address is on our email provider suppression list'],
     ['OnAccountSuppressionList', 'Email address is on the GC Notify suppression list'],
 ])
 def test_ses_callback_should_set_status_to_permanent_failure(

--- a/tests/app/clients/test_aws_ses.py
+++ b/tests/app/clients/test_aws_ses.py
@@ -9,47 +9,8 @@ from notifications_utils.recipients import InvalidEmailError
 from app import aws_ses_client
 from app.clients.email.aws_ses import (
     AwsSesClientException,
-    get_aws_responses,
     punycode_encode_email,
 )
-
-
-def test_should_return_correct_details_for_delivery():
-    response_dict = get_aws_responses('Delivery')
-    assert response_dict['message'] == 'Delivered'
-    assert response_dict['notification_status'] == 'delivered'
-    assert response_dict['notification_statistics_status'] == 'delivered'
-    assert response_dict['success']
-
-
-def test_should_return_correct_details_for_hard_bounced():
-    response_dict = get_aws_responses('Permanent')
-    assert response_dict['message'] == 'Hard bounced'
-    assert response_dict['notification_status'] == 'permanent-failure'
-    assert response_dict['notification_statistics_status'] == 'failure'
-    assert not response_dict['success']
-
-
-def test_should_return_correct_details_for_soft_bounced():
-    response_dict = get_aws_responses('Temporary')
-    assert response_dict['message'] == 'Soft bounced'
-    assert response_dict['notification_status'] == 'temporary-failure'
-    assert response_dict['notification_statistics_status'] == 'failure'
-    assert not response_dict['success']
-
-
-def test_should_return_correct_details_for_complaint():
-    response_dict = get_aws_responses('Complaint')
-    assert response_dict['message'] == 'Complaint'
-    assert response_dict['notification_status'] == 'delivered'
-    assert response_dict['notification_statistics_status'] == 'delivered'
-    assert response_dict['success']
-
-
-def test_should_be_none_if_unrecognised_status_code():
-    with pytest.raises(KeyError) as e:
-        get_aws_responses('99')
-    assert '99' in str(e.value)
 
 
 def email_b64_encoding(input):

--- a/tests/app/notifications/test_notifications_ses_callback.py
+++ b/tests/app/notifications/test_notifications_ses_callback.py
@@ -59,7 +59,7 @@ from tests.app.db import (
             'message': 'Hard bounced',
             'success': False,
             'notification_status': 'permanent-failure',
-            'provider_response': 'Email address is on our email provider suppression list',
+            'provider_response': 'The email address is on our email provider suppression list',
         }
     ),
     (
@@ -69,7 +69,7 @@ from tests.app.db import (
             'message': 'Hard bounced',
             'success': False,
             'notification_status': 'permanent-failure',
-            'provider_response': 'Email address is on the GC Notify suppression list',
+            'provider_response': 'The email address is on the GC Notify suppression list',
         }
     ),
     (
@@ -79,7 +79,7 @@ from tests.app.db import (
             'message': 'Soft bounced',
             'success': False,
             'notification_status': 'temporary-failure',
-            'provider_response': 'Email was rejected because of its attachments',
+            'provider_response': 'The email was rejected because of its attachments',
         }
     ),
     (

--- a/tests/app/notifications/test_notifications_ses_callback.py
+++ b/tests/app/notifications/test_notifications_ses_callback.py
@@ -59,7 +59,7 @@ from tests.app.db import (
             'message': 'Hard bounced',
             'success': False,
             'notification_status': 'permanent-failure',
-            'provider_response': 'Email address is on the Amazon suppression list',
+            'provider_response': 'Email address is on our email provider suppression list',
         }
     ),
     (

--- a/tests/app/notifications/test_notifications_ses_callback.py
+++ b/tests/app/notifications/test_notifications_ses_callback.py
@@ -6,7 +6,11 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from app.dao.notifications_dao import get_notification_by_id
 from app.models import Complaint
-from app.notifications.notifications_ses_callback import handle_complaint, handle_smtp_complaint
+from app.notifications.notifications_ses_callback import (
+    get_aws_responses,
+    handle_complaint,
+    handle_smtp_complaint,
+)
 
 from tests.app.conftest import sample_notification as create_sample_notification
 from tests.app.db import (
@@ -15,6 +19,96 @@ from tests.app.db import (
     ses_complaint_callback,
     create_notification_history
 )
+
+
+@pytest.mark.parametrize('notification_type, bounce_message, expected', [
+    (
+        'Delivery',
+        {},
+        {
+            'message': 'Delivered',
+            'success': True,
+            'notification_status': 'delivered',
+            'provider_response': None,
+        }
+    ),
+    (
+        'Complaint',
+        {},
+        {
+            'message': 'Complaint',
+            'success': True,
+            'notification_status': 'delivered',
+            'provider_response': None,
+        }
+    ),
+    (
+        'Bounce',
+        {'bounceType': 'Permanent', 'bounceSubType': 'NoEmail'},
+        {
+            'message': 'Hard bounced',
+            'success': False,
+            'notification_status': 'permanent-failure',
+            'provider_response': None,
+        }
+    ),
+    (
+        'Bounce',
+        {'bounceType': 'Permanent', 'bounceSubType': 'Suppressed'},
+        {
+            'message': 'Hard bounced',
+            'success': False,
+            'notification_status': 'permanent-failure',
+            'provider_response': 'Email address is on the Amazon suppression list',
+        }
+    ),
+    (
+        'Bounce',
+        {'bounceType': 'Permanent', 'bounceSubType': 'OnAccountSuppressionList'},
+        {
+            'message': 'Hard bounced',
+            'success': False,
+            'notification_status': 'permanent-failure',
+            'provider_response': 'Email address is on the GC Notify suppression list',
+        }
+    ),
+    (
+        'Bounce',
+        {'bounceType': 'Transient', 'bounceSubType': 'AttachmentRejected'},
+        {
+            'message': 'Soft bounced',
+            'success': False,
+            'notification_status': 'temporary-failure',
+            'provider_response': 'Email was rejected because of its attachments',
+        }
+    ),
+    (
+        'Bounce',
+        {'bounceType': 'Transient', 'bounceSubType': 'MailboxFull'},
+        {
+            'message': 'Soft bounced',
+            'success': False,
+            'notification_status': 'temporary-failure',
+            'provider_response': None,
+        }
+    ),
+])
+def test_get_aws_responses(notify_api, notification_type, bounce_message, expected):
+    with notify_api.test_request_context():
+        assert get_aws_responses(
+            {
+                'notificationType': notification_type,
+                'bounce': {'bouncedRecipients': 'fake'} | bounce_message,
+                'mail': {'destination': "fake"},
+            }
+        ) == expected
+
+
+def test_get_aws_responses_should_be_none_if_unrecognised_status_code(notify_api):
+    with notify_api.test_request_context():
+        with pytest.raises(KeyError) as e:
+            get_aws_responses({'notificationType': '99'})
+        assert '99' in str(e.value)
 
 
 def test_ses_callback_should_not_set_status_once_status_is_delivered(client,


### PR DESCRIPTION
Store better error messages for permanent or temporary failures on SES, in the `provider_response` field, as done recently for SNS https://github.com/cds-snc/notification-api/pull/1265

- Email address is on our email provider suppression list
- Email address is on the GC Notify suppression list
- Email was rejected because of its attachments

Trello: https://trello.com/c/HEZcloCO/460-better-error-messages-for-emails-in-case-of-failures