### PR TITLE
Task/fix taskstests

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -814,7 +814,7 @@ def process_incomplete_job(job_id):
     template.process_type = db_template.process_type
 
     csv = get_recipient_csv(job, template)
-    rows = csv.get_rows()
+    rows = csv.get_rows() # This returns an iterator
     first_row = []
     for row in rows:
         if row.index > resume_from_row:
@@ -826,7 +826,7 @@ def process_incomplete_job(job_id):
                     metrics_logger, 1, notification_type=db_template.template_type, priority=db_template.process_type
                 )
                 first_row = []
-            exit
+            break
 
     job_complete(job, resumed=True)
 

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -589,14 +589,16 @@ def handle_batch_error_and_forward(
                 notif=notification_id,
                 max_retry=task.max_retries,
             )
-            current_app.logger.info("Retry" + retry_msg)
+            current_app.logger.warning("Retry " + retry_msg)
             try:
                 if task.max_retries == 5 and len(signed_and_verified) != 1:
                     save_fn.apply_async(
                         (service.id, [signed], None),
                         queue=choose_database_queue(template, service),
                     )
+                    current_app.logger.warning("Made a new task to retry")
                 else:
+                    current_app.logger.warning("Retrying the current task")
                     task.retry(queue=QueueNames.RETRY, exc=exception)
             except task.MaxRetriesExceededError:
                 current_app.logger.error("Max retry failed" + retry_msg)

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -814,7 +814,7 @@ def process_incomplete_job(job_id):
     template.process_type = db_template.process_type
 
     csv = get_recipient_csv(job, template)
-    rows = csv.get_rows() # This returns an iterator
+    rows = csv.get_rows()  # This returns an iterator
     first_row = []
     for row in rows:
         if row.index > resume_from_row:

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -591,7 +591,9 @@ def handle_batch_error_and_forward(
             )
             current_app.logger.warning("Retry " + retry_msg)
             try:
-                if task.max_retries == 5 and len(signed_and_verified) != 1:
+                # If >1 notification has failed, we want to make individual
+                # tasks to retry those notifications.
+                if len(signed_and_verified) != 1:
                     save_fn.apply_async(
                         (service.id, [signed], None),
                         queue=choose_database_queue(template, service),

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -593,7 +593,7 @@ def handle_batch_error_and_forward(
             try:
                 # If >1 notification has failed, we want to make individual
                 # tasks to retry those notifications.
-                if len(signed_and_verified) != 1:
+                if len(signed_and_verified) > 1:
                     save_fn.apply_async(
                         (service.id, [signed], None),
                         queue=choose_database_queue(template, service),

--- a/app/dao/templates_dao.py
+++ b/app/dao/templates_dao.py
@@ -109,8 +109,7 @@ def dao_get_template_by_id(
                 return TemplateHistory.from_json(template_cache_decoded), template_cache_decoded
             else:
                 return Template.from_json(template_cache_decoded), template_cache_decoded
-
-    elif version is not None:
+    if version is not None:
         return TemplateHistory.query.filter_by(id=template_id, version=version).one()
     return Template.query.filter_by(id=template_id).one()
 

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -800,7 +800,7 @@ class TestProcessRows:
             (EMAIL_TYPE, True, "save_emails", "research-mode-tasks", None, None, None),
         ],
     )
-    def test_process_row_sends_save_task(
+    def test_process_rows_sends_save_task(
         self,
         notify_api,
         template_type,

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -1200,7 +1200,7 @@ class TestSaveSmss:
         assert persisted_notification.reply_to_text == "new-sender"
 
 
-class TestHandler:
+class TestSaveErrorHandling:
     def test_handler_send_1notification(self, sample_template, mocker):
         n1 = _notification_json(sample_template, "+1 650 253 2222")
         n1["notification_id"] = str(uuid.uuid4())


### PR DESCRIPTION
# Summary | Résumé

Note: Plural save funcs - save_emails, save_smss (this is the code path we use post feature flag turn on).


Changed test_tasks.py and tasks.py. Main changes:

1. Removed `process_row` and changed all references to `process_rows`
2. Removed `save_sms` and `save_email`. Converted those code paths to `save_emails` and `save_smss`. 
3. Changed tests to accommodate the above two
4. Updated `incomplete_job` code to take `process_rows` instead of `process_row`
5. Changed the `handler` code to use the plural save tasks instead of the old deprecated ones
6. Marked all the `letter` code for deprecation
7.  Changed how we retrieve templates as there was an error in the code

# Testing

1. Updated tests, moved tests around into different classes
2. Moved all tests to use plural save func
3. Updated tests for incomplete jobs
4. Updated handler code

I tested handler code in two ways:  I added unit tests for it, and then I tested it by throwing an error in the save func. The second test showed me `max_retries` is never changed, it remains the same regardless of what "retry" number the task is on. Unfortunately I couldn't find a way to retrieve what "retry" number the task was on (there isn't one according to celery docs) but through logging, I did see that the tasks were tried a certain number of times as well as tasks that should complete, completed.