### PR TITLE
fix: add missing `test_` prefix

### DIFF
--- a/tests/app/test_config.py
+++ b/tests/app/test_config.py
@@ -109,7 +109,7 @@ def test_get_safe_config(mocker, reload_config):
     assert mock_get_sensitive_config.called
 
 
-def get_sensitive_config():
+def test_get_sensitive_config():
     sensitive_config = config.Config.get_sensitive_config()
     assert sensitive_config
     for key in sensitive_config:


### PR DESCRIPTION
# Summary
Update the unit test with the missing `test_` prefix so that it
runs as part of the test suite.

# Related
* cds-snc/notification-planning#421