### PR TITLE
Chore upgrade werkzeug

### DIFF
--- a/app/v2/notifications/get_notifications.py
+++ b/app/v2/notifications/get_notifications.py
@@ -53,7 +53,7 @@ def get_pdf_for_notification(notification_id):
     except Exception:
         raise PDFNotReadyError()
 
-    return send_file(filename_or_fp=BytesIO(pdf_data), mimetype="application/pdf")
+    return send_file(path_or_file=BytesIO(pdf_data), mimetype="application/pdf")
 
 
 @v2_notification_blueprint.route("", methods=["GET"])

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -4,7 +4,7 @@
 apig-wsgi==2.13.0
 boto==2.49.0
 cffi==1.14.5
-celery[sqs]==5.0.5
+celery[sqs]==5.2.7
 docopt==0.6.2
 environs==9.3.2 # pyup: <9.3.3 # marshmallow v3 throws errors
 fido2==0.9.1
@@ -12,7 +12,7 @@ Flask-Bcrypt==0.7.1
 flask-marshmallow==0.14.0
 Flask-Migrate==2.7.0
 git+https://github.com/mitsuhiko/flask-sqlalchemy.git@500e732dd1b975a56ab06a46bd1a20a21e682262#egg=Flask-SQLAlchemy==2.3.2.dev20190108
-Flask==1.1.2
+Flask==2.0.1
 click-datetime==0.2
 eventlet==0.30.2 # currently 0.31.0+ breaks gunicorn. Test the docker image if upgrading!
 gunicorn==20.1.0
@@ -24,10 +24,10 @@ marshmallow==2.21.0 # pyup: <3 # v3 throws errors
 python-magic==0.4.22
 psycopg2-binary==2.8.6
 PyJWT==2.1.0
-pytz==2021.1
+pytz==2021.3
 PyYAML==5.4.1
 SQLAlchemy==1.3.23
-sentry-sdk[flask]==1.0.0
+sentry-sdk[flask]==1.5.12
 cachelib==0.1.1
 
 newrelic==6.2.0.156
@@ -44,13 +44,14 @@ awscli-cwlogs>=1.4.6,<1.5
 aws-embedded-metrics==1.0.7
 
 # Putting upgrade on hold due to new version introducing breaking changes
-Werkzeug==1.0.1
+Werkzeug==2.0.3
 MarkupSafe==2.0.1
 
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
-itsdangerous==0.24  # pyup: <1.0.0
+itsdangerous>=2.0 # flask 2.0.1 depends on itsdangerous>=2.0
 
-git+https://github.com/cds-snc/notifier-utils.git@46.5.0#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@chore-upgrade-werkzeug#egg=notifications-utils
+#file:////libs#egg=notifications-utils
 
 # MLWR
 socketio-client==0.5.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 apig-wsgi==2.13.0
 boto==2.49.0
 cffi==1.14.5
-celery[sqs]==5.0.5
+celery[sqs]==5.2.7
 docopt==0.6.2
 environs==9.3.2 # pyup: <9.3.3 # marshmallow v3 throws errors
 fido2==0.9.1
@@ -14,7 +14,7 @@ Flask-Bcrypt==0.7.1
 flask-marshmallow==0.14.0
 Flask-Migrate==2.7.0
 git+https://github.com/mitsuhiko/flask-sqlalchemy.git@500e732dd1b975a56ab06a46bd1a20a21e682262#egg=Flask-SQLAlchemy==2.3.2.dev20190108
-Flask==1.1.2
+Flask==2.0.1
 click-datetime==0.2
 eventlet==0.30.2 # currently 0.31.0+ breaks gunicorn. Test the docker image if upgrading!
 gunicorn==20.1.0
@@ -26,10 +26,10 @@ marshmallow==2.21.0 # pyup: <3 # v3 throws errors
 python-magic==0.4.22
 psycopg2-binary==2.8.6
 PyJWT==2.1.0
-pytz==2021.1
+pytz==2021.3
 PyYAML==5.4.1
 SQLAlchemy==1.3.23
-sentry-sdk[flask]==1.0.0
+sentry-sdk[flask]==1.5.12
 cachelib==0.1.1
 
 newrelic==6.2.0.156
@@ -46,13 +46,14 @@ awscli-cwlogs>=1.4.6,<1.5
 aws-embedded-metrics==1.0.7
 
 # Putting upgrade on hold due to new version introducing breaking changes
