### PR TITLE
Task/create save notification

### DIFF
--- a/tests/app/api_key/test_rest.py
+++ b/tests/app/api_key/test_rest.py
@@ -7,6 +7,7 @@ from tests.app.db import (
     create_notification,
     create_service,
     create_template,
+    save_notification,
 )
 
 
@@ -18,7 +19,8 @@ def test_get_api_key_stats_with_sends(admin_request, notify_db, notify_db_sessio
     total_sends = 10
 
     for x in range(total_sends):
-        create_notification(template=template, api_key=api_key)
+        notification = create_notification(template=template, api_key=api_key)
+        save_notification(notification)
 
     api_key_stats = admin_request.get("api_key.get_api_key_stats", api_key_id=api_key.id)["data"]
 
@@ -56,10 +58,10 @@ def test_get_api_keys_ranked(admin_request, notify_db, notify_db_session):
     template_email = create_template(service=service, template_type="email")
     total_sends = 10
 
-    create_notification(template=template_email, api_key=api_key_1)
+    save_notification(create_notification(template=template_email, api_key=api_key_1))
     for x in range(total_sends):
-        create_notification(template=template_email, api_key=api_key_1)
-        create_notification(template=template_email, api_key=api_key_2)
+        save_notification(create_notification(template=template_email, api_key=api_key_1))
+        save_notification(create_notification(template=template_email, api_key=api_key_2))
 
     api_keys_ranked = admin_request.get("api_key.get_api_keys_ranked", n_days_back=2)["data"]
 

--- a/tests/app/billing/test_billing.py
+++ b/tests/app/billing/test_billing.py
@@ -20,6 +20,7 @@ from tests.app.db import (
     create_rate,
     create_service,
     create_template,
+    save_notification,
 )
 
 APR_2016_MONTH_START = datetime(2016, 3, 31, 23, 00, 00)
@@ -184,7 +185,7 @@ def test_get_yearly_usage_by_monthly_from_ft_billing_populates_deltas(client, no
         notification_type="sms",
     )
 
-    create_notification(template=sms_template, status="delivered")
+    save_notification(create_notification(template=sms_template, status="delivered"))
 
     assert FactBilling.query.count() == 0
 

--- a/tests/app/celery/test_letters_pdf_tasks.py
+++ b/tests/app/celery/test_letters_pdf_tasks.py
@@ -40,7 +40,7 @@ from app.models import (
     Notification,
 )
 from celery.exceptions import MaxRetriesExceededError, Retry
-from tests.app.db import create_letter_branding, create_notification
+from tests.app.db import create_letter_branding, create_notification, save_notification
 from tests.conftest import set_config_values
 
 
@@ -478,12 +478,14 @@ def test_process_letter_task_check_virus_scan_passed(
     bucket_config_name,
     destination_folder,
 ):
-    letter_notification = create_notification(
-        template=sample_letter_template,
-        billable_units=0,
-        status="pending-virus-check",
-        key_type=key_type,
-        reference="{} letter".format(key_type),
+    letter_notification = save_notification(
+        create_notification(
+            template=sample_letter_template,
+            billable_units=0,
+            status="pending-virus-check",
+            key_type=key_type,
+            reference="{} letter".format(key_type),
+        )
     )
     filename = "NOTIFY.{}".format(letter_notification.reference)
     source_bucket_name = current_app.config["LETTERS_SCAN_BUCKET_NAME"]

--- a/tests/app/celery/test_process_ses_receipts_tasks.py
+++ b/tests/app/celery/test_process_ses_receipts_tasks.py
@@ -20,26 +20,34 @@ from app.notifications.notifications_ses_callback import (
     remove_emails_from_complaint,
 )
 from tests.app.conftest import sample_notification as create_sample_notification
-from tests.app.db import create_notification, create_service_callback_api
+from tests.app.db import (
+    create_notification,
+    create_service_callback_api,
+    save_notification,
+)
 
 
 def test_process_ses_results(sample_email_template):
-    create_notification(
-        sample_email_template,
-        reference="ref1",
-        sent_at=datetime.utcnow(),
-        status="sending",
+    save_notification(
+        create_notification(
+            sample_email_template,
+            reference="ref1",
+            sent_at=datetime.utcnow(),
+            status="sending",
+        )
     )
 
     assert process_ses_results(response=ses_notification_callback(reference="ref1"))
 
 
 def test_process_ses_results_retry_called(sample_email_template, notify_db, mocker):
-    create_notification(
-        sample_email_template,
-        reference="ref1",
-        sent_at=datetime.utcnow(),
-        status="sending",
+    save_notification(
+        create_notification(
+            sample_email_template,
+            reference="ref1",
+            sent_at=datetime.utcnow(),
+            status="sending",
+        )
     )
 
     mocker.patch(
@@ -52,7 +60,7 @@ def test_process_ses_results_retry_called(sample_email_template, notify_db, mock
 
 
 def test_process_ses_results_in_complaint(sample_email_template, mocker):
-    notification = create_notification(template=sample_email_template, reference="ref1")
+    notification = save_notification(create_notification(template=sample_email_template, reference="ref1"))
     mocked = mocker.patch("app.dao.notifications_dao.update_notification_status_by_reference")
     process_ses_results(response=ses_complaint_callback())
     assert mocked.call_count == 0
@@ -101,7 +109,7 @@ def test_ses_callback_should_update_notification_status(notify_db, notify_db_ses
 
 
 def test_ses_callback_should_update_notification_status_when_receiving_new_delivery_receipt(sample_email_template, mocker):
-    notification = create_notification(template=sample_email_template, reference="ref", status="delivered")
+    notification = save_notification(create_notification(template=sample_email_template, reference="ref", status="delivered"))
 
     assert process_ses_results(ses_hard_bounce_callback(reference="ref"))
     assert get_notification_by_id(notification.id).status == "permanent-failure"
@@ -280,11 +288,13 @@ def test_ses_callback_should_send_on_complaint_to_user_callback_api(sample_email
         callback_type="complaint",
     )
 
-    notification = create_notification(
-        template=sample_email_template,
-        reference="ref1",
-        sent_at=datetime.utcnow(),
-        status="sending",
+    notification = save_notification(
+        create_notification(
+            template=sample_email_template,
+            reference="ref1",
+            sent_at=datetime.utcnow(),
+            status="sending",
+        )
     )
     response = ses_complaint_callback()
     assert process_ses_results(response)

--- a/tests/app/celery/test_reporting_tasks.py
+++ b/tests/app/celery/test_reporting_tasks.py
@@ -26,6 +26,7 @@ from tests.app.db import (
     create_rate,
     create_service,
     create_template,
+    save_notification,
 )
 
 
@@ -99,23 +100,27 @@ def test_create_nightly_billing_for_day_sms_rate_multiplier(
     mocker.patch("app.dao.fact_billing_dao.get_rate", side_effect=mocker_get_rate)
 
     # These are sms notifications
-    create_notification(
-        created_at=yesterday,
-        template=sample_template,
-        status="delivered",
-        sent_by="sns",
-        international=False,
-        rate_multiplier=1.0,
-        billable_units=1,
+    save_notification(
+        create_notification(
+            created_at=yesterday,
+            template=sample_template,
+            status="delivered",
+            sent_by="sns",
+            international=False,
+            rate_multiplier=1.0,
+            billable_units=1,
+        )
     )
-    create_notification(
-        created_at=yesterday,
-        template=sample_template,
-        status="delivered",
-        sent_by="sns",
-        international=False,
-        rate_multiplier=second_rate,
-        billable_units=1,
+    save_notification(
+        create_notification(
+            created_at=yesterday,
+            template=sample_template,
+            status="delivered",
+            sent_by="sns",
+            international=False,
+            rate_multiplier=second_rate,
+            billable_units=1,
+        )
     )
 
     records = FactBilling.query.all()
@@ -138,23 +143,27 @@ def test_create_nightly_billing_for_day_different_templates(sample_service, samp
 
     mocker.patch("app.dao.fact_billing_dao.get_rate", side_effect=mocker_get_rate)
 
-    create_notification(
-        created_at=yesterday,
-        template=sample_template,
-        status="delivered",
-        sent_by="sns",
-        international=False,
-        rate_multiplier=1.0,
-        billable_units=1,
+    save_notification(
+        create_notification(
+            created_at=yesterday,
+            template=sample_template,
+            status="delivered",
+            sent_by="sns",
+            international=False,
+            rate_multiplier=1.0,
+            billable_units=1,
+        )
     )
-    create_notification(
-        created_at=yesterday,
-        template=sample_email_template,
-        status="delivered",
-        sent_by="ses",
-        international=False,
-        rate_multiplier=0,
-        billable_units=0,
+    save_notification(
+        create_notification(
+            created_at=yesterday,
+            template=sample_email_template,
+            status="delivered",
+            sent_by="ses",
+            international=False,
+            rate_multiplier=0,
+            billable_units=0,
+        )
     )
 
     records = FactBilling.query.all()
@@ -181,14 +190,16 @@ def test_create_nightly_billing_for_day_different_sent_by(sample_service, sample
     mocker.patch("app.dao.fact_billing_dao.get_rate", side_effect=mocker_get_rate)
 
     # These are sms notifications
-    create_notification(
-        created_at=yesterday,
-        template=sample_template,
-        status="delivered",
-        sent_by="sns",
-        international=False,
-        rate_multiplier=1.0,
-        billable_units=1,
+    save_notification(
+        create_notification(
+            created_at=yesterday,
+            template=sample_template,
+            status="delivered",
+            sent_by="sns",
+            international=False,
+            rate_multiplier=1.0,
+            billable_units=1,
+        )
     )
 
     records = FactBilling.query.all()
@@ -212,21 +223,25 @@ def test_create_nightly_billing_for_day_different_letter_postage(notify_db_sessi
     mocker.patch("app.dao.fact_billing_dao.get_rate", side_effect=mocker_get_rate)
 
     for i in range(2):
+        save_notification(
+            create_notification(
+                created_at=yesterday,
+                template=sample_letter_template,
+                status="delivered",
+                sent_by="dvla",
+                billable_units=2,
+                postage="first",
+            )
+        )
+    save_notification(
         create_notification(
             created_at=yesterday,
             template=sample_letter_template,
             status="delivered",
             sent_by="dvla",
             billable_units=2,
-            postage="first",
+            postage="second",
         )
-    create_notification(
-        created_at=yesterday,
-        template=sample_letter_template,
-        status="delivered",
-        sent_by="dvla",
-        billable_units=2,
-        postage="second",
     )
 
     records = FactBilling.query.all()
@@ -255,14 +270,16 @@ def test_create_nightly_billing_for_day_letter(sample_service, sample_letter_tem
 
     mocker.patch("app.dao.fact_billing_dao.get_rate", side_effect=mocker_get_rate)
 
-    create_notification(
-        created_at=yesterday,
-        template=sample_letter_template,
-        status="delivered",
-        sent_by="dvla",
-        international=False,
-        rate_multiplier=2.0,
-        billable_units=2,
+    save_notification(
+        create_notification(
+            created_at=yesterday,
+            template=sample_letter_template,
+            status="delivered",
+            sent_by="dvla",
+            international=False,
+            rate_multiplier=2.0,
+            billable_units=2,
+        )
     )
 
     records = FactBilling.query.all()
@@ -285,14 +302,16 @@ def test_create_nightly_billing_for_day_null_sent_by_sms(sample_service, sample_
 
     mocker.patch("app.dao.fact_billing_dao.get_rate", side_effect=mocker_get_rate)
 
-    create_notification(
-        created_at=yesterday,
-        template=sample_template,
-        status="delivered",
-        sent_by=None,
-        international=False,
-        rate_multiplier=1.0,
-        billable_units=1,
+    save_notification(
+        create_notification(
+            created_at=yesterday,
+            template=sample_template,
+            status="delivered",
+            sent_by=None,
+            international=False,
+            rate_multiplier=1.0,
+            billable_units=1,
+        )
     )
 
     records = FactBilling.query.all()
@@ -343,29 +362,35 @@ def test_create_nightly_billing_for_day_use_BST(sample_service, sample_template,
     mocker.patch("app.dao.fact_billing_dao.get_rate", side_effect=mocker_get_rate)
 
     # too late
-    create_notification(
-        created_at=datetime(2018, 3, 25, 23, 1),
-        template=sample_template,
-        status="delivered",
-        rate_multiplier=1.0,
-        billable_units=1,
+    save_notification(
+        create_notification(
+            created_at=datetime(2018, 3, 25, 23, 1),
+            template=sample_template,
+            status="delivered",
+            rate_multiplier=1.0,
+            billable_units=1,
+        )
     )
 
-    create_notification(
-        created_at=datetime(2018, 3, 25, 22, 59),
-        template=sample_template,
-        status="delivered",
-        rate_multiplier=1.0,
-        billable_units=2,
+    save_notification(
+        create_notification(
+            created_at=datetime(2018, 3, 25, 22, 59),
+            template=sample_template,
+            status="delivered",
+            rate_multiplier=1.0,
+            billable_units=2,
+        )
     )
 
     # too early
-    create_notification(
-        created_at=datetime(2018, 3, 24, 23, 59),
-        template=sample_template,
-        status="delivered",
-        rate_multiplier=1.0,
-        billable_units=4,
+    save_notification(
+        create_notification(
+            created_at=datetime(2018, 3, 24, 23, 59),
+            template=sample_template,
+            status="delivered",
+            rate_multiplier=1.0,
+            billable_units=4,
+        )
     )
 
     assert Notification.query.count() == 3
@@ -385,14 +410,16 @@ def test_create_nightly_billing_for_day_update_when_record_exists(sample_service
 
     mocker.patch("app.dao.fact_billing_dao.get_rate", side_effect=mocker_get_rate)
 
-    create_notification(
-        created_at=datetime.now() - timedelta(days=1),
-        template=sample_template,
-        status="delivered",
-        sent_by=None,
-        international=False,
-        rate_multiplier=1.0,
-        billable_units=1,
+    save_notification(
+        create_notification(
+            created_at=datetime.now() - timedelta(days=1),
+            template=sample_template,
+            status="delivered",
+            sent_by=None,
+            international=False,
+            rate_multiplier=1.0,
+            billable_units=1,
+        )
     )
 
     records = FactBilling.query.all()
@@ -406,14 +433,16 @@ def test_create_nightly_billing_for_day_update_when_record_exists(sample_service
     assert records[0].billable_units == 1
     assert not records[0].updated_at
 
-    create_notification(
-        created_at=datetime.now() - timedelta(days=1),
-        template=sample_template,
-        status="delivered",
-        sent_by=None,
-        international=False,
-        rate_multiplier=1.0,
-        billable_units=1,
+    save_notification(
+        create_notification(
+            created_at=datetime.now() - timedelta(days=1),
+            template=sample_template,
+            status="delivered",
+            sent_by=None,
+            international=False,
+            rate_multiplier=1.0,
+            billable_units=1,
+        )
     )
 
     # run again, make sure create_nightly_billing() updates with no error
@@ -432,25 +461,31 @@ def test_create_nightly_notification_status_for_day(notify_db_session):
     third_service = create_service(service_name="third Service")
     third_template = create_template(service=third_service, template_type="letter")
 
-    create_notification(template=first_template, status="delivered")
-    create_notification(
-        template=first_template,
-        status="delivered",
-        created_at=datetime(2019, 1, 1, 12, 0),
+    save_notification(create_notification(template=first_template, status="delivered"))
+    save_notification(
+        create_notification(
+            template=first_template,
+            status="delivered",
+            created_at=datetime(2019, 1, 1, 12, 0),
+        )
     )
 
-    create_notification(template=second_template, status="temporary-failure")
-    create_notification(
-        template=second_template,
-        status="temporary-failure",
-        created_at=datetime(2019, 1, 1, 12, 0),
+    save_notification(create_notification(template=second_template, status="temporary-failure"))
+    save_notification(
+        create_notification(
+            template=second_template,
+            status="temporary-failure",
+            created_at=datetime(2019, 1, 1, 12, 0),
+        )
     )
 
-    create_notification(template=third_template, status="created")
-    create_notification(
-        template=third_template,
-        status="created",
-        created_at=datetime(2019, 1, 1, 12, 0),
+    save_notification(create_notification(template=third_template, status="created"))
+    save_notification(
+        create_notification(
+            template=third_template,
+            status="created",
+            created_at=datetime(2019, 1, 1, 12, 0),
+        )
     )
 
     assert len(FactNotificationStatus.query.all()) == 0
@@ -470,12 +505,14 @@ def test_create_nightly_notification_status_for_day(notify_db_session):
 def test_create_nightly_notification_status_for_day_respects_local_timezone(
     sample_template,
 ):
-    create_notification(sample_template, status="delivered", created_at=datetime(2019, 4, 2, 5, 0))  # too new
+    save_notification(create_notification(sample_template, status="delivered", created_at=datetime(2019, 4, 2, 5, 0)))  # too new
 
-    create_notification(sample_template, status="created", created_at=datetime(2019, 4, 2, 6, 59))
-    create_notification(sample_template, status="created", created_at=datetime(2019, 4, 1, 5, 59))
+    save_notification(create_notification(sample_template, status="created", created_at=datetime(2019, 4, 2, 6, 59)))
+    save_notification(create_notification(sample_template, status="created", created_at=datetime(2019, 4, 1, 5, 59)))
 
-    create_notification(sample_template, status="delivered", created_at=datetime(2019, 3, 30, 3, 59))  # too old
+    save_notification(
+        create_notification(sample_template, status="delivered", created_at=datetime(2019, 3, 30, 3, 59))
+    )  # too old
 
     create_nightly_notification_status_for_day("2019-04-01")
 

--- a/tests/app/celery/test_service_callback_tasks.py
+++ b/tests/app/celery/test_service_callback_tasks.py
@@ -16,6 +16,7 @@ from tests.app.db import (
     create_service,
     create_service_callback_api,
     create_template,
+    save_notification,
 )
 
 
@@ -25,12 +26,14 @@ def test_send_delivery_status_to_service_post_https_request_to_service_with_encr
     callback_api, template = _set_up_test_data(notification_type, "delivery_status")
     datestr = datetime(2017, 6, 20)
 
-    notification = create_notification(
-        template=template,
-        created_at=datestr,
-        updated_at=datestr,
-        sent_at=datestr,
-        status="sent",
+    notification = save_notification(
+        create_notification(
+            template=template,
+            created_at=datestr,
+            updated_at=datestr,
+            sent_at=datestr,
+            status="sent",
+        )
     )
     encrypted_status_update = _set_up_data_for_status_update(callback_api, notification)
     with requests_mock.Mocker() as request_mock:
@@ -92,12 +95,14 @@ def test__send_data_to_service_callback_api_retries_if_request_returns_500_with_
 ):
     callback_api, template = _set_up_test_data(notification_type, "delivery_status")
     datestr = datetime(2017, 6, 20)
-    notification = create_notification(
-        template=template,
-        created_at=datestr,
-        updated_at=datestr,
-        sent_at=datestr,
-        status="sent",
+    notification = save_notification(
+        create_notification(
+            template=template,
+            created_at=datestr,
+            updated_at=datestr,
+            sent_at=datestr,
+            status="sent",
+        )
     )
     encrypted_data = _set_up_data_for_status_update(callback_api, notification)
     mocked = mocker.patch("app.celery.service_callback_tasks.send_delivery_status_to_service.retry")
@@ -115,12 +120,14 @@ def test__send_data_to_service_callback_api_does_not_retry_if_request_returns_40
 ):
     callback_api, template = _set_up_test_data(notification_type, "delivery_status")
     datestr = datetime(2017, 6, 20)
-    notification = create_notification(
-        template=template,
-        created_at=datestr,
-        updated_at=datestr,
-        sent_at=datestr,
-        status="sent",
+    notification = save_notification(
+        create_notification(
+            template=template,
+            created_at=datestr,
+            updated_at=datestr,
+            sent_at=datestr,
+            status="sent",
+        )
     )
     encrypted_data = _set_up_data_for_status_update(callback_api, notification)
     mocked = mocker.patch("app.celery.service_callback_tasks.send_delivery_status_to_service.retry")
@@ -134,12 +141,14 @@ def test__send_data_to_service_callback_api_does_not_retry_if_request_returns_40
 def test_send_delivery_status_to_service_succeeds_if_sent_at_is_none(notify_db_session, mocker):
     callback_api, template = _set_up_test_data("email", "delivery_status")
     datestr = datetime(2017, 6, 20)
-    notification = create_notification(
-        template=template,
-        created_at=datestr,
-        updated_at=datestr,
-        sent_at=None,
-        status="technical-failure",
+    notification = save_notification(
+        create_notification(
+            template=template,
+            created_at=datestr,
+            updated_at=datestr,
+            sent_at=None,
+            status="technical-failure",
+        )
     )
     encrypted_data = _set_up_data_for_status_update(callback_api, notification)
     mocked = mocker.patch("app.celery.service_callback_tasks.send_delivery_status_to_service.retry")

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -59,6 +59,7 @@ from tests.app.db import (
     create_service_with_defined_sms_sender,
     create_template,
     create_user,
+    save_notification,
 )
 from tests.conftest import set_config_values
 
@@ -197,7 +198,7 @@ def test_should_not_process_sms_job_if_would_exceed_send_limits_inc_today(notify
     template = create_template(service=service)
     job = create_job(template=template)
 
-    create_notification(template=template, job=job)
+    save_notification(create_notification(template=template, job=job))
 
     mocker.patch("app.celery.tasks.s3.get_job_from_s3", return_value=load_example_csv("sms"))
     mocker.patch("app.celery.tasks.process_row")
@@ -216,7 +217,7 @@ def test_should_not_process_email_job_if_would_exceed_send_limits_inc_today(noti
     template = create_template(service=service, template_type=template_type)
     job = create_job(template=template)
 
-    create_notification(template=template, job=job)
+    save_notification(create_notification(template=template, job=job))
 
     mocker.patch("app.celery.tasks.s3.get_job_from_s3")
     mocker.patch("app.celery.tasks.process_row")
@@ -1658,8 +1659,8 @@ def test_process_incomplete_job_sms(mocker, sample_template):
         job_status=JOB_STATUS_ERROR,
     )
 
-    create_notification(sample_template, job, 0)
-    create_notification(sample_template, job, 1)
+    save_notification(create_notification(sample_template, job, 0))
+    save_notification(create_notification(sample_template, job, 1))
 
     assert Notification.query.filter(Notification.job_id == job.id).count() == 2
 
@@ -1689,16 +1690,16 @@ def test_process_incomplete_job_with_notifications_all_sent(mocker, sample_templ
         job_status=JOB_STATUS_ERROR,
     )
 
-    create_notification(sample_template, job, 0)
-    create_notification(sample_template, job, 1)
-    create_notification(sample_template, job, 2)
-    create_notification(sample_template, job, 3)
-    create_notification(sample_template, job, 4)
-    create_notification(sample_template, job, 5)
-    create_notification(sample_template, job, 6)
-    create_notification(sample_template, job, 7)
-    create_notification(sample_template, job, 8)
-    create_notification(sample_template, job, 9)
+    save_notification(create_notification(sample_template, job, 0))
+    save_notification(create_notification(sample_template, job, 1))
+    save_notification(create_notification(sample_template, job, 2))
+    save_notification(create_notification(sample_template, job, 3))
+    save_notification(create_notification(sample_template, job, 4))
+    save_notification(create_notification(sample_template, job, 5))
+    save_notification(create_notification(sample_template, job, 6))
+    save_notification(create_notification(sample_template, job, 7))
+    save_notification(create_notification(sample_template, job, 8))
+    save_notification(create_notification(sample_template, job, 9))
 
     assert Notification.query.filter(Notification.job_id == job.id).count() == 10
 
@@ -1727,9 +1728,9 @@ def test_process_incomplete_jobs_sms(mocker, sample_template):
         processing_started=datetime.utcnow() - timedelta(minutes=31),
         job_status=JOB_STATUS_ERROR,
     )
-    create_notification(sample_template, job, 0)
-    create_notification(sample_template, job, 1)
-    create_notification(sample_template, job, 2)
+    save_notification(create_notification(sample_template, job, 0))
+    save_notification(create_notification(sample_template, job, 1))
+    save_notification(create_notification(sample_template, job, 2))
 
     assert Notification.query.filter(Notification.job_id == job.id).count() == 3
 
@@ -1742,11 +1743,11 @@ def test_process_incomplete_jobs_sms(mocker, sample_template):
         job_status=JOB_STATUS_ERROR,
     )
 
-    create_notification(sample_template, job2, 0)
-    create_notification(sample_template, job2, 1)
-    create_notification(sample_template, job2, 2)
-    create_notification(sample_template, job2, 3)
-    create_notification(sample_template, job2, 4)
+    save_notification(create_notification(sample_template, job2, 0))
+    save_notification(create_notification(sample_template, job2, 1))
+    save_notification(create_notification(sample_template, job2, 2))
+    save_notification(create_notification(sample_template, job2, 3))
+    save_notification(create_notification(sample_template, job2, 4))
 
     assert Notification.query.filter(Notification.job_id == job2.id).count() == 5
 
@@ -1835,8 +1836,8 @@ def test_process_incomplete_job_email(mocker, sample_email_template):
         job_status=JOB_STATUS_ERROR,
     )
 
-    create_notification(sample_email_template, job, 0)
-    create_notification(sample_email_template, job, 1)
+    save_notification(create_notification(sample_email_template, job, 0))
+    save_notification(create_notification(sample_email_template, job, 1))
 
     assert Notification.query.filter(Notification.job_id == job.id).count() == 2
 
@@ -1865,8 +1866,8 @@ def test_process_incomplete_job_letter(mocker, sample_letter_template):
         job_status=JOB_STATUS_ERROR,
     )
 
-    create_notification(sample_letter_template, job, 0)
-    create_notification(sample_letter_template, job, 1)
+    save_notification(create_notification(sample_letter_template, job, 0))
+    save_notification(create_notification(sample_letter_template, job, 1))
 
     assert Notification.query.filter(Notification.job_id == job.id).count() == 2
 
@@ -1905,8 +1906,8 @@ def test_process_incomplete_jobs_sets_status_to_in_progress_and_resets_processin
 
 
 def test_process_returned_letters_list(sample_letter_template):
-    create_notification(sample_letter_template, reference="ref1")
-    create_notification(sample_letter_template, reference="ref2")
+    save_notification(create_notification(sample_letter_template, reference="ref1"))
+    save_notification(create_notification(sample_letter_template, reference="ref2"))
 
     process_returned_letters_list(["ref1", "ref2", "unknown-ref"])
 

--- a/tests/app/complaint/test_complaint_rest.py
+++ b/tests/app/complaint/test_complaint_rest.py
@@ -10,13 +10,14 @@ from tests.app.db import (
     create_notification,
     create_service,
     create_template,
+    save_notification,
 )
 
 
 def test_get_all_complaints_returns_complaints_for_multiple_services(client, notify_db_session):
     service = create_service(service_name="service1")
     template = create_template(service=service)
-    notification = create_notification(template=template)
+    notification = save_notification(create_notification(template=template))
     complaint_1 = create_complaint()  # default service
     complaint_2 = create_complaint(service=service, notification=notification)
 

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -63,6 +63,7 @@ from tests.app.db import (
     create_service,
     create_template,
     create_user,
+    save_notification,
 )
 
 
@@ -494,19 +495,21 @@ def sample_notification_with_job(
         template = create_template(service=service)
     if job is None:
         job = create_job(template=template)
-    return create_notification(
-        template=template,
-        job=job,
-        job_row_number=job_row_number if job_row_number is not None else None,
-        to_field=to_field,
-        status=status,
-        reference=reference,
-        created_at=created_at,
-        sent_at=sent_at,
-        billable_units=billable_units,
-        personalisation=personalisation,
-        api_key=api_key,
-        key_type=key_type,
+    return save_notification(
+        create_notification(
+            template=template,
+            job=job,
+            job_row_number=job_row_number if job_row_number is not None else None,
+            to_field=to_field,
+            status=status,
+            reference=reference,
+            created_at=created_at,
+            sent_at=sent_at,
+            billable_units=billable_units,
+            personalisation=personalisation,
+            api_key=api_key,
+            key_type=key_type,
+        )
     )
 
 
@@ -612,7 +615,7 @@ def sample_letter_notification(sample_letter_template):
         "address_line_6": "A6",
         "postcode": "A_POST",
     }
-    return create_notification(sample_letter_template, reference="foo", personalisation=address)
+    return save_notification(create_notification(sample_letter_template, reference="foo", personalisation=address))
 
 
 @pytest.fixture(scope="function")

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -59,6 +59,8 @@ from tests.app.db import (
     create_notification_history,
     create_service,
     create_template,
+    save_notification,
+    save_scheduled_notification,
 )
 
 
@@ -117,7 +119,7 @@ def test_should_by_able_to_update_status_by_id(sample_template, sample_job):
 def test_should_not_update_status_by_id_if_not_sending_and_does_not_update_job(
     sample_job,
 ):
-    notification = create_notification(template=sample_job.template, status="delivered", job=sample_job)
+    notification = save_notification(create_notification(template=sample_job.template, status="delivered", job=sample_job))
     assert Notification.query.get(notification.id).status == "delivered"
     assert not update_notification_status_by_id(notification.id, "failed")
     assert Notification.query.get(notification.id).status == "delivered"
@@ -127,11 +129,13 @@ def test_should_not_update_status_by_id_if_not_sending_and_does_not_update_job(
 def test_should_not_update_status_by_reference_if_not_sending_and_does_not_update_job(
     sample_job,
 ):
-    notification = create_notification(
-        template=sample_job.template,
-        status="delivered",
-        reference="reference",
-        job=sample_job,
+    notification = save_notification(
+        create_notification(
+            template=sample_job.template,
+            status="delivered",
+            reference="reference",
+            job=sample_job,
+        )
     )
     assert Notification.query.get(notification.id).status == "delivered"
     assert not update_notification_status_by_reference("reference", "failed")
@@ -147,7 +151,7 @@ def test_should_update_status_by_id_if_created(sample_template, sample_notificat
 
 
 def test_should_update_status_by_id_if_pending_virus_check(sample_letter_template):
-    notification = create_notification(template=sample_letter_template, status="pending-virus-check")
+    notification = save_notification(create_notification(template=sample_letter_template, status="pending-virus-check"))
     assert Notification.query.get(notification.id).status == "pending-virus-check"
     updated = update_notification_status_by_id(notification.id, "cancelled")
     assert Notification.query.get(notification.id).status == "cancelled"
@@ -155,7 +159,7 @@ def test_should_update_status_by_id_if_pending_virus_check(sample_letter_templat
 
 
 def test_should_update_status_by_id_and_set_sent_by(sample_template):
-    notification = create_notification(template=sample_template, status="sending")
+    notification = save_notification(create_notification(template=sample_template, status="sending"))
 
     updated = update_notification_status_by_id(notification.id, "delivered", sent_by="mmg")
     assert updated.status == "delivered"
@@ -165,7 +169,7 @@ def test_should_update_status_by_id_and_set_sent_by(sample_template):
 def test_should_not_update_status_by_reference_if_from_country_with_no_delivery_receipts(
     sample_template,
 ):
-    notification = create_notification(sample_template, status=NOTIFICATION_SENT, reference="foo")
+    notification = save_notification(create_notification(sample_template, status=NOTIFICATION_SENT, reference="foo"))
 
     res = update_notification_status_by_reference("foo", "failed")
 
@@ -176,11 +180,13 @@ def test_should_not_update_status_by_reference_if_from_country_with_no_delivery_
 def test_should_not_update_status_by_id_if_sent_to_country_with_unknown_delivery_receipts(
     sample_template,
 ):
-    notification = create_notification(
-        sample_template,
-        status=NOTIFICATION_SENT,
-        international=True,
-        phone_prefix="249",  # sudan has no delivery receipts (or at least, that we know about)
+    notification = save_notification(
+        create_notification(
+            sample_template,
+            status=NOTIFICATION_SENT,
+            international=True,
+            phone_prefix="249",  # sudan has no delivery receipts (or at least, that we know about)
+        )
     )
 
     res = update_notification_status_by_id(notification.id, "delivered")
@@ -192,11 +198,13 @@ def test_should_not_update_status_by_id_if_sent_to_country_with_unknown_delivery
 def test_should_not_update_status_by_id_if_sent_to_country_with_carrier_delivery_receipts(
     sample_template,
 ):
-    notification = create_notification(
-        sample_template,
-        status=NOTIFICATION_SENT,
-        international=True,
-        phone_prefix="1",  # americans only have carrier delivery receipts
+    notification = save_notification(
+        create_notification(
+            sample_template,
+            status=NOTIFICATION_SENT,
+            international=True,
+            phone_prefix="1",  # americans only have carrier delivery receipts
+        )
     )
 
     res = update_notification_status_by_id(notification.id, "delivered")
@@ -208,11 +216,13 @@ def test_should_not_update_status_by_id_if_sent_to_country_with_carrier_delivery
 def test_should_not_update_status_by_id_if_sent_to_country_with_delivery_receipts(
     sample_template,
 ):
-    notification = create_notification(
-        sample_template,
-        status=NOTIFICATION_SENT,
-        international=True,
-        phone_prefix="7",  # russians have full delivery receipts
+    notification = save_notification(
+        create_notification(
+            sample_template,
+            status=NOTIFICATION_SENT,
+            international=True,
+            phone_prefix="7",  # russians have full delivery receipts
+        )
     )
 
     res = update_notification_status_by_id(notification.id, "delivered")
@@ -222,7 +232,7 @@ def test_should_not_update_status_by_id_if_sent_to_country_with_delivery_receipt
 
 
 def test_should_not_update_status_by_reference_if_not_sending(sample_template):
-    notification = create_notification(template=sample_template, status="created", reference="reference")
+    notification = save_notification(create_notification(template=sample_template, status="created", reference="reference"))
     assert Notification.query.get(notification.id).status == "created"
     updated = update_notification_status_by_reference("reference", "failed")
     assert Notification.query.get(notification.id).status == "created"
@@ -230,7 +240,7 @@ def test_should_not_update_status_by_reference_if_not_sending(sample_template):
 
 
 def test_should_by_able_to_update_status_by_id_from_pending_to_delivered(sample_template, sample_job):
-    notification = create_notification(template=sample_template, job=sample_job, status="sending")
+    notification = save_notification(create_notification(template=sample_template, job=sample_job, status="sending"))
 
     assert update_notification_status_by_id(notification_id=notification.id, status="pending")
     assert Notification.query.get(notification.id).status == "pending"
@@ -240,7 +250,7 @@ def test_should_by_able_to_update_status_by_id_from_pending_to_delivered(sample_
 
 
 def test_should_by_able_to_update_status_by_id_from_pending_to_temporary_failure(sample_template, sample_job):
-    notification = create_notification(template=sample_template, job=sample_job, status="sending")
+    notification = save_notification(create_notification(template=sample_template, job=sample_job, status="sending"))
 
     assert update_notification_status_by_id(notification_id=notification.id, status="pending")
     assert Notification.query.get(notification.id).status == "pending"
@@ -263,7 +273,7 @@ def test_should_by_able_to_update_status_by_id_from_sending_to_permanent_failure
 def test_should_not_update_status_once_notification_status_is_delivered(
     sample_email_template,
 ):
-    notification = create_notification(template=sample_email_template, status="sending")
+    notification = save_notification(create_notification(template=sample_email_template, status="sending"))
     assert Notification.query.get(notification.id).status == "sending"
 
     notification.reference = "reference"
@@ -286,11 +296,13 @@ def test_should_return_zero_count_if_no_notification_with_reference():
 def test_create_notification_creates_notification_with_personalisation(sample_template_with_placeholders, sample_job):
     assert Notification.query.count() == 0
 
-    data = create_notification(
-        template=sample_template_with_placeholders,
-        job=sample_job,
-        personalisation={"name": "Jo"},
-        status="created",
+    data = save_notification(
+        create_notification(
+            template=sample_template_with_placeholders,
+            job=sample_job,
+            personalisation={"name": "Jo"},
+            status="created",
+        )
     )
 
     assert Notification.query.count() == 1
@@ -376,7 +388,7 @@ def test_update_notification_with_research_mode_service_does_not_create_or_updat
     sample_template,
 ):
     sample_template.service.research_mode = True
-    notification = create_notification(template=sample_template)
+    notification = save_notification(create_notification(template=sample_template))
 
     assert Notification.query.count() == 1
     assert NotificationHistory.query.count() == 0
@@ -469,7 +481,9 @@ def test_save_notification_with_no_job(sample_template):
 
 
 def test_get_notification_with_personalisation_by_id(sample_template):
-    notification = create_notification(template=sample_template, scheduled_for="2017-05-05 14:15", status="created")
+    notification = save_scheduled_notification(
+        create_notification(template=sample_template, status="created"), scheduled_for="2017-05-05 14:15"
+    )
     notification_from_db = get_notification_with_personalisation(sample_template.service.id, notification.id, key_type=None)
     assert notification == notification_from_db
     assert notification_from_db.scheduled_notification.scheduled_for == datetime(2017, 5, 5, 14, 15)
@@ -499,9 +513,9 @@ def test_get_notification_by_id_when_notification_exists_for_different_service(
 def test_get_notifications_by_reference(sample_template):
     client_reference = "some-client-ref"
     assert len(Notification.query.all()) == 0
-    create_notification(sample_template, client_reference=client_reference)
-    create_notification(sample_template, client_reference=client_reference)
-    create_notification(sample_template, client_reference="other-ref")
+    save_notification(create_notification(sample_template, client_reference=client_reference))
+    save_notification(create_notification(sample_template, client_reference=client_reference))
+    save_notification(create_notification(sample_template, client_reference="other-ref"))
     all_notifications = get_notifications_for_service(sample_template.service_id, client_reference=client_reference).items
     assert len(all_notifications) == 2
 
@@ -536,7 +550,7 @@ def test_get_notification_for_job(sample_notification):
 def test_get_all_notifications_for_job(sample_job):
     for i in range(0, 5):
         try:
-            create_notification(template=sample_job.template, job=sample_job)
+            save_notification(create_notification(template=sample_job.template, job=sample_job))
         except IntegrityError:
             pass
 
@@ -548,7 +562,7 @@ def test_get_all_notifications_for_job_by_status(sample_job):
     notifications = partial(get_notifications_for_job, sample_job.service.id, sample_job.id)
 
     for status in NOTIFICATION_STATUS_TYPES:
-        create_notification(template=sample_job.template, job=sample_job, status=status)
+        save_notification(create_notification(template=sample_job.template, job=sample_job, status=status))
 
     assert len(notifications().items) == len(NOTIFICATION_STATUS_TYPES)
 
@@ -578,7 +592,7 @@ def test_should_limit_notifications_return_by_day_limit_plus_one(sample_template
     for i in range(1, 11):
         past_date = "2016-01-{0:02d} 12:00:00".format(i)
         with freeze_time(past_date):
-            create_notification(sample_template, created_at=datetime.utcnow(), status="failed")
+            save_notification(create_notification(sample_template, created_at=datetime.utcnow(), status="failed"))
 
     all_notifications = Notification.query.all()
     assert len(all_notifications) == 10
@@ -591,13 +605,13 @@ def test_should_limit_notifications_return_by_day_limit_plus_one(sample_template
 
 
 def test_creating_notification_does_not_add_notification_history(sample_template):
-    create_notification(template=sample_template)
+    save_notification(create_notification(template=sample_template))
     assert Notification.query.count() == 1
     assert NotificationHistory.query.count() == 0
 
 
 def test_should_delete_notification_for_id(sample_template):
-    notification = create_notification(template=sample_template)
+    notification = save_notification(create_notification(template=sample_template))
 
     assert Notification.query.count() == 1
     assert NotificationHistory.query.count() == 0
@@ -612,7 +626,7 @@ def test_should_delete_notification_and_ignore_history_for_research_mode(
 ):
     sample_template.service.research_mode = True
 
-    notification = create_notification(template=sample_template)
+    notification = save_notification(create_notification(template=sample_template))
 
     assert Notification.query.count() == 1
 
@@ -622,8 +636,8 @@ def test_should_delete_notification_and_ignore_history_for_research_mode(
 
 
 def test_should_delete_only_notification_with_id(sample_template):
-    notification_1 = create_notification(template=sample_template)
-    notification_2 = create_notification(template=sample_template)
+    notification_1 = save_notification(create_notification(template=sample_template))
+    notification_2 = save_notification(create_notification(template=sample_template))
     assert Notification.query.count() == 2
 
     dao_delete_notifications_by_id(notification_1.id)
@@ -633,7 +647,7 @@ def test_should_delete_only_notification_with_id(sample_template):
 
 
 def test_should_delete_no_notifications_if_no_matching_ids(sample_template):
-    create_notification(template=sample_template)
+    save_notification(create_notification(template=sample_template))
     assert Notification.query.count() == 1
 
     dao_delete_notifications_by_id(uuid.uuid4())
@@ -664,10 +678,10 @@ def _notification_json(sample_template, job_id=None, id=None, status=None):
 
 def test_dao_timeout_notifications(sample_template):
     with freeze_time(datetime.utcnow() - timedelta(minutes=2)):
-        created = create_notification(sample_template, status="created")
-        sending = create_notification(sample_template, status="sending")
-        pending = create_notification(sample_template, status="pending")
-        delivered = create_notification(sample_template, status="delivered")
+        created = save_notification(create_notification(sample_template, status="created"))
+        sending = save_notification(create_notification(sample_template, status="sending"))
+        pending = save_notification(create_notification(sample_template, status="pending"))
+        delivered = save_notification(create_notification(sample_template, status="delivered"))
 
     assert Notification.query.get(created.id).status == "created"
     assert Notification.query.get(sending.id).status == "sending"
@@ -688,10 +702,10 @@ def test_dao_timeout_notifications_only_updates_for_older_notifications(
     sample_template,
 ):
     with freeze_time(datetime.utcnow() + timedelta(minutes=10)):
-        created = create_notification(sample_template, status="created")
-        sending = create_notification(sample_template, status="sending")
-        pending = create_notification(sample_template, status="pending")
-        delivered = create_notification(sample_template, status="delivered")
+        created = save_notification(create_notification(sample_template, status="created"))
+        sending = save_notification(create_notification(sample_template, status="sending"))
+        pending = save_notification(create_notification(sample_template, status="pending"))
+        delivered = save_notification(create_notification(sample_template, status="delivered"))
 
     assert Notification.query.get(created.id).status == "created"
     assert Notification.query.get(sending.id).status == "sending"
@@ -706,10 +720,10 @@ def test_dao_timeout_notifications_only_updates_for_older_notifications(
 
 def test_dao_timeout_notifications_doesnt_affect_letters(sample_letter_template):
     with freeze_time(datetime.utcnow() - timedelta(minutes=2)):
-        created = create_notification(sample_letter_template, status="created")
-        sending = create_notification(sample_letter_template, status="sending")
-        pending = create_notification(sample_letter_template, status="pending")
-        delivered = create_notification(sample_letter_template, status="delivered")
+        created = save_notification(create_notification(sample_letter_template, status="created"))
+        sending = save_notification(create_notification(sample_letter_template, status="sending"))
+        pending = save_notification(create_notification(sample_letter_template, status="pending"))
+        delivered = save_notification(create_notification(sample_letter_template, status="delivered"))
 
     assert Notification.query.get(created.id).status == "created"
     assert Notification.query.get(sending.id).status == "sending"
@@ -723,8 +737,8 @@ def test_dao_timeout_notifications_doesnt_affect_letters(sample_letter_template)
 
 
 def test_should_return_notifications_excluding_jobs_by_default(sample_template, sample_job, sample_api_key):
-    create_notification(sample_template, job=sample_job)
-    without_job = create_notification(sample_template, api_key=sample_api_key)
+    save_notification(create_notification(sample_template, job=sample_job))
+    without_job = save_notification(create_notification(sample_template, api_key=sample_api_key))
 
     include_jobs = get_notifications_for_service(sample_template.service_id, include_jobs=True).items
     assert len(include_jobs) == 2
@@ -739,8 +753,8 @@ def test_should_return_notifications_excluding_jobs_by_default(sample_template, 
 
 
 def test_should_return_notifications_including_one_offs_by_default(sample_user, sample_template):
-    create_notification(sample_template, one_off=True, created_by_id=sample_user.id)
-    not_one_off = create_notification(sample_template)
+    save_notification(create_notification(sample_template, one_off=True, created_by_id=sample_user.id))
+    not_one_off = save_notification(create_notification(sample_template))
 
     exclude_one_offs = get_notifications_for_service(sample_template.service_id, include_one_off=False).items
     assert len(exclude_one_offs) == 1
@@ -754,8 +768,8 @@ def test_should_return_notifications_including_one_offs_by_default(sample_user, 
 
 
 def test_should_not_count_pages_when_given_a_flag(sample_user, sample_template):
-    create_notification(sample_template)
-    notification = create_notification(sample_template)
+    save_notification(create_notification(sample_template))
+    notification = save_notification(create_notification(sample_template))
 
     pagination = get_notifications_for_service(sample_template.service_id, count_pages=False, page_size=1)
     assert len(pagination.items) == 1
@@ -772,24 +786,30 @@ def test_get_notifications_created_by_api_or_csv_are_returned_correctly_excludin
     sample_team_api_key,
     sample_test_api_key,
 ):
-    create_notification(template=sample_job.template, created_at=datetime.utcnow(), job=sample_job)
-    create_notification(
-        template=sample_job.template,
-        created_at=datetime.utcnow(),
-        api_key=sample_api_key,
-        key_type=sample_api_key.key_type,
+    save_notification(create_notification(template=sample_job.template, created_at=datetime.utcnow(), job=sample_job))
+    save_notification(
+        create_notification(
+            template=sample_job.template,
+            created_at=datetime.utcnow(),
+            api_key=sample_api_key,
+            key_type=sample_api_key.key_type,
+        )
     )
-    create_notification(
-        template=sample_job.template,
-        created_at=datetime.utcnow(),
-        api_key=sample_team_api_key,
-        key_type=sample_team_api_key.key_type,
+    save_notification(
+        create_notification(
+            template=sample_job.template,
+            created_at=datetime.utcnow(),
+            api_key=sample_team_api_key,
+            key_type=sample_team_api_key.key_type,
+        )
     )
-    create_notification(
-        template=sample_job.template,
-        created_at=datetime.utcnow(),
-        api_key=sample_test_api_key,
-        key_type=sample_test_api_key.key_type,
+    save_notification(
+        create_notification(
+            template=sample_job.template,
+            created_at=datetime.utcnow(),
+            api_key=sample_test_api_key,
+            key_type=sample_test_api_key.key_type,
+        )
     )
 
     all_notifications = Notification.query.all()
@@ -809,24 +829,30 @@ def test_get_notifications_created_by_api_or_csv_are_returned_correctly_excludin
 
 
 def test_get_notifications_with_a_live_api_key_type(sample_job, sample_api_key, sample_team_api_key, sample_test_api_key):
-    create_notification(template=sample_job.template, created_at=datetime.utcnow(), job=sample_job)
-    create_notification(
-        template=sample_job.template,
-        created_at=datetime.utcnow(),
-        api_key=sample_api_key,
-        key_type=sample_api_key.key_type,
+    save_notification(create_notification(template=sample_job.template, created_at=datetime.utcnow(), job=sample_job))
+    save_notification(
+        create_notification(
+            template=sample_job.template,
+            created_at=datetime.utcnow(),
+            api_key=sample_api_key,
+            key_type=sample_api_key.key_type,
+        )
     )
-    create_notification(
-        template=sample_job.template,
-        created_at=datetime.utcnow(),
-        api_key=sample_team_api_key,
-        key_type=sample_team_api_key.key_type,
+    save_notification(
+        create_notification(
+            template=sample_job.template,
+            created_at=datetime.utcnow(),
+            api_key=sample_team_api_key,
+            key_type=sample_team_api_key.key_type,
+        )
     )
-    create_notification(
-        template=sample_job.template,
-        created_at=datetime.utcnow(),
-        api_key=sample_test_api_key,
-        key_type=sample_test_api_key.key_type,
+    save_notification(
+        create_notification(
+            template=sample_job.template,
+            created_at=datetime.utcnow(),
+            api_key=sample_test_api_key,
+            key_type=sample_test_api_key.key_type,
+        )
     )
 
     all_notifications = Notification.query.all()
@@ -844,24 +870,30 @@ def test_get_notifications_with_a_live_api_key_type(sample_job, sample_api_key, 
 
 
 def test_get_notifications_with_a_test_api_key_type(sample_job, sample_api_key, sample_team_api_key, sample_test_api_key):
-    create_notification(template=sample_job.template, created_at=datetime.utcnow(), job=sample_job)
-    create_notification(
-        template=sample_job.template,
-        created_at=datetime.utcnow(),
-        api_key=sample_api_key,
-        key_type=sample_api_key.key_type,
+    save_notification(create_notification(template=sample_job.template, created_at=datetime.utcnow(), job=sample_job))
+    save_notification(
+        create_notification(
+            template=sample_job.template,
+            created_at=datetime.utcnow(),
+            api_key=sample_api_key,
+            key_type=sample_api_key.key_type,
+        )
     )
-    create_notification(
-        template=sample_job.template,
-        created_at=datetime.utcnow(),
-        api_key=sample_team_api_key,
-        key_type=sample_team_api_key.key_type,
+    save_notification(
+        create_notification(
+            template=sample_job.template,
+            created_at=datetime.utcnow(),
+            api_key=sample_team_api_key,
+            key_type=sample_team_api_key.key_type,
+        )
     )
-    create_notification(
-        template=sample_job.template,
-        created_at=datetime.utcnow(),
-        api_key=sample_test_api_key,
-        key_type=sample_test_api_key.key_type,
+    save_notification(
+        create_notification(
+            template=sample_job.template,
+            created_at=datetime.utcnow(),
+            api_key=sample_test_api_key,
+            key_type=sample_test_api_key.key_type,
+        )
     )
 
     # only those created with test API key, no jobs
@@ -876,24 +908,30 @@ def test_get_notifications_with_a_test_api_key_type(sample_job, sample_api_key, 
 
 
 def test_get_notifications_with_a_team_api_key_type(sample_job, sample_api_key, sample_team_api_key, sample_test_api_key):
-    create_notification(template=sample_job.template, created_at=datetime.utcnow(), job=sample_job)
-    create_notification(
-        template=sample_job.template,
-        created_at=datetime.utcnow(),
-        api_key=sample_api_key,
-        key_type=sample_api_key.key_type,
+    save_notification(create_notification(template=sample_job.template, created_at=datetime.utcnow(), job=sample_job))
+    save_notification(
+        create_notification(
+            template=sample_job.template,
+            created_at=datetime.utcnow(),
+            api_key=sample_api_key,
+            key_type=sample_api_key.key_type,
+        )
     )
-    create_notification(
-        template=sample_job.template,
-        created_at=datetime.utcnow(),
-        api_key=sample_team_api_key,
-        key_type=sample_team_api_key.key_type,
+    save_notification(
+        create_notification(
+            template=sample_job.template,
+            created_at=datetime.utcnow(),
+            api_key=sample_team_api_key,
+            key_type=sample_team_api_key.key_type,
+        )
     )
-    create_notification(
-        sample_job.template,
-        created_at=datetime.utcnow(),
-        api_key=sample_test_api_key,
-        key_type=sample_test_api_key.key_type,
+    save_notification(
+        create_notification(
+            sample_job.template,
+            created_at=datetime.utcnow(),
+            api_key=sample_test_api_key,
+            key_type=sample_test_api_key.key_type,
+        )
     )
 
     # only those created with team API key, no jobs
@@ -908,25 +946,31 @@ def test_get_notifications_with_a_team_api_key_type(sample_job, sample_api_key, 
 
 
 def test_should_exclude_test_key_notifications_by_default(sample_job, sample_api_key, sample_team_api_key, sample_test_api_key):
-    create_notification(template=sample_job.template, created_at=datetime.utcnow(), job=sample_job)
+    save_notification(create_notification(template=sample_job.template, created_at=datetime.utcnow(), job=sample_job))
 
-    create_notification(
-        template=sample_job.template,
-        created_at=datetime.utcnow(),
-        api_key=sample_api_key,
-        key_type=sample_api_key.key_type,
+    save_notification(
+        create_notification(
+            template=sample_job.template,
+            created_at=datetime.utcnow(),
+            api_key=sample_api_key,
+            key_type=sample_api_key.key_type,
+        )
     )
-    create_notification(
-        template=sample_job.template,
-        created_at=datetime.utcnow(),
-        api_key=sample_team_api_key,
-        key_type=sample_team_api_key.key_type,
+    save_notification(
+        create_notification(
+            template=sample_job.template,
+            created_at=datetime.utcnow(),
+            api_key=sample_team_api_key,
+            key_type=sample_team_api_key.key_type,
+        )
     )
-    create_notification(
-        template=sample_job.template,
-        created_at=datetime.utcnow(),
-        api_key=sample_test_api_key,
-        key_type=sample_test_api_key.key_type,
+    save_notification(
+        create_notification(
+            template=sample_job.template,
+            created_at=datetime.utcnow(),
+            api_key=sample_test_api_key,
+            key_type=sample_test_api_key.key_type,
+        )
     )
 
     all_notifications = Notification.query.all()
@@ -982,13 +1026,13 @@ def test_is_delivery_slow_for_provider(
     )
 
     for _ in range(normal_sending):
-        normal_notification(status="sending")
+        save_notification(normal_notification(status="sending"))
     for _ in range(slow_sending):
-        slow_notification(status="sending")
+        save_notification(slow_notification(status="sending"))
     for _ in range(normal_delivered):
-        normal_notification(status="delivered")
+        save_notification(normal_notification(status="delivered"))
     for _ in range(slow_delivered):
-        slow_notification(status="delivered")
+        save_notification(slow_notification(status="delivered"))
 
     assert is_delivery_slow_for_provider(datetime.utcnow(), "mmg", threshold, timedelta(minutes=4)) is expected_result
 
@@ -1023,7 +1067,7 @@ def test_delivery_is_delivery_slow_for_provider_filters_out_notifications_it_sho
         "updated_at": datetime.now(),
     }
     create_notification_with.update(options)
-    create_notification(**create_notification_with)
+    save_notification(create_notification(**create_notification_with))
     assert is_delivery_slow_for_provider(datetime.utcnow(), "mmg", 0.1, timedelta(minutes=4)) is expected_result
 
 
@@ -1034,17 +1078,21 @@ def test_dao_get_notifications_by_to_field(sample_template):
         "normalised_to": "+16502532222",
     }
 
-    notification1 = create_notification(template=sample_template, **recipient_to_search_for)
-    create_notification(template=sample_template, key_type=KEY_TYPE_TEST, **recipient_to_search_for)
-    create_notification(
-        template=sample_template,
-        to_field="jack@gmail.com",
-        normalised_to="jack@gmail.com",
+    notification1 = save_notification(create_notification(template=sample_template, **recipient_to_search_for))
+    save_notification(create_notification(template=sample_template, key_type=KEY_TYPE_TEST, **recipient_to_search_for))
+    save_notification(
+        create_notification(
+            template=sample_template,
+            to_field="jack@gmail.com",
+            normalised_to="jack@gmail.com",
+        )
     )
-    create_notification(
-        template=sample_template,
-        to_field="jane@gmail.com",
-        normalised_to="jane@gmail.com",
+    save_notification(
+        create_notification(
+            template=sample_template,
+            to_field="jane@gmail.com",
+            normalised_to="jane@gmail.com",
+        )
     )
 
     results = dao_get_notifications_by_to_field(
@@ -1059,10 +1107,12 @@ def test_dao_get_notifications_by_to_field(sample_template):
 
 @pytest.mark.parametrize("search_term", ["JACK", "JACK@gmail.com", "jack@gmail.com"])
 def test_dao_get_notifications_by_to_field_search_is_not_case_sensitive(sample_email_template, search_term):
-    notification = create_notification(
-        template=sample_email_template,
-        to_field="jack@gmail.com",
-        normalised_to="jack@gmail.com",
+    notification = save_notification(
+        create_notification(
+            template=sample_email_template,
+            to_field="jack@gmail.com",
+            normalised_to="jack@gmail.com",
+        )
     )
     results = dao_get_notifications_by_to_field(notification.service_id, search_term, notification_type="email")
     notification_ids = [notification.id for notification in results]
@@ -1074,15 +1124,19 @@ def test_dao_get_notifications_by_to_field_search_is_not_case_sensitive(sample_e
 def test_dao_get_notifications_by_to_field_matches_partial_emails(
     sample_email_template,
 ):
-    notification_1 = create_notification(
-        template=sample_email_template,
-        to_field="jack@gmail.com",
-        normalised_to="jack@gmail.com",
+    notification_1 = save_notification(
+        create_notification(
+            template=sample_email_template,
+            to_field="jack@gmail.com",
+            normalised_to="jack@gmail.com",
+        )
     )
-    notification_2 = create_notification(
-        template=sample_email_template,
-        to_field="jacque@gmail.com",
-        normalised_to="jacque@gmail.com",
+    notification_2 = save_notification(
+        create_notification(
+            template=sample_email_template,
+            to_field="jacque@gmail.com",
+            normalised_to="jacque@gmail.com",
+        )
     )
     results = dao_get_notifications_by_to_field(notification_1.service_id, "ack", notification_type="email")
     notification_ids = [notification.id for notification in results]
@@ -1124,10 +1178,12 @@ def test_dao_get_notifications_by_to_field_escapes(
         "/@example.com",
         "baz\\baz@example.com",
     }:
-        create_notification(
-            template=sample_email_template,
-            to_field=email_address,
-            normalised_to=email_address,
+        save_notification(
+            create_notification(
+                template=sample_email_template,
+                to_field=email_address,
+                normalised_to=email_address,
+            )
         )
 
     assert (
@@ -1169,15 +1225,19 @@ def test_dao_get_notifications_by_to_field_matches_partial_phone_numbers(
     search_term,
 ):
 
-    notification_1 = create_notification(
-        template=sample_template,
-        to_field="+447700900100",
-        normalised_to="447700900100",
+    notification_1 = save_notification(
+        create_notification(
+            template=sample_template,
+            to_field="+447700900100",
+            normalised_to="447700900100",
+        )
     )
-    notification_2 = create_notification(
-        template=sample_template,
-        to_field="+447700900200",
-        normalised_to="447700900200",
+    notification_2 = save_notification(
+        create_notification(
+            template=sample_template,
+            to_field="+447700900200",
+            normalised_to="447700900200",
+        )
     )
     results = dao_get_notifications_by_to_field(notification_1.service_id, search_term, notification_type="sms")
     notification_ids = [notification.id for notification in results]
@@ -1202,21 +1262,29 @@ def test_dao_get_notifications_by_to_field_accepts_invalid_phone_numbers_and_ema
 
 
 def test_dao_get_notifications_by_to_field_search_ignores_spaces(sample_template):
-    notification1 = create_notification(template=sample_template, to_field="+16502532222", normalised_to="+16502532222")
-    notification2 = create_notification(
-        template=sample_template,
-        to_field="+1 650 253 2222",
-        normalised_to="+16502532222",
+    notification1 = save_notification(
+        create_notification(template=sample_template, to_field="+16502532222", normalised_to="+16502532222")
     )
-    notification3 = create_notification(
-        template=sample_template,
-        to_field=" +1650253 2 222",
-        normalised_to="+16502532222",
+    notification2 = save_notification(
+        create_notification(
+            template=sample_template,
+            to_field="+1 650 253 2222",
+            normalised_to="+16502532222",
+        )
     )
-    create_notification(
-        template=sample_template,
-        to_field="jaCK@gmail.com",
-        normalised_to="jack@gmail.com",
+    notification3 = save_notification(
+        create_notification(
+            template=sample_template,
+            to_field=" +1650253 2 222",
+            normalised_to="+16502532222",
+        )
+    )
+    save_notification(
+        create_notification(
+            template=sample_template,
+            to_field="jaCK@gmail.com",
+            normalised_to="jack@gmail.com",
+        )
     )
 
     results = dao_get_notifications_by_to_field(notification1.service_id, "+16502532222", notification_type="sms")
@@ -1244,11 +1312,13 @@ def test_dao_get_notifications_by_to_field_only_searches_one_notification_type(
     service = create_service()
     sms_template = create_template(service=service)
     email_template = create_template(service=service, template_type="email")
-    sms = create_notification(template=sms_template, to_field="6502532222", normalised_to="+16502532222")
-    email = create_notification(
-        template=email_template,
-        to_field="165@example.com",
-        normalised_to="165@example.com",
+    sms = save_notification(create_notification(template=sms_template, to_field="6502532222", normalised_to="+16502532222"))
+    email = save_notification(
+        create_notification(
+            template=email_template,
+            to_field="165@example.com",
+            normalised_to="165@example.com",
+        )
     )
     results = dao_get_notifications_by_to_field(service.id, phone_search, notification_type="sms")
     assert len(results) == 1
@@ -1278,9 +1348,15 @@ def test_dao_created_scheduled_notification(sample_notification):
 
 
 def test_dao_get_scheduled_notifications(sample_template):
-    notification_1 = create_notification(template=sample_template, scheduled_for="2017-05-05 14:15", status="created")
-    create_notification(template=sample_template, scheduled_for="2017-05-04 14:15", status="delivered")
-    create_notification(template=sample_template, status="created")
+    notification_1 = save_scheduled_notification(
+        create_notification(template=sample_template, status="created"),
+        scheduled_for="2017-05-05 14:15",
+    )
+    save_scheduled_notification(
+        create_notification(template=sample_template, status="delivered"),
+        scheduled_for="2017-05-04 14:15",
+    )
+    save_notification(create_notification(template=sample_template, status="created"))
     scheduled_notifications = dao_get_scheduled_notifications()
     assert len(scheduled_notifications) == 1
     assert scheduled_notifications[0].id == notification_1.id
@@ -1288,7 +1364,10 @@ def test_dao_get_scheduled_notifications(sample_template):
 
 
 def test_set_scheduled_notification_to_processed(sample_template):
-    notification_1 = create_notification(template=sample_template, scheduled_for="2017-05-05 14:15", status="created")
+    notification_1 = save_scheduled_notification(
+        create_notification(template=sample_template, status="created"),
+        scheduled_for="2017-05-05 14:15",
+    )
     scheduled_notifications = dao_get_scheduled_notifications()
     assert len(scheduled_notifications) == 1
     assert scheduled_notifications[0].id == notification_1.id
@@ -1300,17 +1379,21 @@ def test_set_scheduled_notification_to_processed(sample_template):
 
 
 def test_dao_get_notifications_by_to_field_filters_status(sample_template):
-    notification = create_notification(
-        template=sample_template,
-        to_field="+16502532222",
-        normalised_to="+16502532222",
-        status="delivered",
+    notification = save_notification(
+        create_notification(
+            template=sample_template,
+            to_field="+16502532222",
+            normalised_to="+16502532222",
+            status="delivered",
+        )
     )
-    create_notification(
-        template=sample_template,
-        to_field="+16502532222",
-        normalised_to="+16502532222",
-        status="temporary-failure",
+    save_notification(
+        create_notification(
+            template=sample_template,
+            to_field="+16502532222",
+            normalised_to="+16502532222",
+            status="temporary-failure",
+        )
     )
 
     notifications = dao_get_notifications_by_to_field(
@@ -1325,17 +1408,21 @@ def test_dao_get_notifications_by_to_field_filters_status(sample_template):
 
 
 def test_dao_get_notifications_by_to_field_filters_multiple_statuses(sample_template):
-    notification1 = create_notification(
-        template=sample_template,
-        to_field="+16502532222",
-        normalised_to="+16502532222",
-        status="delivered",
+    notification1 = save_notification(
+        create_notification(
+            template=sample_template,
+            to_field="+16502532222",
+            normalised_to="+16502532222",
+            status="delivered",
+        )
     )
-    notification2 = create_notification(
-        template=sample_template,
-        to_field="+16502532222",
-        normalised_to="+16502532222",
-        status="sending",
+    notification2 = save_notification(
+        create_notification(
+            template=sample_template,
+            to_field="+16502532222",
+            normalised_to="+16502532222",
+            status="sending",
+        )
     )
 
     notifications = dao_get_notifications_by_to_field(
@@ -1354,17 +1441,21 @@ def test_dao_get_notifications_by_to_field_filters_multiple_statuses(sample_temp
 def test_dao_get_notifications_by_to_field_returns_all_if_no_status_filter(
     sample_template,
 ):
-    notification1 = create_notification(
-        template=sample_template,
-        to_field="+16502532222",
-        normalised_to="+16502532222",
-        status="delivered",
+    notification1 = save_notification(
+        create_notification(
+            template=sample_template,
+            to_field="+16502532222",
+            normalised_to="+16502532222",
+            status="delivered",
+        )
     )
-    notification2 = create_notification(
-        template=sample_template,
-        to_field="+16502532222",
-        normalised_to="+16502532222",
-        status="temporary-failure",
+    notification2 = save_notification(
+        create_notification(
+            template=sample_template,
+            to_field="+16502532222",
+            normalised_to="+16502532222",
+            status="temporary-failure",
+        )
     )
 
     notifications = dao_get_notifications_by_to_field(notification1.service_id, "+16502532222", notification_type="sms")
@@ -1377,15 +1468,16 @@ def test_dao_get_notifications_by_to_field_returns_all_if_no_status_filter(
 
 @freeze_time("2016-01-01 11:10:00")
 def test_dao_get_notifications_by_to_field_orders_by_created_at_desc(sample_template):
-    notification = partial(
-        create_notification,
-        template=sample_template,
-        to_field="+16502532222",
-        normalised_to="+16502532222",
-    )
+    data = {
+        "template": sample_template,
+        "to_field": "+16502532222",
+        "normalised_to": "+16502532222",
+    }
 
-    notification_a_minute_ago = notification(created_at=datetime.utcnow() - timedelta(minutes=1))
-    notification = notification(created_at=datetime.utcnow())
+    notification_a_minute_ago = save_notification(
+        create_notification(created_at=datetime.utcnow() - timedelta(minutes=1), **data)
+    )
+    notification = save_notification(create_notification(created_at=datetime.utcnow(), **data))
 
     notifications = dao_get_notifications_by_to_field(sample_template.service_id, "+16502532222", notification_type="sms")
 
@@ -1429,8 +1521,8 @@ def test_dao_get_last_notification_added_for_job_id_no_job(sample_template, fake
 
 
 def test_dao_update_notifications_by_reference_updated_notifications(sample_template):
-    notification_1 = create_notification(template=sample_template, reference="ref1")
-    notification_2 = create_notification(template=sample_template, reference="ref2")
+    notification_1 = save_notification(create_notification(template=sample_template, reference="ref1"))
+    notification_2 = save_notification(create_notification(template=sample_template, reference="ref2"))
 
     updated_count, updated_history_count = dao_update_notifications_by_reference(
         references=["ref1", "ref2"],
@@ -1450,7 +1542,7 @@ def test_dao_update_notifications_by_reference_updated_notifications(sample_temp
 def test_dao_update_notifications_by_reference_updates_history_some_notifications_exist(
     sample_template,
 ):
-    create_notification(template=sample_template, reference="ref1")
+    save_notification(create_notification(template=sample_template, reference="ref1"))
     create_notification_history(template=sample_template, reference="ref2")
 
     updated_count, updated_history_count = dao_update_notifications_by_reference(
@@ -1489,7 +1581,7 @@ def test_dao_update_notifications_by_reference_returns_zero_when_no_notification
 def test_dao_update_notifications_by_reference_set_returned_letter_status(
     sample_letter_template,
 ):
-    notification = create_notification(template=sample_letter_template, reference="ref")
+    notification = save_notification(create_notification(template=sample_letter_template, reference="ref"))
 
     updated_count, updated_history_count = dao_update_notifications_by_reference(
         references=["ref"], update_dict={"status": "returned-letter"}
@@ -1504,7 +1596,7 @@ def test_dao_update_notifications_by_reference_updates_history_when_one_of_two_n
     sample_letter_template,
 ):
     notification1 = create_notification_history(template=sample_letter_template, reference="ref1")
-    notification2 = create_notification(template=sample_letter_template, reference="ref2")
+    notification2 = save_notification(create_notification(template=sample_letter_template, reference="ref2"))
 
     updated_count, updated_history_count = dao_update_notifications_by_reference(
         references=["ref1", "ref2"], update_dict={"status": "returned-letter"}
@@ -1517,15 +1609,15 @@ def test_dao_update_notifications_by_reference_updates_history_when_one_of_two_n
 
 
 def test_dao_get_notification_by_reference_with_one_match_returns_notification(sample_letter_template, notify_db):
-    create_notification(template=sample_letter_template, reference="REF1")
+    save_notification(create_notification(template=sample_letter_template, reference="REF1"))
     notification = dao_get_notification_by_reference("REF1")
 
     assert notification.reference == "REF1"
 
 
 def test_dao_get_notification_by_reference_with_multiple_matches_raises_error(sample_letter_template, notify_db):
-    create_notification(template=sample_letter_template, reference="REF1")
-    create_notification(template=sample_letter_template, reference="REF1")
+    save_notification(create_notification(template=sample_letter_template, reference="REF1"))
+    save_notification(create_notification(template=sample_letter_template, reference="REF1"))
 
     with pytest.raises(SQLAlchemyError):
         dao_get_notification_by_reference("REF1")
@@ -1537,9 +1629,9 @@ def test_dao_get_notification_by_reference_with_no_matches_raises_error(notify_d
 
 
 def test_dao_get_notifications_by_reference(sample_template):
-    create_notification(template=sample_template, reference="noref")
-    notification_1 = create_notification(template=sample_template, reference="ref")
-    notification_2 = create_notification(template=sample_template, reference="ref")
+    save_notification(create_notification(template=sample_template, reference="noref"))
+    notification_1 = save_notification(create_notification(template=sample_template, reference="ref"))
+    notification_2 = save_notification(create_notification(template=sample_template, reference="ref"))
 
     notifications = dao_get_notifications_by_references(["ref"])
     assert len(notifications) == 2
@@ -1550,7 +1642,7 @@ def test_dao_get_notifications_by_reference(sample_template):
 def test_dao_get_notification_history_by_reference_with_one_match_returns_notification(
     sample_letter_template,
 ):
-    create_notification(template=sample_letter_template, reference="REF1")
+    save_notification(create_notification(template=sample_letter_template, reference="REF1"))
     notification = dao_get_notification_history_by_reference("REF1")
 
     assert notification.reference == "REF1"
@@ -1559,8 +1651,8 @@ def test_dao_get_notification_history_by_reference_with_one_match_returns_notifi
 def test_dao_get_notification_history_by_reference_with_multiple_matches_raises_error(
     sample_letter_template,
 ):
-    create_notification(template=sample_letter_template, reference="REF1")
-    create_notification(template=sample_letter_template, reference="REF1")
+    save_notification(create_notification(template=sample_letter_template, reference="REF1"))
+    save_notification(create_notification(template=sample_letter_template, reference="REF1"))
 
     with pytest.raises(SQLAlchemyError):
         dao_get_notification_history_by_reference("REF1")
@@ -1577,17 +1669,21 @@ def test_dao_get_notification_history_by_reference_with_no_matches_raises_error(
 def test_notifications_not_yet_sent(sample_service, notification_type):
     older_than = 4  # number of seconds the notification can not be older than
     template = create_template(service=sample_service, template_type=notification_type)
-    old_notification = create_notification(
-        template=template,
-        created_at=datetime.utcnow() - timedelta(seconds=older_than),
-        status="created",
+    old_notification = save_notification(
+        create_notification(
+            template=template,
+            created_at=datetime.utcnow() - timedelta(seconds=older_than),
+            status="created",
+        )
     )
-    create_notification(
-        template=template,
-        created_at=datetime.utcnow() - timedelta(seconds=older_than),
-        status="sending",
+    save_notification(
+        create_notification(
+            template=template,
+            created_at=datetime.utcnow() - timedelta(seconds=older_than),
+            status="sending",
+        )
     )
-    create_notification(template=template, created_at=datetime.utcnow(), status="created")
+    save_notification(create_notification(template=template, created_at=datetime.utcnow(), status="created"))
 
     results = notifications_not_yet_sent(older_than, notification_type)
     assert len(results) == 1
@@ -1598,9 +1694,9 @@ def test_notifications_not_yet_sent(sample_service, notification_type):
 def test_notifications_not_yet_sent_return_no_rows(sample_service, notification_type):
     older_than = 5  # number of seconds the notification can not be older than
     template = create_template(service=sample_service, template_type=notification_type)
-    create_notification(template=template, created_at=datetime.utcnow(), status="created")
-    create_notification(template=template, created_at=datetime.utcnow(), status="sending")
-    create_notification(template=template, created_at=datetime.utcnow(), status="delivered")
+    save_notification(create_notification(template=template, created_at=datetime.utcnow(), status="created"))
+    save_notification(create_notification(template=template, created_at=datetime.utcnow(), status="sending"))
+    save_notification(create_notification(template=template, created_at=datetime.utcnow(), status="delivered"))
 
     results = notifications_not_yet_sent(older_than, notification_type)
     assert len(results) == 0

--- a/tests/app/dao/notification_dao/test_notification_dao_performance_platform.py
+++ b/tests/app/dao/notification_dao/test_notification_dao_performance_platform.py
@@ -6,17 +6,17 @@ from app.dao.notifications_dao import (
     dao_get_total_notifications_sent_per_day_for_performance_platform,
 )
 from app.models import KEY_TYPE_NORMAL, KEY_TYPE_TEAM, KEY_TYPE_TEST
-from tests.app.db import create_notification
+from tests.app.db import create_notification, save_notification
 
 BEGINNING_OF_DAY = date(2016, 10, 18)
 END_OF_DAY = date(2016, 10, 19)
 
 
 def test_get_total_notifications_filters_on_date_within_date_range(sample_template):
-    create_notification(sample_template, created_at=datetime(2016, 10, 17, 23, 59, 59))
-    create_notification(sample_template, created_at=BEGINNING_OF_DAY)
-    create_notification(sample_template, created_at=datetime(2016, 10, 18, 23, 59, 59))
-    create_notification(sample_template, created_at=END_OF_DAY)
+    save_notification(create_notification(sample_template, created_at=datetime(2016, 10, 17, 23, 59, 59)))
+    save_notification(create_notification(sample_template, created_at=BEGINNING_OF_DAY))
+    save_notification(create_notification(sample_template, created_at=datetime(2016, 10, 18, 23, 59, 59)))
+    save_notification(create_notification(sample_template, created_at=END_OF_DAY))
 
     result = dao_get_total_notifications_sent_per_day_for_performance_platform(BEGINNING_OF_DAY, END_OF_DAY)
 
@@ -25,11 +25,11 @@ def test_get_total_notifications_filters_on_date_within_date_range(sample_templa
 
 @freeze_time("2016-10-18T10:00")
 def test_get_total_notifications_only_counts_api_notifications(sample_template, sample_job, sample_api_key):
-    create_notification(sample_template, one_off=True)
-    create_notification(sample_template, one_off=True)
-    create_notification(sample_template, job=sample_job)
-    create_notification(sample_template, job=sample_job)
-    create_notification(sample_template, api_key=sample_api_key)
+    save_notification(create_notification(sample_template, one_off=True))
+    save_notification(create_notification(sample_template, one_off=True))
+    save_notification(create_notification(sample_template, job=sample_job))
+    save_notification(create_notification(sample_template, job=sample_job))
+    save_notification(create_notification(sample_template, api_key=sample_api_key))
 
     result = dao_get_total_notifications_sent_per_day_for_performance_platform(BEGINNING_OF_DAY, END_OF_DAY)
 
@@ -40,11 +40,11 @@ def test_get_total_notifications_only_counts_api_notifications(sample_template, 
 def test_get_total_notifications_ignores_test_keys(sample_template):
     # Creating multiple templates with normal and team keys but only 1 template
     # with a test key to test that the count ignores letters
-    create_notification(sample_template, key_type=KEY_TYPE_NORMAL)
-    create_notification(sample_template, key_type=KEY_TYPE_NORMAL)
-    create_notification(sample_template, key_type=KEY_TYPE_TEAM)
-    create_notification(sample_template, key_type=KEY_TYPE_TEAM)
-    create_notification(sample_template, key_type=KEY_TYPE_TEST)
+    save_notification(create_notification(sample_template, key_type=KEY_TYPE_NORMAL))
+    save_notification(create_notification(sample_template, key_type=KEY_TYPE_NORMAL))
+    save_notification(create_notification(sample_template, key_type=KEY_TYPE_TEAM))
+    save_notification(create_notification(sample_template, key_type=KEY_TYPE_TEAM))
+    save_notification(create_notification(sample_template, key_type=KEY_TYPE_TEST))
 
     result = dao_get_total_notifications_sent_per_day_for_performance_platform(BEGINNING_OF_DAY, END_OF_DAY)
 
@@ -55,11 +55,11 @@ def test_get_total_notifications_ignores_test_keys(sample_template):
 def test_get_total_notifications_ignores_letters(sample_template, sample_email_template, sample_letter_template):
     # Creating multiple sms and email templates but only 1 letter template to
     # test that the count ignores letters
-    create_notification(sample_template)
-    create_notification(sample_template)
-    create_notification(sample_email_template)
-    create_notification(sample_email_template)
-    create_notification(sample_letter_template)
+    save_notification(create_notification(sample_template))
+    save_notification(create_notification(sample_template))
+    save_notification(create_notification(sample_email_template))
+    save_notification(create_notification(sample_email_template))
+    save_notification(create_notification(sample_letter_template))
 
     result = dao_get_total_notifications_sent_per_day_for_performance_platform(BEGINNING_OF_DAY, END_OF_DAY)
 
@@ -70,9 +70,9 @@ def test_get_total_notifications_ignores_letters(sample_template, sample_email_t
 def test_get_total_notifications_counts_messages_within_10_seconds(sample_template):
     created_at = datetime.utcnow()
 
-    create_notification(sample_template, sent_at=created_at + timedelta(seconds=5))
-    create_notification(sample_template, sent_at=created_at + timedelta(seconds=10))
-    create_notification(sample_template, sent_at=created_at + timedelta(seconds=15))
+    save_notification(create_notification(sample_template, sent_at=created_at + timedelta(seconds=5)))
+    save_notification(create_notification(sample_template, sent_at=created_at + timedelta(seconds=10)))
+    save_notification(create_notification(sample_template, sent_at=created_at + timedelta(seconds=15)))
 
     result = dao_get_total_notifications_sent_per_day_for_performance_platform(BEGINNING_OF_DAY, END_OF_DAY)
 
@@ -82,7 +82,7 @@ def test_get_total_notifications_counts_messages_within_10_seconds(sample_templa
 
 @freeze_time("2016-10-18T10:00")
 def test_get_total_notifications_counts_messages_that_have_not_sent(sample_template):
-    create_notification(sample_template, status="created", sent_at=None)
+    save_notification(create_notification(sample_template, status="created", sent_at=None))
 
     result = dao_get_total_notifications_sent_per_day_for_performance_platform(BEGINNING_OF_DAY, END_OF_DAY)
 

--- a/tests/app/dao/notification_dao/test_notification_dao_template_usage.py
+++ b/tests/app/dao/notification_dao/test_notification_dao_template_usage.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 import pytest
 
 from app.dao.notifications_dao import dao_get_last_template_usage
-from tests.app.db import create_notification, create_template
+from tests.app.db import create_notification, create_template, save_notification
 
 
 def test_last_template_usage_should_get_right_data(sample_notification):
@@ -21,10 +21,10 @@ def test_last_template_usage_should_be_able_to_get_all_template_usage_history_or
 ):
     template = create_template(sample_service, template_type=notification_type)
 
-    create_notification(template, created_at=datetime.utcnow() - timedelta(seconds=1))
-    create_notification(template, created_at=datetime.utcnow() - timedelta(seconds=2))
-    create_notification(template, created_at=datetime.utcnow() - timedelta(seconds=3))
-    most_recent = create_notification(template)
+    save_notification(create_notification(template, created_at=datetime.utcnow() - timedelta(seconds=1)))
+    save_notification(create_notification(template, created_at=datetime.utcnow() - timedelta(seconds=2)))
+    save_notification(create_notification(template, created_at=datetime.utcnow() - timedelta(seconds=3)))
+    most_recent = save_notification(create_notification(template))
 
     results = dao_get_last_template_usage(template.id, notification_type, template.service_id)
     assert results.id == most_recent.id
@@ -34,12 +34,14 @@ def test_last_template_usage_should_ignore_test_keys(sample_template, sample_tea
     one_minute_ago = datetime.utcnow() - timedelta(minutes=1)
     two_minutes_ago = datetime.utcnow() - timedelta(minutes=2)
 
-    team_key = create_notification(
-        template=sample_template,
-        created_at=two_minutes_ago,
-        api_key=sample_team_api_key,
+    team_key = save_notification(
+        create_notification(
+            template=sample_template,
+            created_at=two_minutes_ago,
+            api_key=sample_team_api_key,
+        )
     )
-    create_notification(template=sample_template, created_at=one_minute_ago, api_key=sample_test_api_key)
+    save_notification(create_notification(template=sample_template, created_at=one_minute_ago, api_key=sample_test_api_key))
 
     results = dao_get_last_template_usage(sample_template.id, "sms", sample_template.service_id)
     assert results.id == team_key.id

--- a/tests/app/dao/test_complaint_dao.py
+++ b/tests/app/dao/test_complaint_dao.py
@@ -13,6 +13,7 @@ from tests.app.db import (
     create_notification,
     create_service,
     create_template,
+    save_notification,
 )
 
 
@@ -72,9 +73,9 @@ def test_fetch_complaint_by_service_return_many(notify_db_session):
     service_2 = create_service(service_name="second")
     template_1 = create_template(service=service_1, template_type="email")
     template_2 = create_template(service=service_2, template_type="email")
-    notification_1 = create_notification(template=template_1)
-    notification_2 = create_notification(template=template_2)
-    notification_3 = create_notification(template=template_2)
+    notification_1 = save_notification(create_notification(template=template_1))
+    notification_2 = save_notification(create_notification(template=template_2))
+    notification_3 = save_notification(create_notification(template=template_2))
     complaint_1 = Complaint(
         notification_id=notification_1.id,
         service_id=service_1.id,

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -83,6 +83,7 @@ from tests.app.db import (
     create_template,
     create_template_folder,
     create_user,
+    save_notification,
 )
 
 # from unittest import mock
@@ -825,7 +826,7 @@ def test_delete_service_and_associated_objects(notify_db_session):
     create_user_code(user=user, code="somecode", code_type="sms")
     template = create_template(service=service)
     api_key = create_api_key(service=service)
-    create_notification(template=template, api_key=api_key)
+    save_notification(create_notification(template=template, api_key=api_key))
     create_invited_user(service=service)
 
     assert ServicePermission.query.count() == len(
@@ -909,7 +910,7 @@ def test_add_existing_user_to_another_service_doesnot_change_old_permissions(
 
 def test_fetch_stats_filters_on_service(notify_db_session):
     service_one = create_service()
-    create_notification(template=create_template(service=service_one))
+    save_notification(create_notification(template=create_template(service=service_one)))
 
     service_two = Service(
         name="service_two",
@@ -939,10 +940,10 @@ def test_fetch_stats_counts_correctly(notify_db_session):
     sms_template = create_template(service=service)
     email_template = create_template(service=service, template_type="email")
     # two created email, one failed email, and one created sms
-    create_notification(template=email_template, status="created")
-    create_notification(template=email_template, status="created")
-    create_notification(template=email_template, status="technical-failure")
-    create_notification(template=sms_template, status="created")
+    save_notification(create_notification(template=email_template, status="created"))
+    save_notification(create_notification(template=email_template, status="created"))
+    save_notification(create_notification(template=email_template, status="technical-failure"))
+    save_notification(create_notification(template=sms_template, status="created"))
 
     stats = dao_fetch_stats_for_service(sms_template.service_id, 7)
     stats = sorted(stats, key=lambda x: (x.notification_type, x.status))
@@ -969,10 +970,10 @@ def test_fetch_stats_counts_should_ignore_team_key(notify_db_session):
     test_api_key = create_api_key(service=service, key_type=KEY_TYPE_TEST)
 
     # two created email, one failed email, and one created sms
-    create_notification(template=template, api_key=live_api_key, key_type=live_api_key.key_type)
-    create_notification(template=template, api_key=test_api_key, key_type=test_api_key.key_type)
-    create_notification(template=template, api_key=team_api_key, key_type=team_api_key.key_type)
-    create_notification(template=template)
+    save_notification(create_notification(template=template, api_key=live_api_key, key_type=live_api_key.key_type))
+    save_notification(create_notification(template=template, api_key=test_api_key, key_type=test_api_key.key_type))
+    save_notification(create_notification(template=template, api_key=team_api_key, key_type=team_api_key.key_type))
+    save_notification(create_notification(template=template))
 
     stats = dao_fetch_stats_for_service(template.service_id, 7)
     assert len(stats) == 1
@@ -986,15 +987,15 @@ def test_fetch_stats_for_today_only_includes_today(notify_db_session):
     # two created email, one failed email, and one created sms
     with freeze_time("2001-01-01T23:59:00"):
         # just_before_midnight_yesterday
-        create_notification(template=template, to_field="1", status="delivered")
+        save_notification(create_notification(template=template, to_field="1", status="delivered"))
 
     with freeze_time("2001-01-02T00:01:00"):
         # just_after_midnight_today
-        create_notification(template=template, to_field="2", status="failed")
+        save_notification(create_notification(template=template, to_field="2", status="failed"))
 
     with freeze_time("2001-01-02T12:00:00"):
         # right_now
-        create_notification(template=template, to_field="3", status="created")
+        save_notification(create_notification(template=template, to_field="3", status="created"))
 
         stats = dao_fetch_todays_stats_for_service(template.service_id)
 
@@ -1021,8 +1022,10 @@ def test_fetch_stats_for_today_only_includes_today(notify_db_session):
 def test_fetch_stats_should_not_gather_notifications_older_than_7_days(sample_template, created_at, limit_days, rows_returned):
     # It's monday today. Things made last monday should still show
     with freeze_time(created_at):
-        create_notification(
-            sample_template,
+        save_notification(
+            create_notification(
+                sample_template,
+            )
         )
 
     with freeze_time("Monday 16th July 2018 12:00"):
@@ -1034,7 +1037,7 @@ def test_fetch_stats_should_not_gather_notifications_older_than_7_days(sample_te
 def test_dao_fetch_todays_total_message_count_returns_count_for_today(
     notify_db_session,
 ):
-    notification = create_notification(template=create_template(service=create_service()))
+    notification = save_notification(create_notification(template=create_template(service=create_service())))
     assert fetch_todays_total_message_count(notification.service.id) == 1
 
 
@@ -1052,10 +1055,10 @@ def test_dao_fetch_todays_stats_for_all_services_includes_all_services(
     template_sms_one = create_template(service=service1, template_type="sms")
     template_email_two = create_template(service=service2, template_type="email")
     template_sms_two = create_template(service=service2, template_type="sms")
-    create_notification(template=template_email_one)
-    create_notification(template=template_sms_one)
-    create_notification(template=template_email_two)
-    create_notification(template=template_sms_two)
+    save_notification(create_notification(template=template_email_one))
+    save_notification(create_notification(template=template_sms_one))
+    save_notification(create_notification(template=template_email_two))
+    save_notification(create_notification(template=template_sms_two))
 
     stats = dao_fetch_todays_stats_for_all_services()
 
@@ -1069,11 +1072,11 @@ def test_dao_fetch_todays_stats_for_all_services_only_includes_today(notify_db_s
     template = create_template(service=create_service())
     with freeze_time("2001-01-02T03:59:00"):
         # just_before_midnight_yesterday
-        create_notification(template=template, to_field="1", status="delivered")
+        save_notification(create_notification(template=template, to_field="1", status="delivered"))
 
     with freeze_time("2001-01-02T05:01:00"):
         # just_after_midnight_today
-        create_notification(template=template, to_field="2", status="failed")
+        save_notification(create_notification(template=template, to_field="2", status="failed"))
 
     with freeze_time("2001-01-02T05:00:00"):
         stats = dao_fetch_todays_stats_for_all_services()
@@ -1090,12 +1093,12 @@ def test_dao_fetch_todays_stats_for_all_services_groups_correctly(notify_db, not
     template_email = create_template(service=service1, template_type="email")
     template_two = create_template(service=service2)
     # service1: 2 sms with status "created" and one "failed", and one email
-    create_notification(template=template_sms)
-    create_notification(template=template_sms)
-    create_notification(template=template_sms, status="failed")
-    create_notification(template=template_email)
+    save_notification(create_notification(template=template_sms))
+    save_notification(create_notification(template=template_sms))
+    save_notification(create_notification(template=template_sms, status="failed"))
+    save_notification(create_notification(template=template_email))
     # service2: 1 sms "created"
-    create_notification(template=template_two)
+    save_notification(create_notification(template=template_two))
 
     stats = dao_fetch_todays_stats_for_all_services()
     assert len(stats) == 4
@@ -1149,9 +1152,9 @@ def test_dao_fetch_todays_stats_for_all_services_includes_all_keys_by_default(
     notify_db_session,
 ):
     template = create_template(service=create_service())
-    create_notification(template=template, key_type=KEY_TYPE_NORMAL)
-    create_notification(template=template, key_type=KEY_TYPE_TEAM)
-    create_notification(template=template, key_type=KEY_TYPE_TEST)
+    save_notification(create_notification(template=template, key_type=KEY_TYPE_NORMAL))
+    save_notification(create_notification(template=template, key_type=KEY_TYPE_TEAM))
+    save_notification(create_notification(template=template, key_type=KEY_TYPE_TEST))
 
     stats = dao_fetch_todays_stats_for_all_services()
 
@@ -1163,9 +1166,9 @@ def test_dao_fetch_todays_stats_for_all_services_can_exclude_from_test_key(
     notify_db_session,
 ):
     template = create_template(service=create_service())
-    create_notification(template=template, key_type=KEY_TYPE_NORMAL)
-    create_notification(template=template, key_type=KEY_TYPE_TEAM)
-    create_notification(template=template, key_type=KEY_TYPE_TEST)
+    save_notification(create_notification(template=template, key_type=KEY_TYPE_NORMAL))
+    save_notification(create_notification(template=template, key_type=KEY_TYPE_TEAM))
+    save_notification(create_notification(template=template, key_type=KEY_TYPE_TEST))
 
     stats = dao_fetch_todays_stats_for_all_services(include_from_test_key=False)
 

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -233,13 +233,15 @@ def create_notification(
     rate_multiplier=None,
     international=False,
     phone_prefix=None,
-    scheduled_for=None,
     normalised_to=None,
     one_off=False,
     reply_to_text=None,
     created_by_id=None,
     postage=None,
 ):
+    """
+    Creates in memory Notification Model
+    """
     assert job or template
     if job:
         template = job.template
@@ -294,19 +296,32 @@ def create_notification(
         "created_by_id": created_by_id,
         "postage": postage,
     }
-    notification = Notification(**data)
-    dao_create_notification(notification)
-    if scheduled_for:
-        scheduled_notification = ScheduledNotification(
-            id=uuid.uuid4(),
-            notification_id=notification.id,
-            scheduled_for=datetime.strptime(scheduled_for, "%Y-%m-%d %H:%M"),
-        )
-        if status != "created":
-            scheduled_notification.pending = False
-        dao_created_scheduled_notification(scheduled_notification)
+    return Notification(**data)
 
-    return notification
+
+def save_notification(notification_model):
+    """
+    Save Notification into the DB
+    """
+    dao_create_notification(notification_model)
+    return notification_model
+
+
+def save_scheduled_notification(notification_model, scheduled_for):
+    """
+    Create and save ScheduledNotifcation object
+    """
+    dao_create_notification(notification_model)
+    scheduled_notification = ScheduledNotification(
+        id=uuid.uuid4(),
+        notification_id=notification_model.id,
+        scheduled_for=datetime.strptime(scheduled_for, "%Y-%m-%d %H:%M"),
+    )
+    if notification_model.status != "created":
+        scheduled_notification.pending = False
+    dao_created_scheduled_notification(scheduled_notification)
+
+    return notification_model
 
 
 def create_notification_history(

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -40,6 +40,7 @@ from tests.app.db import (
     create_service_sms_sender,
     create_service_with_defined_sms_sender,
     create_template,
+    save_notification,
 )
 from tests.conftest import set_config_values
 
@@ -93,12 +94,14 @@ def test_provider_to_use(restore_provider_details):
 
 
 def test_should_send_personalised_template_to_correct_sms_provider_and_persist(sample_sms_template_with_html, mocker):
-    db_notification = create_notification(
-        template=sample_sms_template_with_html,
-        to_field="+16502532222",
-        personalisation={"name": "Jo"},
-        status="created",
-        reply_to_text=sample_sms_template_with_html.service.get_default_sms_sender(),
+    db_notification = save_notification(
+        create_notification(
+            template=sample_sms_template_with_html,
+            to_field="+16502532222",
+            personalisation={"name": "Jo"},
+            status="created",
+            reply_to_text=sample_sms_template_with_html.service.get_default_sms_sender(),
+        )
     )
 
     statsd_mock = mocker.patch("app.delivery.send_to_providers.statsd_client")
@@ -130,10 +133,12 @@ def test_should_send_personalised_template_to_correct_sms_provider_and_persist(s
 
 
 def test_should_send_personalised_template_to_correct_email_provider_and_persist(sample_email_template_with_html, mocker):
-    db_notification = create_notification(
-        template=sample_email_template_with_html,
-        to_field="jo.smith@example.com",
-        personalisation={"name": "Jo"},
+    db_notification = save_notification(
+        create_notification(
+            template=sample_email_template_with_html,
+            to_field="jo.smith@example.com",
+            personalisation={"name": "Jo"},
+        )
     )
 
     mocker.patch("app.aws_ses_client.send_email", return_value="reference")
@@ -168,10 +173,12 @@ def test_should_send_personalised_template_to_correct_email_provider_and_persist
 
 
 def test_should_send_personalised_template_with_html_enabled(sample_email_template_with_advanced_html, mocker, notify_api):
-    db_notification = create_notification(
-        template=sample_email_template_with_advanced_html,
-        to_field="jo.smith@example.com",
-        personalisation={"name": "Jo"},
+    db_notification = save_notification(
+        create_notification(
+            template=sample_email_template_with_advanced_html,
+            to_field="jo.smith@example.com",
+            personalisation={"name": "Jo"},
+        )
     )
 
     mocker.patch("app.aws_ses_client.send_email", return_value="reference")
@@ -215,10 +222,12 @@ def test_should_not_send_email_message_when_service_is_inactive_notifcation_is_i
 
 
 def test_should_respect_custom_sending_domains(sample_service, mocker, sample_email_template_with_html):
-    db_notification = create_notification(
-        template=sample_email_template_with_html,
-        to_field="jo.smith@example.com",
-        personalisation={"name": "Jo"},
+    db_notification = save_notification(
+        create_notification(
+            template=sample_email_template_with_html,
+            to_field="jo.smith@example.com",
+            personalisation={"name": "Jo"},
+        )
     )
 
     sample_service.sending_domain = "foo.bar"
@@ -255,12 +264,14 @@ def test_should_not_send_sms_message_when_service_is_inactive_notifcation_is_in_
 def test_should_not_send_sms_message_when_message_is_empty_or_whitespace(sample_service, mocker, var):
     sample_service.prefix_sms = False
     template = create_template(sample_service, content="((var))")
-    notification = create_notification(
-        template=template,
-        personalisation={"var": var},
-        to_field="+16502532222",
-        status="created",
-        reply_to_text=sample_service.get_default_sms_sender(),
+    notification = save_notification(
+        create_notification(
+            template=template,
+            personalisation={"var": var},
+            to_field="+16502532222",
+            status="created",
+            reply_to_text=sample_service.get_default_sms_sender(),
+        )
     )
 
     send_mock = mocker.patch("app.aws_sns_client.send_sms", return_value="reference")
@@ -272,11 +283,13 @@ def test_should_not_send_sms_message_when_message_is_empty_or_whitespace(sample_
 
 
 def test_send_sms_should_use_template_version_from_notification_not_latest(sample_template, mocker):
-    db_notification = create_notification(
-        template=sample_template,
-        to_field="+16502532222",
-        status="created",
-        reply_to_text=sample_template.service.get_default_sms_sender(),
+    db_notification = save_notification(
+        create_notification(
+            template=sample_template,
+            to_field="+16502532222",
+            status="created",
+            reply_to_text=sample_template.service.get_default_sms_sender(),
+        )
     )
 
     mocker.patch("app.aws_sns_client.send_sms", return_value="message_id_from_sns")
@@ -352,7 +365,7 @@ def test_should_not_have_sent_status_if_fake_callback_function_fails(sample_noti
 
 
 def test_should_not_send_to_provider_when_status_is_not_created(sample_template, mocker):
-    notification = create_notification(template=sample_template, status="sending")
+    notification = save_notification(create_notification(template=sample_template, status="sending"))
     mocker.patch("app.aws_sns_client.send_sms")
     response_mock = mocker.patch("app.delivery.send_to_providers.send_sms_response")
 
@@ -370,7 +383,7 @@ def test_should_send_sms_with_downgraded_content(notify_db_session, mocker):
     gsm_message = "?odz Housing Service: a é i o u ? foo barbaz???abc..."
     service = create_service(service_name="Łódź Housing Service")
     template = create_template(service, content=msg)
-    db_notification = create_notification(template=template, personalisation={"misc": placeholder})
+    db_notification = save_notification(create_notification(template=template, personalisation={"misc": placeholder}))
 
     mocker.patch("app.aws_sns_client.send_sms", return_value="message_id_from_sns")
 
@@ -383,7 +396,7 @@ def test_send_sms_should_use_service_sms_sender(sample_service, sample_template,
     mocker.patch("app.aws_sns_client.send_sms", return_value="message_id_from_sns")
 
     sms_sender = create_service_sms_sender(service=sample_service, sms_sender="123456", is_default=False)
-    db_notification = create_notification(template=sample_template, reply_to_text=sms_sender.sms_sender)
+    db_notification = save_notification(create_notification(template=sample_template, reply_to_text=sms_sender.sms_sender))
 
     send_to_providers.send_sms_to_provider(
         db_notification,
@@ -396,11 +409,13 @@ def test_send_sms_should_use_service_sms_sender(sample_service, sample_template,
 def test_send_email_to_provider_should_call_research_mode_task_response_task_if_research_mode(
     sample_service, sample_email_template, mocker, research_mode, key_type
 ):
-    notification = create_notification(
-        template=sample_email_template,
-        to_field="john@smith.com",
-        key_type=key_type,
-        billable_units=0,
+    notification = save_notification(
+        create_notification(
+            template=sample_email_template,
+            to_field="john@smith.com",
+            key_type=key_type,
+            billable_units=0,
+        )
     )
     sample_service.research_mode = research_mode
 
@@ -424,7 +439,7 @@ def test_send_email_to_provider_should_call_research_mode_task_response_task_if_
 
 
 def test_send_email_to_provider_should_not_send_to_provider_when_status_is_not_created(sample_email_template, mocker):
-    notification = create_notification(template=sample_email_template, status="sending")
+    notification = save_notification(create_notification(template=sample_email_template, status="sending"))
     mocker.patch("app.aws_ses_client.send_email")
     mocker.patch("app.delivery.send_to_providers.send_email_response")
 
@@ -436,7 +451,7 @@ def test_send_email_to_provider_should_not_send_to_provider_when_status_is_not_c
 def test_send_email_should_use_service_reply_to_email(sample_service, sample_email_template, mocker):
     mocker.patch("app.aws_ses_client.send_email", return_value="reference")
 
-    db_notification = create_notification(template=sample_email_template, reply_to_text="foo@bar.com")
+    db_notification = save_notification(create_notification(template=sample_email_template, reply_to_text="foo@bar.com"))
     create_reply_to_email(service=sample_service, email_address="foo@bar.com")
 
     send_to_providers.send_email_to_provider(
@@ -593,7 +608,9 @@ def __update_notification(notification_to_update, research_mode, expected_status
 def test_should_update_billable_units_and_status_according_to_research_mode_and_key_type(
     sample_template, mocker, research_mode, key_type, billable_units, expected_status
 ):
-    notification = create_notification(template=sample_template, billable_units=0, status="created", key_type=key_type)
+    notification = save_notification(
+        create_notification(template=sample_template, billable_units=0, status="created", key_type=key_type)
+    )
     mocker.patch("app.aws_sns_client.send_sms", return_value="message_id_from_sns")
     mocker.patch(
         "app.delivery.send_to_providers.send_sms_response",
@@ -631,22 +648,26 @@ def test_should_send_sms_to_international_providers(restore_provider_details, sa
 
     dao_switch_sms_provider_to_provider_with_identifier("firetext")
 
-    db_notification_uk = create_notification(
-        template=sample_sms_template_with_html,
-        to_field="+16135555555",
-        personalisation={"name": "Jo"},
-        status="created",
-        international=False,
-        reply_to_text=sample_sms_template_with_html.service.get_default_sms_sender(),
+    db_notification_uk = save_notification(
+        create_notification(
+            template=sample_sms_template_with_html,
+            to_field="+16135555555",
+            personalisation={"name": "Jo"},
+            status="created",
+            international=False,
+            reply_to_text=sample_sms_template_with_html.service.get_default_sms_sender(),
+        )
     )
 
-    db_notification_international = create_notification(
-        template=sample_sms_template_with_html,
-        to_field="+1613555555",
-        personalisation={"name": "Jo"},
-        status="created",
-        international=False,
-        reply_to_text=sample_sms_template_with_html.service.get_default_sms_sender(),
+    db_notification_international = save_notification(
+        create_notification(
+            template=sample_sms_template_with_html,
+            to_field="+1613555555",
+            personalisation={"name": "Jo"},
+            status="created",
+            international=False,
+            reply_to_text=sample_sms_template_with_html.service.get_default_sms_sender(),
+        )
     )
 
     mocker.patch("app.aws_sns_client.send_sms")
@@ -688,7 +709,7 @@ def test_should_handle_sms_sender_and_prefix_message(
     mocker.patch("app.aws_sns_client.send_sms", return_value="message_id_from_sns")
     service = create_service_with_defined_sms_sender(sms_sender_value=sms_sender, prefix_sms=prefix_sms)
     template = create_template(service, content="bar")
-    notification = create_notification(template, reply_to_text=sms_sender)
+    notification = save_notification(create_notification(template, reply_to_text=sms_sender))
 
     send_to_providers.send_sms_to_provider(notification)
 
@@ -703,7 +724,7 @@ def test_should_handle_sms_sender_and_prefix_message(
 def test_send_email_to_provider_uses_reply_to_from_notification(sample_email_template, mocker):
     mocker.patch("app.aws_ses_client.send_email", return_value="reference")
 
-    db_notification = create_notification(template=sample_email_template, reply_to_text="test@test.com")
+    db_notification = save_notification(create_notification(template=sample_email_template, reply_to_text="test@test.com"))
 
     send_to_providers.send_email_to_provider(
         db_notification,
@@ -723,7 +744,7 @@ def test_send_email_to_provider_uses_reply_to_from_notification(sample_email_tem
 def test_send_email_to_provider_should_format_reply_to_email_address(sample_email_template, mocker):
     mocker.patch("app.aws_ses_client.send_email", return_value="reference")
 
-    db_notification = create_notification(template=sample_email_template, reply_to_text="test@test.com\t")
+    db_notification = save_notification(create_notification(template=sample_email_template, reply_to_text="test@test.com\t"))
 
     send_to_providers.send_email_to_provider(
         db_notification,
@@ -775,7 +796,7 @@ def test_notification_can_have_document_attachment_without_mlwr_sid(sample_email
     del response["document"]["mlwr_sid"]
     personalisation = {"file": response}
 
-    db_notification = create_notification(template=sample_email_template, personalisation=personalisation)
+    db_notification = save_notification(create_notification(template=sample_email_template, personalisation=personalisation))
 
     send_to_providers.send_email_to_provider(
         db_notification,
@@ -790,7 +811,7 @@ def test_notification_can_have_document_attachment_if_mlwr_sid_is_false(sample_e
     mlwr_mock = mocker.patch("app.delivery.send_to_providers.check_mlwr")
     personalisation = {"file": document_download_response({"mlwr_sid": "false"})}
 
-    db_notification = create_notification(template=sample_email_template, personalisation=personalisation)
+    db_notification = save_notification(create_notification(template=sample_email_template, personalisation=personalisation))
 
     send_to_providers.send_email_to_provider(
         db_notification,
@@ -805,7 +826,7 @@ def test_notification_raises_a_retry_exception_if_mlwr_state_is_missing(sample_e
     mocker.patch("app.delivery.send_to_providers.check_mlwr", return_value={})
     personalisation = {"file": document_download_response()}
 
-    db_notification = create_notification(template=sample_email_template, personalisation=personalisation)
+    db_notification = save_notification(create_notification(template=sample_email_template, personalisation=personalisation))
 
     with pytest.raises(MalwarePendingException):
         send_to_providers.send_email_to_provider(
@@ -818,7 +839,7 @@ def test_notification_raises_a_retry_exception_if_mlwr_state_is_not_complete(sam
     mocker.patch("app.delivery.send_to_providers.check_mlwr", return_value={"state": "foo"})
     personalisation = {"file": document_download_response()}
 
-    db_notification = create_notification(template=sample_email_template, personalisation=personalisation)
+    db_notification = save_notification(create_notification(template=sample_email_template, personalisation=personalisation))
 
     with pytest.raises(MalwarePendingException):
         send_to_providers.send_email_to_provider(
@@ -834,7 +855,7 @@ def test_notification_raises_sets_notification_to_virus_found_if_mlwr_score_is_5
     )
     personalisation = {"file": document_download_response()}
 
-    db_notification = create_notification(template=sample_email_template, personalisation=personalisation)
+    db_notification = save_notification(create_notification(template=sample_email_template, personalisation=personalisation))
 
     with pytest.raises(NotificationTechnicalFailureException) as e:
         send_to_providers.send_email_to_provider(db_notification)
@@ -852,7 +873,7 @@ def test_notification_raises_sets_notification_to_virus_found_if_mlwr_score_abov
     )
     personalisation = {"file": document_download_response()}
 
-    db_notification = create_notification(template=sample_email_template, personalisation=personalisation)
+    db_notification = save_notification(create_notification(template=sample_email_template, personalisation=personalisation))
 
     with pytest.raises(NotificationTechnicalFailureException) as e:
         send_to_providers.send_email_to_provider(db_notification)
@@ -895,7 +916,7 @@ def test_notification_document_with_pdf_attachment(
     else:
         personalisation["file"]["document"]["sending_method"] = "link"
 
-    db_notification = create_notification(template=template, personalisation=personalisation)
+    db_notification = save_notification(create_notification(template=template, personalisation=personalisation))
 
     statsd_mock = mocker.patch("app.delivery.send_to_providers.statsd_client")
     send_mock = mocker.patch("app.aws_ses_client.send_email", return_value="reference")
@@ -968,7 +989,7 @@ def test_notification_with_bad_file_attachment_url(mocker, notify_db, notify_db_
     if sending_method == "attach":
         personalisation["file"]["document"]["filename"] = "file.txt"
 
-    db_notification = create_notification(template=template, personalisation=personalisation)
+    db_notification = save_notification(create_notification(template=template, personalisation=personalisation))
 
     # See https://stackoverflow.com/a/34929900
     cm = MagicMock()
@@ -986,10 +1007,12 @@ def test_notification_raises_error_if_message_contains_sin_pii_that_passes_luhn(
 ):
     send_mock = mocker.patch("app.aws_ses_client.send_email", return_value="reference")
 
-    db_notification = create_notification(
-        template=sample_email_template_with_html,
-        to_field="jo.smith@example.com",
-        personalisation={"name": "046-454-286"},
+    db_notification = save_notification(
+        create_notification(
+            template=sample_email_template_with_html,
+            to_field="jo.smith@example.com",
+            personalisation={"name": "046-454-286"},
+        )
     )
 
     with set_config_values(
@@ -1010,10 +1033,12 @@ def test_notification_raises_error_if_message_contains_sin_pii_that_passes_luhn(
 def test_notification_passes_if_message_contains_sin_pii_that_fails_luhn(sample_email_template_with_html, mocker, notify_api):
     send_mock = mocker.patch("app.aws_ses_client.send_email", return_value="reference")
 
-    db_notification = create_notification(
-        template=sample_email_template_with_html,
-        to_field="jo.smith@example.com",
-        personalisation={"name": "123-456-789"},
+    db_notification = save_notification(
+        create_notification(
+            template=sample_email_template_with_html,
+            to_field="jo.smith@example.com",
+            personalisation={"name": "123-456-789"},
+        )
     )
 
     send_to_providers.send_email_to_provider(db_notification)
@@ -1026,10 +1051,12 @@ def test_notification_passes_if_message_contains_sin_pii_that_fails_luhn(sample_
 def test_notification_passes_if_message_contains_phone_number(sample_email_template_with_html, mocker):
     send_mock = mocker.patch("app.aws_ses_client.send_email", return_value="reference")
 
-    db_notification = create_notification(
-        template=sample_email_template_with_html,
-        to_field="jo.smith@example.com",
-        personalisation={"name": "123-456-7890"},
+    db_notification = save_notification(
+        create_notification(
+            template=sample_email_template_with_html,
+            to_field="jo.smith@example.com",
+            personalisation={"name": "123-456-7890"},
+        )
     )
 
     send_to_providers.send_email_to_provider(db_notification)

--- a/tests/app/letters/test_letter_utils.py
+++ b/tests/app/letters/test_letter_utils.py
@@ -23,7 +23,7 @@ from app.models import (
     NOTIFICATION_VALIDATION_FAILED,
     PRECOMPILED_TEMPLATE_NAME,
 )
-from tests.app.db import create_notification
+from tests.app.db import create_notification, save_notification
 
 FROZEN_DATE_TIME = "2018-03-14 17:00:00"
 
@@ -246,7 +246,7 @@ def test_upload_letter_pdf_to_correct_bucket(sample_letter_notification, mocker,
 
 @pytest.mark.parametrize("postage,expected_postage", [("second", 2), ("first", 1)])
 def test_upload_letter_pdf_uses_postage_from_notification(sample_letter_template, mocker, postage, expected_postage):
-    letter_notification = create_notification(template=sample_letter_template, postage=postage)
+    letter_notification = save_notification(create_notification(template=sample_letter_template, postage=postage))
     mock_s3 = mocker.patch("app.letters.utils.s3upload")
 
     filename = get_letter_pdf_filename(

--- a/tests/app/notifications/test_notifications_ses_callback.py
+++ b/tests/app/notifications/test_notifications_ses_callback.py
@@ -16,7 +16,11 @@ from app.notifications.notifications_ses_callback import (
     handle_complaint,
 )
 from tests.app.conftest import sample_notification as create_sample_notification
-from tests.app.db import create_notification, create_notification_history
+from tests.app.db import (
+    create_notification,
+    create_notification_history,
+    save_notification,
+)
 
 
 @pytest.mark.parametrize(
@@ -131,7 +135,7 @@ def test_ses_callback_should_not_set_status_once_status_is_delivered(
 
 
 def test_process_ses_results_in_complaint(sample_email_template):
-    notification = create_notification(template=sample_email_template, reference="ref1")
+    notification = save_notification(create_notification(template=sample_email_template, reference="ref1"))
     handle_complaint(json.loads(ses_complaint_callback()["Message"]))
     complaints = Complaint.query.all()
     assert len(complaints) == 1
@@ -153,7 +157,7 @@ def test_handle_complaint_does_raise_exception_if_notification_not_found(notify_
 def test_process_ses_results_in_complaint_if_notification_history_does_not_exist(
     sample_email_template,
 ):
-    notification = create_notification(template=sample_email_template, reference="ref1")
+    notification = save_notification(create_notification(template=sample_email_template, reference="ref1"))
     handle_complaint(json.loads(ses_complaint_callback()["Message"]))
     complaints = Complaint.query.all()
     assert len(complaints) == 1
@@ -171,7 +175,7 @@ def test_process_ses_results_in_complaint_if_notification_does_not_exist(
 
 
 def test_process_ses_results_in_complaint_save_complaint_with_null_complaint_type(notify_api, sample_email_template):
-    notification = create_notification(template=sample_email_template, reference="ref1")
+    notification = save_notification(create_notification(template=sample_email_template, reference="ref1"))
     msg = json.loads(ses_complaint_callback_with_missing_complaint_type()["Message"])
     handle_complaint(msg)
     complaints = Complaint.query.all()

--- a/tests/app/notifications/test_rest.py
+++ b/tests/app/notifications/test_rest.py
@@ -11,7 +11,7 @@ from app.dao.templates_dao import dao_update_template
 from app.models import KEY_TYPE_NORMAL, KEY_TYPE_TEAM, KEY_TYPE_TEST, ApiKey
 from tests import create_authorization_header
 from tests.app.conftest import sample_notification as create_sample_notification
-from tests.app.db import create_api_key, create_notification
+from tests.app.db import create_api_key, create_notification, save_notification
 
 
 @pytest.mark.parametrize("type", ("email", "sms", "letter"))
@@ -229,10 +229,10 @@ def test_do_not_return_job_notifications_by_default(client, sample_template, sam
     normal_api_key = create_api_key(sample_template.service, KEY_TYPE_NORMAL)
     test_api_key = create_api_key(sample_template.service, KEY_TYPE_TEST)
 
-    create_notification(sample_template, job=sample_job)
-    normal_notification = create_notification(sample_template, api_key=normal_api_key)
-    team_notification = create_notification(sample_template, api_key=team_api_key)
-    test_notification = create_notification(sample_template, api_key=test_api_key)
+    save_notification(create_notification(sample_template, job=sample_job))
+    normal_notification = save_notification(create_notification(sample_template, api_key=normal_api_key))
+    team_notification = save_notification(create_notification(sample_template, api_key=team_api_key))
+    test_notification = save_notification(create_notification(sample_template, api_key=test_api_key))
 
     notification_objs = {
         KEY_TYPE_NORMAL: normal_notification,
@@ -423,8 +423,8 @@ def test_filter_by_template_type(client, notify_db, notify_db_session, sample_te
 
 
 def test_filter_by_multiple_template_types(client, sample_template, sample_email_template):
-    create_notification(sample_template)
-    create_notification(sample_email_template)
+    save_notification(create_notification(sample_template))
+    save_notification(create_notification(sample_email_template))
 
     auth_header = create_authorization_header(service_id=sample_email_template.service_id)
 
@@ -437,8 +437,8 @@ def test_filter_by_multiple_template_types(client, sample_template, sample_email
 
 
 def test_filter_by_status(client, sample_email_template):
-    create_notification(sample_email_template, status="delivered")
-    create_notification(sample_email_template)
+    save_notification(create_notification(sample_email_template, status="delivered"))
+    save_notification(create_notification(sample_email_template))
 
     auth_header = create_authorization_header(service_id=sample_email_template.service_id)
 
@@ -451,8 +451,8 @@ def test_filter_by_status(client, sample_email_template):
 
 
 def test_filter_by_multiple_statuses(client, sample_email_template):
-    create_notification(sample_email_template, status="delivered")
-    create_notification(sample_email_template, status="sending")
+    save_notification(create_notification(sample_email_template, status="delivered"))
+    save_notification(create_notification(sample_email_template, status="sending"))
 
     auth_header = create_authorization_header(service_id=sample_email_template.service_id)
 
@@ -465,9 +465,9 @@ def test_filter_by_multiple_statuses(client, sample_email_template):
 
 
 def test_filter_by_status_and_template_type(client, sample_template, sample_email_template):
-    create_notification(sample_template)
-    create_notification(sample_email_template)
-    create_notification(sample_email_template, status="delivered")
+    save_notification(create_notification(sample_template))
+    save_notification(create_notification(sample_email_template))
+    save_notification(create_notification(sample_email_template, status="delivered"))
 
     auth_header = create_authorization_header(service_id=sample_email_template.service_id)
 
@@ -482,7 +482,9 @@ def test_filter_by_status_and_template_type(client, sample_template, sample_emai
 
 def test_get_notification_by_id_returns_merged_template_content(client, sample_template_with_placeholders):
 
-    sample_notification = create_notification(sample_template_with_placeholders, personalisation={"name": "world"})
+    sample_notification = save_notification(
+        create_notification(sample_template_with_placeholders, personalisation={"name": "world"})
+    )
 
     auth_header = create_authorization_header(service_id=sample_notification.service_id)
 
@@ -496,7 +498,9 @@ def test_get_notification_by_id_returns_merged_template_content(client, sample_t
 
 
 def test_get_notification_by_id_returns_merged_template_content_for_email(client, sample_email_template_with_placeholders):
-    sample_notification = create_notification(sample_email_template_with_placeholders, personalisation={"name": "world"})
+    sample_notification = save_notification(
+        create_notification(sample_email_template_with_placeholders, personalisation={"name": "world"})
+    )
     auth_header = create_authorization_header(service_id=sample_notification.service_id)
 
     response = client.get("/notifications/{}".format(sample_notification.id), headers=[auth_header])

--- a/tests/app/performance_platform/test_processing_time.py
+++ b/tests/app/performance_platform/test_processing_time.py
@@ -6,7 +6,7 @@ from app.performance_platform.processing_time import (
     send_processing_time_data,
     send_processing_time_to_performance_platform,
 )
-from tests.app.db import create_notification
+from tests.app.db import create_notification, save_notification
 
 
 @freeze_time("2016-10-18T06:00")
@@ -16,17 +16,21 @@ def test_send_processing_time_to_performance_platform_generates_correct_calls(mo
 
     created_at = datetime.utcnow() - timedelta(days=1)
 
-    create_notification(
-        sample_template,
-        created_at=created_at,
-        sent_at=created_at + timedelta(seconds=5),
+    save_notification(
+        create_notification(
+            sample_template,
+            created_at=created_at,
+            sent_at=created_at + timedelta(seconds=5),
+        )
     )
-    create_notification(
-        sample_template,
-        created_at=created_at,
-        sent_at=created_at + timedelta(seconds=15),
+    save_notification(
+        create_notification(
+            sample_template,
+            created_at=created_at,
+            sent_at=created_at + timedelta(seconds=15),
+        )
     )
-    create_notification(sample_template, created_at=datetime.utcnow() - timedelta(days=2))
+    save_notification(create_notification(sample_template, created_at=datetime.utcnow() - timedelta(days=2)))
 
     send_processing_time_to_performance_platform(date(2016, 10, 17))
 

--- a/tests/app/platform_stats/test_rest.py
+++ b/tests/app/platform_stats/test_rest.py
@@ -11,6 +11,7 @@ from tests.app.db import (
     create_notification,
     create_service,
     create_template,
+    save_notification,
     set_up_usage_data,
 )
 
@@ -53,9 +54,9 @@ def test_get_platform_stats_with_real_query(admin_request, notify_db_session):
     create_ft_notification_status(date(2018, 10, 29), "sms", service_1, count=10)
     create_ft_notification_status(date(2018, 10, 29), "email", service_1, count=3)
 
-    create_notification(sms_template, created_at=datetime(2018, 10, 31, 11, 0, 0), key_type="test")
-    create_notification(sms_template, created_at=datetime(2018, 10, 31, 12, 0, 0), status="delivered")
-    create_notification(email_template, created_at=datetime(2018, 10, 31, 13, 0, 0), status="delivered")
+    save_notification(create_notification(sms_template, created_at=datetime(2018, 10, 31, 11, 0, 0), key_type="test"))
+    save_notification(create_notification(sms_template, created_at=datetime(2018, 10, 31, 12, 0, 0), status="delivered"))
+    save_notification(create_notification(email_template, created_at=datetime(2018, 10, 31, 13, 0, 0), status="delivered"))
 
     response = admin_request.get(
         "platform_stats.get_platform_stats",

--- a/tests/app/service/test_statistics_rest.py
+++ b/tests/app/service/test_statistics_rest.py
@@ -18,6 +18,7 @@ from tests.app.db import (
     create_notification,
     create_service,
     create_template,
+    save_notification,
 )
 
 
@@ -25,7 +26,7 @@ from tests.app.db import (
 # This test assumes the local timezone is EST
 def test_get_template_usage_by_month_returns_correct_data(admin_request, sample_template):
     create_ft_notification_status(utc_date=date(2017, 4, 2), template=sample_template, count=3)
-    create_notification(sample_template, created_at=datetime.utcnow())
+    save_notification(create_notification(sample_template, created_at=datetime.utcnow()))
 
     resp_json = admin_request.get(
         "service.get_monthly_template_usage",
@@ -62,7 +63,7 @@ def test_get_template_usage_by_month_returns_two_templates(admin_request, sample
     )
     create_ft_notification_status(utc_date=datetime(2017, 4, 1), template=template_one, count=1)
     create_ft_notification_status(utc_date=datetime(2017, 4, 1), template=sample_template, count=3)
-    create_notification(sample_template, created_at=datetime.utcnow())
+    save_notification(create_notification(sample_template, created_at=datetime.utcnow()))
 
     resp_json = admin_request.get(
         "service.get_monthly_template_usage",
@@ -109,7 +110,7 @@ def test_get_template_usage_by_month_returns_two_templates(admin_request, sample
 def test_get_service_notification_statistics(admin_request, sample_service, sample_template, today_only, stats):
     create_ft_notification_status(date(2000, 1, 1), "sms", sample_service, count=1)
     with freeze_time("2000-01-02T12:00:00"):
-        create_notification(sample_template, status="created")
+        save_notification(create_notification(sample_template, status="created"))
         resp = admin_request.get(
             "service.get_service_notification_statistics",
             service_id=sample_template.service_id,
@@ -230,11 +231,11 @@ def test_get_monthly_notification_stats_combines_todays_data_and_historic_stats(
         count=2,
     )  # noqa
 
-    create_notification(sample_template, created_at=datetime(2016, 6, 5), status="created")
-    create_notification(sample_template, created_at=datetime(2016, 6, 5), status="delivered")
+    save_notification(create_notification(sample_template, created_at=datetime(2016, 6, 5), status="created"))
+    save_notification(create_notification(sample_template, created_at=datetime(2016, 6, 5), status="delivered"))
 
     # this doesn't get returned in the stats because it is old - it should be in ft_notification_status by now
-    create_notification(sample_template, created_at=datetime(2016, 6, 4), status="sending")
+    save_notification(create_notification(sample_template, created_at=datetime(2016, 6, 4), status="sending"))
 
     response = admin_request.get(
         "service.get_monthly_notification_stats",

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -28,6 +28,7 @@ from tests.app.db import (
     create_service,
     create_template,
     create_template_folder,
+    save_notification,
 )
 from tests.conftest import set_config_values
 
@@ -1117,7 +1118,7 @@ def test_preview_letter_template_precompiled_pdf_file_type(notify_api, client, a
         hidden=True,
     )
 
-    notification = create_notification(template)
+    notification = save_notification(create_notification(template))
 
     with set_config_values(
         notify_api,
@@ -1153,7 +1154,7 @@ def test_preview_letter_template_precompiled_s3_error(notify_api, client, admin_
         hidden=True,
     )
 
-    notification = create_notification(template)
+    notification = save_notification(create_notification(template))
 
     with set_config_values(
         notify_api,
@@ -1211,7 +1212,7 @@ def test_preview_letter_template_precompiled_png_file_type_or_pdf_with_overlay(
         hidden=True,
     )
 
-    notification = create_notification(template)
+    notification = save_notification(create_notification(template))
 
     with set_config_values(
         notify_api,
@@ -1285,7 +1286,7 @@ def test_preview_letter_template_precompiled_png_file_type_hide_notify_tag_only_
         hidden=True,
     )
 
-    notification = create_notification(template)
+    notification = save_notification(create_notification(template))
 
     with set_config_values(
         notify_api,
@@ -1325,7 +1326,7 @@ def test_preview_letter_template_precompiled_png_template_preview_500_error(
         hidden=True,
     )
 
-    notification = create_notification(template)
+    notification = save_notification(create_notification(template))
 
     with set_config_values(
         notify_api,
@@ -1374,7 +1375,7 @@ def test_preview_letter_template_precompiled_png_template_preview_400_error(
         hidden=True,
     )
 
-    notification = create_notification(template)
+    notification = save_notification(create_notification(template))
 
     with set_config_values(
         notify_api,
@@ -1423,7 +1424,7 @@ def test_preview_letter_template_precompiled_png_template_preview_pdf_error(
         hidden=True,
     )
 
-    notification = create_notification(template)
+    notification = save_notification(create_notification(template))
 
     with set_config_values(
         notify_api,

--- a/tests/app/template_statistics/test_rest.py
+++ b/tests/app/template_statistics/test_rest.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 import pytest
 from freezegun import freeze_time
 
-from tests.app.db import create_notification
+from tests.app.db import create_notification, save_notification
 
 
 def set_up_get_all_from_hash(mock_redis, side_effect):
@@ -128,9 +128,9 @@ def test_get_template_statistics_for_service_by_day_returns_empty_list_if_no_tem
 
 
 def test_get_template_statistics_for_template_returns_last_notification(admin_request, sample_template):
-    create_notification(sample_template)
-    create_notification(sample_template)
-    notification_3 = create_notification(sample_template)
+    save_notification(create_notification(sample_template))
+    save_notification(create_notification(sample_template))
+    notification_3 = save_notification(create_notification(sample_template))
 
     json_resp = admin_request.get(
         "template_statistics.get_template_statistics_for_template_id",

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -28,6 +28,7 @@ from tests.app.db import (
     create_service,
     create_template,
     create_template_folder,
+    save_notification,
 )
 
 
@@ -110,7 +111,7 @@ def test_status_conversion(initial_statuses, expected_statuses):
 )
 def test_notification_for_csv_returns_correct_type(sample_service, template_type, recipient):
     template = create_template(sample_service, template_type=template_type)
-    notification = create_notification(template, to_field=recipient)
+    notification = save_notification(create_notification(template, to_field=recipient))
 
     serialized = notification.serialize_for_csv()
     assert serialized["template_type"] == template_type
@@ -118,7 +119,7 @@ def test_notification_for_csv_returns_correct_type(sample_service, template_type
 
 @freeze_time("2016-01-01 11:09:00.000000")
 def test_notification_for_csv_returns_correct_job_row_number(sample_job):
-    notification = create_notification(sample_job.template, sample_job, job_row_number=0)
+    notification = save_notification(create_notification(sample_job.template, sample_job, job_row_number=0))
 
     serialized = notification.serialize_for_csv()
     assert serialized["row_number"] == 1
@@ -143,7 +144,7 @@ def test_notification_for_csv_returns_correct_job_row_number(sample_job):
 )
 def test_notification_for_csv_returns_formatted_status(sample_service, template_type, status, expected_status):
     template = create_template(sample_service, template_type=template_type)
-    notification = create_notification(template, status=status)
+    notification = save_notification(create_notification(template, status=status))
 
     serialized = notification.serialize_for_csv()
     assert serialized["status"] == expected_status
@@ -151,7 +152,7 @@ def test_notification_for_csv_returns_formatted_status(sample_service, template_
 
 @freeze_time("2017-03-26 23:01:53.321312")
 def test_notification_for_csv_returns_est_correctly(sample_template):
-    notification = create_notification(sample_template)
+    notification = save_notification(create_notification(sample_template))
 
     serialized = notification.serialize_for_csv()
     assert serialized["created_at"] == "2017-03-26 19:01:53"
@@ -184,7 +185,7 @@ def test_notification_subject_is_none_for_sms():
 @pytest.mark.parametrize("template_type", ["email", "letter"])
 def test_notification_subject_fills_in_placeholders(sample_service, template_type):
     template = create_template(service=sample_service, template_type=template_type, subject="((name))")
-    notification = create_notification(template=template, personalisation={"name": "hello"})
+    notification = save_notification(create_notification(template=template, personalisation={"name": "hello"}))
     assert notification.subject == "hello"
 
 
@@ -232,7 +233,7 @@ def test_letter_notification_serializes_with_subject(client, sample_letter_templ
 
 
 def test_notification_references_template_history(client, sample_template):
-    noti = create_notification(sample_template)
+    noti = save_notification(create_notification(sample_template))
     sample_template.version = 3
     sample_template.content = "New template content"
 
@@ -246,7 +247,7 @@ def test_notification_references_template_history(client, sample_template):
 def test_notification_requires_a_valid_template_version(client, sample_template):
     sample_template.version = 2
     with pytest.raises(IntegrityError):
-        create_notification(sample_template)
+        save_notification(create_notification(sample_template))
 
 
 def test_inbound_number_serializes_with_service(client, notify_db_session):


### PR DESCRIPTION
# Summary | Résumé

Create_notification creates an inmemory
notification object. We make two more
functions - to save the notification to
the DB, and a way to save scheduled notifications
(you can see the first commit to view the change, the second commit is just the test changes)

Regression: low risk as it is all changed only in the test folder