### PR TITLE
default value for reply_to_text

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -268,7 +268,7 @@ def save_smss(self, service_id: str, encrypted_notifications: List[Any]):
         sender_id = notification.get("sender_id")
         notification_id = create_uuid()
         notification["notification_id"] = notification_id
-        reply_to_text = ""
+        reply_to_text = ""  # type: ignore
         if sender_id:
             reply_to_text = dao_get_service_sms_senders_by_id(service_id, sender_id).sms_sender
         if isinstance(template, tuple):
@@ -277,10 +277,10 @@ def save_smss(self, service_id: str, encrypted_notifications: List[Any]):
         # the first element is the Template object and the second the template cache data
         # in the form of a dict
         elif isinstance(template, tuple):
-            reply_to_text = template[1].get("reply_to_text")
+            reply_to_text = template[1].get("reply_to_text")  # type: ignore
             template = template[0]
         else:
-            reply_to_text = template.get_reply_to_text()
+            reply_to_text = template.get_reply_to_text()  # type: ignore
 
         # if the service is obtained from cache a tuple will be returned where
         # the first element is the Service object and the second the service cache data
@@ -416,7 +416,7 @@ def save_emails(self, service_id: str, encrypted_notifications: List[Any]):
         sender_id = notification.get("sender_id")
         notification_id = create_uuid()
         notification["notification_id"] = notification_id
-        reply_to_text = ""
+        reply_to_text = ""  # type: ignore
         if sender_id:
             reply_to_text = dao_get_reply_to_by_id(service_id, sender_id).email_address
         if isinstance(template, tuple):
@@ -425,10 +425,10 @@ def save_emails(self, service_id: str, encrypted_notifications: List[Any]):
         # the first element is the Template object and the second the template cache data
         # in the form of a dict
         elif isinstance(template, tuple):
-            reply_to_text = template[1].get("reply_to_text")
+            reply_to_text = template[1].get("reply_to_text")  # type: ignore
             template = template[0]
         else:
-            reply_to_text = template.get_reply_to_text()
+            reply_to_text = template.get_reply_to_text()  # type: ignore
 
         # if the service is obtained from cache a tuple will be returned where
         # the first element is the Service object and the second the service cache data

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -268,7 +268,7 @@ def save_smss(self, service_id: str, encrypted_notifications: List[Any]):
         sender_id = notification.get("sender_id")
         notification_id = create_uuid()
         notification["notification_id"] = notification_id
-
+        reply_to_text = ""
         if sender_id:
             reply_to_text = dao_get_service_sms_senders_by_id(service_id, sender_id).sms_sender
         if isinstance(template, tuple):
@@ -416,7 +416,7 @@ def save_emails(self, service_id: str, encrypted_notifications: List[Any]):
         sender_id = notification.get("sender_id")
         notification_id = create_uuid()
         notification["notification_id"] = notification_id
-
+        reply_to_text = ""
         if sender_id:
             reply_to_text = dao_get_reply_to_by_id(service_id, sender_id).email_address
         if isinstance(template, tuple):


### PR DESCRIPTION
# Summary | Résumé

Bug in the code:
```


Field | Value
-- | --
@ingestionTime | 1642176021240
@log | 239043911459:/aws/containerinsights/notification-canada-ca-staging-eks-cluster/application
@logStream | celery-675d96fc56-mbhdp_notification-canada-ca_celery-075a31b6158e89c90093b19e1cf60e01f210e93ae407abfd5d12791976218530
@message | {"log":"[2022-01-14 16:00:14,745: ERROR/ForkPoolWorker-2] Task save-emails[aedbcf53-3eac-4130-8702-400ee4beabf2] raised unexpected: UnboundLocalError(\"local variable 'reply_to_text' referenced before assignment\")\n","stream":"stderr","docker":{"container_id":"075a31b6158e89c90093b19e1cf60e01f210e93ae407abfd5d12791976218530"},"kubernetes":{"container_name":"celery","namespace_name":"notification-canada-ca","pod_name":"celery-675d96fc56-mbhdp","container_image":"public.ecr.aws/cds-snc/notify-api:latest","container_image_id":"docker-pullable://public.ecr.aws/cds-snc/notify-api@sha256:e61f326a13b789fd546e467be85a7dd3518bf786602f84d9a08b94f3604c050a","pod_id":"025e8712-a5a2-41f8-bffc-536e6f3062c0","host":"ip-10-0-2-245.ca-central-1.compute.internal","labels":{"app":"celery","pod-template-hash":"675d96fc56"},"master_url":"https://172.20.0.1:443/api","namespace_id":"2b51524d-ae40-444a-a921-ea0a833a4c9d","namespace_labels":{"name":"notification-canada-ca"}}}
@timestamp | 1642176014745
docker.container_id | 075a31b6158e89c90093b19e1cf60e01f210e93ae407abfd5d12791976218530
kubernetes.container_image | public.ecr.aws/cds-snc/notify-api:latest
kubernetes.container_image_id | docker-pullable://public.ecr.aws/cds-snc/notify-api@sha256:e61f326a13b789fd546e467be85a7dd3518bf786602f84d9a08b94f3604c050a
kubernetes.container_name | celery
kubernetes.host | ip-10-0-2-245.ca-central-1.compute.internal
kubernetes.labels.app | celery
kubernetes.labels.pod-template-hash | 675d96fc56
kubernetes.master_url | https://172.20.0.1:443/api
kubernetes.namespace_id | 2b51524d-ae40-444a-a921-ea0a833a4c9d
kubernetes.namespace_labels.name | notification-canada-ca
kubernetes.namespace_name | notification-canada-ca
kubernetes.pod_id | 025e8712-a5a2-41f8-bffc-536e6f3062c0
kubernetes.pod_name | celery-675d96fc56-mbhdp
log | [2022-01-14 16:00:14,745: ERROR/ForkPoolWorker-2] Task save-emails[aedbcf53-3eac-4130-8702-400ee4beabf2] raised unexpected: UnboundLocalError("local variable 'reply_to_text' referenced before assignment")
stream | stderr


```