### PR TITLE
fix: update how devcontainer is initialized

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,7 @@
 		"python.linting.pylintEnabled": true,
 		"python.linting.pylintPath": "/usr/local/bin/pylint",
 		"python.pythonPath": "/usr/local/bin/python",
-		"terminal.integrated.fontFamily": "FiraCode Nerd Font Mono, MonoLisa, monospace"
+		"terminal.integrated.fontFamily": "Fira Mono Medium Nerd Font Complete Mono, MonoLisa, monospace"
 	},
 
 	"containerEnv": {
@@ -34,5 +34,7 @@
 		"yzhang.markdown-all-in-one",
 		"ms-ossdata.vscode-postgresql",
 		"googlecloudtools.cloudcode"
-	]
+	],
+
+	"postCreateCommand": "notify-dev-entrypoint.sh"
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -5,7 +5,6 @@ services:
     build: 
       context: ..
       dockerfile: .devcontainer/Dockerfile
-    entrypoint: notify-dev-entrypoint.sh
     environment:
       SQLALCHEMY_DATABASE_URI: postgresql://postgres:chummy@db/notification_api
       SQLALCHEMY_DATABASE_TEST_URI: postgresql://postgres:chummy@db/test_notification_api
@@ -36,6 +35,7 @@ services:
       - "5432" 
     ports:
       - "5432:5432"
+
   redis:
     image: redis:6.2
     restart: always

--- a/.devcontainer/scripts/notify-dev-entrypoint.sh
+++ b/.devcontainer/scripts/notify-dev-entrypoint.sh
@@ -7,18 +7,14 @@ set -ex
 # tools and the filesystem mount enabled should be located here. 
 ###################################################################
 
-# We want to enable broadcast message which by default is disabled.
-sed '/mesg/d' ~/.profile > ~/.profile.bak && mv ~/.profile.bak ~/.profile
-echo -e "\ntest -t 0 && mesg n" >> ~/.profile
-
 # Define aliases
-echo -e "\n\n# User's Aliases" >> ~/.profile
-echo -e "alias fd=fdfind" >> ~/.profile
-echo -e "alias l='ls -al --color'" >> ~/.profile
-echo -e "alias ls='exa'" >> ~/.profile
-echo -e "alias l='exa -alh'" >> ~/.profile
-echo -e "alias ll='exa -alh@ --git'" >> ~/.profile
-echo -e "alias lt='exa -al -T -L 2'" >> ~/.profile
+echo -e "\n\n# User's Aliases" >> ~/.bashrc
+echo -e "alias fd=fdfind" >> ~/.bashrc
+echo -e "alias l='ls -al --color'" >> ~/.bashrc
+echo -e "alias ls='exa'" >> ~/.bashrc
+echo -e "alias l='exa -alh'" >> ~/.bashrc
+echo -e "alias ll='exa -alh@ --git'" >> ~/.bashrc
+echo -e "alias lt='exa -al -T -L 2'" >> ~/.bashrc
 
 cd /workspace 
 
@@ -32,5 +28,3 @@ pip3 install -r requirements_for_test.txt
 
 # Upgrade schema of the notification_api database.
 flask db upgrade
-
-wall "The dev container entrypoint setup is complete!"

--- a/.devcontainer/scripts/notify-dev-entrypoint.sh
+++ b/.devcontainer/scripts/notify-dev-entrypoint.sh
@@ -34,6 +34,3 @@ pip3 install -r requirements_for_test.txt
 flask db upgrade
 
 wall "The dev container entrypoint setup is complete!"
-
-# Bubble up the main Docker command to container.
-exec "$@"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For any issues during the following instructions, make sure to review the
 
 ### Local installation instruction 
 
-On OS X:
+#### On OS X:
 
 1. Install PyEnv with Homebrew. This will preserve your sanity. 
 
@@ -95,6 +95,23 @@ file. Copy that file to `.env` and customize it to your needs.
 
 `make test`
 
+#### In a [VS Code devcontainer](https://code.visualstudio.com/docs/remote/containers-tutorial)
+
+1. Install VS Code
+
+`brew install --cask visual-studio-code`
+
+2. Install Docker
+   
+`brew install --cask docker`
+   
+3. Install the [Remote-Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+
+4. In VS Code run "Remote-Containers: Open Folder in Container..." and select this repository folder
+
+5. Run the service
+
+`flask run -p 6011 --host=0.0.0.0`
 
 
 ##  To run the queues 


### PR DESCRIPTION
# Summary
Use the postCreateCommand in devcontainer.json to finish
the devcontainer init.

Also updates the README with instructions on how to get
started using the devcontainer.

The updated README section I've added looks like so:
https://github.com/cds-snc/notification-api/blob/fix/devcontainer-entrypoint/README.md#in-a-vs-code-devcontainer
