### PR TITLE
fix: limit ALTER ROLE migration to target database

### DIFF
--- a/migrations/versions/0325_set_transaction_timeout.py
+++ b/migrations/versions/0325_set_transaction_timeout.py
@@ -12,11 +12,12 @@ down_revision = "0324_fix_template_redacted"
 
 user = "postgres"
 timeout = 1200  # in seconds, i.e. 20 minutes
+database_name = op.get_bind().engine.url.database  # database name that the migration is being run on
 
 
 def upgrade():
-    op.execute(f"ALTER ROLE {user} SET statement_timeout = '{timeout}s'")
+    op.execute(f"ALTER ROLE {user} IN DATABASE {database_name} SET statement_timeout = '{timeout}s'")
 
 
 def downgrade():
-    op.execute(f"ALTER ROLE {user} RESET statement_timeout")
+    op.execute(f"ALTER ROLE {user} IN DATABASE {database_name} RESET statement_timeout")

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,4 @@
 [pytest]
-log_file = pytest.log
-log_file_level = DEBUG
 testpaths = tests
 env =
     NOTIFY_ENVIRONMENT=test

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import logging
 import os
 from contextlib import contextmanager
 from urllib.parse import urlparse
@@ -13,17 +12,6 @@ from app import create_app, db
 
 
 def pytest_configure(config):
-    # Create a log file for each test process
-    log_file = config.getini("log_file")
-    log_level = config.getini("log_file_level")
-    worker_process = os.environ.get("PYTEST_XDIST_WORKER")
-    if log_file and log_level and worker_process:
-        logging.basicConfig(
-            format="%(asctime)s %(name)s %(levelname)s %(message)s",
-            filename=log_file.replace(".log", f".{worker_process}.log"),
-            level=log_level,
-        )
-
     # Swap to test database if running from devcontainer
     if os.environ.get("SQLALCHEMY_DATABASE_TEST_URI") is not None:
         os.environ["SQLALCHEMY_DATABASE_URI"] = os.environ.get("SQLALCHEMY_DATABASE_TEST_URI")
@@ -114,10 +102,6 @@ def notify_db(notify_api, worker_id):
         "writer": uri_db_writer,
     }
 
-    logging.debug(f"{worker_id} notify_db app config writer `{current_app.config['SQLALCHEMY_BINDS']['writer']}`")
-    logging.debug(f"{worker_id} notify_db app config reader `{current_app.config['SQLALCHEMY_BINDS']['reader']}`")
-    logging.debug(f"{worker_id} notify_db create writer database `{uri_db_writer}`")
-
     create_test_db(uri_db_writer)
 
     BASE_DIR = os.path.dirname(os.path.dirname(__file__))
@@ -126,7 +110,6 @@ def notify_db(notify_api, worker_id):
     config.set_main_option("script_location", ALEMBIC_CONFIG)
 
     with notify_api.app_context():
-        logging.debug(f"{worker_id} notify_db running database migrations")
         upgrade(config, "head")
 
     grant_test_db(uri_db_writer, uri_db_reader)


### PR DESCRIPTION
# Summary
By default an `ALTER ROLE` statement applies to all databases on a server.  This was causing a race condition in the unit tests which run in multiple worker processes, each with their own database on the same PostgreSQL server.

Adding the `IN DATABASE` clause limits the `ALTER ROLE` to only apply to the database the migration is running against and removes the race condition.  More detail has been added in the [related issue comment](https://github.com/cds-snc/notification-planning/issues/389#issuecomment-1046256266).

This fix also removes the pytest logging configuration which had been added to help diagnose the issue.

# Related
* cds-snc/notification-planning#389