### PR TITLE
feat: migrate to requests endpoint for zendesk

### DIFF
--- a/app/clients/zendesk.py
+++ b/app/clients/zendesk.py
@@ -1,5 +1,3 @@
-from __future__ import annotations  # PEP 563 -- Postponed Evaluation of Annotations
-
 from typing import Any, Dict, List, Union
 from urllib.parse import urljoin
 

--- a/app/clients/zendesk.py
+++ b/app/clients/zendesk.py
@@ -1,4 +1,6 @@
-from typing import Dict, List, Union
+from __future__ import annotations  # PEP 563 -- Postponed Evaluation of Annotations
+
+from typing import Any, Dict, List, Union
 from urllib.parse import urljoin
 
 import requests
@@ -54,7 +56,7 @@ class Zendesk(object):
 
     # Update for Zendesk API Request format
     # read docs: https://developer.zendesk.com/api-reference/ticketing/tickets/ticket-requests/#create-request
-    def _generate_ticket(self) -> Dict[str, Dict[str, Union[str, int, List[str]]]]:
+    def _generate_ticket(self) -> Union[Dict[str, Any], List[Any]]:
         return {
             "request": {
                 "subject": self.contact.friendly_support_type,

--- a/app/clients/zendesk.py
+++ b/app/clients/zendesk.py
@@ -52,14 +52,14 @@ class Zendesk(object):
 
         return message
 
-    # Update for Zendesk API Ticket format
-    # read docs: https://developer.zendesk.com/rest_api/docs/core/tickets#create-ticket
+    # Update for Zendesk API Request format
+    # read docs: https://developer.zendesk.com/api-reference/ticketing/tickets/ticket-requests/#create-request
     def _generate_ticket(self) -> Dict[str, Dict[str, Union[str, int, List[str]]]]:
         return {
-            "ticket": {
+            "request": {
                 "subject": self.contact.friendly_support_type,
-                "description": self._generate_description(),
-                "email": self.contact.email_address,
+                "comment": {"body": self._generate_description()},
+                "requester": {"name": self.contact.name, "email": self.contact.email_address},
                 "tags": self.contact.tags
                 + ["notification_api"],  # Custom tag used to auto-assign ticket to the notification support group
             }
@@ -70,9 +70,9 @@ class Zendesk(object):
             raise NotImplementedError
 
         # The API and field definitions are defined here:
-        # https://developer.zendesk.com/rest_api/docs/support/tickets
+        # https://developer.zendesk.com/rest_api/docs/support/requests
         response = requests.post(
-            urljoin(self.api_url, "/api/v2/tickets"),
+            urljoin(self.api_url, "/api/v2/requests"),
             json=self._generate_ticket(),
             auth=HTTPBasicAuth(f"{self.contact.email_address}/token", self.token),
             timeout=5,

--- a/tests/app/clients/test_zendesk.py
+++ b/tests/app/clients/test_zendesk.py
@@ -1,4 +1,3 @@
-import base64
 from typing import Any, Dict
 
 import pytest

--- a/tests/app/clients/test_zendesk.py
+++ b/tests/app/clients/test_zendesk.py
@@ -13,31 +13,30 @@ from app.user.contact_request import ContactRequest
 def test_send_ticket_go_live_request(notify_api: Flask):
     def match_json(request):
         expected = {
-            "ticket": {
+            "request": {
                 "subject": "Support Request",
-                "description": "t6 just requested to go live.<br><br>"
-                "- Department/org: department_org_name<br>"
-                "- Intended recipients: internal, external, public<br>"
-                "- Purpose: main_use_case<br>"
-                "- Notification types: email, sms<br>"
-                "- Expected monthly volume: 100k+<br>"
-                "---<br>"
-                "http://localhost:6012/services/8624bd36-b70b-4d4b-a459-13e1f4770b92",
-                "email": "test@email.com",
+                "comment": {
+                    "body": "t6 just requested to go live.<br><br>"
+                    "- Department/org: department_org_name<br>"
+                    "- Intended recipients: internal, external, public<br>"
+                    "- Purpose: main_use_case<br>"
+                    "- Notification types: email, sms<br>"
+                    "- Expected monthly volume: 100k+<br>"
+                    "---<br>"
+                    "http://localhost:6012/services/8624bd36-b70b-4d4b-a459-13e1f4770b92"
+                },
+                "requester": {"name": "name", "email": "test@email.com"},
                 "tags": ["notification_api"],
             }
         }
-
-        encoded_auth = base64.b64encode(b"test@email.com/token:zendesk-api-key").decode("ascii")
         json_matches = request.json() == expected
-        basic_auth_header = request.headers.get("Authorization") == f"Basic {encoded_auth}"
 
-        return json_matches and basic_auth_header
+        return json_matches
 
     with requests_mock.mock() as rmock:
         rmock.request(
             "POST",
-            "https://zendesk-test.com/api/v2/tickets",
+            "https://zendesk-test.com/api/v2/requests",
             additional_matcher=match_json,
             status_code=201,
         )
@@ -62,32 +61,32 @@ def test_send_ticket_go_live_request(notify_api: Flask):
 def test_send_ticket_branding_request(notify_api: Flask):
     def match_json(request):
         expected = {
-            "ticket": {
+            "request": {
                 "subject": "Branding request",
-                "description": "A new logo has been uploaded by name (test@email.com) for the following service:<br>"
-                "- Service id: 8624bd36-b70b-4d4b-a459-13e1f4770b92<br>"
-                "- Service name: t6<br>"
-                "- Logo filename: branding_url<br>"
-                "<hr><br>"
-                "Un nouveau logo a été téléchargé par name (test@email.com) pour le service suivant :<br>"
-                "- Identifiant du service : 8624bd36-b70b-4d4b-a459-13e1f4770b92<br>"
-                "- Nom du service : t6<br>"
-                "- Nom du fichier du logo : branding_url",
-                "email": "test@email.com",
+                "comment": {
+                    "body": "A new logo has been uploaded by name (test@email.com) for the following service:<br>"
+                    "- Service id: 8624bd36-b70b-4d4b-a459-13e1f4770b92<br>"
+                    "- Service name: t6<br>"
+                    "- Logo filename: branding_url<br>"
+                    "<hr><br>"
+                    "Un nouveau logo a été téléchargé par name (test@email.com) pour le service suivant :<br>"
+                    "- Identifiant du service : 8624bd36-b70b-4d4b-a459-13e1f4770b92<br>"
+                    "- Nom du service : t6<br>"
+                    "- Nom du fichier du logo : branding_url"
+                },
+                "requester": {"name": "name", "email": "test@email.com"},
                 "tags": ["notification_api"],
             }
         }
 
-        encoded_auth = base64.b64encode(b"test@email.com/token:zendesk-api-key").decode("ascii")
         json_matches = request.json() == expected
-        basic_auth_header = request.headers.get("Authorization") == f"Basic {encoded_auth}"
 
-        return json_matches and basic_auth_header
+        return json_matches
 
     with requests_mock.mock() as rmock:
         rmock.request(
             "POST",
-            "https://zendesk-test.com/api/v2/tickets",
+            "https://zendesk-test.com/api/v2/requests",
             additional_matcher=match_json,
             status_code=201,
         )
@@ -107,19 +106,22 @@ def test_send_ticket_branding_request(notify_api: Flask):
 def test_send_ticket_other(notify_api: Flask):
     def match_json(request):
         expected = {
-            "ticket": {"subject": "Support Request", "description": "", "email": "test@email.com", "tags": ["notification_api"]}
+            "request": {
+                "subject": "Support Request",
+                "comment": {"body": ""},
+                "requester": {"name": "User/Utilisateur", "email": "test@email.com"},
+                "tags": ["notification_api"],
+            }
         }
 
-        encoded_auth = base64.b64encode(b"test@email.com/token:zendesk-api-key").decode("ascii")
         json_matches = request.json() == expected
-        basic_auth_header = request.headers.get("Authorization") == f"Basic {encoded_auth}"
 
-        return json_matches and basic_auth_header
+        return json_matches
 
     with requests_mock.mock() as rmock:
         rmock.request(
             "POST",
-            "https://zendesk-test.com/api/v2/tickets",
+            "https://zendesk-test.com/api/v2/requests",
             additional_matcher=match_json,
             status_code=201,
         )
@@ -131,24 +133,22 @@ def test_send_ticket_other(notify_api: Flask):
 def test_send_ticket_user_profile(notify_api: Flask):
     def match_json(request):
         expected = {
-            "ticket": {
+            "request": {
                 "subject": "Support Request",
-                "description": "<br><br>---<br><br> user_profile",
-                "email": "test@email.com",
+                "comment": {"body": "<br><br>---<br><br> user_profile"},
+                "requester": {"name": "User/Utilisateur", "email": "test@email.com"},
                 "tags": ["notification_api"],
             }
         }
 
-        encoded_auth = base64.b64encode(b"test@email.com/token:zendesk-api-key").decode("ascii")
         json_matches = request.json() == expected
-        basic_auth_header = request.headers.get("Authorization") == f"Basic {encoded_auth}"
 
-        return json_matches and basic_auth_header
+        return json_matches
 
     with requests_mock.mock() as rmock:
         rmock.request(
             "POST",
-            "https://zendesk-test.com/api/v2/tickets",
+            "https://zendesk-test.com/api/v2/requests",
             additional_matcher=match_json,
             status_code=201,
         )
@@ -165,19 +165,21 @@ def test_send_ticket_user_profile(notify_api: Flask):
 def test_send_ticket_unknown_error(notify_api: Flask):
     def match_json(request):
         expected = {
-            "ticket": {"subject": "Support Request", "description": "", "email": "test@email.com", "tags": ["notification_api"]}
+            "request": {
+                "subject": "Support Request",
+                "comment": {"body": ""},
+                "requester": {"name": "User/Utilisateur", "email": "test@email.com"},
+                "tags": ["notification_api"],
+            }
         }
 
-        encoded_auth = base64.b64encode(b"test@email.com/token:zendesk-api-key").decode("ascii")
         json_matches = request.json() == expected
-        basic_auth_header = request.headers.get("Authorization") == f"Basic {encoded_auth}"
-
-        return json_matches and basic_auth_header
+        return json_matches
 
     with requests_mock.mock() as rmock:
         rmock.request(
             "POST",
-            "https://zendesk-test.com/api/v2/tickets",
+            "https://zendesk-test.com/api/v2/requests",
             additional_matcher=match_json,
             status_code=403,
         )


### PR DESCRIPTION
The zendesk client was originally developed to interact with the zendesk `ticket` api. Unfortunately that endpoint is only available for authenticated users. This went undetected during development since all test emails originated from users with zendesk accounts.

Migrating to use the `requests` api allows for tickets to be associated with users without zendesk accounts.