### PR TITLE
Add queue_name for notifications table

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1594,6 +1594,7 @@ class Notification(BaseModel):
 
     postage = db.Column(db.String, nullable=True)
     provider_response = db.Column(db.Text, nullable=True)
+    queue_name = db.Column(db.Text, nullable=True)
 
     CheckConstraint(
         """
@@ -1882,6 +1883,8 @@ class NotificationHistory(BaseModel, HistoryModel):
     created_by_id = db.Column(UUID(as_uuid=True), nullable=True)
 
     postage = db.Column(db.String, nullable=True)
+    queue_name = db.Column(db.Text, nullable=True)
+
     CheckConstraint(
         """
         CASE WHEN notification_type = 'letter' THEN

--- a/migrations/versions/0326_add_queue_notifications.py
+++ b/migrations/versions/0326_add_queue_notifications.py
@@ -18,7 +18,9 @@ timeout = 1200  # in seconds, i.e. 20 minutes
 
 def upgrade():
     op.add_column("notifications", sa.Column("queue_name", sa.Text(), nullable=True))
+    op.add_column("notification_history", sa.Column("queue_name", sa.Text(), nullable=True))
 
 
 def downgrade():
     op.drop_column("notifications", "queue_name")
+    op.drop_column("notification_history", sa.Column("queue_name", sa.Text(), nullable=True))

--- a/migrations/versions/0326_add_queue_notifications.py
+++ b/migrations/versions/0326_add_queue_notifications.py
@@ -23,4 +23,4 @@ def upgrade():
 
 def downgrade():
     op.drop_column("notifications", "queue_name")
-    op.drop_column("notification_history", sa.Column("queue_name", sa.Text(), nullable=True))
+    op.drop_column("notification_history", "queue_name")

--- a/migrations/versions/0326_add_queue_notifications.py
+++ b/migrations/versions/0326_add_queue_notifications.py
@@ -1,0 +1,24 @@
+"""
+
+Revision ID: 0326_add_queue_notifications
+Revises: 0325_set_transaction_timeout
+Create Date: 2021-07-29 17:30:00
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0326_add_queue_notifications"
+down_revision = "0325_set_transaction_timeout"
+
+user = "postgres"
+timeout = 1200  # in seconds, i.e. 20 minutes
+
+
+def upgrade():
+    op.add_column("notifications", sa.Column("queue_name", sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("notifications", "queue_name")

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -538,6 +538,7 @@ def sample_notification(
     scheduled_for=None,
     normalised_to=None,
     postage=None,
+    queue_name=None,
 ):
     if created_at is None:
         created_at = datetime.utcnow()
@@ -585,6 +586,7 @@ def sample_notification(
         "rate_multiplier": rate_multiplier,
         "normalised_to": normalised_to,
         "postage": postage,
+        "queue_name": queue_name,
     }
     if job_row_number is not None:
         data["job_row_number"] = job_row_number

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -238,6 +238,7 @@ def create_notification(
     reply_to_text=None,
     created_by_id=None,
     postage=None,
+    queue_name=None,
 ):
     """
     Creates in memory Notification Model
@@ -295,6 +296,7 @@ def create_notification(
         "reply_to_text": reply_to_text,
         "created_by_id": created_by_id,
         "postage": postage,
+        "queue_name": queue_name,
     }
     return Notification(**data)
 

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -371,3 +371,10 @@ def test_login_event_serialization(sample_login_event):
     json = sample_login_event.serialize()
     assert json["data"] == sample_login_event.data
     assert json["created_at"]
+
+
+class TestNotificationModel:
+    def test_queue_name_in_notifications(self, sample_service):
+        template = create_template(sample_service, template_type="email")
+        notification = save_notification(create_notification(template, to_field="test@example.com", queue_name="tester"))
+        assert notification.queue_name == "tester"


### PR DESCRIPTION
# Summary | Résumé

We are going to store the name of the queue we send the notification to in the notifications table.

Code was tested by running `flask db upgrade`

```
                            Table "public.notifications"
       Column        |            Type             | Collation | Nullable | Default
---------------------+-----------------------------+-----------+----------+---------
 id                  | uuid                        |           | not null |
 to                  | character varying           |           | not null |
 job_id              | uuid                        |           |          |
 service_id          | uuid                        |           |          |
 template_id         | uuid                        |           |          |
 created_at          | timestamp without time zone |           | not null |
 sent_at             | timestamp without time zone |           |          |
 sent_by             | character varying           |           |          |
 updated_at          | timestamp without time zone |           |          |
 reference           | character varying           |           |          |
 template_version    | integer                     |           | not null |
 job_row_number      | integer                     |           |          |
 _personalisation    | character varying           |           |          |
 api_key_id          | uuid                        |           |          |
 key_type            | character varying(255)      |           | not null |
 notification_type   | notification_type           |           | not null |
 billable_units      | integer                     |           | not null |
 client_reference    | character varying           |           |          |
 international       | boolean                     |           |          |
 phone_prefix        | character varying           |           |          |
 rate_multiplier     | numeric                     |           |          |
 notification_status | text                        |           |          |
 normalised_to       | character varying           |           |          |
 created_by_id       | uuid                        |           |          |
 reply_to_text       | character varying           |           |          |
 postage             | character varying           |           |          |
 provider_response   | text                        |           |          |
 queue_name          | text                        |           |          |
Indexes:
```

Also added the code for notification_history:
```
                        Table "public.notification_history"
       Column        |            Type             | Collation | Nullable | Default
---------------------+-----------------------------+-----------+----------+---------
 id                  | uuid                        |           | not null |
 job_id              | uuid                        |           |          |
 job_row_number      | integer                     |           |          |
 service_id          | uuid                        |           |          |
 template_id         | uuid                        |           |          |
 template_version    | integer                     |           | not null |
 api_key_id          | uuid                        |           |          |
 key_type            | character varying           |           | not null |
 notification_type   | notification_type           |           | not null |
 created_at          | timestamp without time zone |           | not null |
 sent_at             | timestamp without time zone |           |          |
 sent_by             | character varying           |           |          |
 updated_at          | timestamp without time zone |           |          |
 reference           | character varying           |           |          |
 billable_units      | integer                     |           | not null |
 client_reference    | character varying           |           |          |
 international       | boolean                     |           |          |
 phone_prefix        | character varying           |           |          |
 rate_multiplier     | numeric                     |           |          |
 notification_status | text                        |           |          |
 created_by_id       | uuid                        |           |          |
 postage             | character varying           |           |          |
 queue_name          | text                        |           |          |
 ```