### PR TITLE
added a migration to populate the template_redacted table

### DIFF
--- a/migrations/versions/0424_fix_template_redacted_sms.py
+++ b/migrations/versions/0424_fix_template_redacted_sms.py
@@ -1,0 +1,40 @@
+"""
+
+Revision ID: 0424_fix_template_redacted_sms
+Revises: 0423_daily_sms_limit_updated
+Create Date: 2022-10-14 00:00:00.000000
+
+"""
+from alembic import op
+from flask import current_app
+
+revision = "0424_fix_template_redacted_sms"
+down_revision = "0423_daily_sms_limit_updated"
+
+daily_limit_updated_id = current_app.config["DAILY_SMS_LIMIT_UPDATED_TEMPLATE_ID"]
+near_daily_limit_id = current_app.config["NEAR_DAILY_SMS_LIMIT_TEMPLATE_ID"]
+reached_daily_limit_id = current_app.config["REACHED_DAILY_SMS_LIMIT_TEMPLATE_ID"]
+
+template_ids = [daily_limit_updated_id, near_daily_limit_id, reached_daily_limit_id]
+
+
+def upgrade():
+    for template_id in template_ids:
+        op.execute(
+            """
+            INSERT INTO template_redacted
+            (
+                template_id,
+                redact_personalisation,
+                updated_at,
+                updated_by_id
+            ) VALUES ( '{}', false, current_timestamp, '{}' )
+            """.format(
+                template_id, current_app.config["NOTIFY_USER_ID"]
+            )
+        )
+
+
+def downgrade():
+    for template_id in template_ids:
+        op.execute("DELETE FROM template_redacted WHERE template_id = '{}'".format(template_id))


### PR DESCRIPTION
# Summary | Résumé

Working on cds-snc/notification-planning#938

This fixes the bug where editing and saving the SMS Limit related email templates causes a server error. The fix is exactly the same as in this PR: https://github.com/cds-snc/notification-api/pull/1332


# Test instructions | Instructions pour tester la modification

Go through the steps to reproduce on the bug card and observe that it is fixed.
