### PR TITLE
Add a continuous deployment step for the lambda image

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   GITHUB_SHA: ${{ github.sha }}
-  REGISTRY: ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.ca-central-1.amazonaws.com/notify/api
+  REGISTRY: ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.ca-central-1.amazonaws.com/notify
 
 jobs:
   changes:
@@ -71,9 +71,3 @@ jobs:
           aws lambda update-function-code \
             --function-name ${{ matrix.image }} \
             --image-uri $REGISTRY/${{ matrix.image }}:latest
-
-      - name: Migrate Database
-        if: ${{ matrix.image == 'api' }}
-        run: |
-          source .github/workflows/scripts/migrate.sh
-          migrate

--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -1,0 +1,53 @@
+
+  build-push-and-deploy:
+    if: ${{ needs.changes.outputs.images != '[]' }}
+    runs-on: ubuntu-latest
+    needs: changes
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJSON(needs.changes.outputs.images) }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build container
+        working-directory: ./${{ matrix.image }}
+        run: |
+          docker build \
+          --build-arg git_sha=$GITHUB_SHA \
+          -t $REGISTRY/${{ matrix.image }}:$GITHUB_SHA \
+          -t $REGISTRY/${{ matrix.image }}:latest .
+
+      - name: Configure AWS credentials
+        id: aws-creds
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+
+      - name: Login to ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Push containers to ECR
+        run: |
+          docker push $REGISTRY/${{ matrix.image }}:$GITHUB_SHA
+          docker push $REGISTRY/${{ matrix.image }}:latest
+
+      - name: Logout of Amazon ECR
+        run: docker logout ${{ steps.login-ecr.outputs.registry }}
+
+      - name: Deploy lambda
+        run: |
+          aws lambda update-function-code \
+            --function-name ${{ matrix.image }} \
+            --image-uri $REGISTRY/${{ matrix.image }}:latest
+
+      - name: Migrate Database
+        if: ${{ matrix.image == 'api' }}
+        run: |
+          source .github/workflows/scripts/migrate.sh
+          migrate

--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -1,4 +1,30 @@
 
+name: Build and Push Container to ECR, deploy to lambda
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+
+env:
+  GITHUB_SHA: ${{ github.sha }}
+  REGISTRY: ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.ca-central-1.amazonaws.com/notify/api
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      images: ${{ steps.filter.outputs.changes }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            api: 'app/**'
+
   build-push-and-deploy:
     if: ${{ needs.changes.outputs.images != '[]' }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Summary | Résumé

Most of this is copied from https://github.com/cds-snc/scan-websites/blob/main/.github/workflows/build_and_push.yml. All I did was copy in the name of our ECR repository in staging (`notify/api`) and set the branch name to "master".

This uses a new env variable that I haven't added yet: our aws account number (`AWS_ACCOUNT`).

I'm sure I missed some things so will keep this a draft for now. 