### PR TITLE
fix/check daily_sms_limit wherever we check daily_message_limit

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -71,7 +71,7 @@ from app.notifications.process_notifications import (
     persist_notifications,
     send_notification_to_queue,
 )
-from app.notifications.validators import check_service_over_daily_message_limit
+from app.notifications.validators import check_service_over_daily_message_limit, check_service_over_daily_sms_limit
 from app.utils import get_csv_max_rows
 
 
@@ -286,6 +286,9 @@ def save_smss(self, service_id: Optional[str], signed_notifications: List[Any], 
         handle_batch_error_and_forward(self, signed_and_verified, SMS_TYPE, e, receipt, template)
 
     check_service_over_daily_message_limit(KEY_TYPE_NORMAL, service)
+    if template.template_type == "sms":
+        check_service_over_daily_sms_limit(KEY_TYPE_NORMAL, service)
+
     research_mode = service.research_mode  # type: ignore
 
     current_app.logger.info(f"Sending following sms notifications to AWS: {notification_id_queue.keys()}")
@@ -388,6 +391,9 @@ def save_emails(self, service_id: Optional[str], signed_notifications: List[Any]
     if saved_notifications:
         current_app.logger.info(f"Sending following email notifications to AWS: {notification_id_queue.keys()}")
         check_service_over_daily_message_limit(KEY_TYPE_NORMAL, service)
+        if template.template_type == "sms":
+            check_service_over_daily_sms_limit(KEY_TYPE_NORMAL, service)
+
         research_mode = service.research_mode  # type: ignore
         for notification in saved_notifications:
             queue = notification_id_queue.get(notification.id) or template.queue_to_use()  # type: ignore

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -71,7 +71,10 @@ from app.notifications.process_notifications import (
     persist_notifications,
     send_notification_to_queue,
 )
-from app.notifications.validators import check_service_over_daily_message_limit, check_service_over_daily_sms_limit
+from app.notifications.validators import (
+    check_service_over_daily_message_limit,
+    check_service_over_daily_sms_limit,
+)
 from app.utils import get_csv_max_rows
 
 
@@ -286,8 +289,7 @@ def save_smss(self, service_id: Optional[str], signed_notifications: List[Any], 
         handle_batch_error_and_forward(self, signed_and_verified, SMS_TYPE, e, receipt, template)
 
     check_service_over_daily_message_limit(KEY_TYPE_NORMAL, service)
-    if template.template_type == "sms":
-        check_service_over_daily_sms_limit(KEY_TYPE_NORMAL, service)
+    check_service_over_daily_sms_limit(KEY_TYPE_NORMAL, service)
 
     research_mode = service.research_mode  # type: ignore
 
@@ -391,8 +393,6 @@ def save_emails(self, service_id: Optional[str], signed_notifications: List[Any]
     if saved_notifications:
         current_app.logger.info(f"Sending following email notifications to AWS: {notification_id_queue.keys()}")
         check_service_over_daily_message_limit(KEY_TYPE_NORMAL, service)
-        if template.template_type == "sms":
-            check_service_over_daily_sms_limit(KEY_TYPE_NORMAL, service)
 
         research_mode = service.research_mode  # type: ignore
         for notification in saved_notifications:

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -393,7 +393,6 @@ def save_emails(self, service_id: Optional[str], signed_notifications: List[Any]
     if saved_notifications:
         current_app.logger.info(f"Sending following email notifications to AWS: {notification_id_queue.keys()}")
         check_service_over_daily_message_limit(KEY_TYPE_NORMAL, service)
-
         research_mode = service.research_mode  # type: ignore
         for notification in saved_notifications:
             queue = notification_id_queue.get(notification.id) or template.queue_to_use()  # type: ignore

--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -97,7 +97,7 @@ def send_notification(notification_type):
     if errors:
         raise InvalidRequest(errors, status_code=400)
 
-    check_rate_limiting(authenticated_service, api_user)
+    check_rate_limiting(authenticated_service, api_user, notification_type)
 
     template = templates_dao.dao_get_template_by_id_and_service_id(
         template_id=notification_form["template"], service_id=authenticated_service.id

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -91,7 +91,7 @@ def check_service_over_daily_message_limit(key_type, service):
     exception=LiveServiceTooManyRequestsError,
 )
 def check_service_over_daily_sms_limit(key_type, service):
-    if key_type != KEY_TYPE_TEST and current_app.config["REDIS_ENABLED"]:
+    if current_app.config["FF_SPIKE_SMS_DAILY_LIMIT"] and key_type != KEY_TYPE_TEST and current_app.config["REDIS_ENABLED"]:
         cache_key = sms_daily_count_cache_key(service.id)
         messages_sent = redis_store.get(cache_key)
         if not messages_sent:
@@ -101,10 +101,10 @@ def check_service_over_daily_sms_limit(key_type, service):
         warn_about_daily_sms_limit(service, int(messages_sent))
 
 
-def check_rate_limiting(service, api_key):
+def check_rate_limiting(service, api_key, template_type):
     check_service_over_api_rate_limit(service, api_key)
     check_service_over_daily_message_limit(api_key.key_type, service)
-    if current_app.config["FF_SPIKE_SMS_DAILY_LIMIT"]:
+    if template_type == "sms":
         check_service_over_daily_sms_limit(api_key.key_type, service)
 
 

--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -33,6 +33,7 @@ from app.notifications.process_notifications import (
 from app.notifications.validators import (
     check_service_has_permission,
     check_service_over_daily_message_limit,
+    check_service_over_daily_sms_limit,
     validate_and_format_recipient,
     validate_template,
 )
@@ -61,6 +62,8 @@ def send_one_off_notification(service_id, post_data):
     validate_template(template.id, personalisation, service, template.template_type)
 
     check_service_over_daily_message_limit(KEY_TYPE_NORMAL, service)
+    if template.template_type == "sms":
+        check_service_over_daily_sms_limit(KEY_TYPE_NORMAL, service)
 
     validate_and_format_recipient(
         send_to=post_data["to"],

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -103,7 +103,7 @@ def post_precompiled_letter_notification():
     # Check permission to send letters
     check_service_has_permission(LETTER_TYPE, authenticated_service.permissions)
 
-    check_rate_limiting(authenticated_service, api_user)
+    check_rate_limiting(authenticated_service, api_user, LETTER_TYPE)
 
     template = get_precompiled_letter_template(authenticated_service.id)
 
@@ -197,7 +197,7 @@ def post_notification(notification_type):
 
     check_service_can_schedule_notification(authenticated_service.permissions, scheduled_for)
 
-    check_rate_limiting(authenticated_service, api_user)
+    check_rate_limiting(authenticated_service, api_user, notification_type)
 
     template, template_with_content = validate_template(
         form["template_id"],

--- a/tests/app/service/test_send_one_off_notification.py
+++ b/tests/app/service/test_send_one_off_notification.py
@@ -264,6 +264,24 @@ def test_send_one_off_notification_raises_if_over_limit(notify_db_session, mocke
         send_one_off_notification(service.id, post_data)
 
 
+def test_send_one_off_notification_raises_if_over_sms_daily_limit(notify_db_session, mocker):
+    service = create_service(message_limit=0)
+    template = create_template(service=service)
+    mocker.patch(
+        "app.service.send_notification.check_service_over_daily_sms_limit",
+        side_effect=TooManyRequestsError(1),
+    )
+
+    post_data = {
+        "template_id": str(template.id),
+        "to": "6502532222",
+        "created_by": str(service.created_by_id),
+    }
+
+    with pytest.raises(TooManyRequestsError):
+        send_one_off_notification(service.id, post_data)
+
+
 def test_send_one_off_notification_raises_if_message_too_long(persist_mock, notify_db_session):
     service = create_service()
     template = create_template(service=service, content="Hello (( Name))\nYour thing is due soon")


### PR DESCRIPTION
# Summary | Résumé

There were several places that we were calling `check_service_over_daily_message_limit` that we weren't calling `check_service_over_daily_sms_limit`. This PR fixes that.

# Test instructions | Instructions pour tester la modification

Basically, whenever you send an sms for the first time in a day, you should see the redis counter `sms-<service_id>-date-count` created.

(example: `sms-3ae2fb6a-bec7-47d6-8f8b-36e2519f7c6d-2022-09-27-count`)

# Release Instructions | Instructions pour le déploiement

None.
