### PR TITLE
fix: improve how the stack is printed

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -206,7 +206,8 @@ def get_notification_with_personalisation(service_id, notification_id, key_type)
     try:
         return Notification.query.filter_by(**filter_dict).options(joinedload("template")).one()
     except NoResultFound:
-        current_app.logger.warning(f"Failed to get notification with filter: {filter_dict}\n\n{traceback.format_stack()}")
+        stack = "".join(traceback.format_stack())
+        current_app.logger.warning(f"Failed to get notification with filter: {filter_dict}\n{stack}")
         raise
 
 


### PR DESCRIPTION
# Summary
Update to have the logged stack printed as a string with newlines
rather than a list of strings.

# Related
* #1514