### PR TITLE
feat: switch to /bin/zsh in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
 
 RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils 2>&1 \
-    && apt-get -y install git openssh-client less iproute2 procps lsb-release libsodium-dev bash-completion vim \
+    && apt-get -y install git openssh-client less iproute2 procps lsb-release libsodium-dev vim zsh \
     && groupadd --gid $USER_GID $USERNAME \
     && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
     && apt-get install -y sudo \
@@ -37,12 +37,10 @@ RUN curl -O -J -L https://github.com/ryanoasis/nerd-fonts/releases/download/v2.1
     && rm FiraMono.zip \
     && fc-cache -fv
 
-RUN curl -fsSL https://starship.rs/install.sh | sh -s -- -y
+RUN sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
 
 COPY .devcontainer/scripts/notify-dev-entrypoint.sh /usr/local/bin/
 
+ENV SHELL /bin/zsh
+
 EXPOSE 8000
-
-RUN python -m pip install wheel
-
-RUN echo "eval '$(starship init bash)'" >> /root/.bashrc

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,10 +12,6 @@
 		"terminal.integrated.fontFamily": "Fira Mono Medium Nerd Font Complete Mono, MonoLisa, monospace"
 	},
 
-	"containerEnv": {
-		"SHELL": "/bin/bash",
-	},
-
 	"features": {
 		"docker-from-docker": {
 			"version": "latest",

--- a/.devcontainer/scripts/notify-dev-entrypoint.sh
+++ b/.devcontainer/scripts/notify-dev-entrypoint.sh
@@ -8,19 +8,18 @@ set -ex
 ###################################################################
 
 # Define aliases
-echo -e "\n\n# User's Aliases" >> ~/.bashrc
-echo -e "alias fd=fdfind" >> ~/.bashrc
-echo -e "alias l='ls -al --color'" >> ~/.bashrc
-echo -e "alias ls='exa'" >> ~/.bashrc
-echo -e "alias l='exa -alh'" >> ~/.bashrc
-echo -e "alias ll='exa -alh@ --git'" >> ~/.bashrc
-echo -e "alias lt='exa -al -T -L 2'" >> ~/.bashrc
+echo -e "\n\n# User's Aliases" >> ~/.zshrc
+echo -e "alias fd=fdfind" >> ~/.zshrc
+echo -e "alias l='ls -al --color'" >> ~/.zshrc
+echo -e "alias ls='exa'" >> ~/.zshrc
+echo -e "alias l='exa -alh'" >> ~/.zshrc
+echo -e "alias ll='exa -alh@ --git'" >> ~/.zshrc
+echo -e "alias lt='exa -al -T -L 2'" >> ~/.zshrc
 
 # Kubectl aliases and command autocomplete
-echo -e "alias k='kubectl'" >> ~/.bashrc
-echo -e "source <(kubectl completion bash)" >> ~/.bashrc
-echo -e "complete -F __start_kubectl k" >> ~/.bashrc
-echo -e "source /usr/share/bash-completion/bash_completion" >> ~/.bashrc
+echo -e "alias k='kubectl'" >> ~/.zshrc
+echo -e "source <(kubectl completion zsh)" >> ~/.zshrc
+echo -e "complete -F __start_kubectl k" >> ~/.zshrc
 
 cd /workspace 
 


### PR DESCRIPTION
# Summary
Replace `/bin/bash` and starship with `/bin/zsh` and oh-my-zsh.

Also removes manual `pip install wheel` as this is satisfied by the
requirement installs done in the devcontainer's postCreateCommand.

# Related
* #1461 