### PR TITLE
fix: use `export` instead of `eval`

### DIFF
--- a/bin/sync_lambda_envs.sh
+++ b/bin/sync_lambda_envs.sh
@@ -29,7 +29,7 @@ load_non_existing_envs() {
     value=$(echo "$line" | cut -d '=' -f 2-)
 
     if [ -z $(var_expand $key) ]; then # Check if environment variable doesn't exist
-      eval "export ${key}=\"$(echo \${value})\""
+      export "${key}=${value}"
     fi
     
   done < $TMP_ENV_FILE


### PR DESCRIPTION
# Summary
Update to use `export` directly to export the environment variables
into the Lambda's execution environment.

# Related
* cds-snc/notification-planning#421