### PR TITLE
feat: new relic lambda wrapper

### DIFF
--- a/.github/workflows/lambda_production.yml
+++ b/.github/workflows/lambda_production.yml
@@ -30,7 +30,6 @@ jobs:
           aws-region: ca-central-1
           
       - name: Retrieve New Relic Lambda layer
-        working-directory: ./ci
         run: |
           aws lambda get-layer-version-by-arn \
           --region ca-central-1 \

--- a/.github/workflows/lambda_production.yml
+++ b/.github/workflows/lambda_production.yml
@@ -21,14 +21,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Build container
-        run: |
-          docker build \
-          --build-arg GIT_SHA=${GITHUB_SHA::7} \
-          -t $REGISTRY/${{ matrix.image }}:${GITHUB_SHA::7} \
-          . \
-          -f ci/Dockerfile.lambda
-
       - name: Configure AWS credentials
         id: aws-creds
         uses: aws-actions/configure-aws-credentials@v1
@@ -36,6 +28,23 @@ jobs:
           aws-access-key-id: ${{ secrets.PRODUCTION_ECR_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.PRODUCTION_ECR_SECRET_ACCESS_KEY }}
           aws-region: ca-central-1
+          
+      - name: Retrieve New Relic Lambda layer
+        working-directory: ./ci
+        run: |
+          aws lambda get-layer-version-by-arn \
+          --region ca-central-1 \
+          --arn arn:aws:lambda:ca-central-1:451483290750:layer:NewRelicPython39:12 \
+          | jq -r '.Content.Location' \
+          | xargs curl -o newrelic-layer.zip        
+
+      - name: Build container
+        run: |
+          docker build \
+          --build-arg GIT_SHA=${GITHUB_SHA::7} \
+          -t $REGISTRY/${{ matrix.image }}:${GITHUB_SHA::7} \
+          . \
+          -f ci/Dockerfile.lambda
 
       - name: Login to ECR
         id: login-ecr

--- a/.github/workflows/lambda_staging.yml
+++ b/.github/workflows/lambda_staging.yml
@@ -30,7 +30,6 @@ jobs:
           aws-region: ca-central-1
 
       - name: Retrieve New Relic Lambda layer
-        working-directory: ./ci
         run: |
           aws lambda get-layer-version-by-arn \
           --region ca-central-1 \

--- a/.github/workflows/lambda_staging.yml
+++ b/.github/workflows/lambda_staging.yml
@@ -21,14 +21,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Build container
-        run: |
-          docker build \
-          --build-arg GIT_SHA=${GITHUB_SHA::7} \
-          -t $REGISTRY/${{ matrix.image }}:${GITHUB_SHA::7} \
-          . \
-          -f ci/Dockerfile.lambda
-
       - name: Configure AWS credentials
         id: aws-creds
         uses: aws-actions/configure-aws-credentials@v1
@@ -36,6 +28,23 @@ jobs:
           aws-access-key-id: ${{ secrets.STAGING_ECR_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.STAGING_ECR_SECRET_ACCESS_KEY }}
           aws-region: ca-central-1
+
+      - name: Retrieve AWS Distro for OpenTelemetry Lambda layer
+        working-directory: ./ci
+        run: |
+          aws lambda get-layer-version-by-arn \
+          --region ca-central-1 \
+          --arn arn:aws:lambda:ca-central-1:451483290750:layer:NewRelicPython39:12 \
+          | jq -r '.Content.Location' \
+          | xargs curl -o newrelic-layer.zip
+
+      - name: Build container
+        run: |
+          docker build \
+          --build-arg GIT_SHA=${GITHUB_SHA::7} \
+          -t $REGISTRY/${{ matrix.image }}:${GITHUB_SHA::7} \
+          . \
+          -f ci/Dockerfile.lambda
 
       - name: Login to ECR
         id: login-ecr

--- a/.github/workflows/lambda_staging.yml
+++ b/.github/workflows/lambda_staging.yml
@@ -29,7 +29,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.STAGING_ECR_SECRET_ACCESS_KEY }}
           aws-region: ca-central-1
 
-      - name: Retrieve AWS Distro for OpenTelemetry Lambda layer
+      - name: Retrieve New Relic Lambda layer
         working-directory: ./ci
         run: |
           aws lambda get-layer-version-by-arn \

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ var/
 .installed.cfg
 *.egg
 /cache
+newrelic-layer.zip
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/bin/get_newrelic_layer.sh
+++ b/bin/get_newrelic_layer.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+aws lambda get-layer-version-by-arn \
+--region ca-central-1 \
+--arn arn:aws:lambda:ca-central-1:451483290750:layer:NewRelicPython39:12 \
+| jq -r '.Content.Location' \
+| xargs curl -o ../ci/newrelic-layer.zip

--- a/bin/get_newrelic_layer.sh
+++ b/bin/get_newrelic_layer.sh
@@ -4,4 +4,4 @@ aws lambda get-layer-version-by-arn \
 --region ca-central-1 \
 --arn arn:aws:lambda:ca-central-1:451483290750:layer:NewRelicPython39:12 \
 | jq -r '.Content.Location' \
