### PR TITLE
pass tests locally and remotely

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:11.8
+        image: postgres:13.4
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -814,9 +814,7 @@ def test_create_service_and_history_is_transactional(notify_db_session):
     with pytest.raises(IntegrityError) as excinfo:
         dao_create_service(service, user)
 
-    assert 'column "name" violates not-null constraint' in str(
-        excinfo.value
-    ) or 'column "name" of relation "services_history" violates not-null constraint' in str(excinfo.value)
+    assert 'column "name" of relation "services_history" violates not-null constraint' in str(excinfo.value)
 
     assert Service.query.count() == 0
     assert Service.get_history_model().query.count() == 0

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -814,7 +814,10 @@ def test_create_service_and_history_is_transactional(notify_db_session):
     with pytest.raises(IntegrityError) as excinfo:
         dao_create_service(service, user)
 
-    assert 'column "name" violates not-null constraint' in str(excinfo.value)
+    assert 'column "name" violates not-null constraint' in str(
+        excinfo.value
+    ) or 'column "name" of relation "services_history" violates not-null constraint' in str(excinfo.value)
+
     assert Service.query.count() == 0
     assert Service.get_history_model().query.count() == 0
 


### PR DESCRIPTION
# Summary | Résumé

Basically, there's a test `test_create_service_and_history_is_transactional` that makes sure that creating a service without a name raises an error. Remotely we expect the error message to be
```
column "name" violates not-null constraint
```
and locally we expect
```
column "name" of relation "services_history" violates not-null constraint
```
Updating the version of postgresql in the action (and updating the test to the new error message) resolves the issue.

# Test instructions | Instructions pour tester la modification

Run the tests locally!

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their
review | Voici une suggestion de liste de vérification comprenant des questions
que les réviseurs pourraient poser pendant leur examen :


- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne
      une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une
      fonctionnalité existante?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une
      modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des
      préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de
      façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de
      risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README
      setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce
      changement (fichier README, etc.)?
