### PR TITLE
Feature: Execute daily the performance tests

### DIFF
--- a/.github/workflows/build_and_push_performance_test.yml
+++ b/.github/workflows/build_and_push_performance_test.yml
@@ -1,0 +1,77 @@
+
+name: Build and Push Performance Testing Container to ECR, deploy to lambda
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'tests-perf/**'
+      - 'tests_smoke/**'
+
+env:
+  GITHUB_SHA: ${{ github.sha }}
+  REGISTRY: ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.ca-central-1.amazonaws.com/notify
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      images: ${{ steps.filter.outputs.changes }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            performance-test: 
+              - 'tests-perf/**'
+              - 'tests_smoke/**'
+
+  build-push-and-deploy:
+    if: ${{ needs.changes.outputs.images != '[]' }}
+    runs-on: ubuntu-latest
+    needs: changes
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJSON(needs.changes.outputs.images) }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build container
+        run: |
+          docker build \
+          --build-arg git_sha=$GITHUB_SHA \
+          -t $REGISTRY/${{ matrix.image }}:$GITHUB_SHA \
+          -t $REGISTRY/${{ matrix.image }}:latest . \
+          -f tests-perf/ops/Dockerfile
+
+      - name: Configure AWS credentials
+        id: aws-creds
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+
+      - name: Login to ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Push containers to ECR
+        run: |
+          docker push $REGISTRY/${{ matrix.image }}:$GITHUB_SHA
+          docker push $REGISTRY/${{ matrix.image }}:latest
+
+      - name: Logout of Amazon ECR
+        run: docker logout ${{ steps.login-ecr.outputs.registry }}
+
+      - name: Deploy lambda
+        run: |
+          aws lambda update-function-code \
+            --function-name ${{ matrix.image }} \
+            --image-uri $REGISTRY/${{ matrix.image }}:latest

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,8 +1,7 @@
 name: Notify Performance / Load Tests
 
-on: []
-  # schedule:
-  #   - cron: '0 0 * * *' # every day at midnight 
+on:
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,0 +1,43 @@
+name: Notify Performance / Load Tests
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:11.8
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: perf_test_notification_api
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    steps:
+      - name: Install libcurl
+        run: sudo apt-get update && sudo apt-get install libssl-dev libcurl4-openssl-dev
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Run performance tests
+        run: /bin/bash -c "pip install -r requirements_for_test.txt && locust --headless --config tests-perf/locust/locust.conf -f tests-perf/locust/locust-notifications.py"
+      - name: Notify Slack channel if this performance test job fails
+        if: ${{ failure() && github.ref == 'refs/heads/master' }}
+        run: |
+          json="{'text':'Scheduled CI Performance testing failed: <https://github.com/cds-snc/notification-api/actions|GitHub actions>'}"
+          curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -2,7 +2,7 @@ name: Notify Performance / Load Tests
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * *' # every day at midnight 
 
 jobs:
   test:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -7,17 +7,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:11.8
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: perf_test_notification_api
-        ports:
-          - 5432:5432
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-
     steps:
       - name: Install libcurl
         run: sudo apt-get update && sudo apt-get install libssl-dev libcurl4-openssl-dev

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,8 +1,8 @@
 name: Notify Performance / Load Tests
 
-on:
-  schedule:
-    - cron: '0 0 * * *' # every day at midnight 
+on: []
+  # schedule:
+  #   - cron: '0 0 * * *' # every day at midnight 
 
 jobs:
   test:

--- a/tests-perf/locust/locust.conf
+++ b/tests-perf/locust/locust.conf
@@ -1,5 +1,5 @@
 # master.conf in current directory
-locustfile = locust-notifications.py
+locustfile = tests-perf/locust/locust-notifications.py
 host = https://api.staging.notification.cdssandbox.xyz
 users = 6000
 spawn-rate = 200

--- a/tests-perf/locust/locust.conf
+++ b/tests-perf/locust/locust.conf
@@ -1,7 +1,7 @@
 # master.conf in current directory
 locustfile = tests-perf/locust/locust-notifications.py
 host = https://api.staging.notification.cdssandbox.xyz
-users = 6000
+users = 2500
 spawn-rate = 200
 
 # headless = true

--- a/tests-perf/ops/Dockerfile
+++ b/tests-perf/ops/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.9-alpine3.13
 
 ENV PYTHONDONTWRITEBYTECODE 1
 
