### PR TITLE
bug fix: don't use latest tag for api lambda image

### DIFF
--- a/.github/workflows/lambda_production.yml
+++ b/.github/workflows/lambda_production.yml
@@ -27,7 +27,6 @@ jobs:
           docker build \
           --build-arg git_sha=$GITHUB_SHA \
           -t $REGISTRY/${{ matrix.image }}:$GITHUB_SHA \
-          -t $REGISTRY/${{ matrix.image }}:latest . \
           -f ci/Dockerfile.lambda
 
       - name: Configure AWS credentials
@@ -45,7 +44,6 @@ jobs:
       - name: Push containers to ECR
         run: |
           docker push $REGISTRY/${{ matrix.image }}:$GITHUB_SHA
-          docker push $REGISTRY/${{ matrix.image }}:latest
 
       - name: Logout of Amazon ECR
         run: docker logout ${{ steps.login-ecr.outputs.registry }}

--- a/.github/workflows/lambda_staging.yml
+++ b/.github/workflows/lambda_staging.yml
@@ -27,7 +27,6 @@ jobs:
           docker build \
           --build-arg git_sha=$GITHUB_SHA \
           -t $REGISTRY/${{ matrix.image }}:$GITHUB_SHA \
-          -t $REGISTRY/${{ matrix.image }}:latest . \
           -f ci/Dockerfile.lambda
 
       - name: Configure AWS credentials
@@ -45,7 +44,6 @@ jobs:
       - name: Push containers to ECR
         run: |
           docker push $REGISTRY/${{ matrix.image }}:$GITHUB_SHA
-          docker push $REGISTRY/${{ matrix.image }}:latest
 
       - name: Logout of Amazon ECR
         run: docker logout ${{ steps.login-ecr.outputs.registry }}
@@ -54,4 +52,4 @@ jobs:
         run: |
           aws lambda update-function-code \
             --function-name ${{ matrix.image }} \
-            --image-uri $REGISTRY/${{ matrix.image }}:latest
+            --image-uri $REGISTRY/${{ matrix.image }}:$GITHUB_SHA


### PR DESCRIPTION
# Summary | Résumé

```
tag invalid: The image tag 'latest' already exists in the 'notify/api-lambda' repository and cannot be overwritten because the repository is immutable.
```

We've marked the repo as immutable, so we can't change the image a tag refers to. This is probably a good thing. Also, since we're deploying by using the gitsha rather than `latest`, we don't need the `latest` tag.

# Test instructions | Instructions pour tester la modification


# Release Instructions | Instructions pour le déploiement

None.


# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their
review | Voici une suggestion de liste de vérification comprenant des questions
que les réviseurs pourraient poser pendant leur examen :


- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne
      une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une
      fonctionnalité existante?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une
      modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des
      préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de
      façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de
      risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README
      setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce
      changement (fichier README, etc.)?
