### PR TITLE
fix: slow down the rate of throttled SMS

### DIFF
--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -20,14 +20,14 @@ from app.notifications.callbacks import _check_and_queue_callback_task
 # https://docs.celeryproject.org/en/stable/userguide/tasks.html#Task.rate_limit
 # This task is dispatched through the `send-throttled-sms-tasks` queue.
 # This queue is consumed by 1 Celery instance with 1 worker, the SMS Celery pod.
-# The maximum throughput is therefore 1 instance * 1 worker = 1 task per 2 seconds
-# if we set rate_limit="2/s" on the Celery task.
+# The maximum throughput is therefore 1 instance * 1 worker = 1 task per rate limit.
+# We the set rate_limit="30/m" on the Celery task to have 1 task per 2 seconds.
 @notify_celery.task(
     bind=True,
     name="deliver_throttled_sms",
     max_retries=48,
     default_retry_delay=300,
-    rate_limit="2/s",
+    rate_limit="30/m",
 )
 @statsd(namespace="tasks")
 def deliver_throttled_sms(self, notification_id):

--- a/scripts/run_celery_sms.ps1
+++ b/scripts/run_celery_sms.ps1
@@ -1,0 +1,3 @@
+$ENV:FORKED_BY_MULTIPROCESSING=1
+
+celery --app run_celery.notify_celery worker --pidfile="$env:TEMP\celery_sms.pid" --pool=solo --loglevel=INFO --concurrency=1 -Q send-throttled-sms-tasks


### PR DESCRIPTION
# Summary | Résumé

Recent incident around AWS SMS rate exceeded in the us-west-2 region forces us to slow down the rate of throttled SMS notifications at 1 request / 2 seconds. This is a quick fix until we have a long term one. That will provide stability over speed which our clients would prefer when sending notifications.

I tested [previous PR](https://github.com/cds-snc/notification-api/pull/1316) and discovered the silly mistake that would rather send 2 request / second instead of 1 request / 2 seconds. Hence these new changes.

# Test instructions | Instructions pour tester la modification

* Send a batch of texto using a simulated long numbers
* Check the log for the message POST simulated notification for id and its frequency to every 2 seconds.
* The notification should be persisted too, despite not being sent. Hence we can check for the notifications in the database and look for the notifications.sent_at column for the service being tested with.

# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their
review | Voici une suggestion de liste de vérification comprenant des questions
que les réviseurs pourraient poser pendant leur examen :


- [ ] Does this meet a user need? | Est-ce que ça répond à un besoin utilisateur?
- [ ] Is it accessible? | Est-ce que c’est accessible?
- [ ] Is it translated between both offical languages? | Est-ce dans les deux
      langues officielles?
- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne
      une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une
      fonctionnalité existante?
- [ ] Should this be split into smaller PRs to decrease change risk? | Est-ce
      que ça devrait être divisé en de plus petites demandes de tirage (« pull
      requests ») afin de réduire le risque lié aux modifications?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une
      modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des
      préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de
      façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de
      risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README
      setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce
      changement (fichier README, etc.)?
