### PR TITLE
Stop passing around sender_id

### DIFF
--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -136,21 +136,6 @@ def test_should_process_sms_job_with_sender_id(sample_template, mocker, fake_uui
     )
 
 
-# def test_should_process_sms_job_with_sender_id_by_kwarg(sample_job, mocker, fake_uuid):
-#     mocker.patch("app.celery.tasks.s3.get_job_from_s3", return_value=load_example_csv("sms"))
-#     mocker.patch("app.celery.tasks.save_sms.apply_async")
-#     mocker.patch("app.encryption.encrypt", return_value="something_encrypted")
-#     mocker.patch("app.celery.tasks.create_uuid", return_value="uuid")
-
-#     process_job(sample_job.id, sender_id=fake_uuid)
-
-#     tasks.save_sms.apply_async.assert_called_once_with(
-#         (str(sample_job.service_id), "uuid", "something_encrypted"),
-#         {"sender_id": fake_uuid},
-#         queue="database-tasks",
-#     )
-
-
 @pytest.mark.parametrize(
     "csv_threshold, expected_queue",
     [
@@ -329,43 +314,6 @@ def test_should_process_email_job(email_job_with_placeholders, mocker):
     redis_mock.assert_called_once_with("job.processing-start-delay", job.processing_started, job.created_at)
 
 
-# def test_should_process_email_job_with_sender_id(sample_email_template, mocker, fake_uuid):
-#     email_csv = """email_address,name
-#     test@test.com,foo
-#     """
-#     job = create_job(template=sample_email_template, sender_id=fake_uuid)
-#     mocker.patch("app.celery.tasks.s3.get_job_from_s3", return_value=email_csv)
-#     mocker.patch("app.celery.tasks.save_email.apply_async")
-#     mocker.patch("app.encryption.encrypt", return_value="something_encrypted")
-#     mocker.patch("app.celery.tasks.create_uuid", return_value="uuid")
-
-#     process_job(job.id, sender_id=fake_uuid)
-
-#     tasks.save_email.apply_async.assert_called_once_with(
-#         (str(job.service_id), "uuid", "something_encrypted"),
-#         {"sender_id": fake_uuid},
-#         queue="database-tasks",
-# )
-
-
-# def test_should_process_email_job_with_sender_id_by_kwarg(email_job_with_placeholders, mocker, fake_uuid):
-#     email_csv = """email_address,name
-#     test@test.com,foo
-#     """
-#     mocker.patch("app.celery.tasks.s3.get_job_from_s3", return_value=email_csv)
-#     mocker.patch("app.celery.tasks.save_email.apply_async")
-#     mocker.patch("app.encryption.encrypt", return_value="something_encrypted")
-#     mocker.patch("app.celery.tasks.create_uuid", return_value="uuid")
-
-#     process_job(email_job_with_placeholders.id, sender_id=fake_uuid)
-
-#     tasks.save_email.apply_async.assert_called_once_with(
-#         (str(email_job_with_placeholders.service_id), "uuid", "something_encrypted"),
-#         {"sender_id": fake_uuid},
-#         queue="database-tasks",
-#     )
-
-
 @freeze_time("2016-01-01 11:09:00.061258")
 def test_should_process_letter_job(sample_letter_job, mocker):
     csv = """address_line_1,address_line_2,address_line_3,address_line_4,postcode,name
@@ -486,41 +434,6 @@ def test_process_row_sends_save_task(
         {"sender_id": str(sender_id)} if sender_id else {},
         queue=expected_queue,
     )
-
-
-# def test_process_row_when_sender_id_is_provided(notify_api, mocker, fake_uuid):
-#     mocker.patch("app.celery.tasks.create_uuid", return_value="noti_uuid")
-#     task_mock = mocker.patch("app.celery.tasks.save_sms.apply_async")
-#     encrypt_mock = mocker.patch("app.celery.tasks.encryption.encrypt")
-#     template = Mock(id="template_id", template_type=SMS_TYPE)
-#     job = Mock(id="job_id", template_version="temp_vers", notification_count=1)
-#     service = Mock(id="service_id", research_mode=False)
-
-#     process_row(
-#         Row(
-#             {"foo": "bar", "to": "recip"},
-#             index="row_num",
-#             error_fn=lambda k, v: None,
-#             recipient_column_headers=["to"],
-#             placeholders={"foo"},
-#             template=template,
-#         ),
-#         template,
-#         job,
-#         service,
-#         sender_id=fake_uuid,
-#     )
-
-#     task_mock.assert_called_once_with(
-#         (
-#             "service_id",
-#             "noti_uuid",
-#             # encrypted data
-#             encrypt_mock.return_value,
-#         ),
-#         {"sender_id": fake_uuid},
-#         queue="database-tasks",
-#     )
 
 
 # -------- save_sms and save_email tests -------- #

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -136,19 +136,19 @@ def test_should_process_sms_job_with_sender_id(sample_template, mocker, fake_uui
     )
 
 
-def test_should_process_sms_job_with_sender_id_by_kwarg(sample_job, mocker, fake_uuid):
-    mocker.patch("app.celery.tasks.s3.get_job_from_s3", return_value=load_example_csv("sms"))
-    mocker.patch("app.celery.tasks.save_sms.apply_async")
-    mocker.patch("app.encryption.encrypt", return_value="something_encrypted")
-    mocker.patch("app.celery.tasks.create_uuid", return_value="uuid")
+# def test_should_process_sms_job_with_sender_id_by_kwarg(sample_job, mocker, fake_uuid):
+#     mocker.patch("app.celery.tasks.s3.get_job_from_s3", return_value=load_example_csv("sms"))
+#     mocker.patch("app.celery.tasks.save_sms.apply_async")
+#     mocker.patch("app.encryption.encrypt", return_value="something_encrypted")
+#     mocker.patch("app.celery.tasks.create_uuid", return_value="uuid")
 
-    process_job(sample_job.id, sender_id=fake_uuid)
+#     process_job(sample_job.id, sender_id=fake_uuid)
 
-    tasks.save_sms.apply_async.assert_called_once_with(
-        (str(sample_job.service_id), "uuid", "something_encrypted"),
-        {"sender_id": fake_uuid},
-        queue="database-tasks",
-    )
+#     tasks.save_sms.apply_async.assert_called_once_with(
+#         (str(sample_job.service_id), "uuid", "something_encrypted"),
+#         {"sender_id": fake_uuid},
+#         queue="database-tasks",
+#     )
 
 
 @pytest.mark.parametrize(
@@ -175,7 +175,7 @@ def test_should_redirect_job_to_queue_depending_on_csv_threshold(
     )
 
     with set_config_values(notify_api, {"CSV_BULK_REDIRECT_THRESHOLD": csv_threshold}):
-        process_row(row, template, job, service, fake_uuid)
+        process_row(row, template, job, service)
 
     tasks.save_email.apply_async.assert_called_once()
     args = mock_save_email.method_calls[0].args
@@ -329,41 +329,41 @@ def test_should_process_email_job(email_job_with_placeholders, mocker):
     redis_mock.assert_called_once_with("job.processing-start-delay", job.processing_started, job.created_at)
 
 
-def test_should_process_email_job_with_sender_id(sample_email_template, mocker, fake_uuid):
-    email_csv = """email_address,name
-    test@test.com,foo
-    """
-    job = create_job(template=sample_email_template, sender_id=fake_uuid)
-    mocker.patch("app.celery.tasks.s3.get_job_from_s3", return_value=email_csv)
-    mocker.patch("app.celery.tasks.save_email.apply_async")
-    mocker.patch("app.encryption.encrypt", return_value="something_encrypted")
-    mocker.patch("app.celery.tasks.create_uuid", return_value="uuid")
+# def test_should_process_email_job_with_sender_id(sample_email_template, mocker, fake_uuid):
+#     email_csv = """email_address,name
+#     test@test.com,foo
+#     """
+#     job = create_job(template=sample_email_template, sender_id=fake_uuid)
+#     mocker.patch("app.celery.tasks.s3.get_job_from_s3", return_value=email_csv)
+#     mocker.patch("app.celery.tasks.save_email.apply_async")
+#     mocker.patch("app.encryption.encrypt", return_value="something_encrypted")
+#     mocker.patch("app.celery.tasks.create_uuid", return_value="uuid")
 
-    process_job(job.id, sender_id=fake_uuid)
+#     process_job(job.id, sender_id=fake_uuid)
 
-    tasks.save_email.apply_async.assert_called_once_with(
-        (str(job.service_id), "uuid", "something_encrypted"),
-        {"sender_id": fake_uuid},
-        queue="database-tasks",
-    )
+#     tasks.save_email.apply_async.assert_called_once_with(
+#         (str(job.service_id), "uuid", "something_encrypted"),
+#         {"sender_id": fake_uuid},
+#         queue="database-tasks",
+# )
 
 
-def test_should_process_email_job_with_sender_id_by_kwarg(email_job_with_placeholders, mocker, fake_uuid):
-    email_csv = """email_address,name
-    test@test.com,foo
-    """
-    mocker.patch("app.celery.tasks.s3.get_job_from_s3", return_value=email_csv)
-    mocker.patch("app.celery.tasks.save_email.apply_async")
-    mocker.patch("app.encryption.encrypt", return_value="something_encrypted")
-    mocker.patch("app.celery.tasks.create_uuid", return_value="uuid")
+# def test_should_process_email_job_with_sender_id_by_kwarg(email_job_with_placeholders, mocker, fake_uuid):
+#     email_csv = """email_address,name
+#     test@test.com,foo
+#     """
+#     mocker.patch("app.celery.tasks.s3.get_job_from_s3", return_value=email_csv)
+#     mocker.patch("app.celery.tasks.save_email.apply_async")
+#     mocker.patch("app.encryption.encrypt", return_value="something_encrypted")
+#     mocker.patch("app.celery.tasks.create_uuid", return_value="uuid")
 
-    process_job(email_job_with_placeholders.id, sender_id=fake_uuid)
+#     process_job(email_job_with_placeholders.id, sender_id=fake_uuid)
 
-    tasks.save_email.apply_async.assert_called_once_with(
-        (str(email_job_with_placeholders.service_id), "uuid", "something_encrypted"),
-        {"sender_id": fake_uuid},
-        queue="database-tasks",
-    )
+#     tasks.save_email.apply_async.assert_called_once_with(
+#         (str(email_job_with_placeholders.service_id), "uuid", "something_encrypted"),
+#         {"sender_id": fake_uuid},
+#         queue="database-tasks",
+#     )
 
 
 @freeze_time("2016-01-01 11:09:00.061258")
@@ -488,39 +488,39 @@ def test_process_row_sends_save_task(
     )
 
 
-def test_process_row_when_sender_id_is_provided(notify_api, mocker, fake_uuid):
-    mocker.patch("app.celery.tasks.create_uuid", return_value="noti_uuid")
-    task_mock = mocker.patch("app.celery.tasks.save_sms.apply_async")
-    encrypt_mock = mocker.patch("app.celery.tasks.encryption.encrypt")
-    template = Mock(id="template_id", template_type=SMS_TYPE)
-    job = Mock(id="job_id", template_version="temp_vers", notification_count=1)
-    service = Mock(id="service_id", research_mode=False)
+# def test_process_row_when_sender_id_is_provided(notify_api, mocker, fake_uuid):
+#     mocker.patch("app.celery.tasks.create_uuid", return_value="noti_uuid")
+#     task_mock = mocker.patch("app.celery.tasks.save_sms.apply_async")
+#     encrypt_mock = mocker.patch("app.celery.tasks.encryption.encrypt")
+#     template = Mock(id="template_id", template_type=SMS_TYPE)
+#     job = Mock(id="job_id", template_version="temp_vers", notification_count=1)
+#     service = Mock(id="service_id", research_mode=False)
 
-    process_row(
-        Row(
-            {"foo": "bar", "to": "recip"},
-            index="row_num",
-            error_fn=lambda k, v: None,
-            recipient_column_headers=["to"],
-            placeholders={"foo"},
-            template=template,
-        ),
-        template,
-        job,
-        service,
-        sender_id=fake_uuid,
-    )
+#     process_row(
+#         Row(
+#             {"foo": "bar", "to": "recip"},
+#             index="row_num",
+#             error_fn=lambda k, v: None,
+#             recipient_column_headers=["to"],
+#             placeholders={"foo"},
+#             template=template,
+#         ),
+#         template,
+#         job,
+#         service,
+#         sender_id=fake_uuid,
+#     )
 
-    task_mock.assert_called_once_with(
-        (
-            "service_id",
-            "noti_uuid",
-            # encrypted data
-            encrypt_mock.return_value,
-        ),
-        {"sender_id": fake_uuid},
-        queue="database-tasks",
-    )
+#     task_mock.assert_called_once_with(
+#         (
+#             "service_id",
+#             "noti_uuid",
+#             # encrypted data
+#             encrypt_mock.return_value,
+#         ),
+#         {"sender_id": fake_uuid},
+#         queue="database-tasks",
+#     )
 
 
 # -------- save_sms and save_email tests -------- #


### PR DESCRIPTION
# Summary | Résumé

https://trello.com/c/Ijn2D73k/576-bulk-api-follow-up-improve-how-sender-id-is-passed

We moved `sender_id` into the job object, so we don't need to pass it around as a kwarg.

Notes:
Currently `process_job()` is only called in
- `run_scheduled_jobs()`
- `create_job()`
- `create_bulk_job()`

Note that it is never called with a `sender_id`. 

In `process_job()` we just use `sender_id` to send to `process_row()`. Since it gets the job, we can pull out the `sender_id` there instead of passing it in.

`process_row()` is called in
- `process_job()`
- `process_incomplete_job()`

In `process_incomplete_job()`, `sender_id` is not set when `process_row()` is called.

So we can stop passing `sender_id` around and set it in `process_row()`


# Test instructions | Instructions pour tester la modification

Send some emails and make sure they go through?

# Help requested | Aide requise

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

In a given job, `save_email()` and `save_sms()` are doing the same database reads each time they're called. We could probably just pull out stuff in `process_job()` and pass it down through the encrypted object. For example, the `reply_to_text` would be easy to move. I think it's better to get into this in a separate PR though.
 
# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their
review | Voici une suggestion de liste de vérification comprenant des questions
que les réviseurs pourraient poser pendant leur examen :


- [ ] Does this meet a user need? | Est-ce que ça répond à un besoin utilisateur?
- [ ] Is it accessible? | Est-ce que c’est accessible?
- [ ] Is it translated between both offical languages? | Est-ce dans les deux
      langues officielles?
- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne
      une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une
      fonctionnalité existante?
- [ ] Should this be split into smaller PRs to decrease change risk? | Est-ce
      que ça devrait être divisé en de plus petites demandes de tirage (« pull
      requests ») afin de réduire le risque lié aux modifications?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une
      modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des
      préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de
      façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de
      risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README
      setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce
      changement (fichier README, etc.)?
