### PR TITLE
batch saving: split up persist_notification function

### DIFF
--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -119,6 +119,78 @@ def persist_notification(
     return notification
 
 
+def transform_notification(
+    *,
+    template_id,
+    template_version,
+    recipient,
+    service,
+    personalisation,
+    notification_type,
+    api_key_id,
+    key_type,
+    created_at=None,
+    job_id=None,
+    job_row_number=None,
+    reference=None,
+    client_reference=None,
+    notification_id=None,
+    created_by_id=None,
+    status=NOTIFICATION_CREATED,
+    reply_to_text=None,
+    billable_units=None,
+    postage=None,
+    template_postage=None,
+):
+    notification_created_at = created_at or datetime.utcnow()
+    if not notification_id:
+        notification_id = uuid.uuid4()
+    notification = Notification(
+        id=notification_id,
+        template_id=template_id,
+        template_version=template_version,
+        to=recipient,
+        service_id=service.id,
+        personalisation=personalisation,
+        notification_type=notification_type,
+        api_key_id=api_key_id,
+        key_type=key_type,
+        created_at=notification_created_at,
+        job_id=job_id,
+        job_row_number=job_row_number,
+        client_reference=client_reference,
+        reference=reference,
+        created_by_id=created_by_id,
+        status=status,
+        reply_to_text=reply_to_text,
+        billable_units=billable_units,
+    )
+
+    if notification_type == SMS_TYPE:
+        formatted_recipient = validate_and_format_phone_number(recipient, international=True)
+        recipient_info = get_international_phone_info(formatted_recipient)
+        notification.normalised_to = formatted_recipient
+        notification.international = recipient_info.international
+        notification.phone_prefix = recipient_info.country_prefix
+        notification.rate_multiplier = recipient_info.billable_units
+    elif notification_type == EMAIL_TYPE:
+        notification.normalised_to = format_email_address(notification.to)
+    elif notification_type == LETTER_TYPE:
+        notification.postage = postage or template_postage
+
+    return notification
+
+
+def db_save_notification(notification):
+    dao_create_notification(notification)
+    if notification.key_type != KEY_TYPE_TEST:
+        if redis_store.get(redis.daily_limit_cache_key(notification.service_id)):
+            redis_store.incr(redis.daily_limit_cache_key(notification.service_id))
+    current_app.logger.info(
+        "{} {} created at {}".format(notification.notification_type, notification.id, notification.created_at)
+    )
+
+
 def send_notification_to_queue(notification, research_mode, queue=None):
     if research_mode or notification.key_type == KEY_TYPE_TEST:
         queue = QueueNames.RESEARCH_MODE

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -175,6 +175,7 @@ def transform_notification(
         notification.rate_multiplier = recipient_info.billable_units
     elif notification_type == EMAIL_TYPE:
         notification.normalised_to = format_email_address(notification.to)
+        notification.international = False
     elif notification_type == LETTER_TYPE:
         notification.postage = postage or template_postage
 

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -141,7 +141,7 @@ def transform_notification(
     billable_units=None,
     postage=None,
     template_postage=None,
-):
+) -> Notification:
     notification_created_at = created_at or datetime.utcnow()
     if not notification_id:
         notification_id = uuid.uuid4()
@@ -181,7 +181,7 @@ def transform_notification(
     return notification
 
 
-def db_save_notification(notification):
+def db_save_notification(notification: Notification):
     dao_create_notification(notification)
     if notification.key_type != KEY_TYPE_TEST:
         if redis_store.get(redis.daily_limit_cache_key(notification.service_id)):

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -52,6 +52,8 @@ from app.notifications.process_notifications import (
     persist_scheduled_notification,
     send_notification_to_queue,
     simulated_recipient,
+    transform_notification,
+    db_save_notification,
 )
 from app.notifications.validators import (
     check_rate_limiting,
@@ -275,20 +277,36 @@ def process_sms_or_email_notification(*, form, notification_type, api_key, templ
 
     scheduled_for = form.get("scheduled_for", None)
     if scheduled_for:
-        notification = persist_notification(
-            template_id=template.id,
-            template_version=template.version,
-            recipient=form_send_to,
-            service=service,
-            personalisation=personalisation,
-            notification_type=notification_type,
-            api_key_id=api_key.id,
-            key_type=api_key.key_type,
-            client_reference=form.get("reference", None),
-            simulated=simulated,
-            reply_to_text=reply_to_text,
-        )
-        persist_scheduled_notification(notification.id, form["scheduled_for"])
+        if current_app.config["FF_REDIS_BATCHING"]:
+            notification = transform_notification(
+                template_id=template.id,
+                template_version=template.version,
+                recipient=form_send_to,
+                service=service,
+                personalisation=personalisation,
+                notification_type=notification_type,
+                api_key_id=api_key.id,
+                key_type=api_key.key_type,
+                client_reference=form.get("reference", None),
+                reply_to_text=reply_to_text,
+            )
+            db_save_notification(notification)
+            persist_scheduled_notification(notification.id, form["scheduled_for"])
+        else:
+            notification = persist_notification(
+                template_id=template.id,
+                template_version=template.version,
+                recipient=form_send_to,
+                service=service,
+                personalisation=personalisation,
+                notification_type=notification_type,
+                api_key_id=api_key.id,
+                key_type=api_key.key_type,
+                client_reference=form.get("reference", None),
+                simulated=simulated,
+                reply_to_text=reply_to_text,
+            )
+            persist_scheduled_notification(notification.id, form["scheduled_for"])
 
     elif current_app.config["FF_NOTIFICATION_CELERY_PERSISTENCE"] and not simulated:
         # depending on the type route to the appropriate save task
@@ -305,27 +323,50 @@ def process_sms_or_email_notification(*, form, notification_type, api_key, templ
             )
 
     else:
-        notification = persist_notification(
-            template_id=template.id,
-            template_version=template.version,
-            recipient=form_send_to,
-            service=service,
-            personalisation=personalisation,
-            notification_type=notification_type,
-            api_key_id=api_key.id,
-            key_type=api_key.key_type,
-            client_reference=form.get("reference", None),
-            simulated=simulated,
-            reply_to_text=reply_to_text,
-        )
-        if not simulated:
-            send_notification_to_queue(
-                notification=notification,
-                research_mode=service.research_mode,
-                queue=template.queue_to_use(),
+        if current_app.config["FF_REDIS_BATCHING"]:
+            notification = transform_notification(
+                template_id=template.id,
+                template_version=template.version,
+                recipient=form_send_to,
+                service=service,
+                personalisation=personalisation,
+                notification_type=notification_type,
+                api_key_id=api_key.id,
+                key_type=api_key.key_type,
+                client_reference=form.get("reference", None),
+                reply_to_text=reply_to_text,
             )
+            if not simulated:
+                db_save_notification(notification)
+                send_notification_to_queue(
+                    notification=notification,
+                    research_mode=service.research_mode,
+                    queue=template.queue_to_use(),
+                )
+            else:
+                current_app.logger.debug("POST simulated notification for id: {}".format(notification.id))
         else:
-            current_app.logger.debug("POST simulated notification for id: {}".format(notification.id))
+            notification = persist_notification(
+                template_id=template.id,
+                template_version=template.version,
+                recipient=form_send_to,
+                service=service,
+                personalisation=personalisation,
+                notification_type=notification_type,
+                api_key_id=api_key.id,
+                key_type=api_key.key_type,
+                client_reference=form.get("reference", None),
+                simulated=simulated,
+                reply_to_text=reply_to_text,
+            )
+            if not simulated:
+                send_notification_to_queue(
+                    notification=notification,
+                    research_mode=service.research_mode,
+                    queue=template.queue_to_use(),
+                )
+            else:
+                current_app.logger.debug("POST simulated notification for id: {}".format(notification.id))
 
     if not isinstance(notification, Notification):
         notification["template_id"] = notification["template"]

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -413,6 +413,7 @@ def test_transform_email_notification_stores_normalised_email(
     assert persisted_notification.normalised_to == expected_recipient_normalised
 
 
+@freeze_time("2016-01-01 11:09:00.061258")
 def test_db_save_notification_saves_to_db(sample_template, sample_api_key, sample_job, mocker):
     mocked_redis = mocker.patch("app.notifications.process_notifications.redis_store.get")
     assert Notification.query.count() == 0
@@ -434,6 +435,7 @@ def test_db_save_notification_saves_to_db(sample_template, sample_api_key, sampl
         to="+16502532222",
         created_at=datetime.datetime(2016, 11, 11, 16, 8, 18),
     )
+    db_save_notification(notification)
     assert Notification.query.get(notification.id) is not None
 
     notification_from_db = Notification.query.one()

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -19,11 +19,13 @@ from app.models import (
 )
 from app.notifications.process_notifications import (
     create_content_for_notification,
+    db_save_notification,
     persist_notification,
     persist_notifications,
     persist_scheduled_notification,
     send_notification_to_queue,
     simulated_recipient,
+    transform_notification,
 )
 from app.v2.errors import BadRequestError
 from tests.app.conftest import sample_api_key as create_api_key
@@ -267,6 +269,58 @@ def test_persist_notification_increments_cache_if_key_exists(sample_template, sa
     mock_incr.assert_called_once_with(
         str(sample_template.service_id) + "-2016-01-01-count",
     )
+
+
+def test_transform_notification_creates_notification():
+    pass
+
+
+def test_transform_notification_with_optionals():
+    pass
+
+
+def test_db_save_notification_saves_to_db():
+    pass
+
+
+def test_db_save_notification_throws_exception_when_missing_template(sample_api_key):
+    assert Notification.query.count() == 0
+    assert NotificationHistory.query.count() == 0
+
+    notification = Notification(
+        id=uuid.uuid4(),
+        template_id=None,
+        template_version=None,
+        to="+16502532222",
+        service=sample_api_key.service,
+        personalisation=None,
+        notification_type="sms",
+        api_key_id=sample_api_key.id,
+        key_type=sample_api_key.key_type,
+        created_at=datetime.datetime(2016, 11, 11, 16, 8, 18),
+    )
+
+    with pytest.raises(SQLAlchemyError):
+        db_save_notification(notification)
+
+    assert Notification.query.count() == 0
+    assert NotificationHistory.query.count() == 0
+
+
+def test_cache_is_not_incremented_on_failure_to_db_save_notification():
+    pass
+
+
+def test_db_save_notification_does_not_increment_cache_if_test_key():
+    pass
+
+
+def test_db_save_notification_doesnt_touch_cache_for_old_keys_that_dont_exist():
+    pass
+
+
+def test_db_save_notification_increments_cache_if_key_exists():
+    pass
 
 
 @pytest.mark.parametrize(

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -271,11 +271,32 @@ def test_persist_notification_increments_cache_if_key_exists(sample_template, sa
     )
 
 
-def test_transform_notification_creates_notification():
+def test_transform_notification_with_optionals():
     pass
 
 
-def test_transform_notification_with_optionals():
+@pytest.mark.parametrize(
+    "recipient, expected_international, expected_prefix, expected_units",
+    [
+        ("6502532222", False, "1", 1),  # NA
+        ("+16502532222", False, "1", 1),  # NA
+        ("+79587714230", True, "7", 1),  # Russia
+        ("+360623400400", True, "36", 3),
+    ],  # Hungary
+)
+def test_transform_notification_with_international_info_stores_correct_info():
+    pass
+
+
+def test_transform_notification_with_international_info_does_not_store_for_email(sample_job, sample_api_key, mocker):
+    pass
+
+
+def test_transform_sms_notification_stores_normalised_number():
+    pass
+
+
+def test_persist_email_notification_stores_normalised_email():
     pass
 
 

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -271,70 +271,303 @@ def test_persist_notification_increments_cache_if_key_exists(sample_template, sa
     )
 
 
-class TestTransformNotification:
-    def test_transform_notification_with_optionals():
-        pass
+def test_transform_notification_with_optionals(sample_job, sample_api_key):
+    assert Notification.query.count() == 0
+    assert NotificationHistory.query.count() == 0
 
-    @pytest.mark.parametrize(
-        "recipient, expected_international, expected_prefix, expected_units",
-        [
-            ("6502532222", False, "1", 1),  # NA
-            ("+16502532222", False, "1", 1),  # NA
-            ("+79587714230", True, "7", 1),  # Russia
-            ("+360623400400", True, "36", 3),
-        ],  # Hungary
+    n_id = uuid.uuid4()
+    created_at = datetime.datetime(2016, 11, 11, 16, 8, 18)
+    notification = transform_notification(
+        template_id=sample_job.template.id,
+        template_version=sample_job.template.version,
+        recipient="+16502532222",
+        service=sample_job.service,
+        personalisation=None,
+        notification_type="sms",
+        api_key_id=sample_api_key.id,
+        key_type=sample_api_key.key_type,
+        created_at=created_at,
+        job_id=sample_job.id,
+        job_row_number=10,
+        client_reference="ref from client",
+        notification_id=n_id,
+        created_by_id=sample_job.created_by_id,
     )
-    def test_transform_notification_with_international_info_stores_correct_info():
-        pass
+    assert notification.id == n_id
+    assert notification.job_id == sample_job.id
+    assert notification.job_row_number == 10
+    assert notification.created_at == created_at
+    assert notification.client_reference == "ref from client"
+    assert notification.reference is None
+    assert notification.international is False
+    assert notification.phone_prefix == "1"
+    assert notification.rate_multiplier == 1
+    assert notification.created_by_id == sample_job.created_by_id
+    assert not notification.reply_to_text
 
-    def test_transform_notification_with_international_info_does_not_store_for_email(sample_job, sample_api_key, mocker):
-        pass
 
-    def test_transform_sms_notification_stores_normalised_number():
-        pass
+@pytest.mark.parametrize(
+    "recipient, expected_international, expected_prefix, expected_units",
+    [
+        ("6502532222", False, "1", 1),  # NA
+        ("+16502532222", False, "1", 1),  # NA
+        ("+79587714230", True, "7", 1),  # Russia
+        ("+360623400400", True, "36", 3),
+    ],  # Hungary
+)
+def test_transform_notification_with_international_info_stores_correct_info(
+    sample_job,
+    sample_api_key,
+    mocker,
+    recipient,
+    expected_international,
+    expected_prefix,
+    expected_units,
+):
+    notification = transform_notification(
+        template_id=sample_job.template.id,
+        template_version=sample_job.template.version,
+        recipient=recipient,
+        service=sample_job.service,
+        personalisation=None,
+        notification_type="sms",
+        api_key_id=sample_api_key.id,
+        key_type=sample_api_key.key_type,
+        job_id=sample_job.id,
+        job_row_number=10,
+        client_reference="ref from client",
+    )
 
-    def test_transform_email_notification_stores_normalised_email():
-        pass
+    assert notification.international is expected_international
+    assert notification.phone_prefix == expected_prefix
+    assert notification.rate_multiplier == expected_units
 
 
-class TestDbSaveNotification:
-    def test_db_save_notification_saves_to_db():
-        pass
+def test_transform_notification_with_international_info_does_not_store_for_email(sample_job, sample_api_key, mocker):
+    notification = transform_notification(
+        template_id=sample_job.template.id,
+        template_version=sample_job.template.version,
+        recipient="foo@bar.com",
+        service=sample_job.service,
+        personalisation=None,
+        notification_type="email",
+        api_key_id=sample_api_key.id,
+        key_type=sample_api_key.key_type,
+        job_id=sample_job.id,
+        job_row_number=10,
+        client_reference="ref from client",
+    )
+    assert notification.international is False
+    assert notification.phone_prefix is None
+    assert notification.rate_multiplier is None
 
-    def test_db_save_notification_throws_exception_when_missing_template(sample_api_key):
-        assert Notification.query.count() == 0
-        assert NotificationHistory.query.count() == 0
 
-        notification = Notification(
-            id=uuid.uuid4(),
-            template_id=None,
-            template_version=None,
-            to="+16502532222",
-            service=sample_api_key.service,
-            personalisation=None,
-            notification_type="sms",
-            api_key_id=sample_api_key.id,
-            key_type=sample_api_key.key_type,
-            created_at=datetime.datetime(2016, 11, 11, 16, 8, 18),
-        )
+@pytest.mark.parametrize(
+    "recipient, expected_recipient_normalised",
+    [
+        ("6502532222", "+16502532222"),
+        ("  6502532223", "+16502532223"),
+        ("6502532223", "+16502532223"),
+    ],
+)
+def test_transform_sms_notification_stores_normalised_number(
+    sample_job, sample_api_key, mocker, recipient, expected_recipient_normalised
+):
+    notification = transform_notification(
+        template_id=sample_job.template.id,
+        template_version=sample_job.template.version,
+        recipient=recipient,
+        service=sample_job.service,
+        personalisation=None,
+        notification_type="sms",
+        api_key_id=sample_api_key.id,
+        key_type=sample_api_key.key_type,
+        job_id=sample_job.id,
+    )
 
-        with pytest.raises(SQLAlchemyError):
-            db_save_notification(notification)
+    assert notification.to == recipient
+    assert notification.normalised_to == expected_recipient_normalised
 
-        assert Notification.query.count() == 0
-        assert NotificationHistory.query.count() == 0
 
-    def test_cache_is_not_incremented_on_failure_to_db_save_notification():
-        pass
+@pytest.mark.parametrize(
+    "recipient, expected_recipient_normalised",
+    [("FOO@bar.com", "foo@bar.com"), ("BAR@foo.com", "bar@foo.com")],
+)
+def test_transform_email_notification_stores_normalised_email(
+    sample_job, sample_api_key, mocker, recipient, expected_recipient_normalised
+):
+    persist_notification(
+        template_id=sample_job.template.id,
+        template_version=sample_job.template.version,
+        recipient=recipient,
+        service=sample_job.service,
+        personalisation=None,
+        notification_type="email",
+        api_key_id=sample_api_key.id,
+        key_type=sample_api_key.key_type,
+        job_id=sample_job.id,
+    )
+    persisted_notification = Notification.query.all()[0]
 
-    def test_db_save_notification_does_not_increment_cache_if_test_key():
-        pass
+    assert persisted_notification.to == recipient
+    assert persisted_notification.normalised_to == expected_recipient_normalised
 
-    def test_db_save_notification_doesnt_touch_cache_for_old_keys_that_dont_exist():
-        pass
 
-    def test_db_save_notification_increments_cache_if_key_exists():
-        pass
+def test_db_save_notification_saves_to_db(sample_template, sample_api_key, sample_job, mocker):
+    mocked_redis = mocker.patch("app.notifications.process_notifications.redis_store.get")
+    assert Notification.query.count() == 0
+    assert NotificationHistory.query.count() == 0
+
+    notification = Notification(
+        id=uuid.uuid4(),
+        template_id=sample_template.id,
+        template_version=sample_template.version,
+        service=sample_template.service,
+        personalisation={},
+        notification_type="sms",
+        api_key_id=sample_api_key.id,
+        key_type=sample_api_key.key_type,
+        job_id=sample_job.id,
+        job_row_number=100,
+        reference="ref",
+        reply_to_text=sample_template.service.get_default_sms_sender(),
+        to="+16502532222",
+        created_at=datetime.datetime(2016, 11, 11, 16, 8, 18),
+    )
+    assert Notification.query.get(notification.id) is not None
+
+    notification_from_db = Notification.query.one()
+
+    assert notification_from_db.id == notification.id
+    assert notification_from_db.template_id == notification.template_id
+    assert notification_from_db.template_version == notification.template_version
+    assert notification_from_db.api_key_id == notification.api_key_id
+    assert notification_from_db.key_type == notification.key_type
+    assert notification_from_db.key_type == notification.key_type
+    assert notification_from_db.billable_units == notification.billable_units
+    assert notification_from_db.notification_type == notification.notification_type
+    assert notification_from_db.created_at == notification.created_at
+    assert not notification_from_db.sent_at
+    assert notification_from_db.updated_at == notification.updated_at
+    assert notification_from_db.status == notification.status
+    assert notification_from_db.reference == notification.reference
+    assert notification_from_db.client_reference == notification.client_reference
+    assert notification_from_db.created_by_id == notification.created_by_id
+    assert notification_from_db.reply_to_text == sample_template.service.get_default_sms_sender()
+
+    mocked_redis.assert_called_once_with(str(sample_template.service_id) + "-2016-01-01-count")
+
+
+def test_db_save_notification_throws_exception_when_missing_template(sample_api_key):
+    assert Notification.query.count() == 0
+    assert NotificationHistory.query.count() == 0
+
+    notification = Notification(
+        id=uuid.uuid4(),
+        template_id=None,
+        template_version=None,
+        to="+16502532222",
+        service=sample_api_key.service,
+        personalisation=None,
+        notification_type="sms",
+        api_key_id=sample_api_key.id,
+        key_type=sample_api_key.key_type,
+        created_at=datetime.datetime(2016, 11, 11, 16, 8, 18),
+    )
+
+    with pytest.raises(SQLAlchemyError):
+        db_save_notification(notification)
+
+    assert Notification.query.count() == 0
+    assert NotificationHistory.query.count() == 0
+
+
+def test_db_save_notification_does_not_increment_cache_if_test_key(
+    notify_db, notify_db_session, sample_template, sample_job, mocker
+):
+    api_key = create_api_key(
+        notify_db=notify_db,
+        notify_db_session=notify_db_session,
+        service=sample_template.service,
+        key_type="test",
+    )
+    mocker.patch("app.notifications.process_notifications.redis_store.get", return_value="cache")
+    mocker.patch(
+        "app.notifications.process_notifications.redis_store.get_all_from_hash",
+        return_value="cache",
+    )
+    daily_limit_cache = mocker.patch("app.notifications.process_notifications.redis_store.incr")
+    template_usage_cache = mocker.patch("app.notifications.process_notifications.redis_store.increment_hash_value")
+
+    assert Notification.query.count() == 0
+    assert NotificationHistory.query.count() == 0
+    persist_notification(
+        template_id=sample_template.id,
+        template_version=sample_template.version,
+        recipient="+16502532222",
+        service=sample_template.service,
+        personalisation={},
+        notification_type="sms",
+        api_key_id=api_key.id,
+        key_type=api_key.key_type,
+        job_id=sample_job.id,
+        job_row_number=100,
+        reference="ref",
+    )
+
+    assert Notification.query.count() == 1
+
+    assert not daily_limit_cache.called
+    assert not template_usage_cache.called
+
+
+@freeze_time("2016-01-01 11:09:00.061258")
+def test_db_save_notification_doesnt_touch_cache_for_old_keys_that_dont_exist(sample_template, sample_api_key, mocker):
+    mock_incr = mocker.patch("app.notifications.process_notifications.redis_store.incr")
+    mocker.patch("app.notifications.process_notifications.redis_store.get", return_value=None)
+    mocker.patch(
+        "app.notifications.process_notifications.redis_store.get_all_from_hash",
+        return_value=None,
+    )
+
+    persist_notification(
+        template_id=sample_template.id,
+        template_version=sample_template.version,
+        recipient="+16502532222",
+        service=sample_template.service,
+        personalisation={},
+        notification_type="sms",
+        api_key_id=sample_api_key.id,
+        key_type=sample_api_key.key_type,
+        reference="ref",
+    )
+    mock_incr.assert_not_called()
+
+
+@freeze_time("2016-01-01 11:09:00.061258")
+def test_db_save_notification_increments_cache_if_key_exists(sample_template, sample_api_key, mocker):
+    mock_incr = mocker.patch("app.notifications.process_notifications.redis_store.incr")
+    mocker.patch("app.notifications.process_notifications.redis_store.get", return_value=1)
+    mocker.patch(
+        "app.notifications.process_notifications.redis_store.get_all_from_hash",
+        return_value={sample_template.id, 1},
+    )
+
+    persist_notification(
+        template_id=sample_template.id,
+        template_version=sample_template.version,
+        recipient="+16502532222",
+        service=sample_template.service,
+        personalisation={},
+        notification_type="sms",
+        api_key_id=sample_api_key.id,
+        key_type=sample_api_key.key_type,
+        reference="ref2",
+    )
+
+    mock_incr.assert_called_once_with(
+        str(sample_template.service_id) + "-2016-01-01-count",
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -271,77 +271,70 @@ def test_persist_notification_increments_cache_if_key_exists(sample_template, sa
     )
 
 
-def test_transform_notification_with_optionals():
-    pass
+class TestTransformNotification:
+    def test_transform_notification_with_optionals():
+        pass
 
-
-@pytest.mark.parametrize(
-    "recipient, expected_international, expected_prefix, expected_units",
-    [
-        ("6502532222", False, "1", 1),  # NA
-        ("+16502532222", False, "1", 1),  # NA
-        ("+79587714230", True, "7", 1),  # Russia
-        ("+360623400400", True, "36", 3),
-    ],  # Hungary
-)
-def test_transform_notification_with_international_info_stores_correct_info():
-    pass
-
-
-def test_transform_notification_with_international_info_does_not_store_for_email(sample_job, sample_api_key, mocker):
-    pass
-
-
-def test_transform_sms_notification_stores_normalised_number():
-    pass
-
-
-def test_persist_email_notification_stores_normalised_email():
-    pass
-
-
-def test_db_save_notification_saves_to_db():
-    pass
-
-
-def test_db_save_notification_throws_exception_when_missing_template(sample_api_key):
-    assert Notification.query.count() == 0
-    assert NotificationHistory.query.count() == 0
-
-    notification = Notification(
-        id=uuid.uuid4(),
-        template_id=None,
-        template_version=None,
-        to="+16502532222",
-        service=sample_api_key.service,
-        personalisation=None,
-        notification_type="sms",
-        api_key_id=sample_api_key.id,
-        key_type=sample_api_key.key_type,
-        created_at=datetime.datetime(2016, 11, 11, 16, 8, 18),
+    @pytest.mark.parametrize(
+        "recipient, expected_international, expected_prefix, expected_units",
+        [
+            ("6502532222", False, "1", 1),  # NA
+            ("+16502532222", False, "1", 1),  # NA
+            ("+79587714230", True, "7", 1),  # Russia
+            ("+360623400400", True, "36", 3),
+        ],  # Hungary
     )
+    def test_transform_notification_with_international_info_stores_correct_info():
+        pass
 
-    with pytest.raises(SQLAlchemyError):
-        db_save_notification(notification)
+    def test_transform_notification_with_international_info_does_not_store_for_email(sample_job, sample_api_key, mocker):
+        pass
 
-    assert Notification.query.count() == 0
-    assert NotificationHistory.query.count() == 0
+    def test_transform_sms_notification_stores_normalised_number():
+        pass
 
-
-def test_cache_is_not_incremented_on_failure_to_db_save_notification():
-    pass
-
-
-def test_db_save_notification_does_not_increment_cache_if_test_key():
-    pass
+    def test_transform_email_notification_stores_normalised_email():
+        pass
 
 
-def test_db_save_notification_doesnt_touch_cache_for_old_keys_that_dont_exist():
-    pass
+class TestDbSaveNotification:
+    def test_db_save_notification_saves_to_db():
+        pass
 
+    def test_db_save_notification_throws_exception_when_missing_template(sample_api_key):
+        assert Notification.query.count() == 0
+        assert NotificationHistory.query.count() == 0
 
-def test_db_save_notification_increments_cache_if_key_exists():
-    pass
+        notification = Notification(
+            id=uuid.uuid4(),
+            template_id=None,
+            template_version=None,
+            to="+16502532222",
+            service=sample_api_key.service,
+            personalisation=None,
+            notification_type="sms",
+            api_key_id=sample_api_key.id,
+            key_type=sample_api_key.key_type,
+            created_at=datetime.datetime(2016, 11, 11, 16, 8, 18),
+        )
+
+        with pytest.raises(SQLAlchemyError):
+            db_save_notification(notification)
+
+        assert Notification.query.count() == 0
+        assert NotificationHistory.query.count() == 0
+
+    def test_cache_is_not_incremented_on_failure_to_db_save_notification():
+        pass
+
+    def test_db_save_notification_does_not_increment_cache_if_test_key():
+        pass
+
+    def test_db_save_notification_doesnt_touch_cache_for_old_keys_that_dont_exist():
+        pass
+
+    def test_db_save_notification_increments_cache_if_key_exists():
+        pass
 
 
 @pytest.mark.parametrize(

--- a/tests/app/v2/notifications/test_post_letter_notifications.py
+++ b/tests/app/v2/notifications/test_post_letter_notifications.py
@@ -278,7 +278,7 @@ def test_notification_returns_400_if_address_doesnt_have_underscores(client, sam
 
 
 def test_returns_a_429_limit_exceeded_if_rate_limit_exceeded(client, sample_letter_template, mocker):
-    persist_mock = mocker.patch("app.v2.notifications.post_notifications.persist_notification")
+    persist_mock = mocker.patch("app.notifications.process_notifications.persist_notification")
     mocker.patch(
         "app.v2.notifications.post_notifications.check_rate_limiting",
         side_effect=RateLimitError("LIMIT", "INTERVAL", "TYPE"),

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -575,7 +575,7 @@ def test_returns_a_429_limit_exceeded_if_rate_limit_exceeded(
 ):
     notify_api.config["FF_NOTIFICATION_CELERY_PERSISTENCE"] = False
     sample = create_template(service=sample_service, template_type=notification_type)
-    persist_mock = mocker.patch("app.v2.notifications.post_notifications.persist_notification")
+    persist_mock = mocker.patch("app.notifications.process_notifications.persist_notification")
     deliver_mock = mocker.patch("app.v2.notifications.post_notifications.send_notification_to_queue")
     mocker.patch(
         "app.v2.notifications.post_notifications.check_rate_limiting",


### PR DESCRIPTION
# Summary | Résumé

https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/cds-snc/notification-planning/149

Split `persist_notification()` into two functions (note: keeping the original there as well):
- `transform_notification()` that takes the same params as `persist_notification()` and returns a notification
- `db_save_notification()` which saves a notification to the database

Change the `/v2/notifications/email` and `/v2/notifications/sms` endpoints to use the two new functions instead of `persist_notification()`.

This will allow us to next replace `db_save_notification()` with something that pushes the notification to redis.

# Test instructions | Instructions pour tester la modification

tested locally by posting to the `/v2/notifications/email` and `/v2/notifications/sms` endpoints

# Release Instructions | Instructions pour le déploiement

None. (in particular, we are still doing the same steps, just in two functions, so there isn't a feature flag yet)

# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their
review | Voici une suggestion de liste de vérification comprenant des questions
que les réviseurs pourraient poser pendant leur examen :


- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne
      une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une
      fonctionnalité existante?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une
      modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des
      préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de
      façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de
      risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README
      setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce
      changement (fichier README, etc.)?
