### PR TITLE
[WIP] Define load tests for one off, bulk  email and SMS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,5 @@ AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 
 AWS_PINPOINT_REGION=us-west-2
+
+LOAD_TEST_DOMAIN=https://api.staging.notification.cdssandbox.xyz

--- a/.env.example
+++ b/.env.example
@@ -21,5 +21,3 @@ AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 
 AWS_PINPOINT_REGION=us-west-2
-
-LOAD_TEST_DOMAIN=https://api.staging.notification.cdssandbox.xyz

--- a/tests-perf/locust/locust-notifications.py
+++ b/tests-perf/locust/locust-notifications.py
@@ -63,7 +63,7 @@ class NotifyApiUser(HttpUser):
 
         self.client.post("/v2/notifications/bulk", json=self.json, headers=self.headers)
 
-    @task(12)
+    @task(16)
     def send_sms_notifications(self):
         self.json = {
             "phone_number": 12897682684,

--- a/tests-perf/locust/locust-notifications.py
+++ b/tests-perf/locust/locust-notifications.py
@@ -34,7 +34,7 @@ class NotifyApiUser(HttpUser):
 
         self.headers = {"Authorization": os.getenv("TEST_AUTH_HEADER")}
         self.email = os.getenv("LOAD_TEST_EMAIL", "success@simulator.amazonses.com")
-        self.phone_number = os.getenv("LOAD_TEST_PHONE_NUMBER", "12897682684")
+        self.phone_number = os.getenv("LOAD_TEST_PHONE_NUMBER", "16132532222")
         self.template_group = NotifyApiUserTemplateGroup(
             bulk_email_id=os.getenv("LOAD_TEST_BULK_EMAIL_TEMPLATE_ID", "5ebee3b7-63c0-4052-a8cb-387b818df627"),
             email_id=os.getenv("LOAD_TEST_EMAIL_TEMPLATE_ID", "a59b313d-8de2-4973-ac2f-66de7ec0b239"),

--- a/tests-perf/locust/locust-notifications.py
+++ b/tests-perf/locust/locust-notifications.py
@@ -1,11 +1,12 @@
 """ locust-notifications.py
-   isort:skip_file
+    isort:skip_file
 """
 # flake8: noqa
 
 import os
 import sys
 from datetime import datetime
+from dataclasses import make_dataclass
 
 sys.path.append(os.path.abspath(os.path.join("..", "tests_smoke")))
 
@@ -14,6 +15,13 @@ from locust import HttpUser, constant_pacing, task
 from tests_smoke.smoke.common import job_line, rows_to_csv  # type: ignore
 
 load_dotenv()
+NotifyApiUserTemplateGroup = make_dataclass('NotifyApiUserTemplateGroup', [
+    'bulk_email_id',
+    'email_id',
+    'email_with_attachment_id',
+    'email_with_link_id',
+    'sms_id',
+])
 
 
 class NotifyApiUser(HttpUser):
@@ -25,26 +33,32 @@ class NotifyApiUser(HttpUser):
         super(NotifyApiUser, self).__init__(*args, **kwargs)
 
         self.headers = {"Authorization": os.getenv("TEST_AUTH_HEADER")}
-        self.email = "success@simulator.amazonses.com"
-        self.template_id = "5ebee3b7-63c0-4052-a8cb-387b818df627"
+        self.email = os.getenv("LOAD_TEST_EMAIL", "success@simulator.amazonses.com")
+        self.phone_number = os.getenv("LOAD_TEST_PHONE_NUMBER", "12897682684")
+        self.template_group = NotifyApiUserTemplateGroup(
+            bulk_email_id=os.getenv("LOAD_TEST_BULK_EMAIL_TEMPLATE_ID", "5ebee3b7-63c0-4052-a8cb-387b818df627"),
+            email_id=os.getenv("LOAD_TEST_EMAIL_TEMPLATE_ID", "a59b313d-8de2-4973-ac2f-66de7ec0b239"),
+            email_with_attachment_id=os.getenv("LOAD_TEST_EMAIL_WITH_ATTACHMENT_TEMPLATE_ID", "a59b313d-8de2-4973-ac2f-66de7ec0b239"),
+            email_with_link_id=os.getenv("LOAD_TEST_EMAIL_WITH_LINK_TEMPLATE_ID", "5ebee3b7-63c0-4052-a8cb-387b818df627"),
+            sms_id=os.getenv("LOAD_TEST_SMS_TEMPLATE_ID", "83d01f06-a818-4134-bd69-ce90a2949280"),
+        )
 
     @task(1)
     def send_email_notifications(self):
-        json = self.__email_json("a59b313d-8de2-4973-ac2f-66de7ec0b239")
+        json = self.__email_json(self.template_group.email_id)
 
         self.client.post("/v2/notifications/email", json=json, headers=self.headers)
 
     @task(2)
     def send_email_with_attachment_notifications(self):
         personalisation = {
-            "application_file": "arbitrary text for this variable",
             "attached_file": {
                 "file": "Q29udGVudCBvZiBBdHRhY2hlZCBmaWxl",
                 "filename": "attached_file.txt",
                 "sending_method": "attach",
             }
         }
-        json = self.__email_json(self.template_id, personalisation)
+        json = self.__email_json(self.template_group.email_with_attachment_id, personalisation)
 
         self.client.post("/v2/notifications/email", json=json, headers=self.headers)
 
@@ -57,7 +71,7 @@ class NotifyApiUser(HttpUser):
                 "sending_method": "link",
             }
         }