-| xargs curl -o ../ci/newrelic-layer.zip
+| xargs curl -o ../newrelic-layer.zip

--- a/ci/Dockerfile.lambda
+++ b/ci/Dockerfile.lambda
@@ -33,4 +33,4 @@ COPY bin/sync_lambda_envs.sh /
 RUN chmod 755 /usr/bin/aws-lambda-rie /entry.sh /sync_lambda_envs.sh
 
 ENTRYPOINT [ "/entry.sh" ]
-CMD [ "application.handler" ]
+CMD [ "newrelic_lambda_wrapper.handler" ]

--- a/ci/Dockerfile.lambda
+++ b/ci/Dockerfile.lambda
@@ -37,4 +37,7 @@ RUN chmod 755 /usr/bin/aws-lambda-rie /entry.sh /sync_lambda_envs.sh
 RUN unzip newrelic-layer.zip -d /opt && rm newrelic-layer.zip
 
 ENTRYPOINT [ "/entry.sh" ]
-CMD [ "newrelic_lambda_wrapper.handler" ]
+
+# Launch the New Relic lambda wrapper which will then launch the app
+# handler defined in the NEW_RELIC_LAMBDA_HANDLER environment variable
+CMD [ "newrelic_lambda_wrapper.handler" ] 

--- a/ci/Dockerfile.lambda
+++ b/ci/Dockerfile.lambda
@@ -1,9 +1,10 @@
 FROM python:3.9-alpine3.13
 
+ENV PYTHONPATH "${PYTHONPATH}:/opt/python/lib/python3.9/site-packages"
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV TASK_ROOT /app
 
-RUN apk add --no-cache bash build-base git libtool cmake autoconf automake gcc musl-dev postgresql-dev g++ libexecinfo-dev make libffi-dev libmagic libcurl curl-dev rust cargo && rm -rf /var/cache/apk/*
+RUN apk add --no-cache bash build-base git libtool cmake autoconf automake gcc musl-dev postgresql-dev g++ libc6-compat libexecinfo-dev make libffi-dev libmagic libcurl curl-dev rust cargo && rm -rf /var/cache/apk/*
 
 # update pip
 RUN python -m pip install wheel
@@ -12,10 +13,12 @@ RUN python -m pip install --upgrade pip
 RUN set -ex && mkdir ${TASK_ROOT}
 
 WORKDIR ${TASK_ROOT}
+COPY ./newrelic-layer.zip /tmp/newrelic-layer.zip
+RUN unzip /tmp/newrelic-layer.zip -d /opt && rm /tmp/newrelic-layer.zip
 
 COPY requirements.txt ${TASK_ROOT}
 RUN set -ex && pip3 install -r requirements.txt
-RUN pip3 install awslambdaric
+RUN pip3 install awslambdaric newrelic-lambda
 
 COPY . ${TASK_ROOT}
 

--- a/ci/Dockerfile.lambda
+++ b/ci/Dockerfile.lambda
@@ -13,8 +13,6 @@ RUN python -m pip install --upgrade pip
 RUN set -ex && mkdir ${TASK_ROOT}
 
 WORKDIR ${TASK_ROOT}
-COPY ./newrelic-layer.zip /tmp/newrelic-layer.zip
-RUN unzip /tmp/newrelic-layer.zip -d /opt && rm /tmp/newrelic-layer.zip
 
 COPY requirements.txt ${TASK_ROOT}
 RUN set -ex && pip3 install -r requirements.txt
@@ -34,6 +32,9 @@ ADD https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/latest
 COPY bin/entry.sh /
 COPY bin/sync_lambda_envs.sh /
 RUN chmod 755 /usr/bin/aws-lambda-rie /entry.sh /sync_lambda_envs.sh
+
+# New Relic lambda layer
+RUN unzip newrelic-layer.zip -d /opt && rm newrelic-layer.zip
 
 ENTRYPOINT [ "/entry.sh" ]
 CMD [ "newrelic_lambda_wrapper.handler" ]


### PR DESCRIPTION
This PR modifies the handler that will be invoked at runtime to the newrelic lambda handler. This handler will hook into the appropriate python modules and then invoke the handler specified in the environment variable `NEW_RELIC_LAMBDA_HANDLER` which is currently set to `application.handler`. This will give the newrelic agent access to the flask stdout and stderr for automatic metric logging.

Summary of changes
- Retrieve the required newrelic lambda layer from aws (ci)
- Install `libc6-compat` so that the necessary link libraries are available to the newrelic agent (dockerfile)
- Install `newrelic-lambda` to send logs directly to newrelic  (dockerfile)
- add `/opt/python/lib/python3.9/site-packages` to the containers pythonpath so that the newrelic wrapper is available  (dockerfile)
- Change entrypoint handler to the new relic handler `newrelic_lambda_wrapper.handler` (dockerfile)

Dependency:
- cds-snc/notification-terraform/pull/415