### PR TITLE
feat: stop devcontainer on exit

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "dev",
 	"workspaceFolder": "/workspace",
+  "shutdownAction": "stopCompose",
 
 	"settings": { 
 		"[python]": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "dev",
 	"workspaceFolder": "/workspace",
-  "shutdownAction": "stopCompose",
+	"shutdownAction": "stopCompose",
 
 	"settings": { 
 		"[python]": {


### PR DESCRIPTION
The devcontainer is currently using docker compose to create the necessary infrastructure for local development, however the devcontainer persists even after the container is exited.

Configuring a `shutdownAction` will ensure vscode performs a `docker-compose down` when vscode is exited.