### PR TITLE
feat: split daily limit errors according to service type

### DIFF
--- a/app/v2/errors.py
+++ b/app/v2/errors.py
@@ -35,6 +35,14 @@ class TooManyRequestsError(InvalidRequest):
         self.message = self.message_template.format(sending_limit)
 
 
+class LiveServiceTooManyRequestsError(TooManyRequestsError):
+    pass
+
+
+class TrialServiceTooManyRequestsError(TooManyRequestsError):
+    pass
+
+
 class RateLimitError(InvalidRequest):
     status_code = 429
     message_template = 'Exceeded rate limit for key type {} of {} requests per {} seconds'


### PR DESCRIPTION
Raise a different exception when services go over the daily limit, according to their service type (trial or live service).

This will enable us to have a warning alarm only for live services and not for trial services anymore.

At the moment we use a log line to raise the alarm, will switch to StatsD counters afterwards (see https://github.com/cds-snc/notification-terraform/pull/101 and https://github.com/cds-snc/notification-terraform/pull/108)