### PR TITLE
test: add multiple different fail email types

### DIFF
--- a/tests-perf/locust/locust-notifications-with-fail.py
+++ b/tests-perf/locust/locust-notifications-with-fail.py
@@ -27,9 +27,8 @@ class NotifyApiUser(HttpUser):
         super(NotifyApiUser, self).__init__(*args, **kwargs)
 
         self.headers = {"Authorization": os.getenv("PERF_TEST_AUTH_HEADER")}
-        self.bounce_rate = float(os.getenv("PERF_TEST_BOUNCE_RATE", "0.1"))
+        self.fail_rate = float(os.getenv("PERF_TEST_FAIL_RATE", "0.1"))
         self.email_success = os.getenv("PERF_TEST_EMAIL_SUCCESS", "success@simulator.amazonses.com")
-        self.email_bounce = os.getenv("PERF_TEST_EMAIL_BOUNCE", "bounce@simulator.amazonses.com")
         self.template_group = NotifyApiUserTemplateGroup(
             email_id=os.getenv("PERF_TEST_EMAIL_TEMPLATE_ID"),
             email_with_attachment_id=os.getenv("PERF_TEST_EMAIL_WITH_ATTACHMENT_TEMPLATE_ID"),
@@ -69,7 +68,14 @@ class NotifyApiUser(HttpUser):
         self.client.post("/v2/notifications/email", json=json, headers=self.headers)
 
     def __email_json(self, template_id, personalisation={}):
-        email = self.email_bounce if random.random() <= self.bounce_rate else self.email_success
+        email_invalid = [
+            "complaint@simulator.amazonses.com", 
+            "bounce@simulator.amazonses.com", 
+            "ooto@simulator.amazonses.com", 
+            "blacklist@simulator.amazonses.com"
+        ]
+        email_index = random.randint(0, len(email_invalid) - 1)
+        email = email_invalid[email_index] if random.random() <= self.fail_rate else self.email_success
         return {
             "email_address": email,
             "template_id": template_id,


### PR DESCRIPTION
# Summary
This causes the performance to randomly select 1 of 4 different
email fail types.

# Related
* cds-snc/notification-planning#412