### PR TITLE
timeout jobs after 2 hours rather than 1

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -122,20 +122,20 @@ def check_job_status():
     from jobs
     where job_status == 'in progress'
     and template_type in ('sms', 'email')
-    and scheduled_at or created_at is older that 60 minutes.
+    and scheduled_at or created_at is older that 120 minutes.
     if any results then
         raise error
         process the rows in the csv that are missing (in another task) just do the check here.
     """
-    sixty_minutes_ago = datetime.utcnow() - timedelta(minutes=60)
-    sixty_five_minutes_ago = datetime.utcnow() - timedelta(minutes=65)
+    minutes_ago_120 = datetime.utcnow() - timedelta(minutes=120)
+    minutes_ago_125 = datetime.utcnow() - timedelta(minutes=125)
 
-    jobs_not_complete_after_60_minutes = (
+    jobs_not_complete_after_120_minutes = (
         Job.query.filter(
             Job.job_status == JOB_STATUS_IN_PROGRESS,
             and_(
-                sixty_five_minutes_ago < Job.processing_started,
-                Job.processing_started < sixty_minutes_ago,
+                minutes_ago_125 < Job.processing_started,
+                Job.processing_started < minutes_ago_120,
             ),
         )
         .order_by(Job.processing_started)
@@ -145,7 +145,7 @@ def check_job_status():
     # temporarily mark them as ERROR so that they don't get picked up by future check_job_status tasks
     # if they haven't been re-processed in time.
     job_ids = []
-    for job in jobs_not_complete_after_60_minutes:
+    for job in jobs_not_complete_after_120_minutes:
         job.job_status = JOB_STATUS_ERROR
         dao_update_job(job)
         job_ids.append(str(job.id))

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -186,8 +186,8 @@ def test_check_job_status_task_raises_job_incomplete_error(mocker, sample_templa
     job = create_job(
         template=sample_template,
         notification_count=3,
-        created_at=datetime.utcnow() - timedelta(minutes=61),
-        processing_started=datetime.utcnow() - timedelta(minutes=61),
+        created_at=datetime.utcnow() - timedelta(minutes=121),
+        processing_started=datetime.utcnow() - timedelta(minutes=121),
         job_status=JOB_STATUS_IN_PROGRESS,
     )
     save_notification(create_notification(template=sample_template, job=job))
@@ -208,8 +208,8 @@ def test_check_job_status_task_raises_job_incomplete_error_when_scheduled_job_is
         template=sample_template,
         notification_count=3,
         created_at=datetime.utcnow() - timedelta(hours=2),
-        scheduled_for=datetime.utcnow() - timedelta(minutes=61),
-        processing_started=datetime.utcnow() - timedelta(minutes=61),
+        scheduled_for=datetime.utcnow() - timedelta(minutes=121),
+        processing_started=datetime.utcnow() - timedelta(minutes=121),
         job_status=JOB_STATUS_IN_PROGRESS,
     )
     with pytest.raises(expected_exception=JobIncompleteError) as e:
@@ -229,16 +229,16 @@ def test_check_job_status_task_raises_job_incomplete_error_for_multiple_jobs(moc
         template=sample_template,
         notification_count=3,
         created_at=datetime.utcnow() - timedelta(hours=2),
-        scheduled_for=datetime.utcnow() - timedelta(minutes=61),
-        processing_started=datetime.utcnow() - timedelta(minutes=61),
+        scheduled_for=datetime.utcnow() - timedelta(minutes=121),
+        processing_started=datetime.utcnow() - timedelta(minutes=121),
         job_status=JOB_STATUS_IN_PROGRESS,
     )
     job_2 = create_job(
         template=sample_template,
         notification_count=3,
         created_at=datetime.utcnow() - timedelta(hours=2),
-        scheduled_for=datetime.utcnow() - timedelta(minutes=61),
-        processing_started=datetime.utcnow() - timedelta(minutes=61),
+        scheduled_for=datetime.utcnow() - timedelta(minutes=121),
+        processing_started=datetime.utcnow() - timedelta(minutes=121),
         job_status=JOB_STATUS_IN_PROGRESS,
     )
     with pytest.raises(expected_exception=JobIncompleteError) as e:
@@ -259,15 +259,15 @@ def test_check_job_status_task_only_sends_old_tasks(mocker, sample_template):
         template=sample_template,
         notification_count=3,
         created_at=datetime.utcnow() - timedelta(hours=2),
-        scheduled_for=datetime.utcnow() - timedelta(minutes=61),
-        processing_started=datetime.utcnow() - timedelta(minutes=61),
+        scheduled_for=datetime.utcnow() - timedelta(minutes=121),
+        processing_started=datetime.utcnow() - timedelta(minutes=121),
         job_status=JOB_STATUS_IN_PROGRESS,
     )
     job_2 = create_job(
         template=sample_template,
         notification_count=3,
-        created_at=datetime.utcnow() - timedelta(minutes=61),
-        processing_started=datetime.utcnow() - timedelta(minutes=59),
+        created_at=datetime.utcnow() - timedelta(minutes=121),
+        processing_started=datetime.utcnow() - timedelta(minutes=119),
         job_status=JOB_STATUS_IN_PROGRESS,
     )
     with pytest.raises(expected_exception=JobIncompleteError) as e:
@@ -289,15 +289,15 @@ def test_check_job_status_task_sets_jobs_to_error(mocker, sample_template):
         template=sample_template,
         notification_count=3,
         created_at=datetime.utcnow() - timedelta(hours=2),
-        scheduled_for=datetime.utcnow() - timedelta(minutes=61),
-        processing_started=datetime.utcnow() - timedelta(minutes=61),
+        scheduled_for=datetime.utcnow() - timedelta(minutes=121),
+        processing_started=datetime.utcnow() - timedelta(minutes=121),
         job_status=JOB_STATUS_IN_PROGRESS,
     )
     job_2 = create_job(
         template=sample_template,
         notification_count=3,
-        created_at=datetime.utcnow() - timedelta(minutes=61),
-        processing_started=datetime.utcnow() - timedelta(minutes=59),
+        created_at=datetime.utcnow() - timedelta(minutes=121),
+        processing_started=datetime.utcnow() - timedelta(minutes=119),
         job_status=JOB_STATUS_IN_PROGRESS,
     )
     with pytest.raises(expected_exception=JobIncompleteError) as e:


### PR DESCRIPTION
# Summary | Résumé
We bumped up the timeout from 30 minutes to an hour in #1375 but occasionally that's still not enough. As another quick hack let's bump it up to 2 hours.

After the current lambda / batch saving / perf testing we should fix this properly as discussed in https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/cds-snc/notification-planning/79

# Test instructions | Instructions pour tester la modification


# Release Instructions | Instructions pour le déploiement

None.


# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their
review | Voici une suggestion de liste de vérification comprenant des questions
que les réviseurs pourraient poser pendant leur examen :


- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne
      une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une
      fonctionnalité existante?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une
      modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des
      préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de
      façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de
      risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README
      setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce
      changement (fichier README, etc.)?
