### PR TITLE
feat: use custom metrics_scope to manage async metrics

### DIFF
--- a/app/aws/metrics.py
+++ b/app/aws/metrics.py
@@ -2,12 +2,13 @@ from __future__ import annotations  # PEP 563 -- Postponed Evaluation of Annotat
 
 from typing import TYPE_CHECKING
 
-from aws_embedded_metrics import metric_scope  # type: ignore
 from aws_embedded_metrics.config import get_config  # type: ignore
 from botocore.exceptions import ClientError
 from flask import current_app
 
 from app.config import Config
+
+from .metrics_scope import metric_scope  # type: ignore
 
 if TYPE_CHECKING:  # A special Python 3 constant that is assumed to be True by 3rd party static type checkers
     from aws_embedded_metrics.logger.metrics_logger import MetricsLogger  # type: ignore

--- a/app/aws/metrics_scope.py
+++ b/app/aws/metrics_scope.py
@@ -49,16 +49,8 @@ def metric_scope(fn):  # type: ignore
             except Exception as e:
                 raise e
             finally:
-                try:
-                    loop = (
-                        asyncio.get_event_loop()
-                    )  # This will fail to create a new event loop if called outside the main thread. https://bugs.python.org/issue39381
-                except RuntimeError as ex:
-                    if "There is no current event loop in thread" in str(ex):
-                        loop = asyncio.new_event_loop()  # https://github.com/awslabs/aws-embedded-metrics-python/issues/14
-                        asyncio.set_event_loop(loop)
-                    else:
-                        raise
+                loop = asyncio.get_event_loop()
+                loop.run_until_complete(logger.flush())
 
                 if not loop.is_running:
                     loop.run_until_complete(logger.flush())

--- a/app/aws/metrics_scope.py
+++ b/app/aws/metrics_scope.py
@@ -1,0 +1,66 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates.
+# Licensed under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import inspect
+from functools import wraps
+
+from aws_embedded_metrics.logger.metrics_logger_factory import (  # type: ignore
+    create_metrics_logger,
+)
+
+
+def metric_scope(fn):  # type: ignore
+
+    if asyncio.iscoroutinefunction(fn):
+
+        @wraps(fn)
+        async def wrapper(*args, **kwargs):  # type: ignore
+            logger = create_metrics_logger()
+            if "metrics" in inspect.signature(fn).parameters:
+                kwargs["metrics"] = logger
+            try:
+                return await fn(*args, **kwargs)
+            except Exception as e:
+                raise e
+            finally:
+                await logger.flush()
+
+        return wrapper
+    else:
+
+        @wraps(fn)
+        def wrapper(*args, **kwargs):  # type: ignore
+            logger = create_metrics_logger()
+            if "metrics" in inspect.signature(fn).parameters:
+                kwargs["metrics"] = logger
+            try:
+                return fn(*args, **kwargs)
+            except Exception as e:
+                raise e
+            finally:
+                try:
+                    loop = (
+                        asyncio.get_event_loop()
+                    )  # This will fail to create a new event loop if called outside the main thread. https://bugs.python.org/issue39381
+                except RuntimeError as ex:
+                    if "There is no current event loop in thread" in str(ex):
+                        loop = asyncio.new_event_loop()  # https://github.com/awslabs/aws-embedded-metrics-python/issues/14
+                        asyncio.set_event_loop(loop)
+                    else:
+                        raise
+
+                if not loop.is_running:
+                    loop.run_until_complete(logger.flush())
+
+        return wrapper

--- a/app/aws/metrics_scope.py
+++ b/app/aws/metrics_scope.py
@@ -49,10 +49,7 @@ def metric_scope(fn):  # type: ignore
             except Exception as e:
                 raise e
             finally:
-                loop = asyncio.get_event_loop()
+                loop = asyncio.new_event_loop()
                 loop.run_until_complete(logger.flush())
-
-                if not loop.is_running:
-                    loop.run_until_complete(logger.flush())
 
         return wrapper

--- a/app/queue.py
+++ b/app/queue.py
@@ -1,3 +1,4 @@
+import asyncio
 import random
 import string
 from abc import ABC, abstractmethod
@@ -103,6 +104,16 @@ class RedisQueue(Queue):
         self._inbox = Buffer.INBOX.inbox_name(suffix)
         self._suffix = suffix
         self._expire_inflight_after_seconds = expire_inflight_after_seconds
+
+        # Create async event loop for CloudWatch metrics
+        try:
+            asyncio.get_event_loop()  # This will fail to create a new event loop if called outside the main thread. https://bugs.python.org/issue39381
+        except RuntimeError as ex:
+            if "There is no current event loop in thread" in str(ex):
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+            else:
+                raise
 
     def init_app(self, redis):
         self._redis_client = redis

--- a/app/queue.py
+++ b/app/queue.py
@@ -105,16 +105,6 @@ class RedisQueue(Queue):
         self._suffix = suffix
         self._expire_inflight_after_seconds = expire_inflight_after_seconds
 
