### PR TITLE
Refactored dao_fetch_service_by_id without tuple return

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -288,12 +288,6 @@ def save_smss(self, service_id: str, encrypted_notifications: List[Any], receipt
             else:
                 reply_to_text = template.get_reply_to_text()  # type: ignore
 
-            # if the service is obtained from cache a tuple will be returned where
-            # the first element is the Service object and the second the service cache data
-            # in the form of a dict
-            if isinstance(service, tuple):
-                service = service[0]
-
             notification["reply_to_text"] = reply_to_text
             notification["service"] = service
             notification["key_type"] = notification.get("key_type", KEY_TYPE_NORMAL)
@@ -360,12 +354,6 @@ def save_sms(self, service_id, notification_id, encrypted_notification, sender_i
         template = template[0]
     else:
         reply_to_text = template.get_reply_to_text()
-
-    # if the service is obtained from cache a tuple will be returned where
-    # the first element is the Service object and the second the service cache data
-    # in the form of a dict
-    if isinstance(service, tuple):
-        service = service[0]
 
     check_service_over_daily_message_limit(KEY_TYPE_NORMAL, service)
 
@@ -442,12 +430,6 @@ def save_emails(self, service_id: str, encrypted_notifications: List[Any], recei
             else:
                 reply_to_text = template.get_reply_to_text()  # type: ignore
 
-            # if the service is obtained from cache a tuple will be returned where
-            # the first element is the Service object and the second the service cache data
-            # in the form of a dict
-            if isinstance(service, tuple):
-                service = service[0]
-
             notification["reply_to_text"] = reply_to_text
             notification["service"] = service
             notification["key_type"] = notification.get("key_type", KEY_TYPE_NORMAL)
@@ -513,12 +495,6 @@ def save_email(self, service_id, notification_id, encrypted_notification, sender
         template = template[0]
     else:
         reply_to_text = template.get_reply_to_text()
-
-    # if the service is obtained from cache a tuple will be returned where
-    # the first element is the Service object and the second the service cache data
-    # in the form of a dict
-    if isinstance(service, tuple):
-        service = service[0]
 
     check_service_over_daily_message_limit(notification.get("key_type", KEY_TYPE_NORMAL), service)
 

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -268,11 +268,6 @@ def save_smss(self, service_id: str, signed_notifications: List[Any], receipt: O
         service_id = notification.get("service_id", service_id)  # take it it out of the notification if it's there
         service = dao_fetch_service_by_id(service_id, use_cache=True)
 
-        # if the service is obtained from cache a tuple will be returned where
-        # the first element is the Service object and the second the service cache data
-        # in the form of a dict
-        if isinstance(service, tuple):
-            service = service[0]
         if service_allowed_to_send_to(notification["to"], service, KEY_TYPE_NORMAL):
             template = dao_get_template_by_id(
                 notification.get("template"), version=notification.get("template_version"), use_cache=True
@@ -417,11 +412,6 @@ def save_emails(self, service_id: str, signed_notification: List[Any], receipt: 
         service_id = notification.get("service_id", service_id)  # take it it out of the notification if it's there
         service = dao_fetch_service_by_id(service_id, use_cache=True)
 
-        # if the service is obtained from cache a tuple will be returned where
-        # the first element is the Service object and the second the service cache data
-        # in the form of a dict
-        if isinstance(service, tuple):
-            service = service[0]
         if service_allowed_to_send_to(notification["to"], service, KEY_TYPE_NORMAL):
             template = dao_get_template_by_id(
                 notification.get("template"), version=notification.get("template_version"), use_cache=True

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -1,7 +1,6 @@
 import json
 import uuid
 from datetime import date, datetime, timedelta
-from typing import Tuple, Union
 
 from flask import current_app
 from notifications_utils.clients.redis import service_cache_key

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -189,12 +189,12 @@ def dao_fetch_live_services_data():
     return results
 
 
-def dao_fetch_service_by_id(service_id, only_active=False, use_cache=False) -> Union[Service, Tuple[Service, dict]]:
+def dao_fetch_service_by_id(service_id, only_active=False, use_cache=False) -> Service:
     if use_cache:
         service_cache = redis_store.get(service_cache_key(service_id))
         if service_cache:
             service_cache_decoded = json.loads(service_cache.decode("utf-8"))["data"]
-            return Service.from_json(service_cache_decoded), service_cache_decoded
+            return Service.from_json(service_cache_decoded)
 
     query = Service.query.filter_by(id=service_id).options(joinedload("users"))
     if only_active:

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -610,7 +610,7 @@ def test_get_service_by_id_uses_redis_cache_when_use_cache_specified(notify_db_s
     service = dao_fetch_service_by_id(sample_service.id, use_cache=True)
 
     assert mocked_redis_get.called
-    assert str(sample_service.id) == service[0].id
+    assert str(sample_service.id) == service.id
 
 
 def test_create_service_returns_service_with_default_permissions(notify_db_session):


### PR DESCRIPTION
# Summary | Résumé

Refactored the `dao_fetch_service_by_id` function to remove the `tuple[Service, Dict]` return, because the `dict` return reflects exactly the same as the `Service` as the latter was created from the former. Inspection of the code shows that the `dict` return is not actually used anywhere.

# Test instructions | Instructions pour tester la modification

Regression tests should cover usage and calls of this refactored function.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their
review | Voici une suggestion de liste de vérification comprenant des questions
que les réviseurs pourraient poser pendant leur examen :


- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne
      une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une
      fonctionnalité existante?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une
      modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des
      préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de
      façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de
      risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README
      setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce
      changement (fichier README, etc.)?
