### PR TITLE
Apply attachment size limit on incoming notifications

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -195,6 +195,7 @@ class Config(object):
 
     NOTIFY_ENVIRONMENT = os.getenv("NOTIFY_ENVIRONMENT", "development")
     ADMIN_CLIENT_USER_NAME = "notify-admin"
+    ATTACHMENT_SIZE_LIMIT = env.int("ATTACHMENT_SIZE_LIMIT", 1024 * 120)  # 120k bytes limit by default
     AWS_REGION = os.getenv("AWS_REGION", "us-east-1")
     AWS_ROUTE53_ZONE = os.getenv("AWS_ROUTE53_ZONE", "Z2OW036USASMAK")
     AWS_SES_REGION = os.getenv("AWS_SES_REGION", "us-east-1")
@@ -225,6 +226,7 @@ class Config(object):
 
     CHECK_PROXY_HEADER = False
 
+    # Notify's notifications templates
     NOTIFY_SERVICE_ID = "d6aa2c68-a2d9-4437-ab19-3ae8eb202553"
     NOTIFY_USER_ID = "6af522d0-2915-4e52-83a3-3690455a5fe6"
     INVITATION_EMAIL_TEMPLATE_ID = "4f46df42-f795-4cc4-83bb-65ca312f49cc"
@@ -252,8 +254,7 @@ class Config(object):
     REACHED_DAILY_LIMIT_TEMPLATE_ID = "fd29f796-fcdc-471b-a0d4-0093880d9173"
     DAILY_LIMIT_UPDATED_TEMPLATE_ID = "b3c766e6-be32-4edf-b8db-0f04ef404edc"
 
-    # List of allowed service IDs that are allowed to send HTML through their
-    # templates.
+    # Allowed service IDs able to send HTML through their templates.
     ALLOW_HTML_SERVICE_IDS: List[str] = [id.strip() for id in os.getenv("ALLOW_HTML_SERVICE_IDS", "").split(",")]
 
     BATCH_INSERTION_CHUNK_SIZE = int(os.getenv("BATCH_INSERTION_CHUNK_SIZE", 500))

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -282,11 +282,12 @@ def decode_personalisation_files(personalisation_data):
             personalisation_data[key]["file"] = base64.b64decode(personalisation_data[key]["file"])
             personalisation_size = len(personalisation_data[key]["file"])
             current_app.logger.debug(f"Personalization data size detected at {personalisation_size} bytes.")
-            if personalisation_size > current_app.config["ATTACHMENT_SIZE_LIMIT"]:
+            size_limit = current_app.config["ATTACHMENT_SIZE_LIMIT"]
+            if personalisation_size > size_limit:
                 errors.append(
                     {
                         "error": "ValidationError",
-                        "message": f"{key} : File size was greater than",
+                        "message": f"{key} : File size is {personalisation_size} and greater than allowed limit of {size_limit}.",
                     }
                 )
         except Exception as e:

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -280,6 +280,15 @@ def decode_personalisation_files(personalisation_data):
     for key in file_keys:
         try:
             personalisation_data[key]["file"] = base64.b64decode(personalisation_data[key]["file"])
