### PR TITLE
fix/last sms / job reaching limit is stuck in limbo

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -73,7 +73,6 @@ from app.notifications.process_notifications import (
 )
 from app.notifications.validators import (
     check_service_over_daily_message_limit,
-    check_service_over_daily_sms_limit,
 )
 from app.utils import get_csv_max_rows
 
@@ -288,6 +287,8 @@ def save_smss(self, service_id: Optional[str], signed_notifications: List[Any], 
         signed_and_verified = list(zip(signed_notifications, verified_notifications))
         handle_batch_error_and_forward(self, signed_and_verified, SMS_TYPE, e, receipt, template)
 
+    check_service_over_daily_message_limit(KEY_TYPE_NORMAL, service)
+
     research_mode = service.research_mode  # type: ignore
 
     current_app.logger.info(f"Sending following sms notifications to AWS: {notification_id_queue.keys()}")
@@ -395,6 +396,7 @@ def save_emails(self, service_id: Optional[str], signed_notifications: List[Any]
 
     if saved_notifications:
         current_app.logger.info(f"Sending following email notifications to AWS: {notification_id_queue.keys()}")
+        check_service_over_daily_message_limit(KEY_TYPE_NORMAL, service)
         research_mode = service.research_mode  # type: ignore
         for notification in saved_notifications:
             queue = notification_id_queue.get(notification.id) or template.queue_to_use()  # type: ignore

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -71,9 +71,7 @@ from app.notifications.process_notifications import (
     persist_notifications,
     send_notification_to_queue,
 )
-from app.notifications.validators import (
-    check_service_over_daily_message_limit,
-)
+from app.notifications.validators import check_service_over_daily_message_limit
 from app.utils import get_csv_max_rows
 
 

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -288,9 +288,6 @@ def save_smss(self, service_id: Optional[str], signed_notifications: List[Any], 
         signed_and_verified = list(zip(signed_notifications, verified_notifications))
         handle_batch_error_and_forward(self, signed_and_verified, SMS_TYPE, e, receipt, template)
 
-    check_service_over_daily_message_limit(KEY_TYPE_NORMAL, service)
-    check_service_over_daily_sms_limit(KEY_TYPE_NORMAL, service)
-
     research_mode = service.research_mode  # type: ignore
 
     current_app.logger.info(f"Sending following sms notifications to AWS: {notification_id_queue.keys()}")
@@ -398,7 +395,6 @@ def save_emails(self, service_id: Optional[str], signed_notifications: List[Any]
 
     if saved_notifications:
         current_app.logger.info(f"Sending following email notifications to AWS: {notification_id_queue.keys()}")
-        check_service_over_daily_message_limit(KEY_TYPE_NORMAL, service)
         research_mode = service.research_mode  # type: ignore
         for notification in saved_notifications:
             queue = notification_id_queue.get(notification.id) or template.queue_to_use()  # type: ignore


### PR DESCRIPTION
# Summary | Résumé

sends with `/sms` or `/bulk` that bring you up to your daily sms limit are created but not actually sent.

This is because we're checking **after** create the notifications and increment the daily sms counter - so the check finds that we're at the limit and fails. 

This PR removes that last check. Tested to ensure that 
- limit reaching sms go out correctly now
- we still block after reaching the limit.

There's another bug where we can hop over the limit sometimes, but that's dealt with in #1632 


# Test instructions | Instructions pour tester la modification

What I did:
- Set sms limit to 6
- /sms one 2 fragment 
    - 3 sent and received
    - 4th blocked

- Reset sms limit to 10
- /bulk two 2 fragment sms - sent and received
- Another 2-2 : blocked

Another /sms one part: blocked


# Release Instructions | Instructions pour le déploiement

None.
