### PR TITLE
fix: only log when no notification found

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -202,8 +202,11 @@ def get_notification_with_personalisation(service_id, notification_id, key_type)
     if key_type:
         filter_dict["key_type"] = key_type
 
-    current_app.logger.info(f"Getting notification with filters: {filter_dict}")
-    return Notification.query.filter_by(**filter_dict).options(joinedload("template")).one()
+    try:
+        return Notification.query.filter_by(**filter_dict).options(joinedload("template")).one()
+    except NoResultFound:
+        current_app.logger.warning(f"Failed to get notification with filter: {filter_dict}")
+        raise
 
 
 @statsd(namespace="dao")

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -490,6 +490,13 @@ def test_get_notification_with_personalisation_by_id(sample_template):
     assert notification_from_db.scheduled_notification.scheduled_for == datetime(2017, 5, 5, 14, 15)
 
 
+def test_get_notification_with_personalisation_by_id_no_result(sample_template, fake_uuid, mocker):
+    mock_logger = mocker.patch("app.authentication.auth.current_app.logger.warning")
+    with pytest.raises(NoResultFound):
+        get_notification_with_personalisation(sample_template.service.id, fake_uuid, key_type=None)
+        assert mock_logger.called
+
+
 def test_get_notification_by_id_when_notification_exists(sample_notification):
     notification_from_db = get_notification_by_id(sample_notification.id)
 


### PR DESCRIPTION
# Summary
Update the logging added to `get_notification_with_personalisation`
so that it only logs the query filters if a NoResultsFound exception
is raised.

# Related
* #1514
* cds-snc/notification-planning#537