### PR TITLE
fix: send AWS lambda function update to /dev/null

### DIFF
--- a/.github/workflows/lambda_staging.yml
+++ b/.github/workflows/lambda_staging.yml
@@ -52,4 +52,4 @@ jobs:
         run: |
           aws lambda update-function-code \
             --function-name ${{ matrix.image }} \
-            --image-uri $REGISTRY/${{ matrix.image }}:${GITHUB_SHA::7}
+            --image-uri $REGISTRY/${{ matrix.image }}:${GITHUB_SHA::7} > /dev/null 2>&1


### PR DESCRIPTION
# Summary
This PR will prevent the lambda cli commands from dumping their outputs to the workflow logs.