### PR TITLE
Serial exec for tests

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -35,6 +35,10 @@ display_result $? 2 "Import order check"
 mypy .
 display_result $? 1 "Type check"
 
-# run with four concurrent threads
-py.test --disable-pytest-warnings --cov=app --cov-report=term-missing tests/ --junitxml=test_results.xml -n4 -v --maxfail=10
-display_result $? 2 "Unit tests"
+# Run tests that need serial execution.
+py.test --disable-pytest-warnings --cov=app --cov-report=term-missing tests/ --junitxml=test_results_serial.xml -v --maxfail=10 -m "serial"
+display_result $? 2 "Unit tests [serial]"
+
+# Run with four concurrent threads.
+py.test --disable-pytest-warnings --cov=app --cov-report=term-missing tests/ --junitxml=test_results.xml -n4 -v --maxfail=10 -m "not serial"
+display_result $? 2 "Unit tests [concurrent]"

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -20,6 +20,7 @@ from app.utils import (
 # We can see this when applying timezones "US/Eastern" of naive times to a datetime on the different platforms
 # they will result in different values. Within this test we normalize the naive datetime to UTC to properly
 # pass the test on both Mac and *nix
+@pytest.mark.serial
 @pytest.mark.parametrize(
     "date_val, expected_date",
     [


### PR DESCRIPTION
# Summary | Résumé

Execute tests that will be tagged with the `@pytest.mark.serial` annotation without concurrent test workers. The goal is to tag the upcoming tests around the `RedisQueue` implementation with these to avoid concurrent access to the fixture cache database.

# Test instructions | Instructions pour tester la modification

Watching for the GitHub pipeline and make sure nothing breaks.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their
review | Voici une suggestion de liste de vérification comprenant des questions
que les réviseurs pourraient poser pendant leur examen :


- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne
      une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une
      fonctionnalité existante?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une
      modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des
      préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de
      façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de
      risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README
      setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce
      changement (fichier README, etc.)?
