### PR TITLE
Remove old code paths - all feature flags (FF_*)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ clean:
 format:
 	isort .
 	black --config pyproject.toml .
+	flake8 .
 
 .PHONY: smoke-test
 smoke-test:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -58,8 +58,6 @@ clients = Clients()
 api_user = LocalProxy(lambda: _request_ctx_stack.top.api_user)
 authenticated_service = LocalProxy(lambda: _request_ctx_stack.top.authenticated_service)
 
-
-# Priority lanes feature (FF_PRIORITY_LANES)
 sms_bulk = RedisQueue("sms", process_type="bulk")
 sms_normal = RedisQueue("sms", process_type="normal")
 sms_priority = RedisQueue("sms", process_type="priority")
@@ -98,21 +96,13 @@ def create_app(application, config=None):
     flask_redis.init_app(application)
     redis_store.init_app(application)
 
-    # Priority lanes feature (FF_PRIORITY_LANES)
     # initialize redis queues
-    if application.config["FF_PRIORITY_LANES"]:
-        sms_bulk.init_app(flask_redis, metrics_logger)
-        sms_normal.init_app(flask_redis, metrics_logger)
-        sms_priority.init_app(flask_redis, metrics_logger)
-        email_bulk.init_app(flask_redis, metrics_logger)
-        email_normal.init_app(flask_redis, metrics_logger)
-        email_priority.init_app(flask_redis, metrics_logger)
-        sms_queue.init_app(flask_redis, metrics_logger)
-        email_queue.init_app(flask_redis, metrics_logger)
-    else:
-        sms_queue.init_app(flask_redis, metrics_logger)
-        email_queue.init_app(flask_redis, metrics_logger)
-    # END FF_PRIORITY_LANES
+    sms_bulk.init_app(flask_redis, metrics_logger)
+    sms_normal.init_app(flask_redis, metrics_logger)
+    sms_priority.init_app(flask_redis, metrics_logger)
+    email_bulk.init_app(flask_redis, metrics_logger)
+    email_normal.init_app(flask_redis, metrics_logger)
+    email_priority.init_app(flask_redis, metrics_logger)
 
     register_blueprint(application)
     register_v2_blueprints(application)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -96,7 +96,6 @@ def create_app(application, config=None):
     flask_redis.init_app(application)
     redis_store.init_app(application)
 
-    # initialize redis queues
     sms_bulk.init_app(flask_redis, metrics_logger)
     sms_normal.init_app(flask_redis, metrics_logger)
     sms_priority.init_app(flask_redis, metrics_logger)

--- a/app/aws/metrics.py
+++ b/app/aws/metrics.py
@@ -5,8 +5,6 @@ from typing import TYPE_CHECKING, Optional
 from botocore.exceptions import ClientError
 from flask import current_app
 
-from app.config import Config
-
 if TYPE_CHECKING:  # A special Python 3 constant that is assumed to be True by 3rd party static type checkers
     from app.aws.metrics_logger import MetricsLogger
     from app.queue import RedisQueue
