### PR TITLE
Feat/include sms parts in daily stats part1

### DIFF
--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -85,6 +85,7 @@ def query_for_fact_status_data(table, start_date, end_date, notification_type, s
             table.key_type,
             table.status,
             func.count().label("notification_count"),
+            func.sum(table.billable_units).label("billable_units"),
         )
         .filter(
             table.created_at >= start_date,
@@ -119,6 +120,7 @@ def update_fact_notification_status(data, process_day):
             key_type=row.key_type,
             notification_status=row.status,
             notification_count=row.notification_count,
+            billable_units=row.billable_units,
         )
         db.session.connection().execute(stmt)
         db.session.commit()

--- a/app/models.py
+++ b/app/models.py
@@ -2281,6 +2281,7 @@ class FactNotificationStatus(BaseModel):
     key_type = db.Column(db.Text, primary_key=True, nullable=False)
     notification_status = db.Column(db.Text, primary_key=True, nullable=False)
     notification_count = db.Column(db.Integer(), nullable=False)
+    billable_units = db.Column(db.Integer(), nullable=False)
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
     updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
 

--- a/migrations/versions/0422_add_billable_units.py
+++ b/migrations/versions/0422_add_billable_units.py
@@ -1,0 +1,26 @@
+"""
+
+Revision ID: 0422_add_billable_units
+Revises: 0421_add_sms_daily_limit
+Create Date: 2022-09-082 15:45:00
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0422_add_billable_units"
+down_revision = "0421_add_sms_daily_limit"
+
+user = "postgres"
+timeout = 1200  # in seconds, i.e. 20 minutes
+default = 1
+
+
+def upgrade():
+    op.add_column("ft_notification_status", sa.Column("billable_units", sa.Integer(), nullable=True),)
+    op.execute(f"UPDATE ft_notification_status SET billable_units = notification_count")
+    op.alter_column("ft_notification_status", "billable_units", nullable=False)
+
+
+def downgrade():
+    op.drop_column("ft_notification_status", "billable_units")

--- a/tests/app/celery/test_reporting_tasks.py
+++ b/tests/app/celery/test_reporting_tasks.py
@@ -23,6 +23,7 @@ from app.models import (
 from tests.app.db import (
     create_letter_rate,
     create_notification,
+    create_notification_history,
     create_rate,
     create_service,
     create_template,
@@ -530,6 +531,28 @@ def test_ensure_create_nightly_notification_status_for_day_copies_billable_units
     assert len(FactNotificationStatus.query.all()) == 0
 
     create_nightly_notification_status_for_day("2019-01-01")
+
+    new_data = FactNotificationStatus.query.all()
+
+    assert len(new_data) == 2
+    assert new_data[0].billable_units == 5
+    assert new_data[1].billable_units == 10    
+
+
+@freeze_time("2019-01-05T06:00:00")
+def test_ensure_create_nightly_notification_status_for_day_copies_billable_units_from_notificationsHistory(notify_db_session):
+    first_service = create_service(service_name="First Service")
+    first_template = create_template(service=first_service)
+    second_service = create_service(service_name="second Service")
+    second_template = create_template(service=second_service, template_type="email")
+
+    create_notification_history(template=first_template, billable_units=5)
+    create_notification_history(template=second_template, billable_units=10)
+
+    
+    assert len(FactNotificationStatus.query.all()) == 0
+
+    create_nightly_notification_status_for_day("2019-01-05")
 
     new_data = FactNotificationStatus.query.all()
 

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -737,6 +737,7 @@ def create_ft_notification_status(
     key_type="normal",
     notification_status="delivered",
     count=1,
+    billable_units=1,
 ):
     if job:
         template = job.template
@@ -757,6 +758,7 @@ def create_ft_notification_status(
         key_type=key_type,
         notification_status=notification_status,
         notification_count=count,
+        billable_units=billable_units,
     )
     db.session.add(data)
     db.session.commit()


### PR DESCRIPTION
# Summary | Résumé

This PR adds `billable_units` to the `ft_notification_status` table so we can track statistics on SMS parts usage and enable daily and yearly limits for them.