### PR TITLE
Clean up feature flags

### DIFF
--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -50,8 +50,6 @@ from app.models import (
 )
 from app.notifications.process_letter_notifications import create_letter_notification
 from app.notifications.process_notifications import (
-    choose_queue,
-    db_save_and_send_notification,
     persist_notification,
     persist_scheduled_notification,
     simulated_recipient,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -8,12 +8,12 @@ from app.dao.services_dao import dao_fetch_service_by_id
 from app.models import KEY_TYPE_NORMAL, ApiKey
 
 
-def create_authorization_header(service_id=None, key_type=KEY_TYPE_NORMAL):
+def create_authorization_header(service_id=None, key_type=KEY_TYPE_NORMAL, api_key_required=False):
     if service_id:
         client_id = str(service_id)
-        secrets = ApiKey.query.filter_by(service_id=service_id, key_type=key_type).all()
-        if secrets:
-            secret = secrets[0].secret
+        api_keys = ApiKey.query.filter_by(service_id=service_id, key_type=key_type).all()
+        if api_keys:
+            api_key = api_keys[0]
         else:
             service = dao_fetch_service_by_id(service_id)
             data = {
@@ -24,14 +24,17 @@ def create_authorization_header(service_id=None, key_type=KEY_TYPE_NORMAL):
             }
             api_key = ApiKey(**data)
             save_model_api_key(api_key)
-            secret = api_key.secret
-
+        secret = api_key.secret
     else:
         client_id = current_app.config["ADMIN_CLIENT_USER_NAME"]
         secret = current_app.config["ADMIN_CLIENT_SECRET"]
 
     token = create_jwt_token(secret=secret, client_id=client_id)
-    return "Authorization", "Bearer {}".format(token)
+
+    if service_id and api_key_required:
+        return (("Authorization", "Bearer {}".format(token)), api_key)
+    else:
+        return "Authorization", "Bearer {}".format(token)
 
 
 def unwrap_function(fn):

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -991,7 +991,6 @@ def test_post_email_notification_with_valid_reply_to_id_returns_201(notify_api, 
     mocked_publish = mocker.patch("app.queue.RedisQueue.publish")
 
     reply_to_email = create_reply_to_email(sample_email_template.service, "test@test.com")
-    mocked = mocker.patch("app.celery.provider_tasks.deliver_email.apply_async")
     data = {
         "email_address": sample_email_template.service.users[0].email_address,
         "template_id": sample_email_template.id,


### PR DESCRIPTION
# Summary | Résumé

change the POST `/email` and `/sms` code to remove the long deprecated "persist in api" code path. Instead, if `FF_REDIS_BATCH_SAVING` is false, do the celery persistence path.

Many of our tests only just testing this deprecated path instead of the redis or celery persistence path. I've changed those tests as appropriate. Some tests no longer apply (for example, if the point of the test is only to evaluate the state of the database after the POST). Those tests have been skipped for now. Either in this PR or a subsequent one we should see if these should be moved down the stack into celery tests (if they're not already there).

# Test instructions | Instructions pour tester la modification

Post to `/v2/notifications/email` and `/v2/notifications/sms`

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their
review | Voici une suggestion de liste de vérification comprenant des questions
que les réviseurs pourraient poser pendant leur examen :


- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne
      une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une
      fonctionnalité existante?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une
      modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des
      préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de
      façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de
      risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README
      setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce
      changement (fichier README, etc.)?
