### PR TITLE
Use sent status on notifications that were sent

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -69,7 +69,7 @@ def send_sms_to_provider(notification):
 
         if service.research_mode or notification.key_type == KEY_TYPE_TEST:
             notification.reference = send_sms_response(provider.get_name(), notification.to)
-            update_notification_to_sending(notification, provider)
+            update_notification_to_sent(notification, provider)
 
         else:
             try:
@@ -178,7 +178,7 @@ def send_email_to_provider(notification):
 
         if service.research_mode or notification.key_type == KEY_TYPE_TEST:
             notification.reference = send_email_response(notification.to)
-            update_notification_to_sending(notification, provider)
+            update_notification_to_sent(notification, provider)
         else:
             if service.sending_domain is None or service.sending_domain.strip() == "":
                 sending_domain = current_app.config["NOTIFY_EMAIL_DOMAIN"]
@@ -199,7 +199,7 @@ def send_email_to_provider(notification):
                 attachments=attachments,
             )
             notification.reference = reference
-            update_notification_to_sending(notification, provider)
+            update_notification_to_sent(notification, provider)
 
         # Record StatsD stats to compute SLOs
         statsd_client.timing_with_dates("email.total-time", notification.sent_at, notification.created_at)
@@ -210,9 +210,18 @@ def send_email_to_provider(notification):
 
 
 def update_notification_to_sending(notification, provider):
+    status = NOTIFICATION_SENT if notification.notification_type == "sms" else NOTIFICATION_SENDING
+    update_notification_with_status(notification, provider, status)
+
+
+def update_notification_to_sent(notification, provider):
+    update_notification_with_status(notification, provider, NOTIFICATION_SENT)
+
+
+def update_notification_with_status(notification, provider, status):
     notification.sent_at = datetime.utcnow()
     notification.sent_by = provider.get_name()
-    notification.status = NOTIFICATION_SENT if notification.notification_type == "sms" else NOTIFICATION_SENDING
+    notification.status = status
     dao_update_notification(notification)
 
 


### PR DESCRIPTION
# Summary | Résumé

Exploring the option to use the `SENT` status for the notifications after it went through the AWS provider. 

At the moment, the current code base for emails complete skip the `SENT` status. The `SENDING` status is set instead when the notifications are sent to the AWS provider. Upon receiving the receipt, the status then becomes `DELIVERED` status. 

This lead to some confusion to know the real status of the notifications, especially as it gets carried up through the UI where users see that many of their notifications that were actually sent are still with a `SENDING` status despite it was really sent, but did not have a receipt yet and might never because there is a certain percentage that never will (around 1%-3% of sent notifications).

# Test instructions | Instructions pour tester la modification

More to come with this...

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

* Will this affect the notifications or their status reporting somehow by having the `SENT` status set earlier?

# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their
review | Voici une suggestion de liste de vérification comprenant des questions
que les réviseurs pourraient poser pendant leur examen :


- [ ] Does this meet a user need? | Est-ce que ça répond à un besoin utilisateur?
- [ ] Is it accessible? | Est-ce que c’est accessible?
- [ ] Is it translated between both offical languages? | Est-ce dans les deux
      langues officielles?
- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne
      une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une
      fonctionnalité existante?
- [ ] Should this be split into smaller PRs to decrease change risk? | Est-ce
      que ça devrait être divisé en de plus petites demandes de tirage (« pull
      requests ») afin de réduire le risque lié aux modifications?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une
      modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des
      préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de
      façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de
      risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README
      setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce
      changement (fichier README, etc.)?
