### PR TITLE
Bump utils to 43.11.0

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -43,7 +43,7 @@ awscli-cwlogs>=1.4.6,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@dfc2bb4a89d72545407a738505bdb64873d9bcbf#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@43.11.0#egg=notifications-utils
 
 # MLWR
 socketio-client==0.5.6

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -43,7 +43,7 @@ awscli-cwlogs>=1.4.6,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@43.9.1#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@dfc2bb4a89d72545407a738505bdb64873d9bcbf#egg=notifications-utils
 
 # MLWR
 socketio-client==0.5.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ awscli-cwlogs>=1.4.6,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@dfc2bb4a89d72545407a738505bdb64873d9bcbf#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@43.11.0#egg=notifications-utils
 
 # MLWR
 socketio-client==0.5.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ awscli-cwlogs>=1.4.6,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@43.9.1#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@dfc2bb4a89d72545407a738505bdb64873d9bcbf#egg=notifications-utils
 
 # MLWR
 socketio-client==0.5.6


### PR DESCRIPTION
Same as https://github.com/cds-snc/notification-admin/pull/1043

Will replace the hash with the version once the utils PR is merged and tagged