### PR TITLE
feat: ability to toggle metrics via env

### DIFF
--- a/app/aws/metrics.py
+++ b/app/aws/metrics.py
@@ -2,7 +2,6 @@ from __future__ import annotations  # PEP 563 -- Postponed Evaluation of Annotat
 
 from typing import TYPE_CHECKING
 
-from aws_embedded_metrics.config import get_config  # type: ignore
 from botocore.exceptions import ClientError
 from flask import current_app
 

--- a/app/aws/metrics.py
+++ b/app/aws/metrics.py
@@ -10,9 +10,6 @@ if TYPE_CHECKING:  # A special Python 3 constant that is assumed to be True by 3
     from app.aws.metrics_logger import MetricsLogger
     from app.queue import RedisQueue
 
-metrics_config = get_config()
-metrics_config.disable_metric_extraction = True
-
 
 def put_batch_saving_metric(metrics_logger: MetricsLogger, queue: RedisQueue, count: int):
     """
@@ -23,7 +20,7 @@ def put_batch_saving_metric(metrics_logger: MetricsLogger, queue: RedisQueue, co
         count (int): default: 1, count of an item added to the INBOX.
         metrics (MetricsLogger): Submit metric to cloudwatch
     """
-    if metrics_config.disable_metric_extraction:
+    if metrics_logger.metrics_config.disable_metric_extraction:
         return
     try:
         metrics_logger.set_namespace("NotificationCanadaCa")
@@ -44,7 +41,7 @@ def put_batch_saving_inflight_metric(metrics_logger: MetricsLogger, count: int):
         count (int): default: 1, count of an inflight list created.
         metrics (MetricsLogger): Submit metric to cloudwatch
     """
-    if metrics_config.disable_metric_extraction:
+    if metrics_logger.metrics_config.disable_metric_extraction:
         return
     try:
         metrics_logger.set_namespace("NotificationCanadaCa")
@@ -65,7 +62,7 @@ def put_batch_saving_inflight_processed(metrics_logger: MetricsLogger, count: in
         count (int): default: 1, count of an inflight list created.
         metrics (MetricsLogger): Submit metric to cloudwatch
     """
-    if metrics_config.disable_metric_extraction:
+    if metrics_logger.metrics_config.disable_metric_extraction:
         return
     try:
         metrics_logger.set_namespace("NotificationCanadaCa")
