### PR TITLE
chore: switch to notification_utils config logging

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -8,6 +8,7 @@ from environs import Env
 from fido2.server import Fido2Server
 from fido2.webauthn import PublicKeyCredentialRpEntity
 from kombu import Exchange, Queue
+from notifications_utils import logging
 
 from celery.schedules import crontab
 
@@ -480,19 +481,9 @@ class Config(object):
         ]
 
     @classmethod
-    def get_config(cls, sensitive_config: list[str]) -> dict[str, Any]:
-        "Returns a dict of config keys and values"
-        config = {}
-        for attr in dir(cls):
-            attr_value = "***" if attr in sensitive_config else getattr(cls, attr)
-            if not attr.startswith("__") and not callable(attr_value):
-                config[attr] = attr_value
-        return config
-
-    @classmethod
     def get_safe_config(cls) -> dict[str, Any]:
         "Returns a dict of config keys and values with sensitive values masked"
-        return cls.get_config(cls.get_sensitive_config())
+        return logging.get_class_attrs(cls, cls.get_sensitive_config())
 
 
 ######################

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -50,7 +50,7 @@ MarkupSafe==2.0.1
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@46.3.0#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@46.5.0#egg=notifications-utils
 
 # MLWR
 socketio-client==0.5.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ MarkupSafe==2.0.1
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@46.3.0#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@46.5.0#egg=notifications-utils
 
 # MLWR
 socketio-client==0.5.6

--- a/tests/app/test_config.py
+++ b/tests/app/test_config.py
@@ -84,28 +84,12 @@ def test_queue_names_all_queues_correct():
     )
 
 
-def test_get_config(reload_config):
-    config.Config.ADMIN_BASE_URL = "http://foo.bar"
-    config.Config.AWS_REGION = "dark-side-of-the-moon"
-    logged_config = config.Config.get_config([])
-    assert logged_config["ADMIN_BASE_URL"] == "http://foo.bar"
-    assert logged_config["AWS_REGION"] == "dark-side-of-the-moon"
-
-    config.Config.AWS_SES_SECRET_KEY = "1234"
-    logged_config = config.Config.get_config(["AWS_SES_SECRET_KEY"])
-    assert logged_config["AWS_SES_SECRET_KEY"] == "***"
-
-    for key, _ in logged_config.items():
-        assert not key.startswith("__")
-        assert not callable(getattr(config.Config, key))
-
-
 def test_get_safe_config(mocker, reload_config):
-    mock_get_config = mocker.patch("app.config.Config.get_config")
+    mock_get_class_attrs = mocker.patch("notification_utils.logging.get_class_attrs")
     mock_get_sensitive_config = mocker.patch("app.config.Config.get_sensitive_config")
 
     config.Config.get_safe_config()
-    assert mock_get_config.called
+    assert mock_get_class_attrs.called
     assert mock_get_sensitive_config.called
 
 

--- a/tests/app/test_config.py
+++ b/tests/app/test_config.py
@@ -85,7 +85,7 @@ def test_queue_names_all_queues_correct():
 
 
 def test_get_safe_config(mocker, reload_config):
-    mock_get_class_attrs = mocker.patch("notification_utils.logging.get_class_attrs")
+    mock_get_class_attrs = mocker.patch("notifications_utils.logging.get_class_attrs")
     mock_get_sensitive_config = mocker.patch("app.config.Config.get_sensitive_config")
 
     config.Config.get_safe_config()


### PR DESCRIPTION
# Summary
Use the Notification Utils `logging.get_class_attrs` to log the API's
config on startup.

# Related
* cds-snc/notification-planning#522