### PR TITLE
fix: use default cloudwatch emf service port

### DIFF
--- a/app/aws/metrics.py
+++ b/app/aws/metrics.py
@@ -20,7 +20,7 @@ metrics_config.service_name = "BatchSaving"
 metrics_config.service_type = "Redis"
 metrics_config.log_group_name = "BatchSaving"
 
-if Config.STATSD_ENABLED == False:
+if not Config.STATSD_ENABLED:
     metrics_config.disable_metric_extraction = True
 
 

--- a/app/aws/metrics.py
+++ b/app/aws/metrics.py
@@ -6,7 +6,6 @@ from aws_embedded_metrics import metric_scope  # type: ignore
 from aws_embedded_metrics.config import get_config  # type: ignore
 from botocore.exceptions import ClientError
 from flask import current_app
-from sqlalchemy import false
 
 from app.config import Config
 

--- a/app/aws/metrics.py
+++ b/app/aws/metrics.py
@@ -6,6 +6,7 @@ from aws_embedded_metrics import metric_scope  # type: ignore
 from aws_embedded_metrics.config import get_config  # type: ignore
 from botocore.exceptions import ClientError
 from flask import current_app
+from sqlalchemy import false
 
 from app.config import Config
 
@@ -19,6 +20,9 @@ metrics_config.agent_endpoint = Config.CLOUDWATCH_AGENT_ENDPOINT
 metrics_config.service_name = "BatchSaving"
 metrics_config.service_type = "Redis"
 metrics_config.log_group_name = "BatchSaving"
+
+if Config.STATSD_ENABLED == False:
+    metrics_config.disable_metric_extraction = True
 
 
 @metric_scope

--- a/app/config.py
+++ b/app/config.py
@@ -410,7 +410,7 @@ class Config(object):
 
     FROM_NUMBER = "development"
 
-    STATSD_HOST = os.getenv("STATSD_HOST")
+    STATSD_HOST = os.getenv("STATSD_HOST") # CloudWatch agent, shared with embedded metrics
     STATSD_PORT = 8125
     STATSD_ENABLED = bool(STATSD_HOST)
 
@@ -459,8 +459,9 @@ class Config(object):
     CSV_MAX_ROWS_BULK_SEND = os.getenv("CSV_MAX_ROWS_BULK_SEND", 100_000)
     CSV_BULK_REDIRECT_THRESHOLD = os.getenv("CSV_BULK_REDIRECT_THRESHOLD", 200)
 
-    # Endpoint of Cloudwatch agent running as a side car in EKS
-    CLOUDWATCH_AGENT_ENDPOINT = os.getenv("CLOUDWATCH_AGENT_ENDPOINT", f"udp://{STATSD_HOST}:{STATSD_PORT}")
+    # Endpoint of Cloudwatch agent running as a side car in EKS listening for embedded metrics
+    CLOUDWATCH_AGENT_EMF_PORT = 8135
+    CLOUDWATCH_AGENT_ENDPOINT = os.getenv("CLOUDWATCH_AGENT_ENDPOINT", f"udp://{STATSD_HOST}:{CLOUDWATCH_AGENT_EMF_PORT}")
 
     # feature flag to toggle persistance of notification in celery instead of the API
     FF_NOTIFICATION_CELERY_PERSISTENCE = str_to_bool(os.getenv("FF_NOTIFICATION_CELERY_PERSISTENCE"), False)

--- a/app/config.py
+++ b/app/config.py
@@ -410,7 +410,7 @@ class Config(object):
 
     FROM_NUMBER = "development"
 
-    STATSD_HOST = os.getenv("STATSD_HOST") # CloudWatch agent, shared with embedded metrics
+    STATSD_HOST = os.getenv("STATSD_HOST")  # CloudWatch agent, shared with embedded metrics
     STATSD_PORT = 8125
     STATSD_ENABLED = bool(STATSD_HOST)
 

--- a/app/config.py
+++ b/app/config.py
@@ -460,8 +460,8 @@ class Config(object):
     CSV_BULK_REDIRECT_THRESHOLD = os.getenv("CSV_BULK_REDIRECT_THRESHOLD", 200)
 
     # Endpoint of Cloudwatch agent running as a side car in EKS listening for embedded metrics
-    CLOUDWATCH_AGENT_EMF_PORT = 8135
-    CLOUDWATCH_AGENT_ENDPOINT = os.getenv("CLOUDWATCH_AGENT_ENDPOINT", f"udp://{STATSD_HOST}:{CLOUDWATCH_AGENT_EMF_PORT}")
+    CLOUDWATCH_AGENT_EMF_PORT = 25888
+    CLOUDWATCH_AGENT_ENDPOINT = os.getenv("CLOUDWATCH_AGENT_ENDPOINT", f"tcp://{STATSD_HOST}:{CLOUDWATCH_AGENT_EMF_PORT}")
 
     # feature flag to toggle persistance of notification in celery instead of the API
     FF_NOTIFICATION_CELERY_PERSISTENCE = str_to_bool(os.getenv("FF_NOTIFICATION_CELERY_PERSISTENCE"), False)


### PR DESCRIPTION
Currently the CloudWatch embedded metrics are being incorrectly being processed by the agent due to the logs being sent to the STATSD port. This PR will submit logs to the correct CloudWatch agent service residing on default port `25888`