### PR TITLE
fix: publish new lambda version and update alias

### DIFF
--- a/.github/workflows/lambda_staging.yml
+++ b/.github/workflows/lambda_staging.yml
@@ -61,3 +61,13 @@ jobs:
           aws lambda update-function-code \
             --function-name ${{ matrix.image }} \
             --image-uri $REGISTRY/${{ matrix.image }}:${GITHUB_SHA::7} > /dev/null 2>&1
+
+      - name: Publish lambda version and update alias
+        run: |
+          aws lambda wait function-updated --function-name ${{ matrix.image }}
+          VERSION="$(aws lambda publish-version --function-name ${{ matrix.image }} | jq -r '.Version')"
+   
+          aws lambda update-alias \
+            --function-name ${{ matrix.image }} \
+            --name latest \
+            --function-version "$VERSION" > /dev/null 2>&1


### PR DESCRIPTION
# Summary
When the workflow updates the Lambda API also publish
a new function version and update the function alias
to reference this new version.

This is required to make sure the function's provisioned concurrency
stays in sync with the `$LATEST` version of the function code.