### PR TITLE
add new sms templates to template_redacted table

### DIFF
--- a/migrations/versions/0424_sms_templates_in_redacted.py
+++ b/migrations/versions/0424_sms_templates_in_redacted.py
@@ -1,0 +1,42 @@
+"""
+
+Revision ID: 0424_sms_templates_in_redacted
+Revises: 0423_daily_sms_limit_updated
+Create Date: 2022-10-13 00:00:00
+
+"""
+from datetime import datetime
+
+from alembic import op
+from flask import current_app
+
+revision = "0424_sms_templates_in_redacted"
+down_revision = "0423_daily_sms_limit_updated"
+
+near_sms_limit_template_id = current_app.config["NEAR_DAILY_SMS_LIMIT_TEMPLATE_ID"]
+at_sms_limit_template_id = current_app.config["REACHED_DAILY_SMS_LIMIT_TEMPLATE_ID"]
+daily_sms_limit_updated_id = current_app.config["DAILY_SMS_LIMIT_UPDATED_TEMPLATE_ID"]
+
+template_ids = [near_sms_limit_template_id, at_sms_limit_template_id, daily_sms_limit_updated_id]
+
+
+def upgrade():
+    for template_id in template_ids:
+        op.execute(
+            """
+            INSERT INTO template_redacted
+            (
+                template_id,
+                redact_personalisation,
+                updated_at,
+                updated_by_id
+            ) VALUES ( '{}', false, current_timestamp, '{}' )
+            """.format(
+                template_id, current_app.config["NOTIFY_USER_ID"]
+            )
+        )
+
+
+def downgrade():
+    for template_id in template_ids:
+        op.execute("DELETE FROM template_redacted WHERE template_id = '{}'".format(template_id))


### PR DESCRIPTION
# Summary | Résumé

https://github.com/cds-snc/notification-planning/issues/924

When we added the new SMS limit templates we forgot to add rows for them to the redacted table. This means that they cannot be edited 😞 

# Test instructions | Instructions pour tester la modification

- `flask db upgrade`
- verify in `localhost:6011` that api sees that the database contains this migration
- can verify that the `template_redacted` table has the 3 new rows
- more to the point, verify that you can now edit and save the new SMS templates

# Release Instructions | Instructions pour le déploiement

None.

