### PR TITLE
feat: add kubectl to devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
 
 RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils 2>&1 \
-    && apt-get -y install git openssh-client less iproute2 procps lsb-release libsodium-dev \
+    && apt-get -y install git openssh-client less iproute2 procps lsb-release libsodium-dev bash-completion \
     && groupadd --gid $USER_GID $USERNAME \
     && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
     && apt-get install -y sudo \
@@ -22,6 +22,15 @@ RUN apt-get update \
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
+
+# Install kubectl
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" \
+    && install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+
+# Install kubens
+RUN git clone -b v0.9.4 --single-branch https://github.com/ahmetb/kubectx /opt/kubectx \
+    && ln -s /opt/kubectx/kubectx /usr/local/bin/kubectx \
+    && ln -s /opt/kubectx/kubens /usr/local/bin/kubens
 
 RUN curl -O -J -L https://github.com/ryanoasis/nerd-fonts/releases/download/v2.1.0/FiraMono.zip \
     && unzip FiraMono.zip -d ~/.fonts \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
 
 RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils 2>&1 \
-    && apt-get -y install git openssh-client less iproute2 procps lsb-release libsodium-dev bash-completion \
+    && apt-get -y install git openssh-client less iproute2 procps lsb-release libsodium-dev bash-completion vim \
     && groupadd --gid $USER_GID $USERNAME \
     && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
     && apt-get install -y sudo \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,7 +33,8 @@
 		"visualstudioexptteam.vscodeintellicode",
 		"yzhang.markdown-all-in-one",
 		"ms-ossdata.vscode-postgresql",
-		"googlecloudtools.cloudcode"
+		"googlecloudtools.cloudcode",
+		"GitHub.copilot"
 	],
 
 	"postCreateCommand": "notify-dev-entrypoint.sh"

--- a/.devcontainer/scripts/notify-dev-entrypoint.sh
+++ b/.devcontainer/scripts/notify-dev-entrypoint.sh
@@ -16,6 +16,12 @@ echo -e "alias l='exa -alh'" >> ~/.bashrc
 echo -e "alias ll='exa -alh@ --git'" >> ~/.bashrc
 echo -e "alias lt='exa -al -T -L 2'" >> ~/.bashrc
 
+# Kubectl aliases and command autocomplete
+echo -e "alias k='kubectl'" >> ~/.bashrc
+echo -e "source <(kubectl completion bash)" >> ~/.bashrc
+echo -e "complete -F __start_kubectl k" >> ~/.bashrc
+echo -e "source /usr/share/bash-completion/bash_completion" >> ~/.bashrc
+
 cd /workspace 
 
 # Warm up git index prior to display status in prompt else it will 


### PR DESCRIPTION
# Summary
Add kubectl, [kubectx](https://github.com/ahmetb/kubectx/) and command auto-complete to
the devcontainer.  This lets us monitor how the cluster
is behaving during API performance testing.

Also adds the [GitHub Copilot](https://copilot.github.com/) VS Code extension.