### PR TITLE
Upgrade to werkzeug 2.0.2

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,7 +6,7 @@ import uuid
 from time import monotonic
 
 from dotenv import load_dotenv
-from flask import _request_ctx_stack, g, jsonify, make_response, request  # type: ignore
+from flask import g, jsonify, make_response, request  # type: ignore
 from flask_marshmallow import Marshmallow
 from flask_migrate import Migrate
 from flask_redis import FlaskRedis
@@ -55,8 +55,8 @@ document_download_client = DocumentDownloadClient()
 
 clients = Clients()
 
-api_user = LocalProxy(lambda: _request_ctx_stack.top.api_user)
-authenticated_service = LocalProxy(lambda: _request_ctx_stack.top.authenticated_service)
+api_user = LocalProxy(lambda: g.api_user)
+authenticated_service = LocalProxy(lambda: g.authenticated_service)
 
 sms_bulk = RedisQueue("sms", process_type="bulk")
 sms_normal = RedisQueue("sms", process_type="normal")

--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -1,4 +1,4 @@
-from flask import _request_ctx_stack, current_app, g, request  # type: ignore
+from flask import current_app, g, request  # type: ignore
 from jwt import PyJWTError
 from notifications_python_client.authentication import (
     decode_jwt_token,

--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -155,8 +155,8 @@ def _auth_with_api_key(api_key, service):
             api_key_id=api_key.id,
         )
     g.service_id = api_key.service_id
