### PR TITLE
Task/fix celery

### DIFF
--- a/scripts/run_celery_exit.sh
+++ b/scripts/run_celery_exit.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+set -e
+
+TERMINATE_TIMEOUT=9
+
+function get_celery_pids {
+  # get the PIDs of the process whose parent is the root process
+  # print only pid and their command, get the ones with "celery" in their name
+  # and keep only these PIDs
+
+  set +o pipefail # so grep returning no matches does not premature fail pipe
+  APP_PIDS=$(ps auxww | awk '/[c]elery worker/ {print $2}')
+  set -o pipefail # pipefail should be set everywhere else
+}
+
+function send_signal_to_celery_processes {
+  # refresh pids to account for the case that some workers may have terminated but others not
+  get_celery_pids
+  # send signal to all remaining apps
+  echo ${APP_PIDS} | tr -d '\n' | tr -s ' ' | xargs echo "Sending signal ${1} to processes with pids: "
+  echo "We will send ${1} signal"
+  for value in ${APP_PIDS}
+  do
+    echo kill -s ${1} $value
+  done
+  #echo ${APP_PIDS} | xargs kill -s ${1}
+}
+
+function error_exit()
+{
+    echo "Error: $1"
+}
+
+function ensure_celery_is_running {
+  if [ "${APP_PIDS}" = "" ]; then
+    echo "There are no celery processes running, this container is bad"
+
+    echo "Exporting CF information for diagnosis"
+
+    env | grep CF
+
+    exit 1
+  fi
+}
+
+
+function on_exit {
+  echo "multi worker app exiting"
+  wait_time=0
+
+  send_signal_to_celery_processes TERM
+
+  # check if the apps are still running every second
+  while [[ "$wait_time" -le "$TERMINATE_TIMEOUT" ]]; do
+    echo "exit function is running with wait time of 9s"
+    get_celery_pids
+    ensure_celery_is_running
+    let wait_time=wait_time+1
+    sleep 1
+  done
+
+  echo "sending signal to celery to kill process"
+  send_signal_to_celery_processes KILL
+}
+
+
+echo "Run script pid: $$"
+
+trap "on_exit" EXIT TERM


### PR DESCRIPTION
# Summary | Résumé

We want a script for when you send a kill signal to celery
The script should:
1. Send a TERM signal
2. Wait 9 seconds
3. Send a KILL signal

# Testing

1. I ran celery in my local container
2. I then manually ran the exit script
3. This is the output:
```
Run script pid: 17243
multi worker app exiting
Sending signal TERM to processes with pids:  16777 16803 16805 16807 16809
We will send TERM signal
kill -s TERM 16777
kill -s TERM 16803
kill -s TERM 16805
kill -s TERM 16807
kill -s TERM 16809
exit function is running with wait time of 9s
exit function is running with wait time of 9s
exit function is running with wait time of 9s
exit function is running with wait time of 9s
exit function is running with wait time of 9s
exit function is running with wait time of 9s
exit function is running with wait time of 9s
exit function is running with wait time of 9s
exit function is running with wait time of 9s
exit function is running with wait time of 9s
sending signal to celery to kill process
Sending signal KILL to processes with pids:  16777 16803 16805 16807 16809
We will send KILL signal
kill -s KILL 16777
kill -s KILL 16803
kill -s KILL 16805
kill -s KILL 16807
kill -s KILL 16809
```

# NOTE
We will need to call this script in the kube deployment process. This part has not been tested yet.

