### PR TITLE
feat: process multiple SES receipts if needed

### DIFF
--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -12,7 +12,6 @@ from sqlalchemy.orm.exc import NoResultFound
 from app import notify_celery, statsd_client
 from app.config import QueueNames
 from app.dao import notifications_dao
-from app.models import NOTIFICATION_SENDING, NOTIFICATION_PENDING
 from app.notifications.callbacks import _check_and_queue_callback_task
 from app.notifications.notifications_ses_callback import (
     get_aws_responses,
@@ -57,10 +56,6 @@ def process_ses_results(self, response):
                 current_app.logger.warning(
                     "notification not found for reference: {} (update to {})".format(reference, notification_status)
                 )
-            return
-
-        if notification.status not in {NOTIFICATION_SENDING, NOTIFICATION_PENDING}:
-            notifications_dao._duplicate_update_warning(notification, notification_status)
             return
 
         notifications_dao._update_notification_status(


### PR DESCRIPTION
At the moment if we receive multiple delivery receipts for a notification, we ignore new delivery receipts. This is not okay as sometimes email bounce after we receive a delivered callback.

The [SES documentation](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/notification-contents.html) says that

> You might receive multiple types of Amazon SNS notifications for one recipient. For example, the receiving mail server might accept the email (triggering a delivery notification), but after processing the email, the receiving mail server might determine that the email actually results in a bounce (triggering a bounce notification). However, these are always separate notifications because they are different notification types.

Make sure we store the latest known state.

Example message:
> Duplicate callback received. Notification id d4b7ddff-03ca-4ea2-8e99-4b9f06ef14c3 received a status update to temporary-failure0:00:17.361924 after being set to delivered. email sent by ses

---

I checked that we don't have the same problem on SNS

Trello: https://trello.com/c/WcEYhnLd/503-store-updated-delivery-status-for-notifications