-        # Create async event loop for CloudWatch metrics
-        try:
-            asyncio.get_event_loop()  # This will fail to create a new event loop if called outside the main thread. https://bugs.python.org/issue39381
-        except RuntimeError as ex:
-            if "There is no current event loop in thread" in str(ex):
-                loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(loop)
-            else:
-                raise
-
     def init_app(self, redis):
         self._redis_client = redis
         self.__register_scripts()

--- a/app/queue.py
+++ b/app/queue.py
@@ -1,4 +1,3 @@
-import asyncio
 import random
 import string
 from abc import ABC, abstractmethod

--- a/tests/app/aws/test_metric_scope.py
+++ b/tests/app/aws/test_metric_scope.py
@@ -1,0 +1,186 @@
+import asyncio
+import time
+
+import pytest
+from aws_embedded_metrics.logger.metrics_logger import MetricsLogger  # type: ignore
+
+from app.aws.metrics_scope import metric_scope
+
+flush_invocations = []  # type: ignore
+
+
+@pytest.fixture
+def mock_logger(mocker):
+    InvocationTracker.reset()
+
+    async def flush(self):
+        print("flush called")
+        InvocationTracker.record()
+
+    MetricsLogger.flush = flush
+
+
+@pytest.mark.asyncio
+async def test_async_scope_executes_handler_function(mock_logger):
+    # arrange
+    test_input = {}
+
+    @metric_scope
+    async def my_handler(test_input):
+        await asyncio.sleep(1)
+        test_input["wasExecuted"] = True
+
+    # act
+    await my_handler(test_input)
+
+    # assert
+    assert test_input["wasExecuted"] is True
+
+
+def test_sync_scope_executes_handler_function(mock_logger):
+    # arrange
+    test_input = {}
+
+    @metric_scope
+    def my_handler(test_input):
+        test_input["wasExecuted"] = True
+
+    # act
+    my_handler(test_input)
+
+    # assert
+    assert test_input["wasExecuted"] is True
+
+
+@pytest.mark.asyncio
+async def test_async_scope_forwards_handler_return_value(mock_logger):
+    # arrange
+    expected_result = True
+
+    @metric_scope
+    async def my_handler():
+        await asyncio.sleep(1)
+        return expected_result
+
+    # act
+    actual_result = await my_handler()
+
+    # assert
+    assert expected_result == actual_result
+
+
+def test_sync_scope_forwards_handler_return_value(mock_logger):
+    # arrange
+    expected_result = True
+
+    @metric_scope
+    def my_handler():
+        return expected_result
+
+    # act
+    actual_result = my_handler()
+
+    # assert
+    assert expected_result == actual_result
+
+
+@pytest.mark.asyncio
+async def test_async_scope_passes_configured_metrics_logger(mock_logger):
+    # arrange
+    @metric_scope
+    async def my_handler(metrics):
+        await asyncio.sleep(1)
+        return metrics
+
+    # act
+    actual_result = await my_handler()
+
+    # assert
+    assert isinstance(actual_result, MetricsLogger)
+
+
+def test_sync_scope_passes_configured_metrics_logger(mock_logger):
+    # arrange
+    @metric_scope
+    def my_handler(metrics):
+        return metrics
+
+    # act
+    actual_result = my_handler()
+
+    # assert
+    assert isinstance(actual_result, MetricsLogger)
+
+
+@pytest.mark.asyncio
+async def test_async_scope_handles_exceptions(mock_logger):
+    exceptions_thrown = 0
+
+    # arrange
+    @metric_scope
+    async def my_handler(metrics):
+        await asyncio.sleep(1)
+        raise Exception("Something bad happened")
+
+    # act
+    try:
+        await my_handler()
+    except Exception:
+        exceptions_thrown = 1
+
+    # assert
+    assert exceptions_thrown == 1
+    assert InvocationTracker.invocations == 1
+
+
+def test_sync_scope_handles_exceptions(mock_logger):
+    exceptions_thrown = 0
+
+    # arrange
+    @metric_scope
+    def my_handler(metrics):
+        raise Exception("Something bad happened")
+
+    # act
+    try:
+        my_handler()
+    except Exception:
+        exceptions_thrown = 1
+
+    # assert
+    assert exceptions_thrown == 1
+    assert InvocationTracker.invocations == 1
+
+
+def test_sync_scope_sets_time_based_on_when_wrapped_fcn_is_called(mock_logger):
+    # arrange
+    sleep_duration_sec = 3
+
+    @metric_scope
+    def my_handler(metrics):
+        return metrics
+
+    time.sleep(sleep_duration_sec)
+
+    # act
+    expected_timestamp_second = int(round(time.time()))
+    logger = my_handler()
+
+    # assert
+    actual_timestamp_second = int(round(logger.context.meta["Timestamp"] / 1000))
+    assert expected_timestamp_second == actual_timestamp_second
+
+
+# Test helpers
+
+
+class InvocationTracker(object):
+    invocations = 0
+
+    @staticmethod
+    def record():
+        InvocationTracker.invocations += 1
+
+    @staticmethod
+    def reset():
+        InvocationTracker.invocations = 0


### PR DESCRIPTION
Bringing in the metrics_scope from the aws projects so that we can manage the async aspects of the aws embedded metrics.