### PR TITLE
feat: check if redis poll returned results

### DIFF
--- a/app/queue.py
+++ b/app/queue.py
@@ -113,7 +113,8 @@ class RedisQueue(Queue):
         receipt = uuid4()
         in_flight_key = Buffer.IN_FLIGHT.inflight_name(receipt, self._suffix)
         results = self.__move_to_inflight(in_flight_key, count)
-        put_batch_saving_inflight_metric(self.__metrics_logger, 1)
+        if results:
+            put_batch_saving_inflight_metric(self.__metrics_logger, 1)
         return (receipt, results)
 
     def expire_inflights(self):

--- a/tests/app/test_queue.py
+++ b/tests/app/test_queue.py
@@ -327,6 +327,16 @@ class TestRedisQueueMetricUsage:
             assert pbsim_mock.assert_called_with(mock.ANY, 1) is None
 
     @pytest.mark.serial
+    def test_polling_metric_no_results(self, redis, redis_queue, mocker):
+        with self.given_inbox_with_one_element(redis, redis_queue):
+            pbsim_mock = mocker.patch("app.queue.put_batch_saving_inflight_metric")
+            redis_queue.poll(10)
+            assert pbsim_mock.assert_called_with(mock.ANY, 1) is None
+            pbsim_mock.reset_mock()
+            redis_queue.poll(10)
+            assert not pbsim_mock.called, "put_batch_saving_inflight_metric was called and should not have been"
+
+    @pytest.mark.serial
     def test_acknowledged_metric(self, redis, redis_queue, mocker):
         with self.given_inbox_with_one_element(redis, redis_queue):
             pbsip_mock = mocker.patch("app.queue.put_batch_saving_inflight_processed")


### PR DESCRIPTION
Currently metrics are being generated without checking if the redis queue poll returned results. This is resulting in metrics being inaccurate. This PR introduces an evaluation of whether the queue returned data before logging a metric.

**note:** `test_should_send_personalised_template_with_html_enabled` test will fail since validator.w3.org is currently offline and is required by the library that validates html templates.