### PR TITLE
fix: appropriate status for sms in reports

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1670,7 +1670,7 @@ class Notification(db.Model):
                 "delivered": "Delivered",
                 "sending": "Sending",
                 "created": "Sending",
-                "sent": "Sent internationally",
+                "sent": "Sent",
             },
             "letter": {
                 "technical-failure": "Technical failure",

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -134,7 +134,7 @@ def test_notification_for_csv_returns_correct_job_row_number(sample_job):
         ("email", "permanent-failure", "Email address doesn’t exist"),
         ("sms", "temporary-failure", "Phone not accepting messages right now"),
         ("sms", "permanent-failure", "Phone number doesn’t exist"),
-        ("sms", "sent", "Sent internationally"),
+        ("sms", "sent", "Sent"),
         ("letter", "created", "Accepted"),
         ("letter", "sending", "Accepted"),
         ("letter", "technical-failure", "Technical failure"),


### PR DESCRIPTION
## Steps to Reproduce
1) Sent an SMS to a CA number
2) Go to the list of notifications in the UI
3) Status show "Sent internationally" instead of "Sent"

Example URL https://notification.canada.ca/services/de598a67-4bf1-4ea0-b515-8014c36b4734/download-notifications.csv?message_type=sms&status=sending%2Cdelivered%2Cfailed

## Expected Behaviour
Status is "Sent"

Trello: https://trello.com/c/VWLjKJwr/678-reports-show-sent-sent-internationally-for-sms