@@ -47,13 +45,7 @@ def put_batch_saving_inflight_metric(metrics_logger: MetricsLogger, queue: Redis
     try:
         metrics_logger.set_namespace("NotificationCanadaCa")
         metrics_logger.put_metric("batch_saving_inflight", count, "Count")
-
-        if Config.FF_PRIORITY_LANES:
-            metrics_logger.set_dimensions(
-                {"created": "True", "notification_type": queue._suffix, "priority": queue._process_type}
-            )
-        else:
-            metrics_logger.set_dimensions({"created": "True"})
+        metrics_logger.set_dimensions({"created": "True", "notification_type": queue._suffix, "priority": queue._process_type})
         metrics_logger.flush()
     except ClientError as e:
         message = "Error sending CloudWatch Metric: {}".format(e)
@@ -74,12 +66,9 @@ def put_batch_saving_inflight_processed(metrics_logger: MetricsLogger, queue: Re
     try:
         metrics_logger.set_namespace("NotificationCanadaCa")
         metrics_logger.put_metric("batch_saving_inflight", count, "Count")
-        if Config.FF_PRIORITY_LANES:
-            metrics_logger.set_dimensions(
-                {"acknowledged": "True", "notification_type": queue._suffix, "priority": queue._process_type}
-            )
-        else:
-            metrics_logger.set_dimensions({"acknowledged": "True"})
+        metrics_logger.set_dimensions(
+            {"acknowledged": "True", "notification_type": queue._suffix, "priority": queue._process_type}
+        )
         metrics_logger.flush()
     except ClientError as e:
         message = "Error sending CloudWatch Metric: {}".format(e)
@@ -101,12 +90,7 @@ def put_batch_saving_expiry_metric(metrics_logger: MetricsLogger, queue: RedisQu
     try:
         metrics_logger.set_namespace("NotificationCanadaCa")
         metrics_logger.put_metric("batch_saving_inflight", count, "Count")
-        if Config.FF_PRIORITY_LANES:
-            metrics_logger.set_dimensions(
-                {"expired": "True", "notification_type": queue._suffix, "priority": queue._process_type}
-            )
-        else:
-            metrics_logger.set_dimensions({"expired": "True"})
+        metrics_logger.set_dimensions({"expired": "True", "notification_type": queue._suffix, "priority": queue._process_type})
         metrics_logger.flush()
     except ClientError as e:
         message = "Error sending CloudWatch Metric: {}".format(e)
@@ -131,14 +115,11 @@ def put_batch_saving_bulk_created(
     try:
         metrics_logger.set_namespace("NotificationCanadaCa")
         metrics_logger.put_metric("batch_saving_bulk", count, "Count")
-        if Config.FF_PRIORITY_LANES:
-            if notification_type is None or priority is None:
-                current_app.logger.warning("either notification_type or priority is None")
-                metrics_logger.set_dimensions({"created": "True"})
-            else:
-                metrics_logger.set_dimensions({"created": "True", "notification_type": notification_type, "priority": priority})
-        else:
+        if notification_type is None or priority is None:
+            current_app.logger.warning("either notification_type or priority is None")
             metrics_logger.set_dimensions({"created": "True"})
+        else:
+            metrics_logger.set_dimensions({"created": "True", "notification_type": notification_type, "priority": priority})
         metrics_logger.flush()
     except ClientError as e:
         message = "Error sending CloudWatch Metric: {}".format(e)
@@ -162,17 +143,11 @@ def put_batch_saving_bulk_processed(
     try:
         metrics_logger.set_namespace("NotificationCanadaCa")
         metrics_logger.put_metric("batch_saving_bulk", count, "Count")
-
-        if Config.FF_PRIORITY_LANES:
-            if notification_type is None or priority is None:
-                current_app.logger.warning("either notification_type or priority is None")
-                metrics_logger.set_dimensions({"acknowledged": "True"})
-            else:
-                metrics_logger.set_dimensions(
-                    {"acknowledged": "True", "notification_type": notification_type, "priority": priority}
-                )
-        else:
+        if notification_type is None or priority is None:
+            current_app.logger.warning("either notification_type or priority is None")
             metrics_logger.set_dimensions({"acknowledged": "True"})
+        else:
+            metrics_logger.set_dimensions({"acknowledged": "True", "notification_type": notification_type, "priority": priority})
         metrics_logger.flush()
     except ClientError as e:
         message = "Error sending CloudWatch Metric: {}".format(e)

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -236,24 +236,12 @@ def check_templated_letter_state():
 @notify_celery.task(name="in-flight-to-inbox")
 @statsd(namespace="tasks")
 def recover_expired_notifications():
-
-    # Priority lanes feature (FF_PRIORITY_LANES)
-    if current_app.config["FF_PRIORITY_LANES"]:
-        sms_bulk.expire_inflights()
-        sms_normal.expire_inflights()
-        sms_priority.expire_inflights()
-        email_bulk.expire_inflights()
-        email_normal.expire_inflights()
-        email_priority.expire_inflights()
-        try:
-            sms_queue.expire_inflights()
-            email_queue.expire_inflights()
-        except Exception:
-            current_app.logger.warning("SMS and Email queues without priority not found")
-    else:
-        sms_queue.expire_inflights()
-        email_queue.expire_inflights()
-    # END FF_PRIORITY_LANES
+    sms_bulk.expire_inflights()
+    sms_normal.expire_inflights()
+    sms_priority.expire_inflights()
+    email_bulk.expire_inflights()
+    email_normal.expire_inflights()
+    email_priority.expire_inflights()
 
 
 @notify_celery.task(name="beat-inbox-sms")
@@ -302,13 +290,12 @@ def beat_inbox_email_normal():
     to another list(list#2). The heartbeat will then call a job that saves list#2 to the DB
     and actually sends the email for each notification saved.
     """
-    if current_app.config["FF_PRIORITY_LANES"]:
-        receipt_id_email, list_of_email_notifications = email_normal.poll()
+    receipt_id_email, list_of_email_notifications = email_normal.poll()
 
-        while list_of_email_notifications:
-            save_emails.apply_async((None, list_of_email_notifications, receipt_id_email), queue=QueueNames.NORMAL_DATABASE)
-            current_app.logger.info(f"Batch saving with Normal Priority: email receipt {receipt_id_email} sent to in-flight.")
-            receipt_id_email, list_of_email_notifications = email_normal.poll()
+    while list_of_email_notifications:
+        save_emails.apply_async((None, list_of_email_notifications, receipt_id_email), queue=QueueNames.NORMAL_DATABASE)
+        current_app.logger.info(f"Batch saving with Normal Priority: email receipt {receipt_id_email} sent to in-flight.")
+        receipt_id_email, list_of_email_notifications = email_normal.poll()
 
 
 @notify_celery.task(name="beat-inbox-email-bulk")
@@ -321,13 +308,12 @@ def beat_inbox_email_bulk():
     to another list(list#2). The heartbeat will then call a job that saves list#2 to the DB
     and actually sends the email for each notification saved.
     """
-    if current_app.config["FF_PRIORITY_LANES"]:
-        receipt_id_email, list_of_email_notifications = email_bulk.poll()
+    receipt_id_email, list_of_email_notifications = email_bulk.poll()
 
-        while list_of_email_notifications:
-            save_emails.apply_async((None, list_of_email_notifications, receipt_id_email), queue=QueueNames.BULK_DATABASE)
-            current_app.logger.info(f"Batch saving with Bulk Priority: email receipt {receipt_id_email} sent to in-flight.")
-            receipt_id_email, list_of_email_notifications = email_bulk.poll()
+    while list_of_email_notifications:
+        save_emails.apply_async((None, list_of_email_notifications, receipt_id_email), queue=QueueNames.BULK_DATABASE)
+        current_app.logger.info(f"Batch saving with Bulk Priority: email receipt {receipt_id_email} sent to in-flight.")
+        receipt_id_email, list_of_email_notifications = email_bulk.poll()
 
 
 @notify_celery.task(name="beat-inbox-email-priority")
@@ -340,13 +326,12 @@ def beat_inbox_email_priority():
     to another list(list#2). The heartbeat will then call a job that saves list#2 to the DB
     and actually sends the email for each notification saved.
     """
-    if current_app.config["FF_PRIORITY_LANES"]:
-        receipt_id_email, list_of_email_notifications = email_priority.poll()
+    receipt_id_email, list_of_email_notifications = email_priority.poll()
 
-        while list_of_email_notifications:
-            save_emails.apply_async((None, list_of_email_notifications, receipt_id_email), queue=QueueNames.PRIORITY_DATABASE)
-            current_app.logger.info(f"Batch saving with Priority: email receipt {receipt_id_email} sent to in-flight.")
-            receipt_id_email, list_of_email_notifications = email_priority.poll()
+    while list_of_email_notifications:
+        save_emails.apply_async((None, list_of_email_notifications, receipt_id_email), queue=QueueNames.PRIORITY_DATABASE)
+        current_app.logger.info(f"Batch saving with Priority: email receipt {receipt_id_email} sent to in-flight.")
+        receipt_id_email, list_of_email_notifications = email_priority.poll()
 
 
 @notify_celery.task(name="beat-inbox-sms-normal")
@@ -359,13 +344,12 @@ def beat_inbox_sms_normal():
     to another list(list#2). The heartbeat will then call a job that saves list#2 to the DB
     and actually sends the sms for each notification saved.
     """
-    if current_app.config["FF_PRIORITY_LANES"]:
-        receipt_id_sms, list_of_sms_notifications = sms_normal.poll()
+    receipt_id_sms, list_of_sms_notifications = sms_normal.poll()
 
-        while list_of_sms_notifications:
-            save_smss.apply_async((None, list_of_sms_notifications, receipt_id_sms), queue=QueueNames.NORMAL_DATABASE)
-            current_app.logger.info(f"Batch saving with Normal Priority: SMS receipt {receipt_id_sms} sent to in-flight.")
-            receipt_id_sms, list_of_sms_notifications = sms_normal.poll()
+    while list_of_sms_notifications:
+        save_smss.apply_async((None, list_of_sms_notifications, receipt_id_sms), queue=QueueNames.NORMAL_DATABASE)
+        current_app.logger.info(f"Batch saving with Normal Priority: SMS receipt {receipt_id_sms} sent to in-flight.")
+        receipt_id_sms, list_of_sms_notifications = sms_normal.poll()
 
 
 @notify_celery.task(name="beat-inbox-sms-bulk")
@@ -378,13 +362,12 @@ def beat_inbox_sms_bulk():
     to another list(list#2). The heartbeat will then call a job that saves list#2 to the DB
     and actually sends the sms for each notification saved.
     """
-    if current_app.config["FF_PRIORITY_LANES"]:
-        receipt_id_sms, list_of_sms_notifications = sms_bulk.poll()
+    receipt_id_sms, list_of_sms_notifications = sms_bulk.poll()
 
-        while list_of_sms_notifications:
-            save_smss.apply_async((None, list_of_sms_notifications, receipt_id_sms), queue=QueueNames.BULK_DATABASE)
-            current_app.logger.info(f"Batch saving with Bulk Priority: SMS receipt {receipt_id_sms} sent to in-flight.")
-            receipt_id_sms, list_of_sms_notifications = sms_bulk.poll()
+    while list_of_sms_notifications:
+        save_smss.apply_async((None, list_of_sms_notifications, receipt_id_sms), queue=QueueNames.BULK_DATABASE)
+        current_app.logger.info(f"Batch saving with Bulk Priority: SMS receipt {receipt_id_sms} sent to in-flight.")
+        receipt_id_sms, list_of_sms_notifications = sms_bulk.poll()
 
 
 @notify_celery.task(name="beat-inbox-sms-priority")
@@ -397,10 +380,9 @@ def beat_inbox_sms_priority():
     to another list(list#2). The heartbeat will then call a job that saves list#2 to the DB
     and actually sends the sms for each notification saved.
     """
-    if current_app.config["FF_PRIORITY_LANES"]:
-        receipt_id_sms, list_of_sms_notifications = sms_priority.poll()
+    receipt_id_sms, list_of_sms_notifications = sms_priority.poll()
 
-        while list_of_sms_notifications:
-            save_smss.apply_async((None, list_of_sms_notifications, receipt_id_sms), queue=QueueNames.PRIORITY_DATABASE)
-            current_app.logger.info(f"Batch saving with Bulk Priority: SMS receipt {receipt_id_sms} sent to in-flight.")
-            receipt_id_sms, list_of_sms_notifications = sms_priority.poll()
+    while list_of_sms_notifications:
+        save_smss.apply_async((None, list_of_sms_notifications, receipt_id_sms), queue=QueueNames.PRIORITY_DATABASE)
+        current_app.logger.info(f"Batch saving with Bulk Priority: SMS receipt {receipt_id_sms} sent to in-flight.")
+        receipt_id_sms, list_of_sms_notifications = sms_priority.poll()

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -137,17 +137,12 @@ def process_job(job_id):
 
     csv = get_recipient_csv(job, template)
 
-    if Config.FF_BATCH_INSERTION:
-        rows = csv.get_rows()
-        for result in chunked(rows, Config.BATCH_INSERTION_CHUNK_SIZE):
-            process_rows(result, template, job, service)
-            put_batch_saving_bulk_created(
-                metrics_logger, 1, notification_type=db_template.template_type, priority=db_template.process_type
-            )
-
-    else:
-        for row in csv.get_rows():
-            process_row(row, template, job, service)
+    rows = csv.get_rows()
+    for result in chunked(rows, Config.BATCH_INSERTION_CHUNK_SIZE):
+        process_rows(result, template, job, service)
+        put_batch_saving_bulk_created(
+            metrics_logger, 1, notification_type=db_template.template_type, priority=db_template.process_type
+        )
 
     job_complete(job, start=start)
 
@@ -168,20 +163,14 @@ def job_complete(job: Job, resumed=False, start=None):
 
 
 def choose_database_queue(template: Any, service: Service):
-    if Config.FF_PRIORITY_LANES:
-        if service.research_mode:
-            return QueueNames.RESEARCH_MODE
-        elif template.process_type == PRIORITY:
-            return QueueNames.PRIORITY_DATABASE
-        elif template.process_type == BULK:
-            return QueueNames.BULK_DATABASE
-        else:
-            return QueueNames.NORMAL_DATABASE
+    if service.research_mode:
+        return QueueNames.RESEARCH_MODE
+    elif template.process_type == PRIORITY:
+        return QueueNames.PRIORITY_DATABASE
+    elif template.process_type == BULK:
+        return QueueNames.BULK_DATABASE
     else:
-        if service.research_mode:
-            return QueueNames.RESEARCH_MODE
-        else:
-            return QueueNames.DATABASE
+        return QueueNames.NORMAL_DATABASE
 
 
 def process_row(row: Row, template: Template, job: Job, service: Service):
@@ -362,15 +351,12 @@ def save_smss(self, service_id: Optional[str], signed_notifications: List[Any], 
                 f"Batch saving: receipt_id {receipt} removed from buffer queue for notification_id {notification_id} for process_type {process_type}"
             )
         else:
-            if Config.FF_PRIORITY_LANES:
-                put_batch_saving_bulk_processed(
-                    metrics_logger,
-                    1,
-                    notification_type=SMS_TYPE,
-                    priority=process_type,
-                )
-            else:
-                put_batch_saving_bulk_processed(metrics_logger, 1)
+            put_batch_saving_bulk_processed(
+                metrics_logger,
+                1,
+                notification_type=SMS_TYPE,
+                priority=process_type,
+            )
 
     except SQLAlchemyError as e:
         signed_and_verified = list(zip(signed_notifications, verified_notifications))
@@ -527,15 +513,12 @@ def save_emails(self, service_id: Optional[str], signed_notifications: List[Any]
                 f"Batch saving: receipt_id {receipt} removed from buffer queue for notification_id {notification_id} for process_type {process_type}"
             )
         else:
-            if Config.FF_PRIORITY_LANES:
-                put_batch_saving_bulk_processed(
-                    metrics_logger,
-                    1,
-                    notification_type=EMAIL_TYPE,
-                    priority=process_type,
-                )
-            else:
-                put_batch_saving_bulk_processed(metrics_logger, 1)
+            put_batch_saving_bulk_processed(
+                metrics_logger,
+                1,
+                notification_type=EMAIL_TYPE,
+                priority=process_type,
+            )
     except SQLAlchemyError as e:
         signed_and_verified = list(zip(signed_notifications, verified_notifications))
         handle_batch_error_and_forward(signed_and_verified, EMAIL_TYPE, e, receipt, template)
@@ -1062,25 +1045,23 @@ def _acknowledge_notification(notification_type: Any, template: Any, receipt: UU
     Returns: None
     """
     if notification_type == SMS_TYPE:
-        if Config.FF_PRIORITY_LANES:
-            if template.process_type == PRIORITY:
-                sms_priority.acknowledge(receipt)
-            elif template.process_type == NORMAL:
-                sms_normal.acknowledge(receipt)
-            elif template.process_type == BULK:
-                sms_bulk.acknowledge(receipt)
+        if template.process_type == PRIORITY:
+            sms_priority.acknowledge(receipt)
+        elif template.process_type == NORMAL:
+            sms_normal.acknowledge(receipt)
+        elif template.process_type == BULK:
+            sms_bulk.acknowledge(receipt)
         try:
             sms_queue.acknowledge(receipt)
         except Exception:
             current_app.logger.warning("SMS queue without priority doesn't exist")
     elif notification_type == EMAIL_TYPE:
-        if Config.FF_PRIORITY_LANES:
-            if template.process_type == PRIORITY:
-                email_priority.acknowledge(receipt)
-            elif template.process_type == NORMAL:
-                email_normal.acknowledge(receipt)
-            elif template.process_type == BULK:
-                email_bulk.acknowledge(receipt)
+        if template.process_type == PRIORITY:
+            email_priority.acknowledge(receipt)
+        elif template.process_type == NORMAL:
+            email_normal.acknowledge(receipt)
+        elif template.process_type == BULK:
+            email_bulk.acknowledge(receipt)
         try:
             email_queue.acknowledge(receipt)
         except Exception:

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -22,14 +22,12 @@ from app import (
     email_bulk,
     email_normal,
     email_priority,
-    email_queue,
     metrics_logger,
     notify_celery,
     signer,
     sms_bulk,
     sms_normal,
     sms_priority,
-    sms_queue,
     statsd_client,
 )
 from app.aws import s3
@@ -1051,10 +1049,6 @@ def _acknowledge_notification(notification_type: Any, template: Any, receipt: UU
             sms_normal.acknowledge(receipt)
         elif template.process_type == BULK:
             sms_bulk.acknowledge(receipt)
-        try:
-            sms_queue.acknowledge(receipt)
-        except Exception:
-            current_app.logger.warning("SMS queue without priority doesn't exist")
     elif notification_type == EMAIL_TYPE:
         if template.process_type == PRIORITY:
             email_priority.acknowledge(receipt)
@@ -1062,8 +1056,4 @@ def _acknowledge_notification(notification_type: Any, template: Any, receipt: UU
             email_normal.acknowledge(receipt)
         elif template.process_type == BULK:
             email_bulk.acknowledge(receipt)
-        try:
-            email_queue.acknowledge(receipt)
-        except Exception:
-            current_app.logger.warning("Email queue without priority doesn't exist")
     current_app.logger.info(f"ACKNOWLEDGED: {notification_type} for receipt_id {receipt}")

--- a/app/config.py
+++ b/app/config.py
@@ -499,10 +499,10 @@ class Config(object):
     CLOUDWATCH_AGENT_ENDPOINT = os.getenv("CLOUDWATCH_AGENT_ENDPOINT", f"tcp://{STATSD_HOST}:{CLOUDWATCH_AGENT_EMF_PORT}")
 
     # feature flag to toggle persistance of notification in celery instead of the API
-    FF_NOTIFICATION_CELERY_PERSISTENCE = env.bool("FF_NOTIFICATION_CELERY_PERSISTENCE", False)
-    FF_BATCH_INSERTION = env.bool("FF_BATCH_INSERTION", False)
-    FF_REDIS_BATCH_SAVING = env.bool("FF_REDIS_BATCH_SAVING", False)
-    FF_PRIORITY_LANES = env.bool("FF_PRIORITY_LANES", False)
+    FF_NOTIFICATION_CELERY_PERSISTENCE = env.bool("FF_NOTIFICATION_CELERY_PERSISTENCE", True)
+    FF_BATCH_INSERTION = env.bool("FF_BATCH_INSERTION", True)
+    FF_REDIS_BATCH_SAVING = env.bool("FF_REDIS_BATCH_SAVING", True)
+    FF_PRIORITY_LANES = env.bool("FF_PRIORITY_LANES", True)
 
     @classmethod
     def get_sensitive_config(cls) -> list[str]:

--- a/app/config.py
+++ b/app/config.py
@@ -314,16 +314,6 @@ class Config(object):
             "schedule": 60,
             "options": {"queue": QueueNames.PERIODIC},
         },
-        "beat-inbox-sms": {
-            "task": "beat-inbox-sms",
-            "schedule": 10,
-            "options": {"queue": QueueNames.PERIODIC},
-        },
-        "beat-inbox-email": {
-            "task": "beat-inbox-email",
-            "schedule": 10,
-            "options": {"queue": QueueNames.PERIODIC},
-        },
         "beat-inbox-sms-normal": {
             "task": "beat-inbox-sms-normal",
             "schedule": 10,
@@ -497,12 +487,6 @@ class Config(object):
     FF_CLOUDWATCH_METRICS_ENABLED = env.bool("FF_CLOUDWATCH_METRICS_ENABLED", False)
     CLOUDWATCH_AGENT_EMF_PORT = 25888
     CLOUDWATCH_AGENT_ENDPOINT = os.getenv("CLOUDWATCH_AGENT_ENDPOINT", f"tcp://{STATSD_HOST}:{CLOUDWATCH_AGENT_EMF_PORT}")
-
-    # feature flag to toggle persistance of notification in celery instead of the API
-    FF_NOTIFICATION_CELERY_PERSISTENCE = env.bool("FF_NOTIFICATION_CELERY_PERSISTENCE", True)
-    FF_BATCH_INSERTION = env.bool("FF_BATCH_INSERTION", True)
-    FF_REDIS_BATCH_SAVING = env.bool("FF_REDIS_BATCH_SAVING", True)
-    FF_PRIORITY_LANES = env.bool("FF_PRIORITY_LANES", True)
 
     @classmethod
     def get_sensitive_config(cls) -> list[str]:

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -311,8 +311,6 @@ def process_sms_or_email_notification(*, form, notification_type, api_key, templ
         "client_reference": form.get("reference", None),
     }
 
-    current_app.logger.info(f"Notification id {notification['id']} sent to buffer queue.")
-
     signed_notification_data = signer.sign(notification)
 
     scheduled_for = form.get("scheduled_for", None)

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -19,19 +19,17 @@ from app import (
     email_bulk,
     email_normal,
     email_priority,
-    email_queue,
     notify_celery,
     signer,
     sms_bulk,
     sms_normal,
     sms_priority,
-    sms_queue,
     statsd_client,
 )
 from app.aws.s3 import upload_job_to_s3
 from app.celery.letters_pdf_tasks import create_letters_pdf, process_virus_scan_passed
 from app.celery.research_mode_tasks import create_fake_letter_response_file
-from app.celery.tasks import process_job, save_email, save_sms
+from app.celery.tasks import process_job
 from app.clients.document_download import DocumentDownloadError
 from app.config import QueueNames, TaskNames
 from app.dao.jobs_dao import dao_create_job
@@ -313,6 +311,8 @@ def process_sms_or_email_notification(*, form, notification_type, api_key, templ
         "client_reference": form.get("reference", None),
     }
 
+    current_app.logger.info(f"Notification id {notification['id']} sent to buffer queue.")
+
     signed_notification_data = signer.sign(notification)
 
     scheduled_for = form.get("scheduled_for", None)
@@ -330,35 +330,12 @@ def process_sms_or_email_notification(*, form, notification_type, api_key, templ
             reply_to_text=reply_to_text,
         )
         persist_scheduled_notification(notification.id, form["scheduled_for"])
-    # Priority lanes feature (FF_PRIORITY_LANES)
-    elif current_app.config["FF_REDIS_BATCH_SAVING"] and current_app.config["FF_PRIORITY_LANES"] and not simulated:
+    elif not simulated:
         triage_notification_to_queues(notification_type, signed_notification_data, template)
 
         current_app.logger.info(
             f"Batch saving: {notification_type}/{template.process_type} {notification['id']} sent to buffer queue."
         )
-    # END FF_PRIORITY_LANES
-    elif current_app.config["FF_REDIS_BATCH_SAVING"] and not simulated:
-        if notification_type == SMS_TYPE:
-            sms_queue.publish(signed_notification_data)
-        else:
-            email_queue.publish(signed_notification_data)
-        current_app.logger.info(f"Batch saving: {notification_type} {notification['id']} sent to buffer queue.")
-
-    elif current_app.config["FF_NOTIFICATION_CELERY_PERSISTENCE"] and not simulated:
-        # depending on the type route to the appropriate save task
-        if notification_type == EMAIL_TYPE:
-            current_app.logger.info("calling save email task")
-            save_email.apply_async(
-                (authenticated_service.id, create_uuid(), signed_notification_data, None),
-                queue=QueueNames.DATABASE if not authenticated_service.research_mode else QueueNames.RESEARCH_MODE,
-            )
-        elif notification_type == SMS_TYPE:
-            save_sms.apply_async(
-                (authenticated_service.id, create_uuid(), signed_notification_data, None),
-                queue=QueueNames.DATABASE if not authenticated_service.research_mode else QueueNames.RESEARCH_MODE,
-            )
-
     else:
         notification = transform_notification(
             template_id=template.id,

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,8 +2,6 @@
 testpaths = tests
 env =
     NOTIFY_ENVIRONMENT=test
-    FF_BATCH_INSERTION=True
-    FF_REDIS_BATCH_SAVING=True
     NOTIFICATION_QUEUE_PREFIX=testing
     MLWR_HOST=https://mlwr.ca
     MLWR_USER=mlwr_user

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,8 +2,8 @@
 testpaths = tests
 env =
     NOTIFY_ENVIRONMENT=test
-    FF_BATCH_INSERTION=False
-    FF_REDIS_BATCH_SAVING=False
+    FF_BATCH_INSERTION=True
+    FF_REDIS_BATCH_SAVING=True
     NOTIFICATION_QUEUE_PREFIX=testing
     MLWR_HOST=https://mlwr.ca
     MLWR_USER=mlwr_user

--- a/tests/app/aws/test_metrics.py
+++ b/tests/app/aws/test_metrics.py
@@ -1,5 +1,3 @@
-from unittest.mock import call
-
 import pytest
 from botocore.exceptions import ClientError
 from flask import Flask
@@ -61,7 +59,6 @@ class TestBatchSavingMetricsFunctions:
         metrics_logger_mock.put_metric.assert_called_with("batch_saving_published", 20, "Count")
 
     def test_put_batch_saving_in_flight_metric_FF_PRIORITY_LANES_true(self, mocker, metrics_logger_mock):
-        mocker.patch.object(Config, "FF_PRIORITY_LANES", True)
         redis_queue = mocker.MagicMock()
         redis_queue._suffix = "foo"
         redis_queue._process_type = "bar"
@@ -69,17 +66,7 @@ class TestBatchSavingMetricsFunctions:
         metrics_logger_mock.set_dimensions.assert_called_with({"created": "True", "notification_type": "foo", "priority": "bar"})
         metrics_logger_mock.put_metric.assert_called_with("batch_saving_inflight", 1, "Count")
 
-    def test_put_batch_saving_in_flight_metric_FF_PRIORITY_LANES_false(self, mocker, metrics_logger_mock):
-        mocker.patch.object(Config, "FF_PRIORITY_LANES", False)
-        redis_queue = mocker.MagicMock()
-        redis_queue._suffix = "foo"
-        redis_queue._process_type = "bar"
-        put_batch_saving_inflight_metric(metrics_logger_mock, redis_queue, 1)
-        metrics_logger_mock.set_dimensions.assert_called_with({"created": "True"})
-        metrics_logger_mock.put_metric.assert_called_with("batch_saving_inflight", 1, "Count")
-
     def test_put_batch_saving_inflight_processed_FF_PRIORITY_LANES_true(self, mocker, metrics_logger_mock):
-        mocker.patch.object(Config, "FF_PRIORITY_LANES", True)
         redis_queue = mocker.MagicMock()
         redis_queue._suffix = "foo"
         redis_queue._process_type = "bar"
@@ -89,18 +76,7 @@ class TestBatchSavingMetricsFunctions:
         )
         metrics_logger_mock.put_metric.assert_called_with("batch_saving_inflight", 1, "Count")
 
-    def test_put_batch_saving_inflight_processed_FF_PRIORITY_LANES_false(self, mocker, metrics_logger_mock):
-        mocker.patch.object(Config, "FF_PRIORITY_LANES", False)
-        redis_queue = mocker.MagicMock()
-        redis_queue._suffix = "foo"
-        redis_queue._process_type = "bar"
-        put_batch_saving_inflight_processed(metrics_logger_mock, redis_queue, 1)
-        assert metrics_logger_mock.set_dimensions.call_count == 1
-        metrics_logger_mock.set_dimensions.assert_has_calls([call({"acknowledged": "True"})])
-        metrics_logger_mock.put_metric.assert_called_with("batch_saving_inflight", 1, "Count")
-
     def test_put_batch_saving_expiry_metric_FF_PRIORITY_LANES_true(self, mocker, metrics_logger_mock):
-        mocker.patch.object(Config, "FF_PRIORITY_LANES", True)
         redis_queue = mocker.MagicMock()
         redis_queue._suffix = "foo"
         redis_queue._process_type = "bar"
@@ -108,40 +84,17 @@ class TestBatchSavingMetricsFunctions:
         metrics_logger_mock.put_metric.assert_called_with("batch_saving_inflight", 1, "Count")
         metrics_logger_mock.set_dimensions.assert_called_with({"expired": "True", "notification_type": "foo", "priority": "bar"})
 
-    def test_put_batch_saving_expiry_metric_FF_PRIORITY_LANES_false(self, mocker, metrics_logger_mock):
-        mocker.patch.object(Config, "FF_PRIORITY_LANES", False)
-        redis_queue = mocker.MagicMock()
-        redis_queue._suffix = "foo"
-        redis_queue._process_type = "bar"
-        put_batch_saving_expiry_metric(metrics_logger_mock, redis_queue, 1)
-        metrics_logger_mock.put_metric.assert_called_with("batch_saving_inflight", 1, "Count")
-        metrics_logger_mock.set_dimensions.assert_called_with({"expired": "True"})
-
     def test_put_batch_saving_bulk_created_FF_PRIORITY_LANES_true(self, mocker, metrics_logger_mock):
-        mocker.patch.object(Config, "FF_PRIORITY_LANES", True)
         put_batch_saving_bulk_created(metrics_logger_mock, 1, "foo", "bar")
         metrics_logger_mock.put_metric.assert_called_with("batch_saving_bulk", 1, "Count")
         metrics_logger_mock.set_dimensions.assert_called_with({"created": "True", "notification_type": "foo", "priority": "bar"})
 
-    def test_put_batch_saving_bulk_created_FF_PRIORITY_LANES_false(self, mocker, metrics_logger_mock):
-        mocker.patch.object(Config, "FF_PRIORITY_LANES", False)
-        put_batch_saving_bulk_created(metrics_logger_mock, 1, "foo", "bar")
-        metrics_logger_mock.put_metric.assert_called_with("batch_saving_bulk", 1, "Count")
-        metrics_logger_mock.set_dimensions.assert_called_with({"created": "True"})
-
     def test_put_batch_saving_bulk_processed_FF_PRIORITY_LANES_true(self, mocker, metrics_logger_mock):
-        mocker.patch.object(Config, "FF_PRIORITY_LANES", True)
         put_batch_saving_bulk_processed(metrics_logger_mock, 1, notification_type="foo", priority="bar")
         metrics_logger_mock.put_metric.assert_called_with("batch_saving_bulk", 1, "Count")
         metrics_logger_mock.set_dimensions.assert_called_with(
             {"acknowledged": "True", "notification_type": "foo", "priority": "bar"}
         )
-
-    def test_put_batch_saving_bulk_processed_FF_PRIORITY_LANES_false(self, mocker, metrics_logger_mock):
-        mocker.patch.object(Config, "FF_PRIORITY_LANES", False)
-        put_batch_saving_bulk_processed(metrics_logger_mock, 1, notification_type="foo", priority="bar")
-        metrics_logger_mock.put_metric.assert_called_with("batch_saving_bulk", 1, "Count")
-        metrics_logger_mock.set_dimensions.assert_called_with({"acknowledged": "True"})
 
     def test_put_batch_metric_unknown_error(self, mocker, metrics_logger_mock):
         redis_queue = mocker.MagicMock()

--- a/tests/app/aws/test_metrics.py
+++ b/tests/app/aws/test_metrics.py
@@ -58,7 +58,7 @@ class TestBatchSavingMetricsFunctions:
         metrics_logger_mock.set_dimensions.assert_called_with({"list_name": "foo"})
         metrics_logger_mock.put_metric.assert_called_with("batch_saving_published", 20, "Count")
 
-    def test_put_batch_saving_in_flight_metric_FF_PRIORITY_LANES_true(self, mocker, metrics_logger_mock):
+    def test_put_batch_saving_in_flight_metric(self, mocker, metrics_logger_mock):
         redis_queue = mocker.MagicMock()
         redis_queue._suffix = "foo"
         redis_queue._process_type = "bar"
@@ -66,7 +66,7 @@ class TestBatchSavingMetricsFunctions:
         metrics_logger_mock.set_dimensions.assert_called_with({"created": "True", "notification_type": "foo", "priority": "bar"})
         metrics_logger_mock.put_metric.assert_called_with("batch_saving_inflight", 1, "Count")
 
-    def test_put_batch_saving_inflight_processed_FF_PRIORITY_LANES_true(self, mocker, metrics_logger_mock):
+    def test_put_batch_saving_inflight_processed(self, mocker, metrics_logger_mock):
         redis_queue = mocker.MagicMock()
         redis_queue._suffix = "foo"
         redis_queue._process_type = "bar"
@@ -76,7 +76,7 @@ class TestBatchSavingMetricsFunctions:
         )
         metrics_logger_mock.put_metric.assert_called_with("batch_saving_inflight", 1, "Count")
 
-    def test_put_batch_saving_expiry_metric_FF_PRIORITY_LANES_true(self, mocker, metrics_logger_mock):
+    def test_put_batch_saving_expiry_metric(self, mocker, metrics_logger_mock):
         redis_queue = mocker.MagicMock()
         redis_queue._suffix = "foo"
         redis_queue._process_type = "bar"
@@ -84,12 +84,12 @@ class TestBatchSavingMetricsFunctions:
         metrics_logger_mock.put_metric.assert_called_with("batch_saving_inflight", 1, "Count")
         metrics_logger_mock.set_dimensions.assert_called_with({"expired": "True", "notification_type": "foo", "priority": "bar"})
 
-    def test_put_batch_saving_bulk_created_FF_PRIORITY_LANES_true(self, mocker, metrics_logger_mock):
+    def test_put_batch_saving_bulk_created(self, mocker, metrics_logger_mock):
         put_batch_saving_bulk_created(metrics_logger_mock, 1, "foo", "bar")
         metrics_logger_mock.put_metric.assert_called_with("batch_saving_bulk", 1, "Count")
         metrics_logger_mock.set_dimensions.assert_called_with({"created": "True", "notification_type": "foo", "priority": "bar"})
 
-    def test_put_batch_saving_bulk_processed_FF_PRIORITY_LANES_true(self, mocker, metrics_logger_mock):
+    def test_put_batch_saving_bulk_processed(self, mocker, metrics_logger_mock):
         put_batch_saving_bulk_processed(metrics_logger_mock, 1, notification_type="foo", priority="bar")
         metrics_logger_mock.put_metric.assert_called_with("batch_saving_bulk", 1, "Count")
         metrics_logger_mock.set_dimensions.assert_called_with(

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -7,11 +7,9 @@ from freezegun import freeze_time
 from app import db
 from app.celery import scheduled_tasks, tasks
 from app.celery.scheduled_tasks import (
-    beat_inbox_email,
     beat_inbox_email_bulk,
     beat_inbox_email_normal,
     beat_inbox_email_priority,
-    beat_inbox_sms,
     beat_inbox_sms_bulk,
     beat_inbox_sms_normal,
     beat_inbox_sms_priority,
@@ -506,30 +504,6 @@ def test_check_templated_letter_state_during_utc(mocker, sample_letter_template)
 
 
 class TestHeartbeatQueues:
-    def test_beat_inbox_sms(self, mocker):
-        mocker.patch("app.celery.tasks.current_app.logger.info")
-        mocker.patch("app.sms_queue.poll", side_effect=[("rec123", ["1", "2", "3", "4"]), ("hello", [])])
-        mocker.patch("app.celery.tasks.save_smss.apply_async")
-
-        beat_inbox_sms()
-
-        tasks.save_smss.apply_async.assert_called_once_with(
-            (None, ["1", "2", "3", "4"], "rec123"),
-            queue="database-tasks",
-        )
-
-    def test_heartbeat_inbox_email(self, mocker):
-        mocker.patch("app.celery.tasks.current_app.logger.info")
-        mocker.patch("app.email_queue.poll", side_effect=[("rec123", ["1", "2", "3", "4"]), ("hello", [])])
-        mocker.patch("app.celery.tasks.save_emails.apply_async")
-
-        beat_inbox_email()
-
-        tasks.save_emails.apply_async.assert_called_once_with(
-            (None, ["1", "2", "3", "4"], "rec123"),
-            queue="database-tasks",
-        )
-
     def test_beat_inbox_sms_normal(self, notify_api, mocker):
         mocker.patch("app.celery.tasks.current_app.logger.info")
         mocker.patch("app.sms_normal.poll", side_effect=[("rec123", ["1", "2", "3", "4"]), ("hello", [])])
@@ -604,7 +578,7 @@ class TestHeartbeatQueues:
 
 
 class TestRecoverExpiredNotification:
-    def test_recover_expired_notifications_priority_lanes(self, mocker, notify_api):
+    def test_recover_expired_notifications(self, mocker, notify_api):
         sms_bulk = mocker.patch("app.sms_bulk.expire_inflights")
         sms_normal = mocker.patch("app.sms_normal.expire_inflights")
         sms_priority = mocker.patch("app.sms_priority.expire_inflights")

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -531,7 +531,6 @@ class TestHeartbeatQueues:
         )
 
     def test_beat_inbox_sms_normal(self, notify_api, mocker):
-        notify_api.config["FF_PRIORITY_LANES"] = True
         mocker.patch("app.celery.tasks.current_app.logger.info")
         mocker.patch("app.sms_normal.poll", side_effect=[("rec123", ["1", "2", "3", "4"]), ("hello", [])])
         mocker.patch("app.celery.tasks.save_smss.apply_async")
@@ -544,7 +543,6 @@ class TestHeartbeatQueues:
         )
 
     def test_beat_inbox_sms_bulk(self, notify_api, mocker):
-        notify_api.config["FF_PRIORITY_LANES"] = True
         mocker.patch("app.celery.tasks.current_app.logger.info")
         mocker.patch("app.sms_bulk.poll", side_effect=[("rec123", ["1", "2", "3", "4"]), ("hello", [])])
         mocker.patch("app.celery.tasks.save_smss.apply_async")
@@ -557,7 +555,6 @@ class TestHeartbeatQueues:
         )
 
     def test_beat_inbox_sms_priority(self, notify_api, mocker):
-        notify_api.config["FF_PRIORITY_LANES"] = True
         mocker.patch("app.celery.tasks.current_app.logger.info")
         mocker.patch("app.sms_priority.poll", side_effect=[("rec123", ["1", "2", "3", "4"]), ("hello", [])])
         mocker.patch("app.celery.tasks.save_smss.apply_async")
@@ -570,7 +567,6 @@ class TestHeartbeatQueues:
         )
 
     def test_beat_inbox_email_normal(self, notify_api, mocker):
-        notify_api.config["FF_PRIORITY_LANES"] = True
         mocker.patch("app.celery.tasks.current_app.logger.info")
         mocker.patch("app.email_normal.poll", side_effect=[("rec123", ["1", "2", "3", "4"]), ("hello", [])])
         mocker.patch("app.celery.tasks.save_emails.apply_async")
@@ -583,7 +579,6 @@ class TestHeartbeatQueues:
         )
 
     def test_beat_inbox_email_bulk(self, notify_api, mocker):
-        notify_api.config["FF_PRIORITY_LANES"] = True
         mocker.patch("app.celery.tasks.current_app.logger.info")
         mocker.patch("app.email_bulk.poll", side_effect=[("rec123", ["1", "2", "3", "4"]), ("hello", [])])
         mocker.patch("app.celery.tasks.save_emails.apply_async")
@@ -596,7 +591,6 @@ class TestHeartbeatQueues:
         )
 
     def test_beat_inbox_email_priority(self, notify_api, mocker):
-        notify_api.config["FF_PRIORITY_LANES"] = True
         mocker.patch("app.celery.tasks.current_app.logger.info")
         mocker.patch("app.email_priority.poll", side_effect=[("rec123", ["1", "2", "3", "4"]), ("hello", [])])
         mocker.patch("app.celery.tasks.save_emails.apply_async")
@@ -610,19 +604,7 @@ class TestHeartbeatQueues:
 
 
 class TestRecoverExpiredNotification:
-    def test_recover_expired_notifications(self, notify_api, mocker):
-        notify_api.config["FF_PRIORITY_LANES"] = False
-        mocker.patch("app.celery.tasks.sms_queue.expire_inflights")
-        mocker.patch("app.celery.tasks.email_queue.expire_inflights")
-
-        recover_expired_notifications()
-
-        tasks.sms_queue.expire_inflights.assert_called_once()
-        tasks.email_queue.expire_inflights.assert_called_once()
-
     def test_recover_expired_notifications_priority_lanes(self, mocker, notify_api):
-        notify_api.config["FF_PRIORITY_LANES"] = True
-
         sms_bulk = mocker.patch("app.sms_bulk.expire_inflights")
         sms_normal = mocker.patch("app.sms_normal.expire_inflights")
         sms_priority = mocker.patch("app.sms_priority.expire_inflights")

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -1072,6 +1072,7 @@ class TestSaveSms:
         assert persisted_notification.notification_type == "sms"
         mocked_deliver_sms.assert_called_once_with([str(persisted_notification.id)], queue="send-sms-tasks")
 
+    @pytest.mark.skip(reason="Deprecated: This test needs to use save_smss path")
     @pytest.mark.parametrize("sender_id", [None, "996958a8-0c06-43be-a40e-56e4a2d1655c"])
     def test_save_sms_should_use_redis_cache_to_retrieve_service_and_template_when_possible(
         self, sample_template_with_placeholders, mocker, sender_id

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -32,7 +32,7 @@ from app.celery.tasks import (
     send_inbound_sms_to_service,
     send_notify_no_reply,
 )
-from app.config import Config, QueueNames
+from app.config import QueueNames
 from app.dao import jobs_dao, service_email_reply_to_dao, service_sms_sender_dao
 from app.models import (
     BULK,
@@ -109,26 +109,9 @@ class TestChooseDatabaseQueue:
         "research_mode,template_priority",
         [(True, PRIORITY), (True, NORMAL), (True, BULK), (False, PRIORITY), (False, NORMAL), (False, BULK)],
     )
-    def test_choose_database_queue_FF_PRIORITY_LANES_false(
-        self, mocker, notify_db, notify_db_session, notify_api, research_mode, template_priority
-    ):
-        mocker.patch.object(Config, "FF_PRIORITY_LANES", False)
-        service = sample_service(notify_db, notify_db_session, research_mode=research_mode)
-        template = sample_template(notify_db, notify_db_session, process_type=template_priority)
-
-        expected_queue = QueueNames.RESEARCH_MODE if research_mode else QueueNames.DATABASE
-        actual_queue = choose_database_queue(template, service)
-
-        assert expected_queue == actual_queue
-
-    @pytest.mark.parametrize(
-        "research_mode,template_priority",
-        [(True, PRIORITY), (True, NORMAL), (True, BULK), (False, PRIORITY), (False, NORMAL), (False, BULK)],
-    )
     def test_choose_database_queue_FF_PRIORITY_LANES_true(
         self, mocker, notify_db, notify_db_session, notify_api, research_mode, template_priority
     ):
-        mocker.patch.object(Config, "FF_PRIORITY_LANES", True)
         service = sample_service(notify_db, notify_db_session, research_mode=research_mode)
         template = sample_template(notify_db, notify_db_session, process_type=template_priority)
 
@@ -237,8 +220,6 @@ class TestBatchSaving:
         mocker.patch("app.celery.provider_tasks.deliver_sms.apply_async")
         acknowldege_mock = mocker.patch("app.sms_normal.acknowledge")
 
-        mocker.patch.object(Config, "FF_PRIORITY_LANES", True)
-
         receipt = uuid.uuid4()
         save_smss(
             str(sample_template_with_placeholders.service.id),
@@ -331,7 +312,7 @@ class TestBatchSaving:
         mock_persist_notifications.assert_called_once()
         mock_save_sms.assert_called_once_with(
             (sample_template_with_placeholders.service.id, notification1["id"], signer.sign(notification1), None),
-            queue=QueueNames.DATABASE,
+            queue=QueueNames.NORMAL_DATABASE,
         )
         mock_acknowldege.assert_called_once_with(receipt)
 
@@ -364,7 +345,7 @@ class TestBatchSaving:
         mock_persist_notifications.assert_called_once()
         mock_save_email.assert_called_once_with(
             (sample_email_template_with_placeholders.service.id, notification1["id"], signer.sign(notification1), None),
-            queue=QueueNames.DATABASE,
+            queue=QueueNames.NORMAL_DATABASE,
         )
         mock_acknowldege.assert_called_once_with(receipt)
 
@@ -444,7 +425,6 @@ class TestBatchSaving:
         mocker.patch("app.celery.tasks.save_smss.apply_async")
         mocker.patch("app.encryption.CryptoSigner.sign", return_value="something_encrypted")
         redis_mock = mocker.patch("app.celery.tasks.statsd_client.timing_with_dates")
-        mocker.patch.object(Config, "FF_BATCH_INSERTION", True)
 
         process_job(job.id)
 
@@ -473,7 +453,7 @@ class TestBatchSaving:
                 ],
                 None,
             ),
-            queue="database-tasks",
+            queue="-normal-database-tasks",
         )
         job = jobs_dao.dao_get_job_by_id(job.id)
         assert job.job_status == "finished"
@@ -519,14 +499,13 @@ class TestBatchSaving:
         assert persisted_notification[0].personalisation == {"name": "Jo"}
         assert persisted_notification[0]._personalisation == signer.sign({"name": "Jo"})
         assert persisted_notification[0].notification_type == SMS_TYPE
-        assert pbsbp_mock.assert_called_with(mock.ANY, 1) is None
+        assert pbsbp_mock.assert_called_with(mock.ANY, 1, notification_type="sms", priority="normal") is None
 
 
 class TestProcessJob:
     def test_should_process_sms_job_FF_PRIORITY_LANES_true(self, sample_job, mocker):
-        mocker.patch.object(Config, "FF_PRIORITY_LANES", True)
         mocker.patch("app.celery.tasks.s3.get_job_from_s3", return_value=load_example_csv("sms"))
-        mocker.patch("app.celery.tasks.save_sms.apply_async")
+        mocker.patch("app.celery.tasks.save_smss.apply_async")
         mocker.patch("app.encryption.CryptoSigner.sign", return_value="something_encrypted")
         mocker.patch("app.celery.tasks.create_uuid", return_value="uuid")
 
@@ -539,35 +518,8 @@ class TestProcessJob:
         assert signer.sign.call_args[0][0]["template_version"] == sample_job.template.version
         assert signer.sign.call_args[0][0]["personalisation"] == {"phonenumber": "+441234123123"}
         assert signer.sign.call_args[0][0]["row_number"] == 0
-        tasks.save_sms.apply_async.assert_called_once_with(
-            (str(sample_job.service_id), "uuid", "something_encrypted"), {}, queue=QueueNames.NORMAL_DATABASE
-        )
-        job = jobs_dao.dao_get_job_by_id(sample_job.id)
-        assert job.job_status == "finished"
-        assert job.processing_started is not None
-        assert job.created_at is not None
-        redis_mock.assert_called_once_with("job.processing-start-delay", job.processing_started, job.created_at)
-
-    def test_should_process_sms_job_FF_PRIORITY_LANES_false(self, sample_job, mocker):
-        mocker.patch.object(Config, "FF_PRIORITY_LANES", False)
-        mocker.patch("app.celery.tasks.s3.get_job_from_s3", return_value=load_example_csv("sms"))
-        mocker.patch("app.celery.tasks.save_sms.apply_async")
-        mocker.patch("app.encryption.CryptoSigner.sign", return_value="something_encrypted")
-        mocker.patch("app.celery.tasks.create_uuid", return_value="uuid")
-
-        redis_mock = mocker.patch("app.celery.tasks.statsd_client.timing_with_dates")
-
-        process_job(sample_job.id)
-        s3.get_job_from_s3.assert_called_once_with(str(sample_job.service.id), str(sample_job.id))
-        assert signer.sign.call_args[0][0]["to"] == "+441234123123"
-        assert signer.sign.call_args[0][0]["template"] == str(sample_job.template.id)
-        assert signer.sign.call_args[0][0]["template_version"] == sample_job.template.version
-        assert signer.sign.call_args[0][0]["personalisation"] == {"phonenumber": "+441234123123"}
-        assert signer.sign.call_args[0][0]["row_number"] == 0
-        tasks.save_sms.apply_async.assert_called_once_with(
-            (str(sample_job.service_id), "uuid", "something_encrypted"),
-            {},
-            queue="database-tasks",
+        tasks.save_smss.apply_async.assert_called_once_with(
+            (str(sample_job.service_id), ["something_encrypted"], None), queue=QueueNames.NORMAL_DATABASE
         )
         job = jobs_dao.dao_get_job_by_id(sample_job.id)
         assert job.job_status == "finished"
@@ -578,16 +530,15 @@ class TestProcessJob:
     def test_should_process_sms_job_with_sender_id(self, sample_template, mocker, fake_uuid):
         job = create_job(template=sample_template, sender_id=fake_uuid)
         mocker.patch("app.celery.tasks.s3.get_job_from_s3", return_value=load_example_csv("sms"))
-        mocker.patch("app.celery.tasks.save_sms.apply_async")
+        mocker.patch("app.celery.tasks.save_smss.apply_async")
         mocker.patch("app.encryption.CryptoSigner.sign", return_value="something_encrypted")
         mocker.patch("app.celery.tasks.create_uuid", return_value="uuid")
 
         process_job(job.id)
 
-        tasks.save_sms.apply_async.assert_called_once_with(
-            (str(job.service_id), "uuid", "something_encrypted"),
-            {"sender_id": fake_uuid},
-            queue="database-tasks",
+        tasks.save_smss.apply_async.assert_called_once_with(
+            (str(job.service_id), ["something_encrypted"], None),
+            queue="-normal-database-tasks",
         )
 
     @freeze_time("2016-01-01 11:09:00.061258")
@@ -599,14 +550,14 @@ class TestProcessJob:
             "app.celery.tasks.s3.get_job_from_s3",
             return_value=load_example_csv("multiple_sms"),
         )
-        mocker.patch("app.celery.tasks.process_row")
+        mocker.patch("app.celery.tasks.process_rows")
 
         process_job(job.id)
 
         job = jobs_dao.dao_get_job_by_id(job.id)
         assert job.job_status == "sending limits exceeded"
         assert s3.get_job_from_s3.called is False
-        assert tasks.process_row.called is False
+        assert tasks.process_rows.called is False
 
     def test_should_not_process_sms_job_if_would_exceed_send_limits_inc_today(self, notify_db_session, mocker):
         service = create_service(message_limit=1)
@@ -663,7 +614,7 @@ class TestProcessJob:
             "app.celery.tasks.s3.get_job_from_s3",
             return_value=load_example_csv("multiple_email"),
         )
-        mocker.patch("app.celery.tasks.save_email.apply_async")
+        mocker.patch("app.celery.tasks.save_emails.apply_async")
         mocker.patch("app.encryption.CryptoSigner.sign", return_value="something_encrypted")
         mocker.patch("app.celery.tasks.create_uuid", return_value="uuid")
 
@@ -672,14 +623,24 @@ class TestProcessJob:
         s3.get_job_from_s3.assert_called_once_with(str(job.service.id), str(job.id))
         job = jobs_dao.dao_get_job_by_id(job.id)
         assert job.job_status == "finished"
-        tasks.save_email.apply_async.assert_called_with(
+        tasks.save_emails.apply_async.assert_called_with(
             (
                 str(job.service_id),
-                "uuid",
-                "something_encrypted",
+                [
+                    "something_encrypted",
+                    "something_encrypted",
+                    "something_encrypted",
+                    "something_encrypted",
+                    "something_encrypted",
+                    "something_encrypted",
+                    "something_encrypted",
+                    "something_encrypted",
+                    "something_encrypted",
+                    "something_encrypted",
+                ],
+                None,
             ),
-            {},
-            queue="database-tasks",
+            queue="-normal-database-tasks",
         )
 
     def test_should_process_smss_job(self, notify_db_session, mocker):
@@ -693,7 +654,6 @@ class TestProcessJob:
         mocker.patch("app.celery.tasks.save_smss.apply_async")
         mocker.patch("app.encryption.CryptoSigner.sign", return_value="something_encrypted")
         redis_mock = mocker.patch("app.celery.tasks.statsd_client.timing_with_dates")
-        mocker.patch.object(Config, "FF_BATCH_INSERTION", True)
 
         process_job(job.id)
 
@@ -722,7 +682,7 @@ class TestProcessJob:
                 ],
                 None,
             ),
-            queue="database-tasks",
+            queue="-normal-database-tasks",
         )
         job = jobs_dao.dao_get_job_by_id(job.id)
         assert job.job_status == "finished"
@@ -746,7 +706,7 @@ class TestProcessJob:
         test@test.com,foo
         """
         mocker.patch("app.celery.tasks.s3.get_job_from_s3", return_value=email_csv)
-        mocker.patch("app.celery.tasks.save_email.apply_async")
+        mocker.patch("app.celery.tasks.save_emails.apply_async")
         mocker.patch("app.encryption.CryptoSigner.sign", return_value="something_encrypted")
         mocker.patch("app.celery.tasks.create_uuid", return_value="uuid")
         redis_mock = mocker.patch("app.celery.tasks.statsd_client.timing_with_dates")
@@ -763,14 +723,9 @@ class TestProcessJob:
             "emailaddress": "test@test.com",
             "name": "foo",
         }
-        tasks.save_email.apply_async.assert_called_once_with(
-            (
-                str(email_job_with_placeholders.service_id),
-                "uuid",
-                "something_encrypted",
-            ),
-            {},
-            queue="database-tasks",
+        tasks.save_emails.apply_async.assert_called_once_with(
+            (str(email_job_with_placeholders.service_id), ["something_encrypted"], None),
+            queue="-normal-database-tasks",
         )
         job = jobs_dao.dao_get_job_by_id(email_job_with_placeholders.id)
         assert job.job_status == "finished"
@@ -789,7 +744,6 @@ class TestProcessJob:
         mocker.patch("app.celery.tasks.save_emails.apply_async")
         mocker.patch("app.encryption.CryptoSigner.sign", return_value="something_encrypted")
         redis_mock = mocker.patch("app.celery.tasks.statsd_client.timing_with_dates")
-        mocker.patch.object(Config, "FF_BATCH_INSERTION", True)
 
         process_job(email_job_with_placeholders.id)
 
@@ -810,7 +764,7 @@ class TestProcessJob:
                 ["something_encrypted", "something_encrypted", "something_encrypted", "something_encrypted"],
                 None,
             ),
-            queue="database-tasks",
+            queue="-normal-database-tasks",
         )
         job = jobs_dao.dao_get_job_by_id(email_job_with_placeholders.id)
         assert job.job_status == "finished"
@@ -824,54 +778,22 @@ class TestProcessJob:
         """
         job = create_job(template=sample_email_template, sender_id=fake_uuid)
         mocker.patch("app.celery.tasks.s3.get_job_from_s3", return_value=email_csv)
-        mocker.patch("app.celery.tasks.save_email.apply_async")
+        mocker.patch("app.celery.tasks.save_emails.apply_async")
         mocker.patch("app.encryption.CryptoSigner.sign", return_value="something_encrypted")
         mocker.patch("app.celery.tasks.create_uuid", return_value="uuid")
 
         process_job(job.id)
 
-        tasks.save_email.apply_async.assert_called_once_with(
-            (str(job.service_id), "uuid", "something_encrypted"),
-            {"sender_id": fake_uuid},
-            queue="database-tasks",
+        tasks.save_emails.apply_async.assert_called_once_with(
+            (str(job.service_id), ["something_encrypted"], None), queue="-normal-database-tasks"
         )
-
-    @freeze_time("2016-01-01 11:09:00.061258")
-    def test_should_process_letter_job(self, sample_letter_job, mocker):
-        csv = """address_line_1,address_line_2,address_line_3,address_line_4,postcode,name
-        A1,A2,A3,A4,A_POST,Alice
-        """
-        s3_mock = mocker.patch("app.celery.tasks.s3.get_job_from_s3", return_value=csv)
-        process_row_mock = mocker.patch("app.celery.tasks.process_row")
-        mocker.patch("app.celery.tasks.create_uuid", return_value="uuid")
-
-        process_job(sample_letter_job.id)
-
-        s3_mock.assert_called_once_with(str(sample_letter_job.service.id), str(sample_letter_job.id))
-
-        row_call = process_row_mock.mock_calls[0][1]
-        assert row_call[0].index == 0
-        assert row_call[0].recipient == ["A1", "A2", "A3", "A4", None, None, "A_POST"]
-        assert row_call[0].personalisation == {
-            "addressline1": "A1",
-            "addressline2": "A2",
-            "addressline3": "A3",
-            "addressline4": "A4",
-            "postcode": "A_POST",
-        }
-        assert row_call[2] == sample_letter_job
-        assert row_call[3] == sample_letter_job.service
-
-        assert process_row_mock.call_count == 1
-
-        assert sample_letter_job.job_status == "finished"
 
     def test_should_process_all_sms_job(self, sample_job_with_placeholdered_template, mocker):
         mocker.patch(
             "app.celery.tasks.s3.get_job_from_s3",
             return_value=load_example_csv("multiple_sms"),
         )
-        mocker.patch("app.celery.tasks.save_sms.apply_async")
+        mocker.patch("app.celery.tasks.save_smss.apply_async")
         mocker.patch("app.encryption.CryptoSigner.sign", return_value="something_encrypted")
         mocker.patch("app.celery.tasks.create_uuid", return_value="uuid")
 
@@ -888,7 +810,7 @@ class TestProcessJob:
             "phonenumber": "+441234123120",
             "name": "chris",
         }
-        assert tasks.save_sms.apply_async.call_count == 10
+        assert tasks.save_smss.apply_async.call_count == 1
         job = jobs_dao.dao_get_job_by_id(sample_job_with_placeholdered_template.id)
         assert job.job_status == "finished"
 
@@ -910,11 +832,11 @@ class TestProcessRow:
     @pytest.mark.parametrize(
         "template_type, research_mode, expected_function, expected_queue, api_key_id, sender_id, reference",
         [
-            (SMS_TYPE, False, "save_sms", "database-tasks", None, None, None),
+            (SMS_TYPE, False, "save_sms", "-normal-database-tasks", None, None, None),
             (SMS_TYPE, True, "save_sms", "research-mode-tasks", uuid.uuid4(), uuid.uuid4(), "ref1"),
-            (EMAIL_TYPE, False, "save_email", "database-tasks", uuid.uuid4(), uuid.uuid4(), "ref2"),
+            (EMAIL_TYPE, False, "save_email", "-normal-database-tasks", uuid.uuid4(), uuid.uuid4(), "ref2"),
             (EMAIL_TYPE, True, "save_email", "research-mode-tasks", None, None, None),
-            (LETTER_TYPE, False, "save_letter", "database-tasks", None, None, None),
+            (LETTER_TYPE, False, "save_letter", "-normal-database-tasks", None, None, None),
             (LETTER_TYPE, True, "save_letter", "research-mode-tasks", uuid.uuid4(), uuid.uuid4(), "ref3"),
         ],
     )
@@ -1900,37 +1822,6 @@ class TestSendInboundSmsToService:
 
 class TestProcessIncompleteJob:
     def test_process_incomplete_job_sms_FF_PRIORITY_LANES_true(self, mocker, sample_template):
-        mocker.patch.object(Config, "FF_PRIORITY_LANES", True)
-        mocker.patch(
-            "app.celery.tasks.s3.get_job_from_s3",
-            return_value=load_example_csv("multiple_sms"),
-        )
-        save_sms = mocker.patch("app.celery.tasks.save_sms.apply_async")
-
-        job = create_job(
-            template=sample_template,
-            notification_count=10,
-            created_at=datetime.utcnow() - timedelta(hours=2),
-            scheduled_for=datetime.utcnow() - timedelta(minutes=31),
-            processing_started=datetime.utcnow() - timedelta(minutes=31),
-            job_status=JOB_STATUS_ERROR,
-        )
-
-        save_notification(create_notification(sample_template, job, 0))
-        save_notification(create_notification(sample_template, job, 1))
-
-        assert Notification.query.filter(Notification.job_id == job.id).count() == 2
-
-        process_incomplete_job(str(job.id))
-
-        completed_job = Job.query.filter(Job.id == job.id).one()
-
-        assert completed_job.job_status == JOB_STATUS_FINISHED
-
-        assert save_sms.call_count == 8  # There are 10 in the file and we've added two already
-
-    def test_process_incomplete_job_sms_FF_PRIORITY_LANES_false(self, mocker, sample_template):
-        mocker.patch.object(Config, "FF_PRIORITY_LANES", False)
         mocker.patch(
             "app.celery.tasks.s3.get_job_from_s3",
             return_value=load_example_csv("multiple_sms"),

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -63,54 +63,6 @@ def test_create_content_for_notification_allows_additional_personalisation(
     create_content_for_notification(template, {"name": "Bobby", "Additional placeholder": "Data"})
 
 
-@freeze_time("2016-01-01 11:09:00.061258")
-def test_persist_notification_creates_and_save_to_db(sample_template, sample_api_key, sample_job, mocker):
-    mocked_redis = mocker.patch("app.notifications.process_notifications.redis_store.get")
-    mocker.patch("app.notifications.process_notifications.dao_get_template_by_id", return_value=sample_template)
-    mocker.patch("app.notifications.process_notifications.choose_queue", return_value="email_queue")
-
-    assert Notification.query.count() == 0
-    assert NotificationHistory.query.count() == 0
-    notification = persist_notification(
-        template_id=sample_template.id,
-        template_version=sample_template.version,
-        recipient="+16502532222",
-        service=sample_template.service,
-        personalisation={},
-        notification_type="sms",
-        api_key_id=sample_api_key.id,
-        key_type=sample_api_key.key_type,
-        job_id=sample_job.id,
-        job_row_number=100,
-        reference="ref",
-        reply_to_text=sample_template.service.get_default_sms_sender(),
-    )
-
-    assert Notification.query.get(notification.id) is not None
-
-    notification_from_db = Notification.query.one()
-
-    assert notification_from_db.id == notification.id
-    assert notification_from_db.template_id == notification.template_id
-    assert notification_from_db.template_version == notification.template_version
-    assert notification_from_db.api_key_id == notification.api_key_id
-    assert notification_from_db.key_type == notification.key_type
-    assert notification_from_db.key_type == notification.key_type
-    assert notification_from_db.billable_units == notification.billable_units
-    assert notification_from_db.notification_type == notification.notification_type
-    assert notification_from_db.created_at == notification.created_at
-    assert not notification_from_db.sent_at
-    assert notification_from_db.updated_at == notification.updated_at
-    assert notification_from_db.status == notification.status
-    assert notification_from_db.reference == notification.reference
-    assert notification_from_db.client_reference == notification.client_reference
-    assert notification_from_db.created_by_id == notification.created_by_id
-    assert notification_from_db.reply_to_text == sample_template.service.get_default_sms_sender()
-    assert notification_from_db.queue_name == "email_queue"
-
-    mocked_redis.assert_called_once_with(str(sample_template.service_id) + "-2016-01-01-count")
-
-
 def test_persist_notification_throws_exception_when_missing_template(sample_api_key):
     assert Notification.query.count() == 0
     assert NotificationHistory.query.count() == 0
@@ -129,27 +81,7 @@ def test_persist_notification_throws_exception_when_missing_template(sample_api_
     assert NotificationHistory.query.count() == 0
 
 
-def test_cache_is_not_incremented_on_failure_to_persist_notification(sample_api_key, mocker, sample_template):
-    mocked_redis = mocker.patch("app.redis_store.get")
-    mock_service_template_cache = mocker.patch("app.redis_store.get_all_from_hash")
-    mocker.patch("app.notifications.process_notifications.dao_get_template_by_id", return_value=sample_template)
-    mocker.patch("app.notifications.process_notifications.choose_queue", return_value="email_queue")
-
-    with pytest.raises(SQLAlchemyError):
-        persist_notification(
-            template_id=None,
-            template_version=None,
-            recipient="+16502532222",
-            service=sample_api_key.service,
-            personalisation=None,
-            notification_type="sms",
-            api_key_id=sample_api_key.id,
-            key_type=sample_api_key.key_type,
-        )
-    mocked_redis.assert_not_called()
-    mock_service_template_cache.assert_not_called()
-
-
+@pytest.mark.skip(reason="Deprecated: This test needs to use the persist_notifications path")
 def test_persist_notification_does_not_increment_cache_if_test_key(
     notify_db, notify_db_session, sample_template, sample_job, mocker
 ):
@@ -191,6 +123,7 @@ def test_persist_notification_does_not_increment_cache_if_test_key(
     assert not template_usage_cache.called
 
 
+@pytest.mark.skip(reason="Deprecated: This test needs to use the persist_notifications path")
 @freeze_time("2016-01-01 11:09:00.061258")
 def test_persist_notification_with_optionals(sample_job, sample_api_key, mocker, sample_template):
     assert Notification.query.count() == 0
@@ -235,6 +168,7 @@ def test_persist_notification_with_optionals(sample_job, sample_api_key, mocker,
     assert not persisted_notification.reply_to_text
 
 
+@pytest.mark.skip(reason="Deprecated: This test needs to use the persist_notifications path")
 @freeze_time("2016-01-01 11:09:00.061258")
 def test_persist_notification_doesnt_touch_cache_for_old_keys_that_dont_exist(sample_template, sample_api_key, mocker):
     mock_incr = mocker.patch("app.notifications.process_notifications.redis_store.incr")
@@ -258,6 +192,7 @@ def test_persist_notification_doesnt_touch_cache_for_old_keys_that_dont_exist(sa
     mock_incr.assert_not_called()
 
 
+@pytest.mark.skip(reason="Deprecated: This test needs to use the persist_notifications path")
 @freeze_time("2016-01-01 11:09:00.061258")
 def test_persist_notification_increments_cache_if_key_exists(sample_template, sample_api_key, mocker):
     mock_incr = mocker.patch("app.notifications.process_notifications.redis_store.incr")

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -53,96 +53,11 @@ def rows_to_csv(rows):
     return output.getvalue()
 
 
-@pytest.mark.parametrize("reference", [None, "reference_from_client"])
-def test_post_sms_notification_returns_201(notify_api, client, sample_template_with_placeholders, mocker, reference):
-    notify_api.config["FF_NOTIFICATION_CELERY_PERSISTENCE"] = False
-    mocked = mocker.patch("app.celery.provider_tasks.deliver_sms.apply_async")
-    data = {
-        "phone_number": "+16502532222",
-        "template_id": str(sample_template_with_placeholders.id),
-        "personalisation": {" Name": "Jo"},
-    }
-    if reference:
-        data.update({"reference": reference})
-    auth_header = create_authorization_header(service_id=sample_template_with_placeholders.service_id)
-
-    response = client.post(
-        path="/v2/notifications/sms",
-        data=json.dumps(data),
-        headers=[("Content-Type", "application/json"), auth_header],
-    )
-    assert response.status_code == 201
-    resp_json = json.loads(response.get_data(as_text=True))
-    assert validate(resp_json, post_sms_response) == resp_json
-    notifications = Notification.query.all()
-    assert len(notifications) == 1
-    assert notifications[0].status == NOTIFICATION_CREATED
-    notification_id = notifications[0].id
-    assert notifications[0].postage is None
-    assert resp_json["id"] == str(notification_id)
-    assert resp_json["reference"] == reference
-    assert resp_json["content"]["body"] == sample_template_with_placeholders.content.replace("(( Name))", "Jo")
-    assert resp_json["content"]["from_number"] == current_app.config["FROM_NUMBER"]
-    assert "v2/notifications/{}".format(notification_id) in resp_json["uri"]
-    assert resp_json["template"]["id"] == str(sample_template_with_placeholders.id)
-    assert resp_json["template"]["version"] == sample_template_with_placeholders.version
-    assert (
-        "services/{}/templates/{}".format(
-            sample_template_with_placeholders.service_id,
-            sample_template_with_placeholders.id,
-        )
-        in resp_json["template"]["uri"]
-    )
-    assert not resp_json["scheduled_for"]
-    assert mocked.called
-
-
-@pytest.mark.parametrize("reference", [None, "reference_from_client"])
-def test_post_sms_notification_with_persistance_in_celery_returns_201(
-    notify_api, client, sample_template_with_placeholders, mocker, reference
-):
-    notify_api.config["FF_NOTIFICATION_CELERY_PERSISTENCE"] = True
-    mocked = mocker.patch("app.celery.tasks.save_sms.apply_async")
-    data = {
-        "phone_number": "+16502532222",
-        "template_id": str(sample_template_with_placeholders.id),
-        "personalisation": {" Name": "Jo"},
-    }
-    if reference:
-        data.update({"reference": reference})
-    auth_header = create_authorization_header(service_id=sample_template_with_placeholders.service_id)
-
-    response = client.post(
-        path="/v2/notifications/sms",
-        data=json.dumps(data),
-        headers=[("Content-Type", "application/json"), auth_header],
-    )
-    assert response.status_code == 201
-    resp_json = json.loads(response.get_data(as_text=True))
-    assert validate(resp_json, post_sms_response) == resp_json
-    assert resp_json["reference"] == reference
-    assert resp_json["content"]["body"] == sample_template_with_placeholders.content.replace("(( Name))", "Jo")
-    assert resp_json["content"]["from_number"] == current_app.config["FROM_NUMBER"]
-    assert "v2/notifications/{}".format(resp_json["id"]) in resp_json["uri"]
-    assert resp_json["template"]["id"] == str(sample_template_with_placeholders.id)
-    assert resp_json["template"]["version"] == sample_template_with_placeholders.version
-    assert (
-        "services/{}/templates/{}".format(
-            sample_template_with_placeholders.service_id,
-            sample_template_with_placeholders.id,
-        )
-        in resp_json["template"]["uri"]
-    )
-    assert not resp_json["scheduled_for"]
-    assert mocked.called
-
-
 class TestRedisBatchSaving:
     @pytest.mark.parametrize("reference", [None, "reference_from_client"])
     def test_post_notification_with_redis_batch_saving_returns_201(
         self, notify_api, client, sample_template_with_placeholders, mocker, reference
     ):
-        notify_api.config["FF_REDIS_BATCH_SAVING"] = True
         mocked_redis_publish = mocker.patch("app.queue.RedisQueue.publish")
 
         data = {
@@ -180,11 +95,9 @@ class TestRedisBatchSaving:
 
 
 def test_post_sms_notification_uses_inbound_number_as_sender(notify_api, client, notify_db_session, mocker):
-    notify_api.config["FF_NOTIFICATION_CELERY_PERSISTENCE"] = False
-    notify_api.config["FF_REDIS_BATCH_SAVING"] = False
     service = create_service_with_inbound_number(inbound_number="1")
     template = create_template(service=service, content="Hello (( Name))\nYour thing is due soon")
-    mocked = mocker.patch("app.celery.provider_tasks.deliver_sms.apply_async")
+    mocked = mocker.patch("app.sms_normal.publish")
     data = {
         "phone_number": "+16502532222",
         "template_id": str(template.id),
@@ -200,21 +113,12 @@ def test_post_sms_notification_uses_inbound_number_as_sender(notify_api, client,
     assert response.status_code == 201
     resp_json = json.loads(response.get_data(as_text=True))
     assert validate(resp_json, post_sms_response) == resp_json
-    notifications = Notification.query.all()
-    assert len(notifications) == 1
-    notification_id = notifications[0].id
-    assert resp_json["id"] == str(notification_id)
-    assert resp_json["content"]["from_number"] == "1"
-    assert notifications[0].reply_to_text == "1"
-    mocked.assert_called_once_with([str(notification_id)], queue="send-sms-tasks")
 
 
 def test_post_sms_notification_uses_inbound_number_reply_to_as_sender(notify_api, client, notify_db_session, mocker):
-    notify_api.config["FF_NOTIFICATION_CELERY_PERSISTENCE"] = False
-    notify_api.config["FF_REDIS_BATCH_SAVING"] = False
     service = create_service_with_inbound_number(inbound_number="6502532222")
     template = create_template(service=service, content="Hello (( Name))\nYour thing is due soon")
-    mocked = mocker.patch("app.celery.provider_tasks.deliver_throttled_sms.apply_async")
+    mocked = mocker.patch("app.sms_normal.publish")
     data = {
         "phone_number": "+16502532222",
         "template_id": str(template.id),
@@ -230,20 +134,12 @@ def test_post_sms_notification_uses_inbound_number_reply_to_as_sender(notify_api
     assert response.status_code == 201
     resp_json = json.loads(response.get_data(as_text=True))
     assert validate(resp_json, post_sms_response) == resp_json
-    notifications = Notification.query.all()
-    assert len(notifications) == 1
-    notification_id = notifications[0].id
-    assert resp_json["id"] == str(notification_id)
-    assert resp_json["content"]["from_number"] == "+16502532222"
-    assert notifications[0].reply_to_text == "+16502532222"
-    mocked.assert_called_once_with([str(notification_id)], queue="send-throttled-sms-tasks")
+    assert mocked.called
 
 
 def test_post_sms_notification_returns_201_with_sms_sender_id(notify_api, client, sample_template_with_placeholders, mocker):
-    notify_api.config["FF_NOTIFICATION_CELERY_PERSISTENCE"] = False
-    notify_api.config["FF_REDIS_BATCH_SAVING"] = False
     sms_sender = create_service_sms_sender(service=sample_template_with_placeholders.service, sms_sender="123456")
-    mocked = mocker.patch("app.celery.provider_tasks.deliver_sms.apply_async")
+    mocked = mocker.patch("app.sms_normal.publish")
     data = {
         "phone_number": "+16502532222",
         "template_id": str(sample_template_with_placeholders.id),
@@ -261,19 +157,14 @@ def test_post_sms_notification_returns_201_with_sms_sender_id(notify_api, client
     resp_json = json.loads(response.get_data(as_text=True))
     assert validate(resp_json, post_sms_response) == resp_json
     assert resp_json["content"]["from_number"] == sms_sender.sms_sender
-    notifications = Notification.query.all()
-    assert len(notifications) == 1
-    assert notifications[0].reply_to_text == sms_sender.sms_sender
-    mocked.assert_called_once_with([resp_json["id"]], queue="send-sms-tasks")
+    assert mocked.called
 
 
 def test_post_sms_notification_with_celery_persistence_returns_201_with_sms_sender_id(
     notify_api, client, sample_template_with_placeholders, mocker
 ):
-    notify_api.config["FF_NOTIFICATION_CELERY_PERSISTENCE"] = True
-    notify_api.config["FF_REDIS_BATCH_SAVING"] = False
     sms_sender = create_service_sms_sender(service=sample_template_with_placeholders.service, sms_sender="123456")
-    mocked = mocker.patch("app.celery.tasks.save_sms.apply_async")
+    mocked = mocker.patch("app.sms_normal.publish")
     data = {
         "phone_number": "+16502532222",
         "template_id": str(sample_template_with_placeholders.id),
@@ -295,10 +186,8 @@ def test_post_sms_notification_with_celery_persistence_returns_201_with_sms_send
 
 
 def test_post_sms_notification_uses_sms_sender_id_reply_to(notify_api, client, sample_template_with_placeholders, mocker):
-    notify_api.config["FF_NOTIFICATION_CELERY_PERSISTENCE"] = False
-    notify_api.config["FF_REDIS_BATCH_SAVING"] = False
     sms_sender = create_service_sms_sender(service=sample_template_with_placeholders.service, sms_sender="6502532222")
-    mocked = mocker.patch("app.celery.provider_tasks.deliver_throttled_sms.apply_async")
+    mocked = mocker.patch("app.sms_normal.publish")
     data = {
         "phone_number": "+16502532222",
         "template_id": str(sample_template_with_placeholders.id),
@@ -316,19 +205,14 @@ def test_post_sms_notification_uses_sms_sender_id_reply_to(notify_api, client, s
     resp_json = json.loads(response.get_data(as_text=True))
     assert validate(resp_json, post_sms_response) == resp_json
     assert resp_json["content"]["from_number"] == "+16502532222"
-    notifications = Notification.query.all()
-    assert len(notifications) == 1
-    assert notifications[0].reply_to_text == "+16502532222"
-    mocked.assert_called_once_with([resp_json["id"]], queue="send-throttled-sms-tasks")
+    mocked.called
 
 
 def test_notification_reply_to_text_is_original_value_if_sender_is_changed_after_post_notification(
     notify_api, client, sample_template, mocker
 ):
-    notify_api.config["FF_NOTIFICATION_CELERY_PERSISTENCE"] = False
-    notify_api.config["FF_REDIS_BATCH_SAVING"] = False
     sms_sender = create_service_sms_sender(service=sample_template.service, sms_sender="123456", is_default=False)
-    mocker.patch("app.celery.provider_tasks.deliver_sms.apply_async")
+    mocker.patch("app.sms_normal.publish")
     data = {
         "phone_number": "+16502532222",
         "template_id": str(sample_template.id),
@@ -350,9 +234,6 @@ def test_notification_reply_to_text_is_original_value_if_sender_is_changed_after
     )
 
     assert response.status_code == 201
-    notifications = Notification.query.all()
-    assert len(notifications) == 1
-    assert notifications[0].reply_to_text == "123456"
 
 
 @pytest.mark.parametrize(
@@ -449,8 +330,7 @@ def test_notification_returns_400_and_for_schema_problems(client, sample_templat
 
 @pytest.mark.parametrize("reference", [None, "reference_from_client"])
 def test_post_email_notification_returns_201(notify_api, client, sample_email_template_with_placeholders, mocker, reference):
-    notify_api.config["FF_NOTIFICATION_CELERY_PERSISTENCE"] = False
-    mocked = mocker.patch("app.celery.provider_tasks.deliver_email.apply_async")
+    mocked = mocker.patch("app.email_normal.publish")
     data = {
         "email_address": sample_email_template_with_placeholders.service.users[0].email_address,
         "template_id": sample_email_template_with_placeholders.id,
@@ -467,30 +347,6 @@ def test_post_email_notification_returns_201(notify_api, client, sample_email_te
     assert response.status_code == 201
     resp_json = json.loads(response.get_data(as_text=True))
     assert validate(resp_json, post_email_response) == resp_json
-    notification = Notification.query.one()
-    assert notification.status == NOTIFICATION_CREATED
-    assert notification.postage is None
-    assert resp_json["id"] == str(notification.id)
-    assert resp_json["reference"] == reference
-    assert notification.reference is None
-    assert notification.reply_to_text is None
-    assert resp_json["content"]["body"] == sample_email_template_with_placeholders.content.replace("((name))", "Bob")
-    assert resp_json["content"]["subject"] == sample_email_template_with_placeholders.subject.replace("((name))", "Bob")
-    assert resp_json["content"]["from_email"] == "{}@{}".format(
-        sample_email_template_with_placeholders.service.email_from,
-        current_app.config["NOTIFY_EMAIL_DOMAIN"],
-    )
-    assert "v2/notifications/{}".format(notification.id) in resp_json["uri"]
-    assert resp_json["template"]["id"] == str(sample_email_template_with_placeholders.id)
-    assert resp_json["template"]["version"] == sample_email_template_with_placeholders.version
-    assert (
-        "services/{}/templates/{}".format(
-            str(sample_email_template_with_placeholders.service_id),
-            str(sample_email_template_with_placeholders.id),
-        )
-        in resp_json["template"]["uri"]
-    )
-    assert not resp_json["scheduled_for"]
     assert mocked.called
 
 
@@ -498,8 +354,7 @@ def test_post_email_notification_returns_201(notify_api, client, sample_email_te
 def test_post_email_notification_returns_201_with_celery_persistence(
     notify_api, client, sample_email_template_with_placeholders, mocker, reference
 ):
-    notify_api.config["FF_NOTIFICATION_CELERY_PERSISTENCE"] = True
-    mocked = mocker.patch("app.celery.tasks.save_email.apply_async")
+    mocked = mocker.patch("app.email_normal.publish")
     data = {
         "email_address": sample_email_template_with_placeholders.service.users[0].email_address,
         "template_id": sample_email_template_with_placeholders.id,
@@ -516,24 +371,6 @@ def test_post_email_notification_returns_201_with_celery_persistence(
     assert response.status_code == 201
     resp_json = json.loads(response.get_data(as_text=True))
     assert validate(resp_json, post_email_response) == resp_json
-    assert resp_json["reference"] == reference
-    assert resp_json["content"]["body"] == sample_email_template_with_placeholders.content.replace("((name))", "Bob")
-    assert resp_json["content"]["subject"] == sample_email_template_with_placeholders.subject.replace("((name))", "Bob")
-    assert resp_json["content"]["from_email"] == "{}@{}".format(
-        sample_email_template_with_placeholders.service.email_from,
-        current_app.config["NOTIFY_EMAIL_DOMAIN"],
-    )
-    assert "v2/notifications/{}".format(resp_json["id"]) in resp_json["uri"]
-    assert resp_json["template"]["id"] == str(sample_email_template_with_placeholders.id)
-    assert resp_json["template"]["version"] == sample_email_template_with_placeholders.version
-    assert (
-        "services/{}/templates/{}".format(
-            str(sample_email_template_with_placeholders.service_id),
-            str(sample_email_template_with_placeholders.id),
-        )
-        in resp_json["template"]["uri"]
-    )
-    assert not resp_json["scheduled_for"]
     assert mocked.called
 
 
@@ -551,7 +388,7 @@ def test_post_email_notification_returns_201_with_celery_persistence(
 def test_should_not_persist_or_send_notification_if_simulated_recipient(
     client, recipient, notification_type, sample_email_template, sample_template, mocker
 ):
-    apply_async = mocker.patch("app.celery.provider_tasks.deliver_{}.apply_async".format(notification_type))
+    apply_async = mocker.patch("app.{}_normal.publish".format(notification_type))
 
     if notification_type == "sms":
         data = {"phone_number": recipient, "template_id": str(sample_template.id)}
@@ -590,16 +427,13 @@ def test_send_notification_uses_appropriate_queue_according_to_template_process_
     send_to,
     process_type,
 ):
-    notify_api.config["FF_NOTIFICATION_CELERY_PERSISTENCE"] = False
-    mocker.patch("app.celery.provider_tasks.deliver_{}.apply_async".format(notification_type))
+    mocked = mocker.patch("app.{}_{}.publish".format(notification_type, process_type))
 
     sample = create_template(
         service=sample_service,
         template_type=notification_type,
         process_type=process_type,
     )
-    mocked = mocker.patch("app.celery.provider_tasks.deliver_{}.apply_async".format(notification_type))
-
     data = {key_send_to: send_to, "template_id": str(sample.id)}
 
     auth_header = create_authorization_header(service_id=sample.service_id)
@@ -613,7 +447,7 @@ def test_send_notification_uses_appropriate_queue_according_to_template_process_
     notification_id = json.loads(response.data)["id"]
 
     assert response.status_code == 201
-    mocked.assert_called_once_with([notification_id], queue=f"{process_type}-tasks")
+    mocked.called
 
 
 @pytest.mark.parametrize(
@@ -626,7 +460,6 @@ def test_send_notification_uses_appropriate_queue_according_to_template_process_
 def test_returns_a_429_limit_exceeded_if_rate_limit_exceeded(
     notify_api, client, sample_service, mocker, notification_type, key_send_to, send_to
 ):
-    notify_api.config["FF_NOTIFICATION_CELERY_PERSISTENCE"] = False
     sample = create_template(service=sample_service, template_type=notification_type)
     save_mock = mocker.patch("app.v2.notifications.post_notifications.db_save_and_send_notification")
     mocker.patch(
@@ -786,10 +619,7 @@ class TestRestrictedServices:
         service.users = [user]
         template = create_template(service=service)
         create_api_key(service=service, key_type="team")
-        mocker.patch("app.celery.tasks.save_sms.apply_async")
-        notify_api.config["FF_REDIS_BATCH_SAVING"] = True
-        notify_api.config["FF_PRIORITY_LANES"] = False
-
+        mocker.patch("app.sms_normal.publish")
         data = {
             "phone_number": "+16132532235",
             "template_id": template.id,
@@ -838,9 +668,7 @@ def test_post_sms_notification_returns_201_if_allowed_to_send_int_sms(
     client,
     mocker,
 ):
-    notify_api.config["FF_NOTIFICATION_CELERY_PERSISTENCE"] = False
-    notify_api.config["FF_PRIORITY_LANES"] = False
-    mocker.patch("app.celery.provider_tasks.deliver_sms.apply_async")
+    mocker.patch("app.sms_normal.publish")
 
     data = {"phone_number": "+20-12-1234-1234", "template_id": sample_template.id}
     auth_header = create_authorization_header(service_id=sample_service.id)
@@ -863,9 +691,7 @@ def test_post_sms_notification_returns_201_if_allowed_to_send_int_sms_with_celer
     client,
     mocker,
 ):
-    notify_api.config["FF_NOTIFICATION_CELERY_PERSISTENCE"] = True
-    notify_api.config["FF_PRIORITY_LANES"] = False
-    mocker.patch("app.celery.tasks.save_sms.apply_async")
+    mocker.patch("app.sms_normal.publish")
 
     data = {"phone_number": "+20-12-1234-1234", "template_id": sample_template.id}
     auth_header = create_authorization_header(service_id=sample_service.id)
@@ -881,10 +707,7 @@ def test_post_sms_notification_returns_201_if_allowed_to_send_int_sms_with_celer
 
 
 def test_post_sms_should_persist_supplied_sms_number(notify_api, client, sample_template_with_placeholders, mocker):
-    notify_api.config["FF_NOTIFICATION_CELERY_PERSISTENCE"] = False
-    notify_api.config["FF_BATCH_INSERTION"] = False
-    notify_api.config["FF_REDIS_BATCH_SAVING"] = False
-    mocked = mocker.patch("app.celery.provider_tasks.deliver_sms.apply_async")
+    mocked = mocker.patch("app.sms_normal.publish")
     data = {
         "phone_number": "+16502532222",
         "template_id": str(sample_template_with_placeholders.id),
@@ -900,11 +723,6 @@ def test_post_sms_should_persist_supplied_sms_number(notify_api, client, sample_
     )
     assert response.status_code == 201
     resp_json = json.loads(response.get_data(as_text=True))
-    notifications = Notification.query.all()
-    assert len(notifications) == 1
-    notification_id = notifications[0].id
-    assert "+16502532222" == notifications[0].to
-    assert resp_json["id"] == str(notification_id)
     assert mocked.called
 
 
@@ -1026,11 +844,8 @@ def test_post_notification_with_wrong_type_of_sender(
 
 
 def test_post_email_notification_with_valid_reply_to_id_returns_201(notify_api, client, sample_email_template, mocker):
-    notify_api.config["FF_NOTIFICATION_CELERY_PERSISTENCE"] = False
-    notify_api.config["FF_BATCH_INSERTION"] = False
-    notify_api.config["FF_REDIS_BATCH_SAVING"] = False
     reply_to_email = create_reply_to_email(sample_email_template.service, "test@test.com")
-    mocked = mocker.patch("app.celery.provider_tasks.deliver_email.apply_async")
+    mocked = mocker.patch("app.email_normal.publish")
     data = {
         "email_address": sample_email_template.service.users[0].email_address,
         "template_id": sample_email_template.id,
@@ -1045,16 +860,11 @@ def test_post_email_notification_with_valid_reply_to_id_returns_201(notify_api, 
     assert response.status_code == 201
     resp_json = json.loads(response.get_data(as_text=True))
     assert validate(resp_json, post_email_response) == resp_json
-    notification = Notification.query.first()
-    assert notification.reply_to_text == "test@test.com"
-    assert resp_json["id"] == str(notification.id)
     assert mocked.called
-
-    assert notification.reply_to_text == reply_to_email.email_address
 
 
 def test_post_email_notification_with_invalid_reply_to_id_returns_400(client, sample_email_template, mocker, fake_uuid):
-    mocker.patch("app.celery.provider_tasks.deliver_email.apply_async")
+    mocker.patch("app.email_normal.publish")
     data = {
         "email_address": sample_email_template.service.users[0].email_address,
         "template_id": sample_email_template.id,
@@ -1082,7 +892,7 @@ def test_post_email_notification_with_archived_reply_to_id_returns_400(client, s
         is_default=False,
         archived=True,
     )
-    mocker.patch("app.celery.provider_tasks.deliver_email.apply_async")
+    mocker.patch("app.email_normal.publish")
     data = {
         "email_address": "test@test.com",
         "template_id": sample_email_template.id,
@@ -1115,7 +925,6 @@ def test_post_email_notification_with_archived_reply_to_id_returns_400(client, s
 def test_post_notification_with_document_upload(
     notify_api, client, notify_db_session, mocker, filename, file_data, sending_method
 ):
-    notify_api.config["FF_NOTIFICATION_CELERY_PERSISTENCE"] = False
     service = create_service(service_permissions=[EMAIL_TYPE, UPLOAD_DOCUMENT])
     content = "See attached file."
     if sending_method == "link":
@@ -1123,7 +932,7 @@ def test_post_notification_with_document_upload(
     template = create_template(service=service, template_type="email", content=content)
 
     statsd_mock = mocker.patch("app.v2.notifications.post_notifications.statsd_client")
-    mocker.patch("app.celery.provider_tasks.deliver_email.apply_async")
+    mocker.patch("app.email_normal.publish")
     document_download_mock = mocker.patch("app.v2.notifications.post_notifications.document_download_client.upload_document")
     document_response = document_download_response({"sending_method": sending_method, "mime_type": "text/plain"})
     document_download_mock.return_value = document_response
@@ -1156,10 +965,6 @@ def test_post_notification_with_document_upload(
         {"file": decoded_file, "filename": filename, "sending_method": sending_method},
     )
 
-    notification = Notification.query.one()
-    assert notification.status == NOTIFICATION_CREATED
-    assert notification.personalisation == {"document": document_response}
-
     if sending_method == "link":
         assert resp_json["content"]["body"] == f"Document: {document_response}"
     else:
@@ -1188,8 +993,7 @@ def test_post_notification_with_document_upload(
 def test_post_notification_with_document_too_large(
     notify_api, client, notify_db_session, mocker, filename, sending_method, attachment_size, expected_success
 ):
-    notify_api.config["FF_NOTIFICATION_CELERY_PERSISTENCE"] = True
-    mocked = mocker.patch("app.celery.tasks.save_email.apply_async")
+    mocked = mocker.patch("app.email_normal.publish")
     service = create_service(service_permissions=[EMAIL_TYPE, UPLOAD_DOCUMENT])
     content = "See attached file."
     if sending_method == "link":
@@ -1197,7 +1001,6 @@ def test_post_notification_with_document_too_large(
     template = create_template(service=service, template_type="email", content=content)
 
     mocker.patch("app.v2.notifications.post_notifications.statsd_client")
-    mocker.patch("app.celery.provider_tasks.deliver_email.apply_async")
     document_download_mock = mocker.patch("app.v2.notifications.post_notifications.document_download_client.upload_document")
     document_response = document_download_response({"sending_method": sending_method, "mime_type": "text/plain"})
     document_download_mock.return_value = document_response
@@ -1250,8 +1053,7 @@ def test_post_notification_with_document_too_large(
 def test_post_notification_with_too_many_documents(
     notify_api, client, notify_db_session, mocker, sending_method, attachment_number, expected_success
 ):
-    notify_api.config["FF_NOTIFICATION_CELERY_PERSISTENCE"] = True
-    mocked = mocker.patch("app.celery.tasks.save_email.apply_async")
+    mocked = mocker.patch("app.email_normal.publish")
     service = create_service(service_permissions=[EMAIL_TYPE, UPLOAD_DOCUMENT])
     template_content = "See attached file.\n"
     if sending_method == "link":
@@ -1260,7 +1062,6 @@ def test_post_notification_with_too_many_documents(
     template = create_template(service=service, template_type="email", content=template_content)
 
     mocker.patch("app.v2.notifications.post_notifications.statsd_client")
-    mocker.patch("app.celery.provider_tasks.deliver_email.apply_async")
     document_download_mock = mocker.patch("app.v2.notifications.post_notifications.document_download_client.upload_document")
     document_response = document_download_response({"sending_method": sending_method, "mime_type": "text/plain"})
     document_download_mock.return_value = document_response
@@ -1309,8 +1110,7 @@ def test_post_notification_with_too_many_documents(
 def test_post_email_notification_with_personalisation_too_large(
     notify_api, client, sample_email_template_with_placeholders, mocker, personalisation_size, expected_success
 ):
-    notify_api.config["FF_NOTIFICATION_CELERY_PERSISTENCE"] = True
-    mocked = mocker.patch("app.celery.tasks.save_email.apply_async")
+    mocked = mocker.patch("app.email_normal.publish")
 
     data = {
         "email_address": sample_email_template_with_placeholders.service.users[0].email_address,
@@ -1556,7 +1356,7 @@ def test_post_notification_with_document_upload_simulated(client, notify_db_sess
     service = create_service(service_permissions=[EMAIL_TYPE, UPLOAD_DOCUMENT])
     template = create_template(service=service, template_type="email", content="Document: ((document))")
 
-    mocker.patch("app.celery.provider_tasks.deliver_email.apply_async")
+    mocker.patch("app.email_normal.publish")
     document_download_mock = mocker.patch("app.v2.notifications.post_notifications.document_download_client")
     document_download_mock.get_upload_url.return_value = "https://document-url"
 
@@ -1584,7 +1384,7 @@ def test_post_notification_without_document_upload_permission(client, notify_db_
     service = create_service(service_permissions=[EMAIL_TYPE])
     template = create_template(service=service, template_type="email", content="Document: ((document))")
 
-    mocker.patch("app.celery.provider_tasks.deliver_email.apply_async")
+    mocker.patch("app.email_normal.publish")
     document_download_mock = mocker.patch("app.v2.notifications.post_notifications.document_download_client")
     document_download_mock.upload_document.return_value = document_download_response()
 
@@ -2138,10 +1938,6 @@ def test_post_bulk_creates_job_and_dispatches_celery_task(
 class TestBatchPriorityLanes:
     @pytest.mark.parametrize("process_type", ["bulk", "normal", "priority"])
     def test_sms_each_queue_is_used(self, notify_api, client, service_factory, mocker, process_type):
-        # turn required feature flags on
-        notify_api.config["FF_REDIS_BATCH_SAVING"] = True
-        notify_api.config["FF_PRIORITY_LANES"] = True
-
         mock_redisQueue_SMS_BULK = mocker.patch("app.sms_bulk.publish")
         mock_redisQueue_SMS_NORMAL = mocker.patch("app.sms_normal.publish")
         mock_redisQueue_SMS_PRIORITY = mocker.patch("app.sms_priority.publish")
@@ -2173,10 +1969,6 @@ class TestBatchPriorityLanes:
 
     @pytest.mark.parametrize("process_type", ["bulk", "normal", "priority"])
     def test_email_each_queue_is_used(self, notify_api, client, mocker, service_factory, process_type):
-        # turn required feature flags on
-        notify_api.config["FF_REDIS_BATCH_SAVING"] = True
-        notify_api.config["FF_PRIORITY_LANES"] = True
-
         mock_redisQueue_EMAIL_BULK = mocker.patch("app.email_bulk.publish")
         mock_redisQueue_EMAIL_NORMAL = mocker.patch("app.email_normal.publish")
         mock_redisQueue_EMAIL_PRIORITY = mocker.patch("app.email_priority.publish")

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -14,7 +14,6 @@ from app.dao.service_sms_sender_dao import dao_update_service_sms_sender
 from app.models import (
     EMAIL_TYPE,
     INTERNATIONAL_SMS_TYPE,
-    NOTIFICATION_CREATED,
     SCHEDULE_NOTIFICATIONS,
     SMS_TYPE,
     UPLOAD_DOCUMENT,
@@ -113,6 +112,7 @@ def test_post_sms_notification_uses_inbound_number_as_sender(notify_api, client,
     assert response.status_code == 201
     resp_json = json.loads(response.get_data(as_text=True))
     assert validate(resp_json, post_sms_response) == resp_json
+    assert mocked.called
 
 
 def test_post_sms_notification_uses_inbound_number_reply_to_as_sender(notify_api, client, notify_db_session, mocker):
@@ -444,8 +444,6 @@ def test_send_notification_uses_appropriate_queue_according_to_template_process_
         headers=[("Content-Type", "application/json"), auth_header],
     )
 
-    notification_id = json.loads(response.data)["id"]
-
     assert response.status_code == 201
     mocked.called
 
@@ -722,7 +720,6 @@ def test_post_sms_should_persist_supplied_sms_number(notify_api, client, sample_
         headers=[("Content-Type", "application/json"), auth_header],
     )
     assert response.status_code == 201
-    resp_json = json.loads(response.get_data(as_text=True))
     assert mocked.called
 
 


### PR DESCRIPTION
# Summary | Résumé

Remove all code paths related to the below 4 configs being set to False:
1.     FF_NOTIFICATION_CELERY_PERSISTENCE = env.bool("FF_NOTIFICATION_CELERY_PERSISTENCE", True)
2.     FF_BATCH_INSERTION = env.bool("FF_BATCH_INSERTION", True)
3.     FF_REDIS_BATCH_SAVING = env.bool("FF_REDIS_BATCH_SAVING", True)
4.     FF_PRIORITY_LANES = env.bool("FF_PRIORITY_LANES", True)

The above 4 are true in prod.
This PR removes all extra code paths that occur when the above configs are `False`.

Tested by running unit test manually. Will further tests when on staging.