### PR TITLE
fix: update service before sending notifications

### DIFF
--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -270,14 +270,14 @@ def update_service(service_id):
         letter_branding_id = req_json['letter_branding']
         service.letter_branding = None if not letter_branding_id else LetterBranding.query.get(letter_branding_id)
 
+    dao_update_service(service)
+
     if message_limit_changed:
         redis_store.delete(daily_limit_cache_key(service_id))
         redis_store.delete(near_daily_limit_cache_key(service_id))
         redis_store.delete(over_daily_limit_cache_key(service_id))
         if not fetched_service.restricted:
             _warn_service_users_about_message_limit_changed(service_id, current_data)
-
-    dao_update_service(service)
 
     if service_going_live:
         _warn_services_users_about_going_live(service_id, current_data)


### PR DESCRIPTION
Rework https://github.com/cds-snc/notification-api/pull/1298

Got the following stracktrace in production

```
File "/app/app/service/rest.py", line 280, in update_service
dao_update_service(service)
File "/app/app/dao/dao_utils.py", line 13, in commit_or_rollback
res = func(*args, **kwargs)
File "/app/app/dao/dao_utils.py", line 58, in record_version
raise RuntimeError((
RuntimeError: Can't record history for Service (something in your code has casued the database to flush the session early so there's nothing to copy into the history table)
```

seems like sending notifications before updating the service flushes the session and then this exception is thrown. It's a shame we didn't get it in tests, because the call to `send_notification_to_service_users` is mocked.

Moved the service update before and tested locally that this solves the error. Would be good to be able to catch this next time.