### PR TITLE
Publish performance test results

### DIFF
--- a/bin/execute_and_publish_performance_test.sh
+++ b/bin/execute_and_publish_performance_test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+current_time=$(date "+%Y.%m.%d-%H.%M.%S")
+load_test_aws_s3_bucket=${LOAD_TEST_AWS_S3_BUCKET:-notify-perfortmance-test-results-staging}
+load_test_csv_directory_path=${LOAD_TEST_CSV_DIRECTORY_PATH:-/tmp/notify_performance_test}
+
+mkdir -p $load_test_csv_directory_path/$current_time
+
+locust --headless --config tests-perf/locust/locust.conf --csv $load_test_csv_directory_path/$current_time/load_test
+
+aws s3 cp $load_test_csv_directory_path/ "s3://$load_test_aws_s3_bucket" --recursive | grep -q 'An error occurred' && exit 1
+
+rm -rf $load_test_csv_directory_path/$current_time

--- a/bin/execute_and_publish_performance_test.sh
+++ b/bin/execute_and_publish_performance_test.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 current_time=$(date "+%Y.%m.%d-%H.%M.%S")
-load_test_aws_s3_bucket=${LOAD_TEST_AWS_S3_BUCKET:-notify-perfortmance-test-results-staging}
-load_test_csv_directory_path=${LOAD_TEST_CSV_DIRECTORY_PATH:-/tmp/notify_performance_test}
+perf_test_aws_s3_bucket=${PERF_TEST_AWS_S3_BUCKET:-notify-perfortmance-test-results-staging}
+perf_test_csv_directory_path=${PERF_TEST_CSV_DIRECTORY_PATH:-/tmp/notify_performance_test}
 
-mkdir -p $load_test_csv_directory_path/$current_time
+mkdir -p $perf_test_csv_directory_path/$current_time
 
-locust --headless --config tests-perf/locust/locust.conf --csv $load_test_csv_directory_path/$current_time/load_test
+locust --headless --config tests-perf/locust/locust.conf --csv $perf_test_csv_directory_path/$current_time/perf_test
 
 aws s3 cp $perf_test_csv_directory_path/ "s3://$perf_test_aws_s3_bucket" --recursive || exit 1
 
-rm -rf $load_test_csv_directory_path/$current_time
+rm -rf $perf_test_csv_directory_path/$current_time

--- a/bin/execute_and_publish_performance_test.sh
+++ b/bin/execute_and_publish_performance_test.sh
@@ -8,6 +8,6 @@ mkdir -p $load_test_csv_directory_path/$current_time
 
 locust --headless --config tests-perf/locust/locust.conf --csv $load_test_csv_directory_path/$current_time/load_test
 
-aws s3 cp $load_test_csv_directory_path/ "s3://$load_test_aws_s3_bucket" --recursive | grep -q 'An error occurred' && exit 1
+aws s3 cp $perf_test_csv_directory_path/ "s3://$perf_test_aws_s3_bucket" --recursive || exit 1
 
 rm -rf $load_test_csv_directory_path/$current_time

--- a/bin/execute_and_publish_performance_test.sh
+++ b/bin/execute_and_publish_performance_test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 current_time=$(date "+%Y.%m.%d-%H.%M.%S")
-perf_test_aws_s3_bucket=${PERF_TEST_AWS_S3_BUCKET:-notify-perfortmance-test-results-staging}
+perf_test_aws_s3_bucket=${PERF_TEST_AWS_S3_BUCKET:-notify-performance-test-results-staging}
 perf_test_csv_directory_path=${PERF_TEST_CSV_DIRECTORY_PATH:-/tmp/notify_performance_test}
 
 mkdir -p $perf_test_csv_directory_path/$current_time