-RUN apk add --no-cache bash build-base git libtool cmake autoconf automake gcc musl-dev g++ libexecinfo-dev make libffi-dev libmagic libcurl curl-dev rust cargo && rm -rf /var/cache/apk/*
+RUN apk add --no-cache bash build-base git libtool cmake autoconf automake gcc musl-dev postgresql-dev g++ libexecinfo-dev make libffi-dev libmagic libcurl curl-dev rust cargo && rm -rf /var/cache/apk/*
 
 # update pip
 RUN python -m pip install wheel

--- a/tests-perf/ops/Dockerfile
+++ b/tests-perf/ops/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.9-alpine3.13
 
 ENV PYTHONDONTWRITEBYTECODE 1
 
-RUN apk add --no-cache bash build-base git libtool cmake autoconf automake gcc musl-dev postgresql-dev g++ libexecinfo-dev make libffi-dev libmagic libcurl curl-dev rust cargo && rm -rf /var/cache/apk/*
+RUN apk add --no-cache bash build-base git libtool cmake autoconf automake gcc musl-dev g++ libexecinfo-dev make libffi-dev libmagic libcurl curl-dev rust cargo && rm -rf /var/cache/apk/*
 
 # update pip
 RUN python -m pip install wheel

--- a/tests-perf/ops/Dockerfile
+++ b/tests-perf/ops/Dockerfile
@@ -16,8 +16,6 @@ COPY . /app
 
 RUN set -ex && pip3 install -r requirements_for_test.txt
 
-RUN make generate-version-file
-
 ARG GIT_SHA
 
 ENV GIT_SHA=${GIT_SHA} \ 

--- a/tests-perf/ops/Dockerfile
+++ b/tests-perf/ops/Dockerfile
@@ -1,0 +1,34 @@
+FROM python:3.9-alpine3.13
+
+ENV PYTHONDONTWRITEBYTECODE 1
+
+RUN apk add --no-cache bash build-base git libtool cmake autoconf automake gcc musl-dev postgresql-dev g++ libexecinfo-dev make libffi-dev libmagic libcurl curl-dev rust cargo && rm -rf /var/cache/apk/*
+
+# update pip
+RUN python -m pip install wheel
+RUN python -m pip install --upgrade pip
+
+RUN set -ex && mkdir /app
+
+WORKDIR /app
+
+COPY . /app
+
+RUN set -ex && pip3 install -r requirements_for_test.txt
+
+RUN make generate-version-file
+
+ARG GIT_SHA
+
+ENV GIT_SHA=${GIT_SHA} \ 
+    LOAD_TEST_PHONE_NUMBER=16132532222 \ 
+    LOAD_TEST_EMAIL=success@simulator.amazonses.com \
+    LOAD_TEST_DOMAIN=https://api.staging.notification.cdssandbox.xyz \
+    LOAD_TEST_SMS_TEMPLATE_ID=83d01f06-a818-4134-bd69-ce90a2949280 \
+    LOAD_TEST_BULK_EMAIL_TEMPLATE_ID=5ebee3b7-63c0-4052-a8cb-387b818df627 \
+    LOAD_TEST_EMAIL_TEMPLATE_ID=a59b313d-8de2-4973-ac2f-66de7ec0b239 \
+    LOAD_TEST_EMAIL_WITH_ATTACHMENT_TEMPLATE_ID=a59b313d-8de2-4973-ac2f-66de7ec0b239 \
+    LOAD_TEST_EMAIL_WITH_LINK_TEMPLATE_ID=5ebee3b7-63c0-4052-a8cb-387b818df627 \
+    TEST_AUTH_HEADER="ApiKey-v1 c55039fc-c0e1-44db-a14e-b6a669148ec6"
+
+ENTRYPOINT [ "sh", "-c", "locust --headless --config tests-perf/locust/locust.conf --csv notify-performance-test" ]


### PR DESCRIPTION
# Related to https://github.com/cds-snc/notification-terraform/pull/305

# Summary | Résumé

To get daily performance tests going, we have identified the need for a dedicated Docker file for this purpose.

This PR defines a new Docker file from which a runtime

Docker container will be created for usage in an AWS lambda.

With are defined the following environment variables:

- LOAD_TEST_PHONE_NUMBER
- LOAD_TEST_EMAIL
- LOAD_TEST_DOMAIN
- LOAD_TEST_SMS_TEMPLATE_ID
- LOAD_TEST_BULK_EMAIL_TEMPLATE_ID
- LOAD_TEST_EMAIL_TEMPLATE_ID
- LOAD_TEST_EMAIL_WITH_ATTACHMENT_TEMPLATE_ID
- LOAD_TEST_EMAIL_WITH_LINK_TEMPLATE_ID
- TEST_AUTH_HEADER

The aforelisted are used in [1], and these have been assigned for staging specific values.

Given the definition within the Docker file, these environment variables can overridden when this container is instantiated.

The performance tests defined in [1], also reuse some code from test_smoke hence its inclusion.

Also within is defined a build, push and deploy steps for performance tests Docker images going forward.

It is triggered only when changes are detected to test-perf and tests_smoke folders/paths[2].

The locust performance tests resuse code define under tests_smoke.

Most of these lines of YAML code is adapted from [3] and follows predefined steps that are very similar to the goals of this commit.



[1] tests-perf/locust/locust-notifications.py
[2] https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#onpushpull_requestpaths
[3] .github/workflows/build_and_push.yml

# Reviewer checklist | Liste de vérification du réviseur

- [ ] Automated workflows with Github
