### PR TITLE
Less noise around errors that are recovered from

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -666,9 +666,9 @@ def handle_batch_error_and_forward(
     signed_and_verified: list[tuple[Any, Any]], notification_type: str, exception, receipt: UUID = None
 ):
     if receipt:
-        current_app.logger.exception(f"Batch saving: could not persist notifications with receipt {receipt}", exception)
+        current_app.logger.warning(f"Batch saving: could not persist notifications with receipt {receipt}: {str(exception)}")
     else:
-        current_app.logger.exception("Batch saving: could not persist notifications.", exception)
+        current_app.logger.warning(f"Batch saving: could not persist notifications: {str(exception)}")
 
     for (signed, notification) in signed_and_verified:
         notification_id = notification["notification_id"]


### PR DESCRIPTION
# Summary | Résumé

Do not log a handled exception as an exception as this will trigger the celery workers to report and page support. Notifications that hit integrity errors on the batch code path will be redirected to the individual saving code path (if not already existing in the database). If these fail again, that will get reported. 

# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their
review | Voici une suggestion de liste de vérification comprenant des questions
que les réviseurs pourraient poser pendant leur examen :


- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne
      une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une
      fonctionnalité existante?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une
      modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des
      préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de
      façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de
      risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README
      setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce
      changement (fichier README, etc.)?
