### PR TITLE
Bump utils to 43.11.1

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -43,7 +43,7 @@ awscli-cwlogs>=1.4.6,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@43.11.0#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@43.11.1#egg=notifications-utils
 
 # MLWR
 socketio-client==0.5.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ awscli-cwlogs>=1.4.6,<1.5
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@43.11.0#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@43.11.1#egg=notifications-utils
 
 # MLWR
 socketio-client==0.5.6


### PR DESCRIPTION
Release a fix to the FR GoC logo height for emails sent. https://github.com/cds-snc/notification-utils/pull/87

Email previews are not affected.

Trello: https://trello.com/c/EogJwolN/550-french-branding-is-stretched-tall