-        json = self.__email_json(self.template_id, personalisation)
+        json = self.__email_json(self.template_group.email_with_link_id, personalisation)
 
         self.client.post("/v2/notifications/email", json=json, headers=self.headers)
 
@@ -65,7 +79,7 @@ class NotifyApiUser(HttpUser):
     def send_bulk_notifications(self):
         json = {
             "name": f"My bulk name {datetime.utcnow().isoformat()}",
-            "template_id": self.template_id,
+            "template_id": self.template_group.bulk_email_id,
             "csv": rows_to_csv([["email address", "application_file"], *job_line(self.email, 2)])
         }
 
@@ -74,8 +88,8 @@ class NotifyApiUser(HttpUser):
     @task(16)
     def send_sms_notifications(self):
         json = {
-            "phone_number": "12897682684",
-            "template_id": "83d01f06-a818-4134-bd69-ce90a2949280"
+            "phone_number": self.phone_number,
+            "template_id": self.template_group.sms_id
         }
 
         self.client.post("/v2/notifications/sms", json=json, headers=self.headers)

--- a/tests-perf/locust/locust-notifications.py
+++ b/tests-perf/locust/locust-notifications.py
@@ -19,63 +19,64 @@ class NotifyApiUser(HttpUser):
         super(NotifyApiUser, self).__init__(*args, **kwargs)
 
         self.headers = {"Authorization": AUTH_HEADER}
-        self.template_id = "5ebee3b7-63c0-4052-a8cb-387b818df627"
         self.email = "success@simulator.amazonses.com"
-        self.json = {
-            "email_address": self.email,
-            "template_id": self.template_id,
-            "personalisation": {},
-        }
+        self.template_id = "5ebee3b7-63c0-4052-a8cb-387b818df627"
 
     @task(1)
     def send_email_notifications(self):
-        self.json = {
-            "email_address": self.email,
-            "template_id": "a59b313d-8de2-4973-ac2f-66de7ec0b239",
-            "personalisation": {},
-        }
+        json = self.__email_json("a59b313d-8de2-4973-ac2f-66de7ec0b239")
 
-        self.client.post("/v2/notifications/email", json=self.json, headers=self.headers)
+        self.client.post("/v2/notifications/email", json=json, headers=self.headers)
 
     @task(2)
     def send_email_with_attachment_notifications(self):
