### PR TITLE
feat: add config logging during app initialize

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,10 @@
 	"workspaceFolder": "/workspace",
 	"shutdownAction": "stopCompose",
 
+	"remoteEnv": {
+		"PATH": "/home/vscode/.local/bin:${containerEnv:PATH}" // give our installed Python modules precedence
+	},
+
 	"settings": {
 		"[python]": {
 			"editor.formatOnSave": true

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -94,6 +94,10 @@ def create_app(application, config=None):
     register_blueprint(application)
     register_v2_blueprints(application)
 
+    # Log the application configuration
+    config_values = config.get_config(config.get_sensitive_config())
+    application.logger.info(f"Notify config: {config_values}")
+
     # avoid circular imports by importing this file later
     from app.commands import setup_commands
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -95,8 +95,7 @@ def create_app(application, config=None):
     register_v2_blueprints(application)
 
     # Log the application configuration
-    config_values = config.get_safe_config()
-    application.logger.info(f"Notify config: {config_values}")
+    application.logger.info(f"Notify config: {config.get_safe_config()}")
 
     # avoid circular imports by importing this file later
     from app.commands import setup_commands

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -95,7 +95,7 @@ def create_app(application, config=None):
     register_v2_blueprints(application)
 
     # Log the application configuration
-    config_values = config.get_config(config.get_sensitive_config())
+    config_values = config.get_safe_config()
     application.logger.info(f"Notify config: {config_values}")
 
     # avoid circular imports by importing this file later

--- a/app/config.py
+++ b/app/config.py
@@ -503,6 +503,11 @@ class Config(object):
                 config[attr] = attr_value
         return config
 
+    @classmethod
+    def get_safe_config(cls) -> dict[str, Any]:
+        "Returns a dict of config keys and values with sensitive values masked"
+        return cls.get_config(cls.get_sensitive_config())
+
 
 ######################
 # Config overrides ###

--- a/app/config.py
+++ b/app/config.py
@@ -469,6 +469,40 @@ class Config(object):
     FF_BATCH_INSERTION = str_to_bool(os.getenv("FF_BATCH_INSERTION"), False)
     FF_REDIS_BATCH_SAVING = str_to_bool(os.getenv("FF_REDIS_BATCH_SAVING"), False)
 
+    @classmethod
+    def get_sensitive_config(cls) -> list[str]:
+        "List of config keys that contain sensitive information"
+        return [
+            "ADMIN_CLIENT_SECRET",
+            "SECRET_KEY",
+            "DANGEROUS_SALT",
+            "SQLALCHEMY_DATABASE_URI",
+            "SQLALCHEMY_DATABASE_READER_URI",
+            "SQLALCHEMY_BINDS",
+            "REDIS_URL",
+            "ZENDESK_API_KEY",
+            "ZENDESK_SELL_API_KEY",
+            "FRESH_DESK_API_KEY",
+            "MLWR_USER",
+            "MLWR_KEY",
+            "AWS_SES_ACCESS_KEY",
+            "AWS_SES_SECRET_KEY",
+            "ROUTE_SECRET_KEY_1",
+            "ROUTE_SECRET_KEY_2",
+            "TEMPLATE_PREVIEW_API_KEY",
+            "DOCUMENT_DOWNLOAD_API_KEY",
+        ]
+
+    @classmethod
+    def get_config(cls, sensitive_config: list[str]) -> dict[str, Any]:
+        "Returns a dict of config keys and values"
+        config = {}
+        for attr in dir(cls):
+            attr_value = "***" if attr in sensitive_config else getattr(cls, attr)
+            if not attr.startswith("__") and not callable(attr_value):
+                config[attr] = attr_value
+        return config
+
 
 ######################
 # Config overrides ###

--- a/tests/app/test_config.py
+++ b/tests/app/test_config.py
@@ -132,6 +132,15 @@ def test_get_config(reload_config):
         assert not callable(getattr(config.Config, key))
 
 
+def test_get_safe_config(mocker, reload_config):
+    mock_get_config = mocker.patch("app.config.Config.get_config")
+    mock_get_sensitive_config = mocker.patch("app.config.Config.get_sensitive_config")
+
+    config.Config.get_safe_config()
+    assert mock_get_config.called
+    assert mock_get_sensitive_config.called
+
+
 def get_sensitive_config():
     sensitive_config = config.Config.get_sensitive_config()
     assert sensitive_config

--- a/tests/app/test_config.py
+++ b/tests/app/test_config.py
@@ -122,11 +122,11 @@ def test_get_config():
     logged_config = config.Config.get_config([])
     assert logged_config["ADMIN_BASE_URL"] == "http://foo.bar"
     assert logged_config["AWS_REGION"] == "dark-side-of-the-moon"
-    
+
     config.Config.AWS_SES_SECRET_KEY = "1234"
     logged_config = config.Config.get_config(["AWS_SES_SECRET_KEY"])
     assert logged_config["AWS_SES_SECRET_KEY"] == "***"
-    
+
     for key, _ in logged_config.items():
         assert not key.startswith("__")
         assert not callable(getattr(config.Config, key))

--- a/tests/app/test_config.py
+++ b/tests/app/test_config.py
@@ -114,3 +114,26 @@ def test_when_env_value_default_is_used(reload_config):
     assert str_to_bool("mmmm cheese", True) is True
     assert str_to_bool(None, True) is True
     assert str_to_bool(None, False) is False
+
+
+def test_get_config():
+    config.Config.ADMIN_BASE_URL = "http://foo.bar"
+    config.Config.AWS_REGION = "dark-side-of-the-moon"
+    logged_config = config.Config.get_config([])
+    assert logged_config["ADMIN_BASE_URL"] == "http://foo.bar"
+    assert logged_config["AWS_REGION"] == "dark-side-of-the-moon"
+    
+    config.Config.AWS_SES_SECRET_KEY = "1234"
+    logged_config = config.Config.get_config(["AWS_SES_SECRET_KEY"])
+    assert logged_config["AWS_SES_SECRET_KEY"] == "***"
+    
+    for key, _ in logged_config.items():
+        assert not key.startswith("__")
+        assert not callable(getattr(config.Config, key))
+
+
+def get_sensitive_config():
+    sensitive_config = config.Config.get_sensitive_config()
+    assert sensitive_config
+    for key in sensitive_config:
+        assert key

--- a/tests/app/test_config.py
+++ b/tests/app/test_config.py
@@ -116,7 +116,7 @@ def test_when_env_value_default_is_used(reload_config):
     assert str_to_bool(None, False) is False
 
 
-def test_get_config():
+def test_get_config(reload_config):
     config.Config.ADMIN_BASE_URL = "http://foo.bar"
     config.Config.AWS_REGION = "dark-side-of-the-moon"
     logged_config = config.Config.get_config([])


### PR DESCRIPTION
# Summary
This config logging can be used to troubleshoot app init problems and confirm
that future changes to how environment variables are set work as expected.

As part of this change, a list of sensitive config keys has also been
defined to avoid leaking secrets in the app logs.

# Related
* cds-snc/notification-planning#421