### PR TITLE
Upgrade flask to v2 (api)

### DIFF
--- a/app/v2/notifications/get_notifications.py
+++ b/app/v2/notifications/get_notifications.py
@@ -53,7 +53,7 @@ def get_pdf_for_notification(notification_id):
     except Exception:
         raise PDFNotReadyError()
 
-    return send_file(filename_or_fp=BytesIO(pdf_data), mimetype="application/pdf")
+    return send_file(path_or_file=BytesIO(pdf_data), mimetype="application/pdf")
 
 
 @v2_notification_blueprint.route("", methods=["GET"])

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -50,8 +50,7 @@ MarkupSafe==2.0.1
 # REVIEW: v2 is using sha512 instead of sha1 by default (in v1)
 itsdangerous==2.0.1
 
-#git+https://github.com/cds-snc/notifier-utils.git@47.0.0#egg=notifications-utils
-git+https://github.com/cds-snc/notifier-utils.git@be1a983ee91f8b3a0ea426d46e91fb5293159e42
+git+https://github.com/cds-snc/notifier-utils.git@48.0.0#egg=notifications-utils
 
 # MLWR
 socketio-client==0.5.6

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -12,7 +12,7 @@ Flask-Bcrypt==0.7.1
 flask-marshmallow==0.14.0
 Flask-Migrate==2.7.0
 git+https://github.com/mitsuhiko/flask-sqlalchemy.git@500e732dd1b975a56ab06a46bd1a20a21e682262#egg=Flask-SQLAlchemy==2.3.2.dev20190108
-Flask==1.1.2
+Flask==2.0.3
 click-datetime==0.2
 eventlet==0.30.2 # currently 0.31.0+ breaks gunicorn. Test the docker image if upgrading!
 gunicorn==20.1.0
@@ -47,8 +47,8 @@ aws-embedded-metrics==1.0.7
 Werkzeug==2.0.2
 MarkupSafe==2.0.1
 
-# Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
-itsdangerous==0.24  # pyup: <1.0.0
+# REVIEW: v2 is using sha512 instead of sha1 by default (in v1)
+itsdangerous==2.0.1
 
 git+https://github.com/cds-snc/notifier-utils.git@47.0.0#egg=notifications-utils
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -40,7 +40,7 @@ unidecode==1.2.0
 more-itertools==8.12.0
 
 # PaaS
-awscli-cwlogs>=1.4.6,<1.5
+awscli-cwlogs>=1.4.6,<1.57
 aws-embedded-metrics==1.0.7
 
 # Putting upgrade on hold due to new version introducing breaking changes
@@ -50,8 +50,8 @@ MarkupSafe==2.0.1
 # REVIEW: v2 is using sha512 instead of sha1 by default (in v1)
 itsdangerous==2.0.1
 
-git+https://github.com/cds-snc/notifier-utils.git@47.0.0#egg=notifications-utils
-
+#git+https://github.com/cds-snc/notifier-utils.git@47.0.0#egg=notifications-utils
+/libs
 # MLWR
 socketio-client==0.5.6
 requests

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -51,7 +51,8 @@ MarkupSafe==2.0.1
 itsdangerous==2.0.1
 
 #git+https://github.com/cds-snc/notifier-utils.git@47.0.0#egg=notifications-utils
-/libs
+git+https://github.com/cds-snc/notifier-utils.git@be1a983ee91f8b3a0ea426d46e91fb5293159e42
+
 # MLWR
 socketio-client==0.5.6
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ Flask-Bcrypt==0.7.1
 flask-marshmallow==0.14.0
 Flask-Migrate==2.7.0
 git+https://github.com/mitsuhiko/flask-sqlalchemy.git@500e732dd1b975a56ab06a46bd1a20a21e682262#egg=Flask-SQLAlchemy==2.3.2.dev20190108
-Flask==1.1.2
+Flask==2.0.3
 click-datetime==0.2
 eventlet==0.30.2 # currently 0.31.0+ breaks gunicorn. Test the docker image if upgrading!
 gunicorn==20.1.0
@@ -42,18 +42,18 @@ unidecode==1.2.0
 more-itertools==8.12.0
 
 # PaaS
-awscli-cwlogs>=1.4.6,<1.5
+awscli-cwlogs>=1.4.6,<1.57
 aws-embedded-metrics==1.0.7
 
 # Putting upgrade on hold due to new version introducing breaking changes
 Werkzeug==2.0.2
 MarkupSafe==2.0.1
 
-# Putting upgrade on hold due to v1.0.0 using sha512 instead of sha1 by default
-itsdangerous==0.24  # pyup: <1.0.0
+# REVIEW: v2 is using sha512 instead of sha1 by default (in v1)
+itsdangerous==2.0.1
 
-git+https://github.com/cds-snc/notifier-utils.git@47.0.0#egg=notifications-utils
-
+#git+https://github.com/cds-snc/notifier-utils.git@47.0.0#egg=notifications-utils
+/libs
 # MLWR
 socketio-client==0.5.6
 requests
