### PR TITLE
fix: print the invocation stack

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -206,7 +206,7 @@ def get_notification_with_personalisation(service_id, notification_id, key_type)
     try:
         return Notification.query.filter_by(**filter_dict).options(joinedload("template")).one()
     except NoResultFound:
-        current_app.logger.warning(f"Failed to get notification with filter: {filter_dict}\n\n{traceback.format_exc()}")
+        current_app.logger.warning(f"Failed to get notification with filter: {filter_dict}\n\n{traceback.format_stack()}")
         raise
 
 


### PR DESCRIPTION
# Summary
Update `get_notification_with_personalisation` to print the full
invocation stack rather than the stack trace.

Using `traceback.format_exc()` was only giving the stack trace
from within the `try/except` block:

```python
Traceback (most recent call last):
File "/app/app/dao/notifications_dao.py", line 207, in get_notification_with_personalisation
return Notification.query.filter_by(**filter_dict).options(joinedload("template")).one()
File "/usr/local/lib/python3.9/site-packages/sqlalchemy/orm/query.py", line 3500, in one
raise orm_exc.NoResultFound("No row was found for one()")
sqlalchemy.orm.exc.NoResultFound: No row was found for one()
```

# Summary
* #1514
* #1516 