### PR TITLE
Add sms parts to fact queries

### DIFF
--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -231,7 +231,6 @@ def fetch_notification_status_for_service_for_day(bst_day, service_id):
             Notification.status.label("notification_status"),
             func.count().label("count"),
             func.sum(Notification.billable_units).label("billable_units"),
-            
         )
         .filter(
             Notification.created_at >= get_local_timezone_midnight_in_utc(bst_day),
@@ -300,7 +299,7 @@ def fetch_notification_status_for_service_for_today_and_7_previous_days(service_
     if by_template:
         query = query.filter(all_stats_table.c.template_id == Template.id)
 
-    data =  query.group_by(
+    data = query.group_by(
         *(
             [
                 Template.name,
@@ -313,7 +312,7 @@ def fetch_notification_status_for_service_for_today_and_7_previous_days(service_
         all_stats_table.c.notification_type,
         all_stats_table.c.status,
     ).all()
-    
+
     return data
 
 
@@ -684,7 +683,7 @@ def fetch_monthly_template_usage_for_service(start_date, end_date, service_id):
                 extract("month", month).label("month"),
                 extract("year", month).label("year"),
                 func.count().label("count"),
-                func.sum(Notification.billable_units).label("billable_units")
+                func.sum(Notification.billable_units).label("billable_units"),
             )
             .join(
                 Template,

--- a/app/template_statistics/rest.py
+++ b/app/template_statistics/rest.py
@@ -37,6 +37,7 @@ def get_template_statistics_for_service_by_day(service_id):
         data=[
             {
                 "count": row.count,
+                "parts": row.billable_units,
                 "template_id": str(row.template_id),
                 "template_name": row.template_name,
                 "template_type": row.notification_type,

--- a/tests/app/dao/test_fact_notification_status_dao.py
+++ b/tests/app/dao/test_fact_notification_status_dao.py
@@ -198,18 +198,12 @@ def test_fetch_notification_status_for_service_for_day(notify_db_session):
     save_notification(create_notification(service_1.templates[0], created_at=datetime(2018, 6, 1, 22, 59, 0)))
     save_notification(
         create_notification(
-            service_1.templates[0],
-            created_at=datetime(2018, 6, 1, 12, 0, 0),
-            key_type=KEY_TYPE_TEAM,
-            billable_units=30
+            service_1.templates[0], created_at=datetime(2018, 6, 1, 12, 0, 0), key_type=KEY_TYPE_TEAM, billable_units=30
         )
     )
     save_notification(
         create_notification(
-            service_1.templates[0],
-            created_at=datetime(2018, 6, 1, 12, 0, 0),
-            status="delivered",
-            billable_units=10
+            service_1.templates[0], created_at=datetime(2018, 6, 1, 12, 0, 0), status="delivered", billable_units=10
         )
     )
 
@@ -372,7 +366,7 @@ def test_get_total_notifications_sent_for_api_key(notify_db_session):
         save_notification(create_notification(template=template_sms, api_key=api_key, billable_units=2))
 
     api_key_stats_3 = get_total_notifications_sent_for_api_key(str(api_key.id))
-    assert api_key_stats_3 == [(EMAIL_TYPE, total_sends, total_sends), (SMS_TYPE, total_sends, (total_sends*2))]
+    assert api_key_stats_3 == [(EMAIL_TYPE, total_sends, total_sends), (SMS_TYPE, total_sends, (total_sends * 2))]
 
 
 def test_get_last_send_for_api_key(notify_db_session):
@@ -492,9 +486,15 @@ def test_fetch_notification_status_totals_for_all_services_works_in_bst(
     sms_template = create_template(service=service_1, template_type=SMS_TYPE)
     email_template = create_template(service=service_1, template_type=EMAIL_TYPE)
 
-    save_notification(create_notification(sms_template, created_at=datetime(2018, 4, 20, 12, 0, 0), status="delivered", billable_units=10))
-    save_notification(create_notification(sms_template, created_at=datetime(2018, 4, 21, 11, 0, 0), status="created", billable_units=10))
-    save_notification(create_notification(sms_template, created_at=datetime(2018, 4, 21, 12, 0, 0), status="delivered", billable_units=10))
+    save_notification(
+        create_notification(sms_template, created_at=datetime(2018, 4, 20, 12, 0, 0), status="delivered", billable_units=10)
+    )
+    save_notification(
+        create_notification(sms_template, created_at=datetime(2018, 4, 21, 11, 0, 0), status="created", billable_units=10)
+    )
+    save_notification(
+        create_notification(sms_template, created_at=datetime(2018, 4, 21, 12, 0, 0), status="delivered", billable_units=10)
+    )
     save_notification(create_notification(email_template, created_at=datetime(2018, 4, 21, 13, 0, 0), status="delivered"))
     save_notification(create_notification(email_template, created_at=datetime(2018, 4, 21, 14, 0, 0), status="delivered"))
 
@@ -541,7 +541,9 @@ def set_up_data():
         )
     )
     save_notification(create_notification(sms_template, created_at=datetime(2018, 10, 31, 11, 0, 0)))
-    save_notification(create_notification(sms_template, created_at=datetime(2018, 10, 31, 12, 0, 0), status="delivered", billable_units=10))
+    save_notification(
+        create_notification(sms_template, created_at=datetime(2018, 10, 31, 12, 0, 0), status="delivered", billable_units=10)
+    )
     save_notification(create_notification(email_template, created_at=datetime(2018, 10, 31, 13, 0, 0), status="delivered"))
     return service_1, service_2
 
@@ -684,14 +686,14 @@ def test_fetch_delivered_notification_stats_by_month(sample_service):
         template=email_template,
         count=3,
     )
-   
+
     create_ft_notification_status(
         utc_date=date(2019, 12, 5),
         service=sample_service,
         template=sms_template,
         notification_status=NOTIFICATION_DELIVERED,
         count=6,
-        billable_units=12
+        billable_units=12,
     )
 
     create_ft_notification_status(


### PR DESCRIPTION
# Summary | Résumé

This PR exposes the sum of `billable_units` into many of the existing `ft_notification_status` queries, including:
- `fetch_notification_status_for_service_by_month`
- `fetch_delivered_notification_stats_by_month`
- `fetch_notification_stats_for_trial_services`
- `fetch_notification_status_for_service_for_day`
- `fetch_notification_status_for_service_for_today_and_7_previous_days`
- `get_total_notifications_sent_for_api_key`
- `fetch_notification_status_totals_for_all_services`
- `def fetch_notification_statuses_for_job(job_id)`
- `fetch_stats_for_all_services_by_date_range`
- `fetch_monthly_template_usage_for_service`
- `get_total_sent_notifications_for_day_and_type`
