### PR TITLE
feat: add pytest logging to tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,8 +31,17 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
+    - name: Install requirements
+      run: pip install -r requirements_for_test.txt
     - name: Run tests
-      run: /bin/bash -c "pip install -r requirements_for_test.txt && make test"
+      run: make test
+    - name: Upload pytest logs on failure
+      if: ${{ failure() }} 
+      uses: actions/upload-artifact@v2
+      with:
+        name: pytest-logs
+        path: |
+          pytest*.log  
     - name: Notify Slack channel if this job fails
       if: ${{ failure() && github.ref == 'refs/heads/master' }}
       run: |

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,6 @@
 [pytest]
+log_file = pytest.log
+log_file_level = DEBUG
 testpaths = tests
 env =
     NOTIFY_ENVIRONMENT=test

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from contextlib import contextmanager
 from urllib.parse import urlparse
@@ -12,6 +13,17 @@ from app import create_app, db
 
 
 def pytest_configure(config):
+    # Create a log file for each test process
+    log_file = config.getini("log_file")
+    log_level = config.getini("log_file_level")
+    worker_process = os.environ.get("PYTEST_XDIST_WORKER")
+    if log_file and log_level and worker_process:
+        logging.basicConfig(
+            format="%(asctime)s %(name)s %(levelname)s %(message)s",
+            filename=log_file.replace(".log", f".{worker_process}.log"),
+            level=log_level,
+        )
+
     # Swap to test database if running from devcontainer
     if os.environ.get("SQLALCHEMY_DATABASE_TEST_URI") is not None:
         os.environ["SQLALCHEMY_DATABASE_URI"] = os.environ.get("SQLALCHEMY_DATABASE_TEST_URI")
@@ -101,6 +113,11 @@ def notify_db(notify_api, worker_id):
         "reader": uri_db_reader,
         "writer": uri_db_writer,
     }
+
+    logging.debug(f"{worker_id} notify_db app config writer `{current_app.config['SQLALCHEMY_BINDS']['writer']}`")
+    logging.debug(f"{worker_id} notify_db app config reader `{current_app.config['SQLALCHEMY_BINDS']['reader']}`")
+    logging.debug(f"{worker_id} notify_db create writer database `{uri_db_writer}`")
+
     create_test_db(uri_db_writer)
 
     BASE_DIR = os.path.dirname(os.path.dirname(__file__))
@@ -109,6 +126,7 @@ def notify_db(notify_api, worker_id):
     config.set_main_option("script_location", ALEMBIC_CONFIG)
 
     with notify_api.app_context():
+        logging.debug(f"{worker_id} notify_db running database migrations")
         upgrade(config, "head")
 
     grant_test_db(uri_db_writer, uri_db_reader)


### PR DESCRIPTION
# Summary
Add pytest logging for the `notify_db` fixture creation.  A `pytest.{worker_id}.log` file will be created for each worker and saved as a GitHub workflow artifact if the tests fail.

# Related
* cds-snc/notification-planning#389.
