### PR TITLE
Performance tests: Increase the file descriptor maximum

### DIFF
--- a/tests-perf/ops/Dockerfile
+++ b/tests-perf/ops/Dockerfile
@@ -15,6 +15,7 @@ WORKDIR /app
 COPY . /app
 
 RUN set -ex && pip3 install -r requirements_for_test.txt
+RUN echo "fs.file-max = 100000" >> /etc/sysctl.conf
 
 ARG GIT_SHA
 


### PR DESCRIPTION
[Zenhub card](https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/cds-snc/notification-planning/183)

# Summary | Résumé

This PR increases the file descriptor maximum to 1000000, which is well above the 100000.

This PR is very experimental and seeks to test the viability of this within the AWS setup


# Test instructions | Instructions pour tester la modification

```
cat /proc/sys/fs/file-max

```

Should return 100000

# Reviewer checklist | Liste de vérification du réviseur


- [ ] Change made to /etc/sysctl.conf persists and helps reduce the occurence of errors as defined in the card.