### PR TITLE
fix: adjust log level when email address is invalid

### DIFF
--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -58,7 +58,9 @@ def deliver_email(self, notification_id):
             raise NoResultFound()
         send_to_providers.send_email_to_provider(notification)
     except InvalidEmailError as e:
-        current_app.logger.exception(e)
+        current_app.logger.info(
+            f"Cannot send notification {notification_id}, got an invalid email address: {str(e)}."
+        )
         update_notification_status_by_id(notification_id, 'technical-failure')
     except MalwarePendingException:
         current_app.logger.info(


### PR DESCRIPTION
Logging an exception counts as an error, while those things are "normal".

Happens in production at the moment when an email address contains accents, SES does not support email addresses with accents.

See https://gcdigital.slack.com/archives/CNWA63606/p1619182249228800