-Werkzeug==1.0.1
+Werkzeug==2.0.3
 MarkupSafe==2.0.1
 
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
-itsdangerous==0.24  # pyup: <1.0.0
+itsdangerous>=2.0 # flask 2.0.1 depends on itsdangerous>=2.0
 
-git+https://github.com/cds-snc/notifier-utils.git@46.5.0#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@chore-upgrade-werkzeug#egg=notifications-utils
+#file:////libs#egg=notifications-utils
 
 # MLWR
 socketio-client==0.5.6
@@ -67,41 +68,44 @@ rsa>=4.1 # not directly required, pinned by Snyk to avoid a vulnerability
 ## The following requirements were added by pip freeze:
 aiohttp==3.8.1
 aiosignal==1.2.0
-alembic==1.7.7
-amqp==5.0.9
+alembic==1.8.0
+amqp==5.1.1
 async-timeout==4.0.2
 attrs==21.4.0
 awscli==1.19.58
-bcrypt==3.2.0
+bcrypt==3.2.2
 billiard==3.6.4.0
 bleach==3.3.0
 blinker==1.4
 boto3==1.17.58
 botocore==1.20.58
 cachetools==4.2.1
-certifi==2021.10.8
+certifi==2022.5.18.1
 chardet==4.0.0
 charset-normalizer==2.0.12
-click==7.1.2
+click==8.1.3
 click-didyoumean==0.3.0
 click-plugins==1.1.1
 click-repl==0.2.0
 colorama==0.4.3
-cryptography==36.0.1
+cryptography==37.0.2
 Deprecated==1.2.13
 dnspython==1.16.0
 docutils==0.15.2
-filelock==3.6.0
+filelock==3.7.1
 flask-redis==0.4.0
 frozenlist==1.3.0
 future==0.18.2
 greenlet==1.1.2
-Jinja2==2.11.3
+importlib-metadata==4.11.4
+Jinja2==3.1.2
 jmespath==0.10.0
 kombu==5.2.4
-Mako==1.1.6
+Mako==1.2.0
 mistune==0.8.4
 multidict==6.0.2
+mypy==0.961
+mypy-extensions==0.4.3
 orderedset==2.0.3
 packaging==21.3
 phonenumbers==8.12.21
@@ -109,23 +113,35 @@ prompt-toolkit==3.0.29
 py-w3c==0.3.1
 pyasn1==0.4.8
 pycparser==2.21
-pycurl==7.43.0.5
+pycurl==7.44.1
 pyOpenSSL==22.0.0
-pyparsing==3.0.8
+pyparsing==3.0.9
 PyPDF2==1.26.0
 pyrsistent==0.18.1
 python-dateutil==2.8.2
 python-json-logger==2.0.1
-redis==4.1.4
+redis==4.3.3
 requests-file==1.5.1
 s3transfer==0.4.2
 six==1.16.0
 smartypants==2.0.1
 statsd==3.3.0
+tomli==2.0.1
+types-bleach==5.0.2
+types-cachetools==5.0.1
+types-freezegun==1.1.9
+types-python-dateutil==2.8.17
+types-pytz==2021.3.8
+types-PyYAML==6.0.8
+types-redis==4.2.6
+types-requests==2.27.30
+types-urllib3==1.26.15
+typing_extensions==4.2.0
 urllib3==1.26.9
 vine==5.0.0
 wcwidth==0.2.5
 webencodings==0.5.1
-websocket-client==1.2.3
-wrapt==1.13.3
+websocket-client==1.3.2
+wrapt==1.14.1
 yarl==1.7.2
+zipp==3.8.0

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 flake8==3.8.4
-isort==5.6.4
+isort==5.10.1
 moto==1.3.14
 idna==2.8
 pytest==3.10.1  # pyup: <4
@@ -16,9 +16,18 @@ strict-rfc3339==0.7
 rfc3987==1.3.8
 # used for creating manifest file locally
 jinja2-cli[yaml]==0.6.0
-black==21.5b2
-locust==1.5.3
-mypy==0.812
+black==22.3.0
+locust==2.9.0
 sqlalchemy-stubs==0.4
 networkx>=2.6 # not directly required, pinned by Snyk to avoid a vulnerability
 pytest-mock-resources[redis]==2.1.11
