### PR TITLE
feat: add `make run` to start app locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,3 +56,7 @@ format:
 .PHONY: smoke-test
 smoke-test:
 	cd tests_smoke && python smoke_test.py
+
+.PHONY: run
+run:
+	flask run -p 6011 --host=0.0.0.0

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ file. Copy that file to `.env` and customize it to your needs.
 
 15. Run the service
 
-`flask run -p 6011 --host=0.0.0.0`
+`make run`
 
 15a. To test
 
@@ -111,7 +111,7 @@ file. Copy that file to `.env` and customize it to your needs.
 
 5. Run the service
 
-`flask run -p 6011 --host=0.0.0.0`
+`make run`
 
 
 ##  To run the queues 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - SQLALCHEMY_DATABASE_URI=postgres://postgres:chummy@db:5432/notification_api
     entrypoint: local/scripts/notify-web-entrypoint.sh
     command: >
-      bash -c "make generate-version-file && flask run -p 6011 --host=0.0.0.0"
+      bash -c "make generate-version-file && make run"
     volumes:
       - .:/app
     ports:

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-flask run -p 6011 --host=0.0.0.0
+make run


### PR DESCRIPTION
# Summary 
Add a Makefile `run` target to start the app locally.  This change was driven by me getting tried of copy/pasting the command out of the README.