-    _request_ctx_stack.top.authenticated_service = service
-    _request_ctx_stack.top.api_user = api_key
+    g.authenticated_service = service
+    g.api_user = api_key
     current_app.logger.info(
         "API authorised for service {} with api key {}, using client {}".format(
             service.id, api_key.id, request.headers.get("User-Agent")

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -44,14 +44,14 @@ awscli-cwlogs>=1.4.6,<1.5
 aws-embedded-metrics==1.0.7
 
 # Putting upgrade on hold due to new version introducing breaking changes
-Werkzeug==1.0.1
+Werkzeug==2.0.2
 MarkupSafe==2.0.1
 
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@46.5.0#egg=notifications-utils
-
+#git+https://github.com/cds-snc/notifier-utils.git@46.5.0#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@81e2fcdcb7c4d2ce3814af6db2ceb0ccd8f258f1
 # MLWR
 socketio-client==0.5.6
 requests

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -50,8 +50,8 @@ MarkupSafe==2.0.1
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-#git+https://github.com/cds-snc/notifier-utils.git@46.5.0#egg=notifications-utils
-git+https://github.com/cds-snc/notifier-utils.git@81e2fcdcb7c4d2ce3814af6db2ceb0ccd8f258f1
+git+https://github.com/cds-snc/notifier-utils.git@47.0.0#egg=notifications-utils
+
 # MLWR
 socketio-client==0.5.6
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,14 +46,14 @@ awscli-cwlogs>=1.4.6,<1.5
 aws-embedded-metrics==1.0.7
 
 # Putting upgrade on hold due to new version introducing breaking changes
-Werkzeug==1.0.1
+Werkzeug==2.0.2
 MarkupSafe==2.0.1
 
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-git+https://github.com/cds-snc/notifier-utils.git@46.5.0#egg=notifications-utils
-
+#git+https://github.com/cds-snc/notifier-utils.git@46.5.0#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@81e2fcdcb7c4d2ce3814af6db2ceb0ccd8f258f1
 # MLWR
 socketio-client==0.5.6
 requests
@@ -67,31 +67,31 @@ rsa>=4.1 # not directly required, pinned by Snyk to avoid a vulnerability
 ## The following requirements were added by pip freeze:
 aiohttp==3.8.1
 aiosignal==1.2.0
-alembic==1.7.7
-amqp==5.0.9
+alembic==1.8.0
+amqp==5.1.1
 async-timeout==4.0.2
 attrs==21.4.0
 awscli==1.19.58
-bcrypt==3.2.0
+bcrypt==3.2.2
 billiard==3.6.4.0
 bleach==3.3.0
 blinker==1.4
 boto3==1.17.58
 botocore==1.20.58
 cachetools==4.2.1
-certifi==2021.10.8
+certifi==2022.6.15
 chardet==4.0.0
-charset-normalizer==2.0.12
+charset-normalizer==2.1.0
 click==7.1.2
 click-didyoumean==0.3.0
 click-plugins==1.1.1
 click-repl==0.2.0
 colorama==0.4.3
-cryptography==36.0.1
+cryptography==37.0.2
 Deprecated==1.2.13
 dnspython==1.16.0
 docutils==0.15.2
-filelock==3.6.0
+filelock==3.7.1
 flask-redis==0.4.0
 frozenlist==1.3.0
 future==0.18.2
@@ -99,24 +99,24 @@ greenlet==1.1.2
 Jinja2==2.11.3
 jmespath==0.10.0
 kombu==5.2.4
-Mako==1.1.6
+Mako==1.2.0
 mistune==0.8.4
 multidict==6.0.2
 orderedset==2.0.3
 packaging==21.3
 phonenumbers==8.12.21
-prompt-toolkit==3.0.29
+prompt-toolkit==3.0.30
 py-w3c==0.3.1
 pyasn1==0.4.8
 pycparser==2.21
 pycurl==7.43.0.5
 pyOpenSSL==22.0.0
-pyparsing==3.0.8
+pyparsing==3.0.9
 PyPDF2==1.26.0
 pyrsistent==0.18.1
 python-dateutil==2.8.2
 python-json-logger==2.0.1
-redis==4.1.4
+redis==4.3.4
 requests-file==1.5.1
 s3transfer==0.4.2
 six==1.16.0
@@ -126,6 +126,6 @@ urllib3==1.26.9
 vine==5.0.0
 wcwidth==0.2.5
 webencodings==0.5.1
-websocket-client==1.2.3
-wrapt==1.13.3
+websocket-client==1.3.3
+wrapt==1.14.1
 yarl==1.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,8 +52,8 @@ MarkupSafe==2.0.1
 # Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
 itsdangerous==0.24  # pyup: <1.0.0
 
-#git+https://github.com/cds-snc/notifier-utils.git@46.5.0#egg=notifications-utils
-git+https://github.com/cds-snc/notifier-utils.git@81e2fcdcb7c4d2ce3814af6db2ceb0ccd8f258f1
+git+https://github.com/cds-snc/notifier-utils.git@47.0.0#egg=notifications-utils
+
 # MLWR
 socketio-client==0.5.6
 requests

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,21 +1,21 @@
 -r requirements.txt
-flake8==3.8.4
-isort==5.6.4
+flake8==4.0.1
+isort==5.10.1
 moto==1.3.14
 idna==2.8
-pytest==5.3.2
+pytest==7.1.2
 pytest-env==0.6.2
 pytest-mock==3.7.0
 pytest-cov==3.0.0
 coveralls==1.11.1
-pytest-xdist==1.31.0
-freezegun==1.0.0
-requests-mock==1.8.0
+pytest-xdist==2.5.0
+freezegun==1.2.1
+requests-mock==1.9.3
 # optional requirements for jsonschema
 strict-rfc3339==0.7
 rfc3987==1.3.8
 # used for creating manifest file locally
-jinja2-cli[yaml]==0.6.0
+jinja2-cli[yaml]==0.8.2
 black==21.5b2
 locust==1.5.3
 mypy==0.812

--- a/tests/app/authentication/test_authentication.py
+++ b/tests/app/authentication/test_authentication.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 import jwt
 import pytest
-from flask import current_app, json, request
+from flask import current_app, g, json, request
 from freezegun import freeze_time
 from notifications_python_client.authentication import create_jwt_token
 
@@ -336,7 +336,7 @@ def test_should_attach_the_current_api_key_to_current_app(notify_api, sample_ser
         token = __create_token(sample_api_key.service_id)
         response = client.get("/notifications", headers={"Authorization": "Bearer {}".format(token)})
         assert response.status_code == 200
-        assert api_user == sample_api_key
+        assert g.api_user == sample_api_key
 
 
 def test_should_return_403_when_token_is_expired(

--- a/tests/app/authentication/test_authentication.py
+++ b/tests/app/authentication/test_authentication.py
@@ -8,7 +8,6 @@ from flask import current_app, g, json, request
 from freezegun import freeze_time
 from notifications_python_client.authentication import create_jwt_token
 
-from app import api_user
 from app.authentication.auth import (
     AUTH_TYPES,
     AuthError,


### PR DESCRIPTION
# Summary | Résumé

Updates API to werkzeug 2.0.2.

This required a small refactor of part of the app that used Flask internals directly (`authentication/auth.py` and `app/__init__.py`):
- Stop using `flask._request_ctx_stack`; instead use`flask.g`
