### PR TITLE
fix: improve logging for get notification by ID

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -202,6 +202,7 @@ def get_notification_with_personalisation(service_id, notification_id, key_type)
     if key_type:
         filter_dict["key_type"] = key_type
 
+    current_app.logger.info(f"Getting notification with filters: {filter_dict}")
     return Notification.query.filter_by(**filter_dict).options(joinedload("template")).one()
 
 


### PR DESCRIPTION
# Summary
Update `get_notification_with_personalisation` to improve logging.

This will be used to help troubleshoot the issue we're seeing where
the number of `No row was found for one()` warnings returned seems
high for the Lambda API.

# Related
* cds-snc/notification-planning#537