### PR TITLE
Upgrade Pytest to 5.3.2

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -20,7 +20,7 @@ from sqlalchemy import asc, desc, func
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.exc import NoResultFound
-from sqlalchemy.sql import functions
+from sqlalchemy.sql import functions, text
 from sqlalchemy.sql.expression import case
 from werkzeug.datastructures import MultiDict
 
@@ -376,7 +376,7 @@ def _delete_for_query(subquery):
 
 
 def insert_update_notification_history(notification_type, date_to_delete_from, service_id):
-    notifications = db.session.query(*[x.name for x in NotificationHistory.__table__.c]).filter(
+    notifications = db.session.query(*[text(x.name) for x in NotificationHistory.__table__.c]).filter(
         Notification.notification_type == notification_type,
         Notification.service_id == service_id,
         Notification.created_at < date_to_delete_from,

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -20,7 +20,7 @@ from sqlalchemy import asc, desc, func
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.exc import NoResultFound
-from sqlalchemy.sql import functions, text
+from sqlalchemy.sql import functions, literal_column
 from sqlalchemy.sql.expression import case
 from werkzeug.datastructures import MultiDict
 
@@ -319,8 +319,7 @@ def delete_notifications_older_than_retention_by_type(notification_type, qry_lim
         days=7
     )
     services_with_data_retention = [x.service_id for x in flexible_data_retention]
-    # service_ids_to_purge = Service.query.filter(Service.id.notin_(services_with_data_retention)).all()
-    service_ids_to_purge = Service.query.filter(Service.id.notin_(services_with_data_retention)).all()
+    service_ids_to_purge = db.session.query(Service.id).filter(Service.id.notin_(services_with_data_retention)).all()
 
     for service_id in service_ids_to_purge:
         if notification_type == LETTER_TYPE:
@@ -377,7 +376,7 @@ def _delete_for_query(subquery):
 
 
 def insert_update_notification_history(notification_type, date_to_delete_from, service_id):
-    notifications = db.session.query(*[text(x.name) for x in NotificationHistory.__table__.c]).filter(
+    notifications = db.session.query(*[literal_column(x.name) for x in NotificationHistory.__table__.c]).filter(
         Notification.notification_type == notification_type,
         Notification.service_id == service_id,
         Notification.created_at < date_to_delete_from,

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -321,7 +321,8 @@ def delete_notifications_older_than_retention_by_type(notification_type, qry_lim
     services_with_data_retention = [x.service_id for x in flexible_data_retention]
     service_ids_to_purge = db.session.query(Service.id).filter(Service.id.notin_(services_with_data_retention)).all()
 
-    for service_id in service_ids_to_purge:
+    for row in service_ids_to_purge:
+        service_id = row._mapping['id']
         if notification_type == LETTER_TYPE:
             _delete_letters_from_s3(notification_type, service_id, seven_days_ago, qry_limit)
         insert_update_notification_history(notification_type, seven_days_ago, service_id)

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -319,13 +319,13 @@ def delete_notifications_older_than_retention_by_type(notification_type, qry_lim
         days=7
     )
     services_with_data_retention = [x.service_id for x in flexible_data_retention]
-    service_ids_to_purge = db.session.query(Service.id).filter(Service.id.notin_(services_with_data_retention)).all()
+    service_ids_to_purge = Service.query.filter(Service.id.notin_(services_with_data_retention)).all()
 
-    for service_id in service_ids_to_purge:
+    for service in service_ids_to_purge:
         if notification_type == LETTER_TYPE:
-            _delete_letters_from_s3(notification_type, service_id, seven_days_ago, qry_limit)
-        insert_update_notification_history(notification_type, seven_days_ago, service_id)
-        deleted += _delete_notifications(notification_type, seven_days_ago, service_id, qry_limit)
+            _delete_letters_from_s3(notification_type, service.id, seven_days_ago, qry_limit)
+        insert_update_notification_history(notification_type, seven_days_ago, service.id)
+        deleted += _delete_notifications(notification_type, seven_days_ago, service.id, qry_limit)
 
     current_app.logger.info("Finished deleting {} notifications".format(notification_type))
 

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -322,7 +322,7 @@ def delete_notifications_older_than_retention_by_type(notification_type, qry_lim
     service_ids_to_purge = db.session.query(Service.id).filter(Service.id.notin_(services_with_data_retention)).all()
 
     for row in service_ids_to_purge:
-        service_id = row._mapping['id']
+        service_id = row._mapping["id"]
         if notification_type == LETTER_TYPE:
             _delete_letters_from_s3(notification_type, service_id, seven_days_ago, qry_limit)
         insert_update_notification_history(notification_type, seven_days_ago, service_id)

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -319,13 +319,14 @@ def delete_notifications_older_than_retention_by_type(notification_type, qry_lim
         days=7
     )
     services_with_data_retention = [x.service_id for x in flexible_data_retention]
+    # service_ids_to_purge = Service.query.filter(Service.id.notin_(services_with_data_retention)).all()
     service_ids_to_purge = Service.query.filter(Service.id.notin_(services_with_data_retention)).all()
 
-    for service in service_ids_to_purge:
+    for service_id in service_ids_to_purge:
         if notification_type == LETTER_TYPE:
-            _delete_letters_from_s3(notification_type, service.id, seven_days_ago, qry_limit)
-        insert_update_notification_history(notification_type, seven_days_ago, service.id)
-        deleted += _delete_notifications(notification_type, seven_days_ago, service.id, qry_limit)
+            _delete_letters_from_s3(notification_type, service_id, seven_days_ago, qry_limit)
+        insert_update_notification_history(notification_type, seven_days_ago, service_id)
+        deleted += _delete_notifications(notification_type, seven_days_ago, service_id, qry_limit)
 
     current_app.logger.info("Finished deleting {} notifications".format(notification_type))
 

--- a/app/dao/service_user_dao.py
+++ b/app/dao/service_user_dao.py
@@ -8,8 +8,11 @@ def dao_get_service_user(user_id, service_id):
 
 
 def dao_get_active_service_users(service_id):
-    query = ServiceUser.query.join(ServiceUser.user).filter(ServiceUser.service_id == service_id, User.state == "active")
-
+    query = (
+        db.session.query(ServiceUser)
+        .join(User, User.id == ServiceUser.user_id)
+        .filter(User.state == "active", ServiceUser.service_id == service_id)
+    )
     return query.all()
 
 

--- a/app/dao/templates_dao.py
+++ b/app/dao/templates_dao.py
@@ -41,9 +41,6 @@ def dao_create_template(template):
 @transactional
 @version_class(VersionOptions(Template, history_class=TemplateHistory))
 def dao_update_template(template):
-    if template.archived:
-        template.folder = None
-
     db.session.add(template)
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -199,8 +199,6 @@ class ServiceUser(BaseModel):
 
     __table_args__ = (UniqueConstraint("user_id", "service_id", name="uix_user_to_service"),)
 
-    user = db.relationship("User")
-
 
 user_to_organisation = db.Table(
     "user_to_organisation",
@@ -748,7 +746,6 @@ class ServicePermission(BaseModel):
         primary_key=True,
         nullable=False,
     )
-    service = db.relationship("Service")
     created_at = db.Column(db.DateTime, default=datetime.datetime.utcnow, nullable=False)
 
     service_permission_types = db.relationship(Service, backref=db.backref("permissions", cascade="all, delete-orphan"))

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -126,6 +126,8 @@ def update_template(service_id, template_id):
         raise InvalidRequest(errors, status_code=400)
 
     update_dict = template_schema.load(updated_template).data
+    if update_dict.archived:
+        update_dict.folder = None
 
     dao_update_template(update_dict)
     return jsonify(data=template_schema.dump(update_dict).data), 200

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -509,7 +509,7 @@ def set_permissions(user_id, service_id):
     # TODO fix security hole, how do we verify that the user
     # who is making this request has permission to make the request.
     service_user = dao_get_service_user(user_id, service_id)
-    user = service_user.user
+    user = get_user_by_id(user_id)
     service = dao_fetch_service_by_id(service_id=service_id)
 
     data = request.get_json()

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -26,7 +26,7 @@ psycopg2-binary==2.8.6
 PyJWT==2.1.0
 pytz==2021.1
 PyYAML==5.4.1
-SQLAlchemy==1.3.23
+SQLAlchemy==1.4.37
 sentry-sdk[flask]==1.0.0
 cachelib==0.1.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ psycopg2-binary==2.8.6
 PyJWT==2.1.0
 pytz==2021.1
 PyYAML==5.4.1
-SQLAlchemy==1.3.23
+SQLAlchemy==1.4.37
 sentry-sdk[flask]==1.0.0
 cachelib==0.1.1
 

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -3,12 +3,12 @@ flake8==3.8.4
 isort==5.6.4
 moto==1.3.14
 idna==2.8
-pytest==5.3.2  # pyup: <4
+pytest==5.3.2
 pytest-env==0.6.2
 pytest-mock==3.7.0
 pytest-cov==3.0.0
 coveralls==1.11.1
-pytest-xdist==1.31.0  # pyup: ignore, version 1.28.0 requires pytest >= 4.4
+pytest-xdist==1.31.0
 freezegun==1.0.0
 requests-mock==1.8.0
 # optional requirements for jsonschema

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,14 +1,12 @@
--r requirements.txt
-flake8==3.8.4
 isort==5.6.4
 moto==1.3.14
 idna==2.8
-pytest==3.10.1  # pyup: <4
+pytest==5.3.2  # pyup: <4
 pytest-env==0.6.2
-pytest-mock==1.10.4
-pytest-cov==2.6.1
+pytest-mock==3.7.0
+pytest-cov==3.0.0
 coveralls==1.11.1
-pytest-xdist==1.27.0  # pyup: ignore, version 1.28.0 requires pytest >= 4.4
+pytest-xdist==1.31.0  # pyup: ignore, version 1.28.0 requires pytest >= 4.4
 freezegun==1.0.0
 requests-mock==1.8.0
 # optional requirements for jsonschema
@@ -21,4 +19,4 @@ locust==1.5.3
 mypy==0.812
 sqlalchemy-stubs==0.4
 networkx>=2.6 # not directly required, pinned by Snyk to avoid a vulnerability
-pytest-mock-resources[redis]==2.1.11
+pytest-mock-resources[redis]==2.4.0

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,3 +1,5 @@
+-r requirements.txt
+flake8==3.8.4
 isort==5.6.4
 moto==1.3.14
 idna==2.8

--- a/tests/app/dao/test_invited_user_dao.py
+++ b/tests/app/dao/test_invited_user_dao.py
@@ -79,7 +79,7 @@ def test_get_unknown_invited_user_returns_none(notify_db, notify_db_session, sam
 
     with pytest.raises(NoResultFound) as e:
         get_invited_user(sample_service.id, unknown_id)
-    assert "No row was found for one()" in str(e.value)
+    assert "No row was found when one was required" in str(e.value)
 
 
 def test_get_invited_users_for_service(notify_db, notify_db_session, sample_service):

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -579,7 +579,7 @@ def test_dao_fetch_live_services_data(sample_user):
 def test_get_service_by_id_returns_none_if_no_service(notify_db):
     with pytest.raises(NoResultFound) as e:
         dao_fetch_service_by_id(str(uuid.uuid4()))
-    assert "No row was found for one()" in str(e)
+    assert "No row was found when one was required" in str(e)
 
 
 def test_get_service_by_id_returns_service(notify_db_session):

--- a/tests/app/dao/test_templates_dao.py
+++ b/tests/app/dao/test_templates_dao.py
@@ -99,35 +99,6 @@ def test_update_template(sample_service, sample_user):
     assert dao_get_all_templates_for_service(sample_service.id)[0].name == "new name"
 
 
-def test_update_template_in_a_folder_to_archived(sample_service, sample_user):
-    template_data = {
-        "name": "Sample Template",
-        "template_type": "sms",
-        "content": "Template content",
-        "service": sample_service,
-        "created_by": sample_user,
-    }
-    template = Template(**template_data)
-
-    template_folder_data = {
-        "name": "My Folder",
-        "service_id": sample_service.id,
-    }
-    template_folder = TemplateFolder(**template_folder_data)
-
-    template.folder = template_folder
-    dao_create_template(template)
-
-    template.archived = True
-    dao_update_template(template)
-
-    template_folder = TemplateFolder.query.one()
-    archived_template = Template.query.one()
-
-    assert template_folder
-    assert not archived_template.folder
-
-
 def test_dao_update_template_reply_to_none_to_some(sample_service, sample_user):
     letter_contact = create_letter_contact(sample_service, "Edinburgh, ED1 1AA")
 

--- a/tests/app/dao/test_templates_dao.py
+++ b/tests/app/dao/test_templates_dao.py
@@ -18,7 +18,7 @@ from app.dao.templates_dao import (
     dao_update_template,
     dao_update_template_reply_to,
 )
-from app.models import Template, TemplateFolder, TemplateHistory, TemplateRedacted
+from app.models import Template, TemplateHistory, TemplateRedacted
 from app.schemas import template_schema
 from tests.app.db import create_letter_contact, create_template
 

--- a/tests/app/dao/test_templates_dao.py
+++ b/tests/app/dao/test_templates_dao.py
@@ -377,7 +377,7 @@ def test_get_template_version_returns_none_for_hidden_templates(sample_service):
 def test_get_template_by_id_and_service_returns_none_if_no_template(sample_service, fake_uuid):
     with pytest.raises(NoResultFound) as e:
         dao_get_template_by_id_and_service_id(template_id=fake_uuid, service_id=sample_service.id)
-    assert "No row was found for one" in str(e.value)
+    assert "No row was found when one was required" in str(e.value)
 
 
 def test_create_template_creates_a_history_record_with_current_data(sample_service, sample_user):

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -407,20 +407,18 @@ def test_should_be_able_to_archive_template(client, sample_template):
     assert Template.query.first().archived
 
 
-def test_should_be_able_to_archive_template_should_remove_template_folders(
-        client, sample_service
-):
+def test_should_be_able_to_archive_template_should_remove_template_folders(client, sample_service):
     template_folder = create_template_folder(service=sample_service)
     template = create_template(service=sample_service, folder=template_folder)
 
     data = {
-        'archived': True,
+        "archived": True,
     }
 
     client.post(
-        f'/service/{sample_service.id}/template/{template.id}',
-        headers=[('Content-Type', 'application/json'),  create_authorization_header()],
-        data=json.dumps(data)
+        f"/service/{sample_service.id}/template/{template.id}",
+        headers=[("Content-Type", "application/json"), create_authorization_header()],
+        data=json.dumps(data),
     )
 
     updated_template = Template.query.get(template.id)

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -407,6 +407,27 @@ def test_should_be_able_to_archive_template(client, sample_template):
     assert Template.query.first().archived
 
 
+def test_should_be_able_to_archive_template_should_remove_template_folders(
+        client, sample_service
+):
+    template_folder = create_template_folder(service=sample_service)
+    template = create_template(service=sample_service, folder=template_folder)
+
+    data = {
+        'archived': True,
+    }
+
+    client.post(
+        f'/service/{sample_service.id}/template/{template.id}',
+        headers=[('Content-Type', 'application/json'),  create_authorization_header()],
+        data=json.dumps(data)
+    )
+
+    updated_template = Template.query.get(template.id)
+    assert updated_template.archived
+    assert not updated_template.folder
+
+
 def test_get_precompiled_template_for_service(
     client,
     notify_user,


### PR DESCRIPTION
# Summary | Résumé

Finish upgrading pytest to 5.3.2 (and others required)
Started the process in https://github.com/cds-snc/notification-api/pull/1564

Fixes largely copied from https://github.com/alphagov/notifications-api/pull/3228

# Test instructions | Instructions pour tester la modification

Smoke test (in particular admin), specifically around the code this PR touched:
- `ServiceUser` and `ServicePermission`:
  - add a user to a service
  - change the user's permissions
  - remove the user from the service
- archiving  templates:
  - Make a template in a folder
  - See it in the `template_folder_map` table
  - Delete the template
  - Ensure that in the `templates` table it has `archived = True`
  - Ensure that it is no longer in the `template_folder_map` table
- query change in `delete_notifications_older_than_retention_by_type` and change to `insert_update_notification_history`:
  - ? these are harder to test. basically we want to ensure that the whole retention period still works. We should set it to 1 or 2 days for a particular service in staging and check that notifications have been moved to the history table after that time.