### PR TITLE
Only do malware scan if MLWR_HOST looks like a url

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -115,6 +115,7 @@ def send_email_to_provider(notification):
             # Check if a MLWR sid exists
             if (
                 current_app.config["MLWR_HOST"]
+                and "https" in str(current_app.config["MLWR_HOST"])
                 and "mlwr_sid" in personalisation_data[key]["document"]
                 and personalisation_data[key]["document"]["mlwr_sid"] != "false"
             ):


### PR DESCRIPTION
# Summary | Résumé

https://trello.com/c/vXs2FgT0/595-malware-checking-exploit-to-get-notifications-stuck-in-queue

App is trying to do malware scan when we don't want it to. I believe that the environment variable `MLWR_HOST` is a string, so its value of `"False"` is being evaluated as the boolean `True` in the `if` statement. Isn't Python grand?

Here we add a check that `https` is in `MLWR_HOST` to prevent such shenanigans.

# Test instructions | Instructions pour tester la modification

Run this branch of api and notification-document-download-api locally, make sure that your service is allowed to send files, and do a curl such as
```
curl -i -X POST \
   -H "Authorization:ApiKey-v1  *** API SECRET ***" \
   -H "Content-Type:application/json" \
   -d \
'{
  "email_address": "*** your email address*** ",
  "template_id": "*** TEMPLATE ID ***",
  "personalisation": {
        "some_file": {
            "file": "dGVzdGluZyBvbmUgdHdvIHRocmVlZQ==",
            "filename": "some_file.txt",
            "sending_method": "attach",
            "mlwr_sid": "testing"
        }
    }
}' \
 'http://localhost:6011/v2/notifications/email'
``` 

This should cause a failure in celery in the current master branch, but no failure in this branch.

# Help requested | Aide requise

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their
review | Voici une suggestion de liste de vérification comprenant des questions
que les réviseurs pourraient poser pendant leur examen :


- [ ] Does this meet a user need? | Est-ce que ça répond à un besoin utilisateur?
- [ ] Is it accessible? | Est-ce que c’est accessible?
- [ ] Is it translated between both offical languages? | Est-ce dans les deux
      langues officielles?
- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne
      une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une
      fonctionnalité existante?
- [ ] Should this be split into smaller PRs to decrease change risk? | Est-ce
      que ça devrait être divisé en de plus petites demandes de tirage (« pull
      requests ») afin de réduire le risque lié aux modifications?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une
      modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des
      préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de
      façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de
      risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README
      setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce
      changement (fichier README, etc.)?
