### PR TITLE
feat: generate Software Bill of Materials

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -77,7 +77,7 @@ jobs:
         TOKEN: ${{ steps.notify-pr-bot.outputs.token }}
 
     - name: Generate docker SBOM
-      uses: cds-snc/security-tools/.github/actions/generate-sbom@d39a08b2145375940f52c0b4b8c58a8cf3603bdb
+      uses: cds-snc/security-tools/.github/actions/generate-sbom@b09c1aefae9876dd2a23888c50b2daaa137ba01d # pin@v1
       with:
         dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
         docker_image: $DOCKER_SLUG:${GITHUB_SHA::7}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -76,6 +76,14 @@ jobs:
       env:
         TOKEN: ${{ steps.notify-pr-bot.outputs.token }}
 
+    - name: Generate docker SBOM
+      uses: cds-snc/security-tools/.github/actions/generate-sbom@d39a08b2145375940f52c0b4b8c58a8cf3603bdb
+      with:
+        dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
+        docker_image: $DOCKER_SLUG:${GITHUB_SHA::7}
+        project_name: notification-api/docker
+        project_type: docker
+
     - name: Notify Slack channel if this job failed
       if: ${{ failure() }}
       run: |

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -77,7 +77,7 @@ jobs:
         TOKEN: ${{ steps.notify-pr-bot.outputs.token }}
 
     - name: Generate docker SBOM
-      uses: cds-snc/security-tools/.github/actions/generate-sbom@b09c1aefae9876dd2a23888c50b2daaa137ba01d # pin@v1
+      uses: cds-snc/security-tools/.github/actions/generate-sbom@14ab23f07437d642594c56003db1f4bd34e54bbb # renovate: tag=v1
       with:
         dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
         docker_image: $DOCKER_SLUG:${GITHUB_SHA::7}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -77,7 +77,7 @@ jobs:
         TOKEN: ${{ steps.notify-pr-bot.outputs.token }}
 
     - name: Generate docker SBOM
-      uses: cds-snc/security-tools/.github/actions/generate-sbom@14ab23f07437d642594c56003db1f4bd34e54bbb # renovate: tag=v1
+      uses: cds-snc/security-tools/.github/actions/generate-sbom@4c6b386722985552f3f008d04279a3f01402cc35 # renovate: tag=v1
       with:
         dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
         docker_image: $DOCKER_SLUG:${GITHUB_SHA::7}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -81,7 +81,7 @@ jobs:
       with:
         dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
         docker_image: $DOCKER_SLUG:${GITHUB_SHA::7}
-        project_name: notification-api/docker
+        project_name: notification-api/docker/k8s
         project_type: docker
 
     - name: Notify Slack channel if this job failed

--- a/.github/workflows/generate_sbom.yml
+++ b/.github/workflows/generate_sbom.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Generate app SBOM
-        uses: cds-snc/security-tools/.github/actions/generate-sbom@d39a08b2145375940f52c0b4b8c58a8cf3603bdb
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@b09c1aefae9876dd2a23888c50b2daaa137ba01d # pin@v1
         with:
           dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
           project_name: notification-api/app

--- a/.github/workflows/generate_sbom.yml
+++ b/.github/workflows/generate_sbom.yml
@@ -1,0 +1,29 @@
+name: Generate SBOM
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - requirements.txt
+      - .github/workflows/generate_sbom.yml
+  push:
+    branches:
+      - main
+    paths:
+      - requirements.txt
+      - .github/workflows/generate_sbom.yml
+
+jobs:
+  generate-sbom:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Generate app SBOM
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@d39a08b2145375940f52c0b4b8c58a8cf3603bdb
+        with:
+          dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
+          project_name: notification-api/app
+          project_type: python        

--- a/.github/workflows/generate_sbom.yml
+++ b/.github/workflows/generate_sbom.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Generate app SBOM
-        uses: cds-snc/security-tools/.github/actions/generate-sbom@b09c1aefae9876dd2a23888c50b2daaa137ba01d # pin@v1
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@14ab23f07437d642594c56003db1f4bd34e54bbb # renovate: tag=v1
         with:
           dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
           project_name: notification-api/app

--- a/.github/workflows/generate_sbom.yml
+++ b/.github/workflows/generate_sbom.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Generate app SBOM
-        uses: cds-snc/security-tools/.github/actions/generate-sbom@14ab23f07437d642594c56003db1f4bd34e54bbb # renovate: tag=v1
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@4c6b386722985552f3f008d04279a3f01402cc35 # renovate: tag=v1
         with:
           dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
           project_name: notification-api/app

--- a/.github/workflows/lambda_production.yml
+++ b/.github/workflows/lambda_production.yml
@@ -54,7 +54,7 @@ jobs:
           docker push $REGISTRY/${{ matrix.image }}:${GITHUB_SHA::7}
 
       - name: Generate docker SBOM
-        uses: cds-snc/security-tools/.github/actions/generate-sbom@14ab23f07437d642594c56003db1f4bd34e54bbb # renovate: tag=v1
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@4c6b386722985552f3f008d04279a3f01402cc35 # renovate: tag=v1
         with:
           dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
           docker_image: $REGISTRY/${{ matrix.image }}:${GITHUB_SHA::7}

--- a/.github/workflows/lambda_production.yml
+++ b/.github/workflows/lambda_production.yml
@@ -53,5 +53,13 @@ jobs:
         run: |
           docker push $REGISTRY/${{ matrix.image }}:${GITHUB_SHA::7}
 
+      - name: Generate docker SBOM
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@d39a08b2145375940f52c0b4b8c58a8cf3603bdb
+        with:
+          dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
+          docker_image: $REGISTRY/${{ matrix.image }}:${GITHUB_SHA::7}
+          project_name: notification-api/docker/lambda
+          project_type: docker
+
       - name: Logout of Amazon ECR
         run: docker logout ${{ steps.login-ecr.outputs.registry }}

--- a/.github/workflows/lambda_production.yml
+++ b/.github/workflows/lambda_production.yml
@@ -54,7 +54,7 @@ jobs:
           docker push $REGISTRY/${{ matrix.image }}:${GITHUB_SHA::7}
 
       - name: Generate docker SBOM
-        uses: cds-snc/security-tools/.github/actions/generate-sbom@d39a08b2145375940f52c0b4b8c58a8cf3603bdb
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@b09c1aefae9876dd2a23888c50b2daaa137ba01d # pin@v1
         with:
           dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
           docker_image: $REGISTRY/${{ matrix.image }}:${GITHUB_SHA::7}

--- a/.github/workflows/lambda_production.yml
+++ b/.github/workflows/lambda_production.yml
@@ -54,7 +54,7 @@ jobs:
           docker push $REGISTRY/${{ matrix.image }}:${GITHUB_SHA::7}
 
       - name: Generate docker SBOM
-        uses: cds-snc/security-tools/.github/actions/generate-sbom@b09c1aefae9876dd2a23888c50b2daaa137ba01d # pin@v1
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@14ab23f07437d642594c56003db1f4bd34e54bbb # renovate: tag=v1
         with:
           dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
           docker_image: $REGISTRY/${{ matrix.image }}:${GITHUB_SHA::7}


### PR DESCRIPTION
# Summary
Add GitHub workflows to generate SBOMs and upload them
to Dependency-Track. This will allow us to have a view of all
the dependencies used by the org and their potential
vulnerabilities.

# Related
* cds-snc/platform-sre-security-support#94