### PR TITLE
Empty messages fail validation

### DIFF
--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -34,7 +34,7 @@ from app.models import (
 from app.notifications.process_notifications import create_content_for_notification
 from app.service.sender import send_notification_to_service_users
 from app.service.utils import service_allowed_to_send_to
-from app.utils import get_document_url, get_public_notify_type_text
+from app.utils import get_document_url, get_public_notify_type_text, is_blank
 from app.v2.errors import (
     BadRequestError,
     LiveServiceTooManyRequestsError,
@@ -200,11 +200,6 @@ def check_sms_content_char_count(content_count):
     if content_count > SMS_CHAR_COUNT_LIMIT:
         message = "Content for template has a character count greater than the limit of {}".format(SMS_CHAR_COUNT_LIMIT)
         raise BadRequestError(message=message)
-
-
-def is_blank(content):
-    content = str(content)
-    return not content or content.isspace()
 
 
 def check_content_is_not_blank(content):

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -202,8 +202,13 @@ def check_sms_content_char_count(content_count):
         raise BadRequestError(message=message)
 
 
-def check_content_is_not_empty_or_just_whitespace(content):
-    if not content or content.isspace():
+def is_blank(content):
+    content = str(content)
+    return not content or content.isspace()
+
+
+def check_content_is_not_blank(content):
+    if is_blank(content):
         message = "Message is empty or just whitespace"
         raise BadRequestError(message=message)
 
@@ -224,7 +229,7 @@ def validate_template(template_id, personalisation, service, notification_type):
     if template.template_type == SMS_TYPE:
         check_sms_content_char_count(template_with_content.content_count)
 
-    check_content_is_not_empty_or_just_whitespace(str(template_with_content))
+    check_content_is_not_blank(template_with_content)
 
     return template, template_with_content
 

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -202,6 +202,12 @@ def check_sms_content_char_count(content_count):
         raise BadRequestError(message=message)
 
 
+def check_content_is_not_empty_or_just_whitespace(content):
+    if not content or content.isspace():
+        message = "Message is empty or just whitespace"
+        raise BadRequestError(message=message)
+
+
 def validate_template_exists(template_id, service):
     template = check_template_exists_by_id_and_service(template_id, service)
     check_template_is_active(template)
@@ -217,6 +223,8 @@ def validate_template(template_id, personalisation, service, notification_type):
     template_with_content = create_content_for_notification(template, personalisation)
     if template.template_type == SMS_TYPE:
         check_sms_content_char_count(template_with_content.content_count)
+
+    check_content_is_not_empty_or_just_whitespace(str(template_with_content))
 
     return template, template_with_content
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,5 +1,6 @@
 import os
 from datetime import datetime, timedelta
+from typing import Any
 
 import pytz
 from flask import current_app, url_for
@@ -189,3 +190,8 @@ def get_logo_url(logo_file):
 
 def get_document_url(lang: str, path: str):
     return f'https://{current_app.config["DOCUMENTATION_DOMAIN"]}/{lang}/{path}'
+
+
+def is_blank(content: Any) -> bool:
+    content = str(content)
+    return not content or content.isspace()


### PR DESCRIPTION
# Summary | Résumé

https://trello.com/c/XXHbhWfq/688-validate-empty-sms-messages

Validate up front for empty sms messages sent through the api

# Test instructions | Instructions pour tester la modification

Same instructions as for https://github.com/cds-snc/notification-api/pull/1372, but this time you'll get a `Bad Request` error when you post to the api, and no notification will be created.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their
review | Voici une suggestion de liste de vérification comprenant des questions
que les réviseurs pourraient poser pendant leur examen :


- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne
      une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une
      fonctionnalité existante?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une
      modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des
      préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de
      façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de
      risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README
      setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce
      changement (fichier README, etc.)?
