### PR TITLE
Added more type stubs/definitions for SQLAlchemy

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -94,5 +94,3 @@ ignore_missing_imports = True
 [mypy-flask_sqlalchemy.*]
 ignore_missing_imports = True
 
-[mypy-sqlalchemy.*]
-ignore_missing_imports = True

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -19,6 +19,6 @@ jinja2-cli[yaml]==0.8.2
 black==21.5b2
 locust==2.10.1
 mypy==0.812
-sqlalchemy-stubs==0.4
+sqlalchemy2-stubs==0.0.2a27
 networkx==2.8.6 # not directly required, pinned by Snyk to avoid a vulnerability
 pytest-mock-resources[redis]==2.4.0

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -19,7 +19,6 @@ jinja2-cli[yaml]==0.8.2
 black==21.5b2
 locust==2.10.1
 mypy==0.812
-sqlalchemy-stubs==0.4
 sqlalchemy2-stubs==0.0.2a27
 networkx==2.8.6 # not directly required, pinned by Snyk to avoid a vulnerability
 pytest-mock-resources[redis]==2.4.0

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -19,6 +19,7 @@ jinja2-cli[yaml]==0.8.2
 black==21.5b2
 locust==2.10.1
 mypy==0.812
+sqlalchemy-stubs==0.4
 sqlalchemy2-stubs==0.0.2a27
 networkx==2.8.6 # not directly required, pinned by Snyk to avoid a vulnerability
 pytest-mock-resources[redis]==2.4.0


### PR DESCRIPTION
# Summary | Résumé

I found another package with more type definitions for SQLAlchemy. This allows us to remove the "mypy ignore" setting for that import.