-        self.json["personalisation"] = {
+        personalisation = {
             "application_file": {
                 "file": "Q29udGVudCBvZiBBdHRhY2hlZCBmaWxl",
                 "filename": "attached_file.txt",
                 "sending_method": "attach",
             }
         }
+        json = self.__email_json(self.template_id, personalisation)
 
-        self.client.post("/v2/notifications/email", json=self.json, headers=self.headers)
+        self.client.post("/v2/notifications/email", json=json, headers=self.headers)
 
     @task(4)
     def send_email_with_link_notifications(self):
-        self.json["personalisation"] = {
+        personalisation = {
             "application_file": {
                 "file": "Q29udGVudCBvZiBBdHRhY2hlZCBmaWxl",
                 "filename": "attached_file.txt",
                 "sending_method": "link",
             }
         }
+        json = self.__email_json(self.template_id, personalisation)
 
-        self.client.post("/v2/notifications/email", json=self.json, headers=self.headers)
+
+        self.client.post("/v2/notifications/email", json=json, headers=self.headers)
 
     @task(8)
     def send_bulk_notifications(self):
-        self.json = {
+        json = {
             "name": f"My bulk name {datetime.utcnow().isoformat()}",
-            "template_id": "5ebee3b7-63c0-4052-a8cb-387b818df627",
+            "template_id": self.template_id,
             "csv": rows_to_csv([["email address", "application_file"], *job_line(self.email, 2)])
         }
 
-        self.client.post("/v2/notifications/bulk", json=self.json, headers=self.headers)
+        self.client.post("/v2/notifications/bulk", json=json, headers=self.headers)
 
     @task(16)
     def send_sms_notifications(self):
-        self.json = {
+        json = {
             "phone_number": "12897682684",
             "template_id": "83d01f06-a818-4134-bd69-ce90a2949280"
         }
 
-        self.client.post("/v2/notifications/sms", json=self.json, headers=self.headers)
+        self.client.post("/v2/notifications/sms", json=json, headers=self.headers)
+
+    def __email_json(self, template_id, personalisation = {}):
+        return {
+            "email_address": self.email,
+            "template_id": template_id,
+            "personalisation": personalisation,
+        }

--- a/tests-perf/locust/locust-notifications.py
+++ b/tests-perf/locust/locust-notifications.py
@@ -19,15 +19,22 @@ class NotifyApiUser(HttpUser):
         super(NotifyApiUser, self).__init__(*args, **kwargs)
 
         self.headers = {"Authorization": AUTH_HEADER}
+        self.template_id = "5ebee3b7-63c0-4052-a8cb-387b818df627"
         self.email = "success@simulator.amazonses.com"
         self.json = {
             "email_address": self.email,
-            "template_id": "5ebee3b7-63c0-4052-a8cb-387b818df627",
+            "template_id": self.template_id,
             "personalisation": {},
         }
 
     @task(1)
     def send_email_notifications(self):
+        self.json = {
+            "email_address": self.email,
+            "template_id": "a59b313d-8de2-4973-ac2f-66de7ec0b239",
+            "personalisation": {},
+        }
+
         self.client.post("/v2/notifications/email", json=self.json, headers=self.headers)
 
     @task(2)

--- a/tests-perf/locust/locust-notifications.py
+++ b/tests-perf/locust/locust-notifications.py
@@ -43,13 +43,13 @@ class NotifyApiUser(HttpUser):
             sms_id=os.getenv("LOAD_TEST_SMS_TEMPLATE_ID", "83d01f06-a818-4134-bd69-ce90a2949280"),
         )
 
-    @task(1)
+    @task(16)
     def send_email_notifications(self):
         json = self.__email_json(self.template_group.email_id)
 
         self.client.post("/v2/notifications/email", json=json, headers=self.headers)
 
-    @task(2)
+    @task(8)
     def send_email_with_attachment_notifications(self):
         personalisation = {
             "attached_file": {
@@ -75,7 +75,7 @@ class NotifyApiUser(HttpUser):
 
         self.client.post("/v2/notifications/email", json=json, headers=self.headers)
 
-    @task(8)
+    @task(2)
     def send_bulk_notifications(self):
         json = {
             "name": f"My bulk name {datetime.utcnow().isoformat()}",
@@ -85,7 +85,7 @@ class NotifyApiUser(HttpUser):
 
         self.client.post("/v2/notifications/bulk", json=json, headers=self.headers)
 
-    @task(16)
+    @task(1)
     def send_sms_notifications(self):
         json = {
             "phone_number": self.phone_number,

--- a/tests-perf/locust/locust-notifications.py
+++ b/tests-perf/locust/locust-notifications.py
@@ -30,7 +30,8 @@ class NotifyApiUser(HttpUser):
     @task(2)
     def send_email_with_attachment_notifications(self):
         personalisation = {
-            "application_file": {
+            "application_file": "arbitrary text for this variable", 
+            "attached_file": {
                 "file": "Q29udGVudCBvZiBBdHRhY2hlZCBmaWxl",
                 "filename": "attached_file.txt",
                 "sending_method": "attach",

--- a/tests-perf/locust/locust-notifications.py
+++ b/tests-perf/locust/locust-notifications.py
@@ -85,7 +85,7 @@ class NotifyApiUser(HttpUser):
 
         self.client.post("/v2/notifications/bulk", json=json, headers=self.headers)
 
-    @task(1)
+    @task(10)
     def send_sms_notifications(self):
         json = {
             "phone_number": self.phone_number,

--- a/tests-perf/locust/locust-notifications.py
+++ b/tests-perf/locust/locust-notifications.py
@@ -1,7 +1,14 @@
-import sys, os
+""" locust-notifications.py
+   isort:skip_file
+"""
+# flake8: noqa
+
+import os
+import sys
+from datetime import datetime
+
 sys.path.append(os.path.abspath(os.path.join("..", "tests_smoke")))
 
-from datetime import datetime
 from dotenv import load_dotenv
 from locust import HttpUser, constant_pacing, task
 from tests_smoke.smoke.common import job_line, rows_to_csv
@@ -30,7 +37,7 @@ class NotifyApiUser(HttpUser):
     @task(2)
     def send_email_with_attachment_notifications(self):
         personalisation = {
-            "application_file": "arbitrary text for this variable", 
+            "application_file": "arbitrary text for this variable",
             "attached_file": {
                 "file": "Q29udGVudCBvZiBBdHRhY2hlZCBmaWxl",
                 "filename": "attached_file.txt",
@@ -51,7 +58,6 @@ class NotifyApiUser(HttpUser):
             }
         }
         json = self.__email_json(self.template_id, personalisation)
-
 
         self.client.post("/v2/notifications/email", json=json, headers=self.headers)
 
@@ -74,7 +80,7 @@ class NotifyApiUser(HttpUser):
 
         self.client.post("/v2/notifications/sms", json=json, headers=self.headers)
 
-    def __email_json(self, template_id, personalisation = {}):
+    def __email_json(self, template_id, personalisation={}):
         return {
             "email_address": self.email,
             "template_id": template_id,

--- a/tests-perf/locust/locust-notifications.py
+++ b/tests-perf/locust/locust-notifications.py
@@ -1,7 +1,10 @@
-import os
+import sys, os
+sys.path.append(os.path.abspath(os.path.join("..", "tests_smoke")))
 
+from datetime import datetime
 from dotenv import load_dotenv
 from locust import HttpUser, constant_pacing, task
+from tests_smoke.smoke.common import job_line, rows_to_csv
 
 load_dotenv()
 AUTH_HEADER = os.getenv("TEST_AUTH_HEADER")
@@ -49,3 +52,23 @@ class NotifyApiUser(HttpUser):
         }
 
         self.client.post("/v2/notifications/email", json=self.json, headers=self.headers)
+
+    @task(8)
+    def send_bulk_notifications(self):
+        self.json = {
+            "name": f"My bulk name {datetime.utcnow().isoformat()}",
+            "template_id": "5ebee3b7-63c0-4052-a8cb-387b818df627",
+            "csv": rows_to_csv([["email address", "var"], *job_line(self.json["email_address"], 2)])
+        }
+
+        self.client.post("/v2/notifications/bulk", json=self.json, headers=self.headers)
+
+    @task(12)
+    def send_sms_notifications(self):
+        self.json = {
+            "phone_number": 12897682684,
+            "template_id": "d8234b4d-4def-4ad6-aafe-526a24ee5f19",
+            "var": "var"
+        }
+
+        self.client.post("/v2/notifications/sms", json=self.json, headers=self.headers)

--- a/tests-perf/locust/locust-notifications.py
+++ b/tests-perf/locust/locust-notifications.py
@@ -59,7 +59,7 @@ class NotifyApiUser(HttpUser):
         self.json = {
             "name": f"My bulk name {datetime.utcnow().isoformat()}",
             "template_id": "5ebee3b7-63c0-4052-a8cb-387b818df627",
-            "csv": rows_to_csv([["email address", "var"], *job_line(self.email, 2)])
+            "csv": rows_to_csv([["email address", "application_file"], *job_line(self.email, 2)])
         }
 
         self.client.post("/v2/notifications/bulk", json=self.json, headers=self.headers)

--- a/tests-perf/locust/locust-notifications.py
+++ b/tests-perf/locust/locust-notifications.py
@@ -1,7 +1,7 @@
 import os
 
 from dotenv import load_dotenv
-from locust import HttpUser, constant_pacing, task
+from locust import HttpUser, constant_pacing, task, tag
 
 load_dotenv()
 AUTH_HEADER = os.getenv("TEST_AUTH_HEADER")
@@ -12,13 +12,50 @@ class NotifyApiUser(HttpUser):
     wait_time = constant_pacing(60)
     host = "https://api.staging.notification.cdssandbox.xyz"
 
-    @task
-    def send_notifications(self):
-        headers = {"Authorization": AUTH_HEADER}
-        json = {
+    def __init__(self, *args, **kwargs):
+        super(NotifyApiUser, self).__init__(*args, **kwargs)
+
+        self.headers = {"Authorization": AUTH_HEADER}
+        self.json = {
             "email_address": "success@simulator.amazonses.com",
             "template_id": "9c17633c-126a-4ad3-ad2f-b14c3a85314a",
             "personalisation": {"colour": "Fulvous"},
         }
 
-        self.client.post("/v2/notifications/email", json=json, headers=headers)
+    @task
+    def task(self):
+        pass
+
+class OneOffEmailMessage(NotifyApiUser):
+    @tag("one-off-email")
+    @task
+    def send_one_off_email_notifications(self):
+        self.client.post("/v2/notifications/email", json=self.json, headers=self.headers)
+
+class OneOffEmailWithFileAttachmentMessage(NotifyApiUser):
+    @tag("one-off-email-attached")
+    @task
+    def send_one_off_email_with_attachment_notifications(self):
+        self.json["personalisation"] = {
+            "application_file": {
+                "file": "Q29udGVudCBvZiBBdHRhY2hlZCBmaWxl",
+                "filename": "attached_file.txt",
+                "sending_method": "attach",
+            }
+        }
+
+        self.client.post("/v2/notifications/email", json=self.json, headers=self.headers)
+
+class OneOffEmailWithLinkMessage(NotifyApiUser):
+    @tag("one-off-email-link")
+    @task
+    def send_one_off_email_with_link_notifications(self):
+        self.json["personalisation"] = {
+            "var": {
+                "file": "Q29udGVudCBvZiBBdHRhY2hlZCBmaWxl",
+                "filename": "attached_file.txt",
+                "sending_method": "link",
+            }
+        }
+
+        self.client.post("/v2/notifications/email", json=self.json, headers=self.headers)

--- a/tests-perf/locust/locust-notifications.py
+++ b/tests-perf/locust/locust-notifications.py
@@ -1,7 +1,7 @@
 import os
 
 from dotenv import load_dotenv
-from locust import HttpUser, constant_pacing, task, tag
+from locust import HttpUser, constant_pacing, task
 
 load_dotenv()
 AUTH_HEADER = os.getenv("TEST_AUTH_HEADER")
@@ -18,24 +18,16 @@ class NotifyApiUser(HttpUser):
         self.headers = {"Authorization": AUTH_HEADER}
         self.json = {
             "email_address": "success@simulator.amazonses.com",
-            "template_id": "9c17633c-126a-4ad3-ad2f-b14c3a85314a",
-            "personalisation": {"colour": "Fulvous"},
+            "template_id": "5ebee3b7-63c0-4052-a8cb-387b818df627",
+            "personalisation": {},
         }
 
-    @task
-    def task(self):
-        pass
-
-class OneOffEmailMessage(NotifyApiUser):
-    @tag("one-off-email")
-    @task
-    def send_one_off_email_notifications(self):
+    @task(1)
+    def send_email_notifications(self):
         self.client.post("/v2/notifications/email", json=self.json, headers=self.headers)
 
-class OneOffEmailWithFileAttachmentMessage(NotifyApiUser):
-    @tag("one-off-email-attached")
-    @task
-    def send_one_off_email_with_attachment_notifications(self):
+    @task(2)
+    def send_email_with_attachment_notifications(self):
         self.json["personalisation"] = {
             "application_file": {
                 "file": "Q29udGVudCBvZiBBdHRhY2hlZCBmaWxl",
@@ -46,10 +38,8 @@ class OneOffEmailWithFileAttachmentMessage(NotifyApiUser):
 
         self.client.post("/v2/notifications/email", json=self.json, headers=self.headers)
 
-class OneOffEmailWithLinkMessage(NotifyApiUser):
-    @tag("one-off-email-link")
-    @task
-    def send_one_off_email_with_link_notifications(self):
+    @task(4)
+    def send_email_with_link_notifications(self):
         self.json["personalisation"] = {
             "var": {
                 "file": "Q29udGVudCBvZiBBdHRhY2hlZCBmaWxl",

--- a/tests-perf/locust/locust-notifications.py
+++ b/tests-perf/locust/locust-notifications.py
@@ -68,7 +68,7 @@ class NotifyApiUser(HttpUser):
     def send_sms_notifications(self):
         self.json = {
             "phone_number": "12897682684",
-            "template_id": "d8234b4d-4def-4ad6-aafe-526a24ee5f19"
+            "template_id": "83d01f06-a818-4134-bd69-ce90a2949280"
         }
 
         self.client.post("/v2/notifications/sms", json=self.json, headers=self.headers)

--- a/tests-perf/locust/locust-notifications.py
+++ b/tests-perf/locust/locust-notifications.py
@@ -7,18 +7,17 @@ from locust import HttpUser, constant_pacing, task
 from tests_smoke.smoke.common import job_line, rows_to_csv
 
 load_dotenv()
-AUTH_HEADER = os.getenv("TEST_AUTH_HEADER")
 
 
 class NotifyApiUser(HttpUser):
 
     wait_time = constant_pacing(60)
-    host = "https://api.staging.notification.cdssandbox.xyz"
+    host = os.getenv("LOAD_TEST_DOMAIN", "https://api.staging.notification.cdssandbox.xyz")
 
     def __init__(self, *args, **kwargs):
         super(NotifyApiUser, self).__init__(*args, **kwargs)
 
-        self.headers = {"Authorization": AUTH_HEADER}
+        self.headers = {"Authorization": os.getenv("TEST_AUTH_HEADER")}
         self.email = "success@simulator.amazonses.com"
         self.template_id = "5ebee3b7-63c0-4052-a8cb-387b818df627"
 

--- a/tests-perf/locust/locust-notifications.py
+++ b/tests-perf/locust/locust-notifications.py
@@ -11,7 +11,7 @@ sys.path.append(os.path.abspath(os.path.join("..", "tests_smoke")))
 
 from dotenv import load_dotenv
 from locust import HttpUser, constant_pacing, task
-from tests_smoke.smoke.common import job_line, rows_to_csv
+from tests_smoke.smoke.common import job_line, rows_to_csv  # type: ignore
 
 load_dotenv()
 

--- a/tests-perf/locust/locust-notifications.py
+++ b/tests-perf/locust/locust-notifications.py
@@ -19,8 +19,9 @@ class NotifyApiUser(HttpUser):
         super(NotifyApiUser, self).__init__(*args, **kwargs)
 
         self.headers = {"Authorization": AUTH_HEADER}
+        self.email = "success@simulator.amazonses.com"
         self.json = {
-            "email_address": "success@simulator.amazonses.com",
+            "email_address": self.email,
             "template_id": "5ebee3b7-63c0-4052-a8cb-387b818df627",
             "personalisation": {},
         }
@@ -44,7 +45,7 @@ class NotifyApiUser(HttpUser):
     @task(4)
     def send_email_with_link_notifications(self):
         self.json["personalisation"] = {
-            "var": {
+            "application_file": {
                 "file": "Q29udGVudCBvZiBBdHRhY2hlZCBmaWxl",
                 "filename": "attached_file.txt",
                 "sending_method": "link",
@@ -58,7 +59,7 @@ class NotifyApiUser(HttpUser):
         self.json = {
             "name": f"My bulk name {datetime.utcnow().isoformat()}",
             "template_id": "5ebee3b7-63c0-4052-a8cb-387b818df627",
-            "csv": rows_to_csv([["email address", "var"], *job_line(self.json["email_address"], 2)])
+            "csv": rows_to_csv([["email address", "var"], *job_line(self.email, 2)])
         }
 
         self.client.post("/v2/notifications/bulk", json=self.json, headers=self.headers)
@@ -66,9 +67,8 @@ class NotifyApiUser(HttpUser):
     @task(16)
     def send_sms_notifications(self):
         self.json = {
-            "phone_number": 12897682684,
-            "template_id": "d8234b4d-4def-4ad6-aafe-526a24ee5f19",
-            "var": "var"
+            "phone_number": "12897682684",
+            "template_id": "d8234b4d-4def-4ad6-aafe-526a24ee5f19"
         }
 
         self.client.post("/v2/notifications/sms", json=self.json, headers=self.headers)

--- a/tests_smoke/smoke_test.py
+++ b/tests_smoke/smoke_test.py
@@ -1,8 +1,8 @@
-from smoke.common import Attachment_type, Config, Notification_type
-from smoke.test_admin_csv import test_admin_csv
-from smoke.test_admin_one_off import test_admin_one_off
-from smoke.test_api_bulk import test_api_bulk
-from smoke.test_api_one_off import test_api_one_off
+from smoke.common import Attachment_type, Config, Notification_type  # type: ignore
+from smoke.test_admin_csv import test_admin_csv  # type: ignore
+from smoke.test_admin_one_off import test_admin_one_off  # type: ignore
+from smoke.test_api_bulk import test_api_bulk  # type: ignore
+from smoke.test_api_one_off import test_api_one_off  # type: ignore
 
 if __name__ == "__main__":
     print("API Smoke test\n")


### PR DESCRIPTION

[Trello card](https://trello.com/c/xkZD3br3/618-define-and-load-test-plans-api-bulk-api-in-staging)

# Summary | Résumé

This PR seeks to define load tests to test the one off email endpoint[1].

Prior to this, an example load tests already exists. This effort expands the one off email endpoint load test to cover attachment and link.

This choice is influenced by the already existing smoke tests for one off email.

Locust insists on have a task defined[2], which it uses to simulate the to run the task, this can be weighted which yields probable selection based on the weight.

The developers understand, would be that of isolated tasks that would run on their own greenlet(thread), hence this has led to the definition of separate class in order to achieve the aforementioned.

[1] \<domain>/v2/notifications/email
[2] https://docs.locust.io/en/stable/writing-a-locustfile.html

# Test instructions | Instructions pour tester la modification

> workon notifications-api
>  locust --headless -u 1000 -r 100 -f tests-perf/locust/locust-notifications.py


# Reviewer checklist | Liste de vérification du réviseur
- [ ] Load testing can be executed 