@@ -87,7 +87,7 @@ click-didyoumean==0.3.0
 click-plugins==1.1.1
 click-repl==0.2.0
 colorama==0.4.3
-cryptography==37.0.2
+cryptography==37.0.4
 Deprecated==1.2.13
 dnspython==1.16.0
 docutils==0.15.2
@@ -96,12 +96,13 @@ flask-redis==0.4.0
 frozenlist==1.3.0
 future==0.18.2
 greenlet==1.1.2
-Jinja2==2.11.3
+Jinja2==3.1.2
 jmespath==0.10.0
 kombu==5.2.4
-Mako==1.2.0
+Mako==1.2.1
 mistune==0.8.4
 multidict==6.0.2
+notifications-utils @ file:///libs
 orderedset==2.0.3
 packaging==21.3
 phonenumbers==8.12.21
@@ -122,7 +123,7 @@ s3transfer==0.4.2
 six==1.16.0
 smartypants==2.0.1
 statsd==3.3.0
-urllib3==1.26.9
+urllib3==1.26.10
 vine==5.0.0
 wcwidth==0.2.5
 webencodings==0.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,8 +52,7 @@ MarkupSafe==2.0.1
 # REVIEW: v2 is using sha512 instead of sha1 by default (in v1)
 itsdangerous==2.0.1
 
-#git+https://github.com/cds-snc/notifier-utils.git@47.0.0#egg=notifications-utils
-git+https://github.com/cds-snc/notifier-utils.git@be1a983ee91f8b3a0ea426d46e91fb5293159e42
+git+https://github.com/cds-snc/notifier-utils.git@48.0.0#egg=notifications-utils
 
 # MLWR
 socketio-client==0.5.6
@@ -103,7 +102,6 @@ kombu==5.2.4
 Mako==1.2.1
 mistune==0.8.4
 multidict==6.0.2
-notifications-utils @ git+https://github.com/cds-snc/notifier-utils.git@be1a983ee91f8b3a0ea426d46e91fb5293159e42
 orderedset==2.0.3
 packaging==21.3
 phonenumbers==8.12.21

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,8 @@ MarkupSafe==2.0.1
 itsdangerous==2.0.1
 
 #git+https://github.com/cds-snc/notifier-utils.git@47.0.0#egg=notifications-utils
-/libs
+git+https://github.com/cds-snc/notifier-utils.git@be1a983ee91f8b3a0ea426d46e91fb5293159e42
+
 # MLWR
 socketio-client==0.5.6
 requests
@@ -102,7 +103,7 @@ kombu==5.2.4
 Mako==1.2.1
 mistune==0.8.4
 multidict==6.0.2
-notifications-utils @ file:///libs
+notifications-utils @ git+https://github.com/cds-snc/notifier-utils.git@be1a983ee91f8b3a0ea426d46e91fb5293159e42
 orderedset==2.0.3
 packaging==21.3
 phonenumbers==8.12.21

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -17,7 +17,7 @@ rfc3987==1.3.8
 # used for creating manifest file locally
 jinja2-cli[yaml]==0.8.2
 black==21.5b2
-locust==1.5.3
+locust==2.10.1
 mypy==0.812
 sqlalchemy-stubs==0.4
 networkx>=2.6 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -2121,7 +2121,7 @@ def test_update_service_calls_send_notification_as_service_becomes_live(
         get_user_by_id_mock.assert_not_called()
         fetch_service_creator_mock.assert_called_once_with(restricted_service.id)
 
-    assert resp.status_code == 200
+    assert resp.status_code == 200  # type: ignore
     send_notification_mock.assert_called_once_with(
         service_id=restricted_service.id,
         template_id="618185c6-3636-49cd-b7d2-6f6f5eb3bdde",

--- a/tests/app/v2/test_errors.py
+++ b/tests/app/v2/test_errors.py
@@ -1,4 +1,5 @@
 import json
+
 import pytest
 from flask import url_for
 from sqlalchemy.exc import DataError
@@ -170,4 +171,3 @@ def test_bad_method(app_for_test):
             assert response.status_code == 405
 
             assert json.loads(response.data) == {"message": "The method is not allowed for the requested URL.", "result": "error"}
-            

--- a/tests/app/v2/test_errors.py
+++ b/tests/app/v2/test_errors.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 from flask import url_for
 from sqlalchemy.exc import DataError
@@ -168,7 +169,5 @@ def test_bad_method(app_for_test):
 
             assert response.status_code == 405
 
-            assert response.json == {
-                "result": "error",
-                "message": "The method is not allowed for the requested URL.",
-            }
+            assert json.loads(response.data) == {"message": "The method is not allowed for the requested URL.", "result": "error"}
+            


### PR DESCRIPTION
# Summary | Résumé

## Package bumps
This PR upgrades:
- Flask to 2.0.3
- itsdangerous to 2.0.1
- locust (for testing) to 2.10.0

## Flask changes
- the `send_file` method renamed the parameter `filename_or_fp` to `path_or_file`

# Testing
- [ ] Ensure locust tests still work with new version of locust
- [ ] Ensure change to `get_pdf_for_notification()` works