### PR TITLE
Refactor/load envs directly

### DIFF
--- a/bin/entry.sh
+++ b/bin/entry.sh
@@ -2,6 +2,6 @@
 if [ -z "${AWS_LAMBDA_RUNTIME_API}" ]; then
     exec /usr/bin/aws-lambda-rie /usr/local/bin/python -m awslambdaric $1
 else
-    . ./sync_lambda_envs.sh # Retrieve .env from parameter store and remove currently set environement variables
+    . /sync_lambda_envs.sh # Retrieve .env from parameter store and remove currently set environement variables
     exec /usr/local/bin/python -m awslambdaric $1
 fi

--- a/bin/sync_lambda_envs.sh
+++ b/bin/sync_lambda_envs.sh
@@ -39,4 +39,5 @@ if [ ! -f "$TMP_ENV_FILE" ]; then # Only setup envs once per lambda lifecycle
   echo "Retrieving environment parameters"
   aws ssm get-parameters --region ca-central-1 --with-decryption --names ENVIRONMENT_VARIABLES --query 'Parameters[*].Value' --output text > "$TMP_ENV_FILE"
   load_non_existing_envs
+  rm -f $TMP_ENV_FILE
 fi

--- a/bin/sync_lambda_envs.sh
+++ b/bin/sync_lambda_envs.sh
@@ -38,6 +38,6 @@ load_non_existing_envs() {
 if [ ! -f "$TMP_ENV_FILE" ]; then # Only setup envs once per lambda lifecycle
   echo "Retrieving environment parameters"
   aws ssm get-parameters --region ca-central-1 --with-decryption --names ENVIRONMENT_VARIABLES --query 'Parameters[*].Value' --output text > "$TMP_ENV_FILE"
-  load_non_existing_envs
-  rm -f $TMP_ENV_FILE
 fi
+
+load_non_existing_envs


### PR DESCRIPTION
Due to lambda containers only allowing write access to the /tmp directory, we'll need to load the environment variables directly.