--- a/tests-perf/locust/locust-notifications.py
+++ b/tests-perf/locust/locust-notifications.py
@@ -27,20 +27,20 @@ NotifyApiUserTemplateGroup = make_dataclass('NotifyApiUserTemplateGroup', [
 class NotifyApiUser(HttpUser):
 
     wait_time = constant_pacing(60)
-    host = os.getenv("LOAD_TEST_DOMAIN", "https://api.staging.notification.cdssandbox.xyz")
+    host = os.getenv("PERF_TEST_DOMAIN", "https://api.staging.notification.cdssandbox.xyz")
 
     def __init__(self, *args, **kwargs):
         super(NotifyApiUser, self).__init__(*args, **kwargs)
 
         self.headers = {"Authorization": os.getenv("TEST_AUTH_HEADER")}
-        self.email = os.getenv("LOAD_TEST_EMAIL", "success@simulator.amazonses.com")
-        self.phone_number = os.getenv("LOAD_TEST_PHONE_NUMBER", "16132532222")
+        self.email = os.getenv("PERF_TEST_EMAIL", "success@simulator.amazonses.com")
+        self.phone_number = os.getenv("PERF_TEST_PHONE_NUMBER", "16132532222")
         self.template_group = NotifyApiUserTemplateGroup(
-            bulk_email_id=os.getenv("LOAD_TEST_BULK_EMAIL_TEMPLATE_ID", "5ebee3b7-63c0-4052-a8cb-387b818df627"),
-            email_id=os.getenv("LOAD_TEST_EMAIL_TEMPLATE_ID", "a59b313d-8de2-4973-ac2f-66de7ec0b239"),
-            email_with_attachment_id=os.getenv("LOAD_TEST_EMAIL_WITH_ATTACHMENT_TEMPLATE_ID", "a59b313d-8de2-4973-ac2f-66de7ec0b239"),
-            email_with_link_id=os.getenv("LOAD_TEST_EMAIL_WITH_LINK_TEMPLATE_ID", "5ebee3b7-63c0-4052-a8cb-387b818df627"),
-            sms_id=os.getenv("LOAD_TEST_SMS_TEMPLATE_ID", "83d01f06-a818-4134-bd69-ce90a2949280"),
+            bulk_email_id=os.getenv("PERF_TEST_BULK_EMAIL_TEMPLATE_ID", "5ebee3b7-63c0-4052-a8cb-387b818df627"),
+            email_id=os.getenv("PERF_TEST_EMAIL_TEMPLATE_ID", "a59b313d-8de2-4973-ac2f-66de7ec0b239"),
+            email_with_attachment_id=os.getenv("PERF_TEST_EMAIL_WITH_ATTACHMENT_TEMPLATE_ID", "a59b313d-8de2-4973-ac2f-66de7ec0b239"),
+            email_with_link_id=os.getenv("PERF_TEST_EMAIL_WITH_LINK_TEMPLATE_ID", "5ebee3b7-63c0-4052-a8cb-387b818df627"),
+            sms_id=os.getenv("PERF_TEST_SMS_TEMPLATE_ID", "83d01f06-a818-4134-bd69-ce90a2949280"),
         )
 
     @task(16)

--- a/tests-perf/locust/locust.conf
+++ b/tests-perf/locust/locust.conf
@@ -3,8 +3,8 @@ locustfile = tests-perf/locust/locust-notifications.py
 host = https://api.staging.notification.cdssandbox.xyz
 users = 2500
 spawn-rate = 200
+run-time = 5m
 
 # headless = true
 # master = true
 # expect-workers = 5
-# run-time = 5m

--- a/tests-perf/ops/Dockerfile
+++ b/tests-perf/ops/Dockerfile
@@ -19,16 +19,16 @@ RUN set -ex && pip3 install -r requirements_for_test.txt
 ARG GIT_SHA
 
 ENV GIT_SHA=${GIT_SHA} \ 
-    LOAD_TEST_PHONE_NUMBER=16132532222 \ 
-    LOAD_TEST_EMAIL=success@simulator.amazonses.com \
-    LOAD_TEST_AWS_S3_BUCKET=notify-perfortmance-test-results-staging \ 
-    LOAD_TEST_CSV_DIRECTORY_PATH=/tmp/notify_performance_test \
-    LOAD_TEST_DOMAIN=https://api.staging.notification.cdssandbox.xyz \
-    LOAD_TEST_SMS_TEMPLATE_ID=83d01f06-a818-4134-bd69-ce90a2949280 \
-    LOAD_TEST_BULK_EMAIL_TEMPLATE_ID=5ebee3b7-63c0-4052-a8cb-387b818df627 \
-    LOAD_TEST_EMAIL_TEMPLATE_ID=a59b313d-8de2-4973-ac2f-66de7ec0b239 \
-    LOAD_TEST_EMAIL_WITH_ATTACHMENT_TEMPLATE_ID=a59b313d-8de2-4973-ac2f-66de7ec0b239 \
-    LOAD_TEST_EMAIL_WITH_LINK_TEMPLATE_ID=5ebee3b7-63c0-4052-a8cb-387b818df627 \
+    PERF_TEST_PHONE_NUMBER=16132532222 \ 
+    PERF_TEST_EMAIL=success@simulator.amazonses.com \
+    PERF_TEST_AWS_S3_BUCKET=notify-perfortmance-test-results-staging \ 
+    PERF_TEST_CSV_DIRECTORY_PATH=/tmp/notify_performance_test \
+    PERF_TEST_DOMAIN=https://api.staging.notification.cdssandbox.xyz \
+    PERF_TEST_SMS_TEMPLATE_ID=83d01f06-a818-4134-bd69-ce90a2949280 \
+    PERF_TEST_BULK_EMAIL_TEMPLATE_ID=5ebee3b7-63c0-4052-a8cb-387b818df627 \
+    PERF_TEST_EMAIL_TEMPLATE_ID=a59b313d-8de2-4973-ac2f-66de7ec0b239 \
+    PERF_TEST_EMAIL_WITH_ATTACHMENT_TEMPLATE_ID=a59b313d-8de2-4973-ac2f-66de7ec0b239 \
+    PERF_TEST_EMAIL_WITH_LINK_TEMPLATE_ID=5ebee3b7-63c0-4052-a8cb-387b818df627 \
     TEST_AUTH_HEADER="ApiKey-v1 c55039fc-c0e1-44db-a14e-b6a669148ec6"
 
 ENTRYPOINT [ "bin/execute_and_publish_performance_test.sh" ]

--- a/tests-perf/ops/Dockerfile
+++ b/tests-perf/ops/Dockerfile
@@ -21,6 +21,8 @@ ARG GIT_SHA
 ENV GIT_SHA=${GIT_SHA} \ 
     LOAD_TEST_PHONE_NUMBER=16132532222 \ 
     LOAD_TEST_EMAIL=success@simulator.amazonses.com \
+    LOAD_TEST_AWS_S3_BUCKET=notify-perfortmance-test-results-staging \ 
+    LOAD_TEST_CSV_DIRECTORY_PATH=/tmp/notify_performance_test \
     LOAD_TEST_DOMAIN=https://api.staging.notification.cdssandbox.xyz \
     LOAD_TEST_SMS_TEMPLATE_ID=83d01f06-a818-4134-bd69-ce90a2949280 \
     LOAD_TEST_BULK_EMAIL_TEMPLATE_ID=5ebee3b7-63c0-4052-a8cb-387b818df627 \
@@ -29,4 +31,4 @@ ENV GIT_SHA=${GIT_SHA} \
     LOAD_TEST_EMAIL_WITH_LINK_TEMPLATE_ID=5ebee3b7-63c0-4052-a8cb-387b818df627 \
     TEST_AUTH_HEADER="ApiKey-v1 c55039fc-c0e1-44db-a14e-b6a669148ec6"
 
-ENTRYPOINT [ "sh", "-c", "locust --headless --config tests-perf/locust/locust.conf --csv notify-performance-test" ]
+ENTRYPOINT [ "bin/execute_and_publish_performance_test.sh" ]


### PR DESCRIPTION
Related to https://github.com/cds-snc/notification-terraform/pull/317

# Summary | Résumé

Within this commit, we have defined a script that setups the performance test environment executes the performance test an publishes it to S3 bucket.

The run time duration has also been set to 5 minutes to discourage endless run of the performance tests

The s3 bucket is managed with a terraform script as defined here [1] and will be used to hold the performance test results per environment (production or staging).

[1] github.com/cds-snc/notification-terraform/pull/317
