### PR TITLE
chore: dont log errors on metrics failures

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -46,8 +46,8 @@ zendesk_client = ZendeskClient()
 statsd_client = StatsdClient()
 flask_redis = FlaskRedis()
 redis_store = RedisClient()
-# TODO: Rework instantiation to decouple redis_store.redis_store and pass it in.\
 metrics_logger = MetricsLogger()
+# TODO: Rework instantiation to decouple redis_store.redis_store and pass it in.\
 email_queue = RedisQueue("email")
 sms_queue = RedisQueue("sms")
 performance_platform_client = PerformancePlatformClient()

--- a/app/aws/metrics.py
+++ b/app/aws/metrics.py
@@ -38,7 +38,7 @@ def put_batch_saving_metric(metrics_logger: MetricsLogger, queue: RedisQueue, co
         metrics_logger.flush()
     except ClientError as e:
         message = "Error sending CloudWatch Metric: {}".format(e)
-        current_app.logger.exception(message)
+        current_app.logger.warning(message)
     return
 
 
@@ -57,7 +57,7 @@ def put_batch_saving_inflight_metric(metrics_logger: MetricsLogger, count: int):
         metrics_logger.flush()
     except ClientError as e:
         message = "Error sending CloudWatch Metric: {}".format(e)
-        current_app.logger.exception(message)
+        current_app.logger.warning(message)
     return
 
 
@@ -76,7 +76,7 @@ def put_batch_saving_inflight_processed(metrics_logger: MetricsLogger, count: in
         metrics_logger.flush()
     except ClientError as e:
         message = "Error sending CloudWatch Metric: {}".format(e)
-        current_app.logger.exception(message)
+        current_app.logger.warning(message)
     return
 
 
@@ -96,5 +96,5 @@ def put_batch_saving_expiry_metric(metrics_logger, count: int):
         metrics_logger.flush()
     except ClientError as e:
         message = "Error sending CloudWatch Metric: {}".format(e)
-        current_app.logger.exception(message)
+        current_app.logger.warning(message)
     return

--- a/tests/app/aws/test_metrics.py
+++ b/tests/app/aws/test_metrics.py
@@ -1,12 +1,31 @@
+import pytest
+from botocore.exceptions import ClientError
+from flask import Flask
+
+from app import create_app
 from app.aws.metrics import (
     put_batch_saving_expiry_metric,
     put_batch_saving_inflight_metric,
     put_batch_saving_inflight_processed,
     put_batch_saving_metric,
 )
+from app.config import Config, Test
 
 
 class TestBatchSavingMetricsFunctions:
+    @pytest.fixture(autouse=True)
+    def app(self):
+        config: Config = Test()
+        config.REDIS_ENABLED = True
+        app = Flask(config.NOTIFY_ENVIRONMENT)
+        create_app(app, config)
+        ctx = app.app_context()
+        ctx.push()
+        with app.test_request_context():
+            yield app
+        ctx.pop()
+        return app
+
     def test_put_batch_metric(self, mocker):
         redis_queue = mocker.MagicMock()
         metrics_logger_mock = mocker.patch("app.aws.metrics_logger")
@@ -45,3 +64,18 @@ class TestBatchSavingMetricsFunctions:
         put_batch_saving_expiry_metric(metrics_logger_mock, 1)
         metrics_logger_mock.put_metric.assert_called_with("batch_saving_inflight", 1, "Count")
         metrics_logger_mock.set_dimensions.assert_called_with({"expired": "True"})
+
+    def test_put_batch_metric_unknown_error(self, app, mocker):
+        redis_queue = mocker.MagicMock()
+        metrics_logger_mock = mocker.patch("app.aws.metrics_logger")
+        mock_logger = mocker.patch("app.aws.metrics.current_app.logger.warning")
+        redis_queue._inbox = "foo"
+
+        metrics_logger_mock.flush.side_effect = ClientError(
+            {"Error": {"Code": "ResourceNotFoundException", "Message": "Not Found"}}, "bar"
+        )
+
+        put_batch_saving_metric(metrics_logger_mock, redis_queue, 1)
+        mock_logger.assert_called_with(
+            "Error sending CloudWatch Metric: An error occurred (ResourceNotFoundException) when calling the bar operation: Not Found"
+        )


### PR DESCRIPTION
Failures related to logging metrics should not generate error logs, instead we'll generate warnings going forward.