### PR TITLE
Update statsd counter name to differentiate from overall limit

### DIFF
--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -91,12 +91,12 @@ def check_service_over_daily_message_limit(key_type: ApiKeyType, service: Servic
 
 @statsd_catch(
     namespace="validators",
-    counter_name="rate_limit.trial_service_daily",
+    counter_name="rate_limit.trial_service_daily_sms",
     exception=TrialServiceTooManySMSRequestsError,
 )
 @statsd_catch(
     namespace="validators",
-    counter_name="rate_limit.live_service_daily",
+    counter_name="rate_limit.live_service_daily_sms",
     exception=LiveServiceTooManySMSRequestsError,
 )
 def check_service_over_daily_sms_limit(key_type: ApiKeyType, service: Service):

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -314,8 +314,8 @@ class TestCheckDailyLimits:
         [
             ("all", True, "validators.rate_limit.trial_service_daily"),
             ("all", False, "validators.rate_limit.live_service_daily"),
-            ("sms", True, "validators.rate_limit.trial_service_daily"),
-            ("sms", False, "validators.rate_limit.live_service_daily"),
+            ("sms", True, "validators.rate_limit.trial_service_daily_sms"),
+            ("sms", False, "validators.rate_limit.live_service_daily_sms"),
         ],
         ids=["trial service", "live service", "trial service", "live service"],
     )


### PR DESCRIPTION
# Summary | Résumé

This PR renames the statsd counter when the `LiveServiceTooManySMSRequestsError` and `TrialServiceTooManySMSRequestsError` errors are thrown so we can add alarms for sms daily limits going forward.
