### PR TITLE
Fix send-notify-no-reply

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -885,8 +885,7 @@ def send_notify_no_reply(self, data):
         ]
         current_app.logger.info(f"Data we are sending to persist_notifications is {data_to_send}")
         saved_notifications = persist_notifications(data_to_send)
-        if saved_notifications and len(saved_notifications) == 1:
-            send_notification_to_queue(saved_notifications[0], False, queue=QueueNames.NOTIFY)
+        send_notification_to_queue(saved_notifications[0], False, queue=QueueNames.NOTIFY)
     except Exception as e:
         try:
             current_app.logger.warning(f"The exception is {repr(e)}")

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -889,7 +889,6 @@ def send_notify_no_reply(self, data):
             send_notification_to_queue(saved_notifications[0], False, queue=QueueNames.NOTIFY)
     except Exception as e:
         try:
-            current_app.logger.warning("We are going to retry send_no_reply")
             current_app.logger.warning(f"The exception is {repr(e)}")
             self.retry(queue=QueueNames.RETRY)
         except self.MaxRetriesExceededError:

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -860,8 +860,6 @@ def process_returned_letters_list(notification_references):
 @notify_celery.task(bind=True, name="send-notify-no-reply", max_retries=5)
 @statsd(namespace="tasks")
 def send_notify_no_reply(self, data):
-    current_app.logger.info(f"send_notify_no_reply data is : {data}")
-    current_app.logger.info(f"The self data is {self}")
     payload = json.loads(data)
 
     service = dao_fetch_service_by_id(current_app.config["NOTIFY_SERVICE_ID"])
@@ -886,13 +884,13 @@ def send_notify_no_reply(self, data):
             )
         ]
         current_app.logger.info(f"Data we are sending to persist_notifications is {data_to_send}")
-        saved_notification = persist_notifications(data_to_send)
-        send_notification_to_queue(saved_notification, False, queue=QueueNames.NOTIFY)
+        saved_notifications = persist_notifications(data_to_send)
+        if saved_notifications and len(saved_notifications) == 1:
+            send_notification_to_queue(saved_notifications[0], False, queue=QueueNames.NOTIFY)
     except Exception as e:
         try:
             current_app.logger.warning("We are going to retry send_no_reply")
-            current_app.logger.warning(f"The exception is {e}")
-            raise
+            current_app.logger.warning(f"The exception is {repr(e)}")
             self.retry(queue=QueueNames.RETRY)
         except self.MaxRetriesExceededError:
             current_app.logger.error(

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -2048,8 +2048,8 @@ class TestProcessReturnedLettersList:
 
 
 class TestSendNotifyNoReply:
-    def test_send_notify_no_reply(self, mocker, no_reply_template):
-        persist_mock = mocker.patch("app.celery.tasks.persist_notifications")
+    def test_send_notify_no_reply(self, mocker, sample_notification, no_reply_template):
+        persist_mock = mocker.patch("app.celery.tasks.persist_notifications", return_value=[sample_notification])
         queue_mock = mocker.patch("app.celery.tasks.send_notification_to_queue")
 
         data = json.dumps(
@@ -2068,13 +2068,11 @@ class TestSendNotifyNoReply:
             "sending_email_address": "service@notify.ca",
         }
         assert persist_call["reply_to_text"] is None
-
         assert len(queue_mock.call_args_list) == 1
         queue_call = queue_mock.call_args_list[0][1]
 
         assert queue_call["queue"] == QueueNames.NOTIFY
 
-    @pytest.mark.skip(reason="To test on staging - MUST REMOVE")
     def test_send_notify_no_reply_retry(self, mocker, no_reply_template):
         mocker.patch("app.celery.tasks.send_notify_no_reply.retry", side_effect=Retry)
         mocker.patch("app.celery.tasks.send_notification_to_queue", side_effect=Exception())


### PR DESCRIPTION
# Summary | Résumé

We were incorrectly sending a list object to `send_notification_to_queue`. We fixed this and also cleaned up some logs we had added while debugging why this function wasn't working as expected.