### PR TITLE
Bump notification-utils to 48.2.0

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -50,7 +50,7 @@ MarkupSafe==2.0.1
 # REVIEW: v2 is using sha512 instead of sha1 by default (in v1)
 itsdangerous==2.0.1
 
-git+https://github.com/cds-snc/notifier-utils.git@48.1.0#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@48.2.0#egg=notifications-utils
 
 # MLWR
 socketio-client==0.5.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ MarkupSafe==2.0.1
 # REVIEW: v2 is using sha512 instead of sha1 by default (in v1)
 itsdangerous==2.0.1
 
-git+https://github.com/cds-snc/notifier-utils.git@48.1.0#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@48.2.0#egg=notifications-utils
 
 # MLWR
 socketio-client==0.5.6
@@ -79,7 +79,7 @@ blinker==1.5
 boto3==1.17.58
 botocore==1.20.58
 cachetools==4.2.1
-certifi==2022.6.15
+certifi==2022.6.15.1
 chardet==4.0.0
 charset-normalizer==2.1.1
 click==7.1.2
@@ -87,7 +87,7 @@ click-didyoumean==0.3.0
 click-plugins==1.1.1
 click-repl==0.2.0
 colorama==0.4.3
-cryptography==37.0.4
+cryptography==38.0.1
 Deprecated==1.2.13
 dnspython==1.16.0
 docutils==0.15.2
@@ -105,7 +105,7 @@ multidict==6.0.2
 orderedset==2.0.3
 packaging==21.3
 phonenumbers==8.12.21
-prompt-toolkit==3.0.30
+prompt-toolkit==3.0.31
 py-w3c==0.3.1
 pyasn1==0.4.8
 pycparser==2.21
@@ -126,6 +126,6 @@ urllib3==1.26.12
 vine==5.0.0
 wcwidth==0.2.5
 webencodings==0.5.1
-websocket-client==1.4.0
+websocket-client==1.4.1
 wrapt==1.14.1
 yarl==1.8.1


### PR DESCRIPTION
# Summary | Résumé
This PR bumps the notification-utils version to make use of the lang tag fixes from https://github.com/cds-snc/notification-utils/pull/129

This PR should be deployed along with:
- https://github.com/cds-snc/notification-admin/pull/1330