### PR TITLE
Bulk Notification Insert : Add test for duplicate ids

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -17,7 +17,6 @@ from notifications_utils.timezones import (
 )
 from sqlalchemy import asc, desc, func
 from sqlalchemy.dialects.postgresql import insert
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.sql import functions

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -110,7 +110,7 @@ def bulk_insert_notifications(notifications):
     # TODO: Add error handling (Redis queue?) for failed notifications
     try:
         return db.session.bulk_save_objects(notifications)
-    except IntegrityError as e:
+    except IntegrityError:
         raise
 
 

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -108,10 +108,7 @@ def bulk_insert_notifications(notifications):
             notification.status = NOTIFICATION_CREATED
 
     # TODO: Add error handling (Redis queue?) for failed notifications
-    try:
-        return db.session.bulk_save_objects(notifications)
-    except IntegrityError:
-        raise
+    return db.session.bulk_save_objects(notifications)
 
 
 def _decide_permanent_temporary_failure(current_status, status):

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -111,7 +111,6 @@ def bulk_insert_notifications(notifications):
     try:
         return db.session.bulk_save_objects(notifications)
     except IntegrityError as e:
-        current_app.logger.error(e)
         raise
 
 

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -1769,13 +1769,25 @@ def test_send_method_stats_by_service(sample_service, sample_organisation):
     )
 
 
-def test_bulk_insert_notification(sample_template):
-    assert len(Notification.query.all()) == 0
-    n1 = create_notification(sample_template, client_reference="happy")
-    n1.id = None
-    n1.status = None
-    n2 = create_notification(sample_template, client_reference="sad")
-    n3 = create_notification(sample_template, client_reference="loud")
-    bulk_insert_notifications([n1, n2, n3])
-    all_notifications = get_notifications_for_service(sample_template.service_id).items
-    assert len(all_notifications) == 3
+class TestBulkInsertNotifications:
+    def test_bulk_insert_notification(self, sample_template):
+        assert len(Notification.query.all()) == 0
+        n1 = create_notification(sample_template, client_reference="happy")
+        n1.id = None
+        n1.status = None
+        n2 = create_notification(sample_template, client_reference="sad")
+        n3 = create_notification(sample_template, client_reference="loud")
+        bulk_insert_notifications([n1, n2, n3])
+        all_notifications = get_notifications_for_service(sample_template.service_id).items
+        assert len(all_notifications) == 3
+
+    def test_bulk_insert_notification_duplicate_ids(self, sample_template):
+        assert len(Notification.query.all()) == 0
+        n1 = create_notification(sample_template, client_reference="happy")
+        n2 = create_notification(sample_template, client_reference="sad")
+        n3 = create_notification(sample_template, client_reference="loud")
+        n1.id = n2.id
+        n1.status = n2.status
+        with pytest.raises(Exception):
+            bulk_insert_notifications([n1, n2, n3])
+        assert len(get_notifications_for_service(sample_template.service_id).items) == 0


### PR DESCRIPTION
# Summary | Résumé

When we have a list of notifications and we use the bulk save functionality, if there are duplicate IDs, we should throw an error.
The code in this PR adds error handling and a test to handle the above scenario. 