### PR TITLE
Experimental: Invoke New Relic's `register_application`

### DIFF
--- a/application.py
+++ b/application.py
@@ -42,4 +42,5 @@ if os.environ.get("USE_LOCAL_JINJA_TEMPLATES") == "True":
 
 def handler(event, context):
     newrelic.agent.initialize()  # noqa: E402
+    newrelic.agent.register_application(timeout=20.0)
     return awsgi.response(app, event, context)


### PR DESCRIPTION
[Zenhub card](https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/cds-snc/notification-planning/238)

# Summary | Résumé

Following on from PR #1420, we have decided to invoke register application to help register the our Lambda based notify applications.

This effort is experimental especially with the conditions highlighted in the activate application code [1], which is invoked by register_application [2].

[1] https://github.com/newrelic/newrelic-python-agent/blob/f99da493986f24a588af50e197bbe62f5ad6332a/newrelic/core/agent.py#L298
[2] https://github.com/newrelic/newrelic-python-agent/blob/f99da493986f24a588af50e197bbe62f5ad6332a/newrelic/api/application.py#L169

# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their
review | Voici une suggestion de liste de vérification comprenant des questions
que les réviseurs pourraient poser pendant leur examen :


- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne
      une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une
      fonctionnalité existante?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une
      modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des
      préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de
      façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de
      risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README
      setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce
      changement (fichier README, etc.)?