+mypy==0.961
+types-requests==2.27.30 # adding for mypy
+types-pytz==2021.3.8 # adding for mypy
+types-boto==2.49.15 # adding for mypy
+types-freezegun==1.1.9 # adding for mypy
+types-mock==4.0.15 # adding for mypy
+types-click==7.1.8 # adding for mypy
+sqlalchemy-stubs==0.4 # adding for mypy
+pytest-stub==1.1.0 # adding for mypy
+pytest_mock_resources

--- a/tests/app/celery/test_ftp_update_tasks.py
+++ b/tests/app/celery/test_ftp_update_tasks.py
@@ -159,13 +159,10 @@ def test_update_letter_notifications_statuses_persisted(notify_api, mocker, samp
     assert failed_letter.status == NOTIFICATION_TEMPORARY_FAILURE
     assert failed_letter.billable_units == 2
     assert failed_letter.updated_at
-    assert (
-        "DVLA response file: {filename} has failed letters with notification.reference {failures}".format(
-            filename="NOTIFY-20170823160812-RSP.TXT",
-            failures=[format(failed_letter.reference)],
-        )
-        in str(e)
-    )
+    assert "DVLA response file: {filename} has failed letters with notification.reference {failures}".format(
+        filename="NOTIFY-20170823160812-RSP.TXT",
+        failures=[format(failed_letter.reference)],
+    ) in str(e)
 
 
 def test_update_letter_notifications_does_not_call_send_callback_if_no_db_entry(notify_api, mocker, sample_letter_template):

--- a/tests/app/dao/test_permissions_dao.py
+++ b/tests/app/dao/test_permissions_dao.py
@@ -5,21 +5,18 @@ from tests.app.conftest import sample_service as create_service
 def test_get_permissions_by_user_id_returns_all_permissions(sample_service):
     permissions = permission_dao.get_permissions_by_user_id(user_id=sample_service.users[0].id)
     assert len(permissions) == 8
-    assert (
-        sorted(
-            [
-                "manage_users",
-                "manage_templates",
-                "manage_settings",
-                "send_texts",
-                "send_emails",
-                "send_letters",
-                "manage_api_keys",
-                "view_activity",
-            ]
-        )
-        == sorted([i.permission for i in permissions])
-    )
+    assert sorted(
+        [
+            "manage_users",
+            "manage_templates",
+            "manage_settings",
+            "send_texts",
+            "send_emails",
+            "send_letters",
+            "manage_api_keys",
+            "view_activity",
+        ]
+    ) == sorted([i.permission for i in permissions])
 
 
 def test_get_permissions_by_user_id_returns_only_active_service(notify_db, notify_db_session, sample_user):

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -2101,7 +2101,7 @@ def test_update_service_calls_send_notification_as_service_becomes_live(
         get_user_by_id_mock.assert_not_called()
         fetch_service_creator_mock.assert_called_once_with(restricted_service.id)
 
-    assert resp.status_code == 200
+    assert resp.status_code == 200  # type: ignore
     send_notification_mock.assert_called_once_with(
         service_id=restricted_service.id,
         template_id="618185c6-3636-49cd-b7d2-6f6f5eb3bdde",

--- a/tests/app/test_config.py
+++ b/tests/app/test_config.py
@@ -59,32 +59,29 @@ def test_queue_names_all_queues_correct():
     # Need to ensure that all_queues() only returns queue names used in API
     queues = QueueNames.all_queues()
     assert len(queues) == 17
-    assert (
-        set(
-            [
-                QueueNames.PRIORITY,
-                QueueNames.BULK,
-                QueueNames.PERIODIC,
-                QueueNames.DATABASE,
-                QueueNames.PRIORITY_DATABASE,
-                QueueNames.NORMAL_DATABASE,
-                QueueNames.BULK_DATABASE,
-                QueueNames.SEND_SMS,
-                QueueNames.SEND_THROTTLED_SMS,
-                QueueNames.SEND_EMAIL,
-                QueueNames.RESEARCH_MODE,
-                QueueNames.REPORTING,
-                QueueNames.JOBS,
-                QueueNames.RETRY,
-                QueueNames.NOTIFY,
-                # QueueNames.CREATE_LETTERS_PDF,
-                QueueNames.CALLBACKS,
-                # QueueNames.LETTERS,
-                QueueNames.DELIVERY_RECEIPTS,
-            ]
-        )
-        == set(queues)
-    )
+    assert set(
+        [
+            QueueNames.PRIORITY,
+            QueueNames.BULK,
+            QueueNames.PERIODIC,
+            QueueNames.DATABASE,
+            QueueNames.PRIORITY_DATABASE,
+            QueueNames.NORMAL_DATABASE,
+            QueueNames.BULK_DATABASE,
+            QueueNames.SEND_SMS,
+            QueueNames.SEND_THROTTLED_SMS,
+            QueueNames.SEND_EMAIL,
+            QueueNames.RESEARCH_MODE,
+            QueueNames.REPORTING,
+            QueueNames.JOBS,
+            QueueNames.RETRY,
+            QueueNames.NOTIFY,
+            # QueueNames.CREATE_LETTERS_PDF,
+            QueueNames.CALLBACKS,
+            # QueueNames.LETTERS,
+            QueueNames.DELIVERY_RECEIPTS,
+        ]
+    ) == set(queues)
 
 
 def test_get_safe_config(mocker, reload_config):

--- a/tests/app/v2/test_errors.py
+++ b/tests/app/v2/test_errors.py
@@ -168,7 +168,6 @@ def test_bad_method(app_for_test):
 
             assert response.status_code == 405
 
-            assert response.json == {
-                "result": "error",
-                "message": "The method is not allowed for the requested URL.",
-            }
+            assert (
+                response.data == b'{\n  "message": "The method is not allowed for the requested URL.", \n  "result": "error"\n}\n'
+            )

--- a/tests/app/v2/test_errors.py
+++ b/tests/app/v2/test_errors.py
@@ -1,4 +1,5 @@
 import json
+
 import pytest
 from flask import url_for
 from sqlalchemy.exc import DataError
@@ -169,6 +170,4 @@ def test_bad_method(app_for_test):
 
             assert response.status_code == 405
 
-            assert (
-                json.loads(response.data) == {"message": "The method is not allowed for the requested URL.", "result": "error"}
-            )
+            assert json.loads(response.data) == {"message": "The method is not allowed for the requested URL.", "result": "error"}

--- a/tests/app/v2/test_errors.py
+++ b/tests/app/v2/test_errors.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 from flask import url_for
 from sqlalchemy.exc import DataError
@@ -169,5 +170,5 @@ def test_bad_method(app_for_test):
             assert response.status_code == 405
 
             assert (
-                response.data == b'{\n  "message": "The method is not allowed for the requested URL.", \n  "result": "error"\n}\n'
+                json.loads(response.data) == {"message": "The method is not allowed for the requested URL.", "result": "error"}
             )


### PR DESCRIPTION
# Summary | Résumé

Upgrading to flask 2 / werkzeug 2.  Full list of updated deps:

Deps:
- celery[sqs]==5.2.7 (from 5.0.5)
- Flask==2.0.1 (from 1.1.2)
- pytz==2021.3 (from 2021.1)
- sentry-sdk[flask]==1.5.12 (from 1.0.0)
- Werkzeug==2.0.3 (from 1.0.1)
- itsdangerous==2.0 (from 0.24)
- notifications-utils 47.0.0 (from 46.5)

Test deps:
- isort==5.10.1 (from 5.6.4)
- black==22.3.0 (from 21.5b2)
- locust==2.9.0 (from 1.5.3)
- pytest-mock-resources[redis]==2.1.11
- mypy==0.961 (from 0.812)
- types-requests==2.27.30 # adding for mypy
- types-pytz==2021.3.8 # adding for mypy
- types-boto==2.49.15 # adding for mypy
- types-freezegun==1.1.9 # adding for mypy
- types-mock==4.0.15 # adding for mypy
- types-click==7.1.8 # adding for mypy
- sqlalchemy-stubs==0.4 # adding for mypy
- pytest-stub==1.1.0 # adding for mypy
- pytest_mock_resources

Other notes:
- updated instances of Flask.send_file due to parameter name change
- updated `tests/app/v2/test_errors test_bad_method` due to content-type change in werkzeug

## Testing considerations
- [ ] locust was updated, so we should ensure that the smoke tests still work
- [ ] Will updating `itsdangerous` require us to re-sign anything?