### PR TITLE
Removed cron scheduler in the CI test github action.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,6 @@
 on:
   push:
-name: CI testing
+name: Python tests
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Summary | Résumé

We have lots of false positive noise in our #notify-dev Slack channel due to flaky CI tests running on the cron schedule. Until we fix the concurrent DB issues, we should disable these because these are useless for now.

A couple of solutions:

1. Fix the flaky tests with concurrent db tests causing a failure.
2. Use an aggregate over a period of time to trigger a Slack notification instead of reporting on the first failure.

# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their
review | Voici une suggestion de liste de vérification comprenant des questions
que les réviseurs pourraient poser pendant leur examen :


- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne
      une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une
      fonctionnalité existante?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une
      modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des
      préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de
      façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de
      risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README
      setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce
      changement (fichier README, etc.)?
