### PR TITLE
Add logging for template ID

### DIFF
--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -199,6 +199,8 @@ def post_notification(notification_type):
         notification_type,
     )
 
+    current_app.logger.info(f"Trying to send notification for Template ID: {template.id}")
+
     reply_to = get_reply_to_text(notification_type, form, template)
 
     if notification_type == LETTER_TYPE:


### PR DESCRIPTION
# Summary | Résumé

Ran this locally:
```
2022-05-03T18:19:53 api api INFO None "Trying to send notification for Template ID: 41e5b0bb-3d4f-42b0-ad6d-0be9c4ac8a77" [in /workspace/app/v2/notifications/post_notifications.py:202]
```

We are doing this so we can tell users which Templates are causing API key failures.