+            personalisation_size = len(personalisation_data[key]["file"])
+            current_app.logger.debug(f"Personalization data size detected at {personalisation_size} bytes.")
+            if personalisation_size > current_app.config["ATTACHMENT_SIZE_LIMIT"]:
+                errors.append(
+                    {
+                        "error": "ValidationError",
+                        "message": f"{key} : File size was greater than",
+                    }
+                )
         except Exception as e:
             errors.append(
                 {

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -284,10 +284,11 @@ def decode_personalisation_files(personalisation_data):
             current_app.logger.debug(f"Personalization data size detected at {personalisation_size} bytes.")
             size_limit = current_app.config["ATTACHMENT_SIZE_LIMIT"]
             if personalisation_size > size_limit:
+                filename = base64.b64decode(personalisation_data[key]["filename"])
                 errors.append(
                     {
                         "error": "ValidationError",
-                        "message": f"{key} : File size is {personalisation_size} and greater than allowed limit of {size_limit}.",
+                        "message": f"{key} : File size for {filename} is {personalisation_size} and greater than allowed limit of {size_limit}.",
                     }
                 )
         except Exception as e:

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -284,7 +284,7 @@ def decode_personalisation_files(personalisation_data):
             current_app.logger.debug(f"Personalization data size detected at {personalisation_size} bytes.")
             size_limit = current_app.config["ATTACHMENT_SIZE_LIMIT"]
             if personalisation_size > size_limit:
-                filename = base64.b64decode(personalisation_data[key]["filename"])
+                filename = personalisation_data[key]["filename"]
                 errors.append(
                     {
                         "error": "ValidationError",

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -1,8 +1,8 @@
 import base64
 import csv
-import uuid
-import string
 import random
+import string
+import uuid
 from datetime import datetime, timedelta
 from io import StringIO
 from unittest.mock import call
@@ -1181,9 +1181,7 @@ def test_post_notification_with_document_upload(
         ("linked_file.txt", "link"),
     ],
 )
-def test_post_notification_with_document_too_large(
-    notify_api, client, notify_db_session, mocker, filename, sending_method
-):
+def test_post_notification_with_document_too_large(notify_api, client, notify_db_session, mocker, filename, sending_method):
     def random_sized_content(chars=string.ascii_uppercase + string.digits, size=10):
         return "".join(random.choice(chars) for _ in range(size))
 

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -1222,7 +1222,10 @@ def test_post_notification_with_document_too_large(notify_api, client, notify_db
 
     resp_json = json.loads(response.get_data(as_text=True))
     print(f"resp_json={resp_json}")
-    assert validate(resp_json, post_email_response) == resp_json
+    # {'errors': [{'error': 'ValidationError', 'message': 'document : File size was greater than'}], 'status_code': 400}
+    assert "ValidationError" in resp_json["errors"][0]["error"]
+    assert filename in resp_json["errors"][0]["message"]
+    assert "and greater than allowed limit of" in resp_json["errors"][0]["message"]
 
     # if sending_method == "link":
     #     assert resp_json["content"]["body"] == f"Document: {document_response}"

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -1217,8 +1217,8 @@ def test_post_notification_with_document_too_large(notify_api, client, notify_db
         headers=[("Content-Type", "application/json"), auth_header],
     )
 
-    assert response.status_code == 201
-    assert mocked.called
+    assert response.status_code == 400
+    assert not mocked.called
 
     resp_json = json.loads(response.get_data(as_text=True))
     print(f"resp_json={resp_json}")

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -1196,7 +1196,7 @@ def test_post_notification_with_document_too_large(notify_api, client, notify_db
     mocker.patch("app.celery.provider_tasks.deliver_email.apply_async")
 
     file_data = random_sized_content(size=1024 * 120 + 100)
-    encoded_file = base64.b64encode(file_data)
+    encoded_file = base64.b64encode(file_data.encode())
 
     data = {
         "email_address": service.users[0].email_address,

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -1196,7 +1196,7 @@ def test_post_notification_with_document_too_large(notify_api, client, notify_db
     mocker.patch("app.celery.provider_tasks.deliver_email.apply_async")
 
     file_data = random_sized_content(size=1024 * 120 + 100)
-    encoded_file = base64.b64encode(file_data.encode())
+    encoded_file = base64.b64encode(file_data.encode()).decode()
 
     data = {
         "email_address": service.users[0].email_address,

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -1197,7 +1197,11 @@ def test_post_notification_with_document_too_large(
         content = "Document: ((document))"
     template = create_template(service=service, template_type="email", content=content)
 
+    mocker.patch("app.v2.notifications.post_notifications.statsd_client")
     mocker.patch("app.celery.provider_tasks.deliver_email.apply_async")
+    document_download_mock = mocker.patch("app.v2.notifications.post_notifications.document_download_client.upload_document")
+    document_response = document_download_response({"sending_method": sending_method, "mime_type": "text/plain"})
+    document_download_mock.return_value = document_response
 
     file_data = random_sized_content(size=attachment_size)
     encoded_file = base64.b64encode(file_data.encode()).decode()


### PR DESCRIPTION
# Summary | Résumé

Added a file size validation on attachments, around 120k for now by default. This value can be overridden via the `ATTACHMENT_SIZE_LIMIT` environment variable. The 120k default limit might still be too high if two attachments of 119k would come in the same batch, but it offers for now a sensitive limit and highly reduce the risk as usually, high size attachments get way beyond.

If a client to the Notify API get past the attachment size limit, they will be met with a `400` HTTP status code just like any other validation error that can occur on personalisation data or other schema related check ups. The error describes which file by name got past the limit, mentioning the allowed limit and the actual size of the file.

# Test instructions | Instructions pour tester la modification

New automated tests were added with file size larger to the allowed limit by 100 bytes or lower to the allowed limit by 100 bytes, for the two different sending methods of attachments.

# Release Instructions | Instructions pour le déploiement

None.

> Necessary steps to perform before and after the deployment of these changes.
> For example, emptying the cache on a feature that changes the cache data
> structure in Redis could be mentioned.

---

> Étapes nécessaires à exécuter avant et après le déploiement des changements
> introduits par cette proposition. Par exemple, vider la cache suite à des
> changements modifiant une structure de données de la cache pourrait être
> mentionné.

# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their
review | Voici une suggestion de liste de vérification comprenant des questions
que les réviseurs pourraient poser pendant leur examen :


- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne
      une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une
      fonctionnalité existante?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une
      modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des
      préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de
      façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de
      risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README
      setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce
      changement (fichier README, etc.)?
