### PR TITLE
Fix/non default replyto

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -357,22 +357,22 @@ def save_emails(self, service_id: Optional[str], signed_notifications: List[Any]
             else:
                 reply_to_text = template.get_reply_to_text()  # type: ignore
 
-        notification["reply_to_text"] = reply_to_text
-        notification["service"] = service
-        notification["key_type"] = notification.get("key_type", KEY_TYPE_NORMAL)
-        notification["template_id"] = template.id
-        notification["template_version"] = template.version
-        notification["recipient"] = notification.get("to")
-        notification["personalisation"] = notification.get("personalisation")
-        notification["notification_type"] = EMAIL_TYPE
-        notification["simulated"] = notification.get("simulated", None)
-        notification["api_key_id"] = notification.get("api_key", None)
-        notification["created_at"] = datetime.utcnow()
-        notification["job_id"] = notification.get("job", None)
-        notification["job_row_number"] = notification.get("row_number", None)
-        verified_notifications.append(notification)
-        notification_id_queue[notification_id] = notification.get("queue")
-        process_type = template.process_type
+            notification["reply_to_text"] = reply_to_text
+            notification["service"] = service
+            notification["key_type"] = notification.get("key_type", KEY_TYPE_NORMAL)
+            notification["template_id"] = template.id
+            notification["template_version"] = template.version
+            notification["recipient"] = notification.get("to")
+            notification["personalisation"] = notification.get("personalisation")
+            notification["notification_type"] = EMAIL_TYPE
+            notification["simulated"] = notification.get("simulated", None)
+            notification["api_key_id"] = notification.get("api_key", None)
+            notification["created_at"] = datetime.utcnow()
+            notification["job_id"] = notification.get("job", None)
+            notification["job_row_number"] = notification.get("row_number", None)
+            verified_notifications.append(notification)
+            notification_id_queue[notification_id] = notification.get("queue")
+            process_type = template.process_type
 
     try:
         # If the data is not present in the encrypted data then fallback on whats needed for process_job

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -338,18 +338,22 @@ def save_emails(self, service_id: Optional[str], signed_notifications: List[Any]
         notification_id = notification.get("id", create_uuid())
         notification["notification_id"] = notification_id
         reply_to_text = ""  # type: ignore
-        if sender_id:
-            reply_to_text = dao_get_reply_to_by_id(service_id, sender_id).email_address
-            if isinstance(template, tuple):
-                template = template[0]
-        # if the template is obtained from cache a tuple will be returned where
-        # the first element is the Template object and the second the template cache data
-        # in the form of a dict
-        elif isinstance(template, tuple):
-            reply_to_text = template[1].get("reply_to_text")  # type: ignore
-            template = template[0]
+        
+        if "reply_to_text" in notification and notification["reply_to_text"]: # first just see if we already have a value of this and use it, otherwise continue with the logic below
+            reply_to_text = notification["reply_to_text"]
         else:
-            reply_to_text = template.get_reply_to_text()  # type: ignore
+            if sender_id:
+                reply_to_text = dao_get_reply_to_by_id(service_id, sender_id).email_address
+                if isinstance(template, tuple):
+                    template = template[0]
+            # if the template is obtained from cache a tuple will be returned where
+            # the first element is the Template object and the second the template cache data
+            # in the form of a dict
+            elif isinstance(template, tuple):
+                reply_to_text = template[1].get("reply_to_text")  # type: ignore
+                template = template[0]
+            else:
+                reply_to_text = template.get_reply_to_text()  # type: ignore
 
         notification["reply_to_text"] = reply_to_text
         notification["service"] = service

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -338,8 +338,10 @@ def save_emails(self, service_id: Optional[str], signed_notifications: List[Any]
         notification_id = notification.get("id", create_uuid())
         notification["notification_id"] = notification_id
         reply_to_text = ""  # type: ignore
-        
-        if "reply_to_text" in notification and notification["reply_to_text"]: # first just see if we already have a value of this and use it, otherwise continue with the logic below
+
+        if (
+            "reply_to_text" in notification and notification["reply_to_text"]
+        ):  # first just see if we already have a value of this and use it, otherwise continue with the logic below
             reply_to_text = notification["reply_to_text"]
         else:
             if sender_id:

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -342,37 +342,37 @@ def save_emails(self, service_id: Optional[str], signed_notifications: List[Any]
         if (
             "reply_to_text" in notification and notification["reply_to_text"]
         ):  # first just see if we already have a value of this and use it, otherwise continue with the logic below
-            reply_to_text = notification["reply_to_text"]
+            reply_to_text = notification["reply_to_text"]  # type: ignore
         else:
             if sender_id:
                 reply_to_text = dao_get_reply_to_by_id(service_id, sender_id).email_address
-                if isinstance(template, tuple):
-                    template = template[0]
             # if the template is obtained from cache a tuple will be returned where
             # the first element is the Template object and the second the template cache data
             # in the form of a dict
             elif isinstance(template, tuple):
                 reply_to_text = template[1].get("reply_to_text")  # type: ignore
-                template = template[0]
             else:
                 reply_to_text = template.get_reply_to_text()  # type: ignore
 
-            notification["reply_to_text"] = reply_to_text
-            notification["service"] = service
-            notification["key_type"] = notification.get("key_type", KEY_TYPE_NORMAL)
-            notification["template_id"] = template.id
-            notification["template_version"] = template.version
-            notification["recipient"] = notification.get("to")
-            notification["personalisation"] = notification.get("personalisation")
-            notification["notification_type"] = EMAIL_TYPE
-            notification["simulated"] = notification.get("simulated", None)
-            notification["api_key_id"] = notification.get("api_key", None)
-            notification["created_at"] = datetime.utcnow()
-            notification["job_id"] = notification.get("job", None)
-            notification["job_row_number"] = notification.get("row_number", None)
-            verified_notifications.append(notification)
-            notification_id_queue[notification_id] = notification.get("queue")
-            process_type = template.process_type
+        if isinstance(template, tuple):
+            template = template[0]
+
+        notification["reply_to_text"] = reply_to_text
+        notification["service"] = service
+        notification["key_type"] = notification.get("key_type", KEY_TYPE_NORMAL)
+        notification["template_id"] = template.id
+        notification["template_version"] = template.version
+        notification["recipient"] = notification.get("to")
+        notification["personalisation"] = notification.get("personalisation")
+        notification["notification_type"] = EMAIL_TYPE
+        notification["simulated"] = notification.get("simulated", None)
+        notification["api_key_id"] = notification.get("api_key", None)
+        notification["created_at"] = datetime.utcnow()
+        notification["job_id"] = notification.get("job", None)
+        notification["job_row_number"] = notification.get("row_number", None)
+        verified_notifications.append(notification)
+        notification_id_queue[notification_id] = notification.get("queue")
+        process_type = template.process_type
 
     try:
         # If the data is not present in the encrypted data then fallback on whats needed for process_job

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -309,6 +309,7 @@ def process_sms_or_email_notification(*, form, notification_type, api_key, templ
         "api_key": str(api_key.id),
         "key_type": str(api_key.key_type),
         "client_reference": form.get("reference", None),
+        "reply_to_text": reply_to_text
     }
 
     signed_notification_data = signer.sign(notification)

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -309,7 +309,7 @@ def process_sms_or_email_notification(*, form, notification_type, api_key, templ
         "api_key": str(api_key.id),
         "key_type": str(api_key.key_type),
         "client_reference": form.get("reference", None),
-        "reply_to_text": reply_to_text
+        "reply_to_text": reply_to_text,
     }
 
     signed_notification_data = signer.sign(notification)

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -72,7 +72,7 @@ class AnyStringWith(str):
         return self in other
 
 
-def _notification_json(template, to, personalisation=None, job_id=None, row_number=0, queue=None):
+def _notification_json(template, to, personalisation=None, job_id=None, row_number=0, queue=None, reply_to_text=None):
     return {
         "template": str(template.id),
         "template_version": template.version,
@@ -82,6 +82,7 @@ def _notification_json(template, to, personalisation=None, job_id=None, row_numb
         "job": job_id and str(job_id),
         "row_number": row_number,
         "queue": queue,
+        "reply_to_text": reply_to_text,
     }
 
 
@@ -1451,6 +1452,21 @@ class TestSaveEmails:
 
         persisted_notification = Notification.query.one()
         assert persisted_notification.reply_to_text == "reply_to@digital.gov.uk"
+    
+    def test_save_email_should_save_non_default_email_reply_to_text_on_notification_when_set(self, notify_db_session, mocker):
+        service = create_service()
+        create_reply_to_email(service=service, email_address="reply_to@digital.gov.uk", is_default=True)
+        create_reply_to_email(service=service, email_address="reply_two@digital.gov.uk", is_default=False)
+        template = create_template(service=service, template_type="email", subject="Hello")
+
+        notification = _notification_json(template, to="test@example.com", reply_to_text="reply_two@digital.gov.uk")
+        mocker.patch("app.celery.provider_tasks.deliver_email.apply_async")
+
+        notification_id = uuid.uuid4()
+        save_emails(service.id, [signer.sign(notification)], notification_id)
+
+        persisted_notification = Notification.query.one()
+        assert persisted_notification.reply_to_text == "reply_two@digital.gov.uk"
 
     def test_should_put_save_email_task_in_research_mode_queue_if_research_mode_service(self, notify_db_session, mocker):
         service = create_service(research_mode=True)

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -1452,7 +1452,7 @@ class TestSaveEmails:
 
         persisted_notification = Notification.query.one()
         assert persisted_notification.reply_to_text == "reply_to@digital.gov.uk"
-    
+
     def test_save_email_should_save_non_default_email_reply_to_text_on_notification_when_set(self, notify_db_session, mocker):
         service = create_service()
         create_reply_to_email(service=service, email_address="reply_to@digital.gov.uk", is_default=True)

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -1,3 +1,4 @@
+from email.policy import default
 import uuid
 from collections import namedtuple
 from datetime import datetime
@@ -469,7 +470,50 @@ def test_send_email_should_use_service_reply_to_email(sample_service, sample_ema
         attachments=[],
     )
 
+def test_send_email_should_use_default_service_reply_to_email_when_two_are_set(sample_service, sample_email_template, mocker):
+    mocker.patch("app.aws_ses_client.send_email", return_value="reference")
+    
+    create_reply_to_email(service=sample_service, email_address="foo@bar.com")
+    create_reply_to_email(service=sample_service, email_address="foo_two@bar.com", is_default=False)
+    
+    db_notification = save_notification(create_notification(template=sample_email_template, reply_to_text="foo@bar.com"))
 
+    send_to_providers.send_email_to_provider(
+        db_notification,
+    )
+
+    app.aws_ses_client.send_email.assert_called_once_with(
+        ANY,
+        ANY,
+        ANY,
+        body=ANY,
+        html_body=ANY,
+        reply_to_address="foo@bar.com",
+        attachments=[],
+    )
+
+def test_send_email_should_use_non_default_service_reply_to_email_when_it_is_set(sample_service, sample_email_template, mocker):
+    mocker.patch("app.aws_ses_client.send_email", return_value="reference")
+    
+    create_reply_to_email(service=sample_service, email_address="foo@bar.com")
+    create_reply_to_email(service=sample_service, email_address="foo_two@bar.com", is_default=False)
+    
+    db_notification = save_notification(create_notification(template=sample_email_template, reply_to_text="foo_two@bar.com"))
+
+    send_to_providers.send_email_to_provider(
+        db_notification,
+    )
+
+    app.aws_ses_client.send_email.assert_called_once_with(
+        ANY,
+        ANY,
+        ANY,
+        body=ANY,
+        html_body=ANY,
+        reply_to_address="foo_two@bar.com",
+        attachments=[],
+    )
+    
 def test_get_html_email_renderer_should_return_for_normal_service(sample_service):
     options = send_to_providers.get_html_email_options(sample_service)
     assert options["fip_banner_english"] is True

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -1,4 +1,3 @@
-from email.policy import default
 import uuid
 from collections import namedtuple
 from datetime import datetime
@@ -470,12 +469,13 @@ def test_send_email_should_use_service_reply_to_email(sample_service, sample_ema
         attachments=[],
     )
 
+
 def test_send_email_should_use_default_service_reply_to_email_when_two_are_set(sample_service, sample_email_template, mocker):
     mocker.patch("app.aws_ses_client.send_email", return_value="reference")
-    
+
     create_reply_to_email(service=sample_service, email_address="foo@bar.com")
     create_reply_to_email(service=sample_service, email_address="foo_two@bar.com", is_default=False)
-    
+
     db_notification = save_notification(create_notification(template=sample_email_template, reply_to_text="foo@bar.com"))
 
     send_to_providers.send_email_to_provider(
@@ -492,12 +492,13 @@ def test_send_email_should_use_default_service_reply_to_email_when_two_are_set(s
         attachments=[],
     )
 
+
 def test_send_email_should_use_non_default_service_reply_to_email_when_it_is_set(sample_service, sample_email_template, mocker):
     mocker.patch("app.aws_ses_client.send_email", return_value="reference")
-    
+
     create_reply_to_email(service=sample_service, email_address="foo@bar.com")
     create_reply_to_email(service=sample_service, email_address="foo_two@bar.com", is_default=False)
-    
+
     db_notification = save_notification(create_notification(template=sample_email_template, reply_to_text="foo_two@bar.com"))
 
     send_to_providers.send_email_to_provider(
@@ -513,7 +514,8 @@ def test_send_email_should_use_non_default_service_reply_to_email_when_it_is_set
         reply_to_address="foo_two@bar.com",
         attachments=[],
     )
-    
+
+
 def test_get_html_email_renderer_should_return_for_normal_service(sample_service):
     options = send_to_providers.get_html_email_options(sample_service)
     assert options["fip_banner_english"] is True


### PR DESCRIPTION
# Summary | Résumé

This PR makes it possible to select a non-default reply to when multiple have been created.  This applies to bulk and one-off API sending.

---

## Test instructions | Instructions pour tester la modification

- Setup a service with 2 reply-to addresses.
- Test API one-off:
   - Send a one-off email notification and include the `email_reply_to_id` of the non-default reply to address
   - Ensure that reply-to address is set in the email you receive
- Test API bulk:
   - Send a bulk email notification and include the `reply_to_id` of the non-default reply to address
   - Ensure that reply-to address is set in the email you receive