@@ -87,7 +84,7 @@ def put_batch_saving_expiry_metric(metrics_logger, count: int):
         count (int): Number of inlfight lists sent to inbox
         metrics (MetricsLogger): Submit metric to cloudwatch
     """
-    if metrics_config.disable_metric_extraction:
+    if metrics_logger.metrics_config.disable_metric_extraction:
         return
     try:
         metrics_logger.set_namespace("NotificationCanadaCa")

--- a/app/aws/metrics_logger.py
+++ b/app/aws/metrics_logger.py
@@ -18,18 +18,19 @@ from app.config import Config
 class MetricsLogger(_MetricsLogger):
     def __init__(self):
         super().__init__(None, None)
-        metrics_config = get_config()
-        metrics_config.agent_endpoint = Config.CLOUDWATCH_AGENT_ENDPOINT
-        metrics_config.service_name = "BatchSaving"
-        metrics_config.service_type = "Redis"
-        metrics_config.log_group_name = "BatchSaving"
+        self.metrics_config = get_config()
+        self.metrics_config.agent_endpoint = Config.CLOUDWATCH_AGENT_ENDPOINT
+        self.metrics_config.service_name = "BatchSaving"
+        self.metrics_config.service_type = "Redis"
+        self.metrics_config.log_group_name = "BatchSaving"
 
-        metrics_config.disable_metric_extraction = True
+        if not Config.FF_CLOUDWATCH_METRICS_ENABLED:
+            self.metrics_config.disable_metric_extraction = True
 
         if "AWS_EXECUTION_ENV" in environ:
-            metrics_config.environment = "lambda"
+            self.metrics_config.environment = "lambda"
 
-        lower_configured_enviroment = metrics_config.environment.lower()
+        lower_configured_enviroment = self.metrics_config.environment.lower()
         if lower_configured_enviroment == "local":
             self.environment = LocalEnvironment()
         elif lower_configured_enviroment == "lambda":

--- a/app/config.py
+++ b/app/config.py
@@ -460,6 +460,7 @@ class Config(object):
     CSV_BULK_REDIRECT_THRESHOLD = os.getenv("CSV_BULK_REDIRECT_THRESHOLD", 200)
 
     # Endpoint of Cloudwatch agent running as a side car in EKS listening for embedded metrics
+    FF_CLOUDWATCH_METRICS_ENABLED = str_to_bool(os.getenv("FF_CLOUDWATCH_METRICS_ENABLED"), False)
     CLOUDWATCH_AGENT_EMF_PORT = 25888
     CLOUDWATCH_AGENT_ENDPOINT = os.getenv("CLOUDWATCH_AGENT_ENDPOINT", f"tcp://{STATSD_HOST}:{CLOUDWATCH_AGENT_EMF_PORT}")
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -22,6 +22,7 @@ env =
     ASSET_DOMAIN=assets.notification.canada.ca
     NOTIFY_EMAIL_DOMAIN=notification.canada.ca
     AWS_EMF_ENVIRONMENT=local
+    D:FF_CLOUDWATCH_METRICS_ENABLED=True
     D:REDIS_URL=redis://localhost:6380
     D:DOCUMENTATION_DOMAIN=documentation.notification.canada.ca
     D:SQLALCHEMY_DATABASE_URI=postgresql://postgres:postgres@localhost:5432/test_notification_api

--- a/tests/app/aws/test_metric_logger.py
+++ b/tests/app/aws/test_metric_logger.py
@@ -1,5 +1,6 @@
 from os import environ
 from unittest.mock import patch
+from uuid import uuid4
 
 from aws_embedded_metrics.config import get_config  # type: ignore
 from aws_embedded_metrics.environment.ec2_environment import (  # type: ignore
@@ -34,7 +35,8 @@ class TestMetricsLogger:
         metrics_config = get_config()
         metrics_config.environment = "local"
         metrics_logger = MetricsLogger()
-        metrics_logger.put_metric("foo_bar_baz", 1, "Count")
+        metric_name = f"foo_bar_baz_{str(uuid4())}"
+        metrics_logger.put_metric(metric_name, 1, "Count")
         metrics_logger.flush()
         captured = capsys.readouterr()
-        assert '{"foo_bar_baz": 1}' in captured.out
+        assert metric_name in str(captured.out)

--- a/tests/app/aws/test_metrics.py
+++ b/tests/app/aws/test_metrics.py
@@ -1,0 +1,88 @@
+import pytest
+from botocore.exceptions import ClientError
+from flask import Flask
+
+from app import create_app
+from app.aws.metrics import (
+    put_batch_saving_expiry_metric,
+    put_batch_saving_inflight_metric,
+    put_batch_saving_inflight_processed,
+    put_batch_saving_metric,
+)
+from app.config import Config, Test
+
+
+class TestBatchSavingMetricsFunctions:
+    @pytest.fixture(autouse=True)
+    def app(self):
+        config: Config = Test()
+        config.REDIS_ENABLED = True
+        app = Flask(config.NOTIFY_ENVIRONMENT)
+        create_app(app, config)
+        ctx = app.app_context()
+        ctx.push()
+        with app.test_request_context():
+            yield app
+        ctx.pop()
+        return app
+
+    @pytest.fixture(autouse=True)
+    def metrics_logger_mock(self, mocker):
+        metrics_logger_mock = mocker.patch("app.aws.metrics_logger")
+        metrics_logger_mock.metrics_config.disable_metric_extraction = False
+        return metrics_logger_mock
+
+    def test_put_batch_metric(self, mocker, metrics_logger_mock):
+        redis_queue = mocker.MagicMock()
+        redis_queue._inbox = "foo"
+        put_batch_saving_metric(metrics_logger_mock, redis_queue, 1)
+        metrics_logger_mock.set_dimensions.assert_called_with({"list_name": "foo"})
+        metrics_logger_mock.put_metric.assert_called_with("batch_saving_published", 1, "Count")
+        assert metrics_logger_mock.set_dimensions.called, "set_dimensions was not called and should have been"
+
+    def test_put_batch_metric_disabled(self, mocker, metrics_logger_mock):
+        redis_queue = mocker.MagicMock()
+        redis_queue._inbox = "foo"
+        metrics_logger_mock.metrics_config.disable_metric_extraction = True
+        put_batch_saving_metric(metrics_logger_mock, redis_queue, 1)
+        assert not metrics_logger_mock.set_dimensions.called, "set_dimensions was called and should not have been"
+        assert not metrics_logger_mock.put_metric.called, "put_metric was called and should not have been"
+
+    def test_put_batch_metric_multiple_items(self, mocker, metrics_logger_mock):
+        redis_queue = mocker.MagicMock()
+        redis_queue._inbox = "foo"
+
+        put_batch_saving_metric(metrics_logger_mock, redis_queue, 20)
+        metrics_logger_mock.set_dimensions.assert_called_with({"list_name": "foo"})
+        metrics_logger_mock.put_metric.assert_called_with("batch_saving_published", 20, "Count")
+
+    def test_put_batch_saving_in_flight_metric(self, metrics_logger_mock):
+
+        put_batch_saving_inflight_metric(metrics_logger_mock, 1)
+        metrics_logger_mock.set_dimensions.assert_called_with({"created": "True"})
+        metrics_logger_mock.put_metric.assert_called_with("batch_saving_inflight", 1, "Count")
+
+    def test_put_batch_saving_inflight_processed(self, metrics_logger_mock):
+
+        put_batch_saving_inflight_processed(metrics_logger_mock, 1)
+        metrics_logger_mock.set_dimensions.assert_called_with({"acknowledged": "True"})
+        metrics_logger_mock.put_metric.assert_called_with("batch_saving_inflight", 1, "Count")
+
+    def test_put_batch_saving_expiry_metric(self, metrics_logger_mock):
+        put_batch_saving_expiry_metric(metrics_logger_mock, 1)
+        metrics_logger_mock.put_metric.assert_called_with("batch_saving_inflight", 1, "Count")
+        metrics_logger_mock.set_dimensions.assert_called_with({"expired": "True"})
+
+    def test_put_batch_metric_unknown_error(self, mocker, metrics_logger_mock):
+        redis_queue = mocker.MagicMock()
+        mock_logger = mocker.patch("app.aws.metrics.current_app.logger.warning")
+        redis_queue._inbox = "foo"
+
+        metrics_logger_mock.flush.side_effect = ClientError(
+            {"Error": {"Code": "ResourceNotFoundException", "Message": "Not Found"}}, "bar"
+        )
+
+        put_batch_saving_metric(metrics_logger_mock, redis_queue, 1)
+        mock_logger.assert_called_with(
+            "Error sending CloudWatch Metric: An error occurred (ResourceNotFoundException) when calling the bar operation: Not Found"
+        )


### PR DESCRIPTION
CloudWatch metrics will not be managed via environment variable. Default to `disabled` if the environment variable is not present.