### PR TITLE
Added tests around the cache not loading properly with reply address

### DIFF
--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -589,7 +589,7 @@ def test_save_sms_should_use_redis_cache_to_retrieve_service_and_template_when_p
     sms_sender.sms_sender = "+16502532222"
 
     mocked_get_sender_id = mocker.patch("app.celery.tasks.dao_get_service_sms_senders_by_id", return_value=sms_sender)
-    celery_task = 'deliver_throttled_sms' if sender_id else "deliver_sms"
+    celery_task = "deliver_throttled_sms" if sender_id else "deliver_sms"
     mocked_deliver_sms = mocker.patch(f"app.celery.provider_tasks.{celery_task}.apply_async")
     json_template_date = {"data": template_schema.dump(sample_template_with_placeholders).data}
     json_service_data = {"data": service_schema.dump(sample_template_with_placeholders.service).data}


### PR DESCRIPTION
# Summary | Résumé

Added tests [around the changes](https://github.com/cds-snc/notification-api/pull/13590 that fixed the issue when cache would not properly load with a notification that had a sender ID defined.

# Test instructions | Instructions pour tester la modification

Test the tests?

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their
review | Voici une suggestion de liste de vérification comprenant des questions
que les réviseurs pourraient poser pendant leur examen :


- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne
      une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une
      fonctionnalité existante?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une
      modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des
      préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de
      façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de
      risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README
      setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce
      changement (fichier README, etc.)?
