### PR TITLE
Print out performance test result in html

### DIFF
--- a/bin/execute_and_publish_performance_test.sh
+++ b/bin/execute_and_publish_performance_test.sh
@@ -6,7 +6,7 @@ perf_test_csv_directory_path=${PERF_TEST_CSV_DIRECTORY_PATH:-/tmp/notify_perform
 
 mkdir -p $perf_test_csv_directory_path/$current_time
 
-locust --headless --config tests-perf/locust/locust.conf --csv $perf_test_csv_directory_path/$current_time/perf_test
+locust --headless --config tests-perf/locust/locust.conf --html $perf_test_csv_directory_path/$current_time/index.html --csv $perf_test_csv_directory_path/$current_time/perf_test
 
 aws s3 cp $perf_test_csv_directory_path/ "s3://$perf_test_aws_s3_bucket" --recursive || exit 1
 


### PR DESCRIPTION
[Zenhub card](https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/cds-snc/notification-planning/205)

# Summary | Résumé

Within we have added the --html flag that instructs the locust script to produce the performance test result in
html format.

This has been done so that the public facing url can quickly present its index html page for analysis via internet browsers.

Following this PR will be one that will expose a cloudfriont facade for the s3.

![Screenshot 2021-11-25 at 11 02 43](https://user-images.githubusercontent.com/983625/143464296-9b098a39-4a89-4308-820e-1a026d685d5d.png)


# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] Uses the option for html report