### PR TITLE
fix: setup of VS Code devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -O -J -L https://github.com/ryanoasis/nerd-fonts/releases/download/v2.1
     && rm FiraMono.zip \
     && fc-cache -fv
 
-RUN curl -fsSL https://starship.rs/install.sh | bash -s -- -y
+RUN curl -fsSL https://starship.rs/install.sh | sh -s -- -y
 
 COPY .devcontainer/scripts/notify-dev-entrypoint.sh /usr/local/bin/
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,8 +9,11 @@
 		"python.linting.pylintEnabled": true,
 		"python.linting.pylintPath": "/usr/local/bin/pylint",
 		"python.pythonPath": "/usr/local/bin/python",
-		"terminal.integrated.shell.linux": "/bin/bash",
-		"terminal.integrated.fontFamily": "FiraCode Nerd Font Mono"
+		"terminal.integrated.fontFamily": "FiraCode Nerd Font Mono, MonoLisa, monospace"
+	},
+
+	"containerEnv": {
+		"SHELL": "/bin/bash"
 	},
 
 	"extensions": [


### PR DESCRIPTION
# Summary
Fix the local build of the VS Code devcontainer by:

* updating the starship prompt install;
* setting the default shell to `/bin/bash`; and
* updating the terminal font to fallback to `monospace`.