### PR TITLE
Add code for inbetween phase

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -107,6 +107,8 @@ def create_app(application, config=None):
         email_bulk.init_app(flask_redis, metrics_logger)
         email_normal.init_app(flask_redis, metrics_logger)
         email_priority.init_app(flask_redis, metrics_logger)
+        sms_queue.init_app(flask_redis, metrics_logger)
+        email_queue.init_app(flask_redis, metrics_logger)
     else:
         sms_queue.init_app(flask_redis, metrics_logger)
         email_queue.init_app(flask_redis, metrics_logger)

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -245,6 +245,11 @@ def recover_expired_notifications():
         email_bulk.expire_inflights()
         email_normal.expire_inflights()
         email_priority.expire_inflights()
+        try:
+            sms_queue.expire_inflights()
+            email_queue.expire_inflights()
+        except Exception:
+            current_app.logger.warning("SMS and Email queues without priority not found")
     else:
         sms_queue.expire_inflights()
         email_queue.expire_inflights()

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -1061,8 +1061,10 @@ def _acknowledge_notification(notification_type: Any, template: Any, receipt: UU
                 sms_normal.acknowledge(receipt)
             elif template.process_type == BULK:
                 sms_bulk.acknowledge(receipt)
-        else:
+        try:
             sms_queue.acknowledge(receipt)
+        except Exception:
+            current_app.logger.warning("SMS queue without priority doesn't exist")
     elif notification_type == EMAIL_TYPE:
         if Config.FF_PRIORITY_LANES:
             if template.process_type == PRIORITY:
@@ -1071,5 +1073,7 @@ def _acknowledge_notification(notification_type: Any, template: Any, receipt: UU
                 email_normal.acknowledge(receipt)
             elif template.process_type == BULK:
                 email_bulk.acknowledge(receipt)
-        else:
+        try:
             email_queue.acknowledge(receipt)
+        except Exception:
+            current_app.logger.warning("Email queue without priority doesn't exist")

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -1041,7 +1041,7 @@ def get_recipient_csv(job: Job, template: Template) -> RecipientCSV:
     )
 
 
-def _acknowledge_notification(notification_type: Any, template: Any, receipt: UUID):
+def _acknowledge_notification(notification_type: Any, template: Any, receipt: UUID):  # noqa
     """
     Acknowledge the notification has been saved to the DB and sent to the service.
 


### PR DESCRIPTION
# Summary | Résumé
We need to add code so that while there is data in the sms
and email queues, it still gets processed. No new data will be
added to those queues

# Testing:
I will test this on staging once merged

Butlocally

I switched off the feature flag and watch the queue get drained.
There was nothing left to acknowledge or expire in the old queue, but the old queues will stick around and will need to be removed after go-live