### PR TITLE
Fix/hop over sms limit

### DIFF
--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -64,13 +64,13 @@ from app.models import (
 )
 from app.notifications.process_letter_notifications import create_letter_notification
 from app.notifications.process_notifications import (
+    check_if_request_would_put_service_over_daily_sms_limit,
     choose_queue,
     db_save_and_send_notification,
     persist_notification,
     persist_scheduled_notification,
     simulated_recipient,
     transform_notification,
-    check_if_request_would_put_service_over_daily_sms_limit,
 )
 from app.notifications.validators import (
     check_rate_limiting,

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -70,6 +70,7 @@ from app.notifications.process_notifications import (
     persist_scheduled_notification,
     simulated_recipient,
     transform_notification,
+    check_if_request_would_put_service_over_daily_sms_limit,
 )
 from app.notifications.validators import (
     check_rate_limiting,
@@ -217,6 +218,10 @@ def post_notification(notification_type: NotificationType):
         authenticated_service,
         notification_type,
     )
+    if notification_type == SMS_TYPE:
+        check_if_request_would_put_service_over_daily_sms_limit(
+            api_user.key_type, authenticated_service, template_with_content.fragment_count
+        )
 
     current_app.logger.info(f"Trying to send notification for Template ID: {template.id}")
 

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -29,8 +29,8 @@ from app.v2.notifications.notification_schemas import (
 )
 from tests import create_authorization_header
 from tests.app.conftest import (
-    create_sample_template,
     create_sample_notification,
+    create_sample_template,
     document_download_response,
     random_sized_content,
 )

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -30,6 +30,7 @@ from app.v2.notifications.notification_schemas import (
 from tests import create_authorization_header
 from tests.app.conftest import (
     create_sample_template,
+    create_sample_notification,
     document_download_response,
     random_sized_content,
 )
@@ -42,7 +43,7 @@ from tests.app.db import (
     create_template,
     create_user,
 )
-from tests.conftest import set_config
+from tests.conftest import set_config, set_config_values
 
 
 def rows_to_csv(rows):
@@ -1415,6 +1416,73 @@ class TestSendingDocuments:
         )
 
         assert response.status_code == 400
+
+
+class TestSMSSendFragments:
+    def test_post_sms_enough_fragments_left(self, notify_api, client, notify_db, notify_db_session, mocker):
+        mocker.patch("app.sms_normal.publish")
+        service = create_service(sms_daily_limit=10, message_limit=100)
+        template = create_sample_template(notify_db, notify_db_session, content=500 * "a", service=service, template_type="sms")
+        data = {
+            "phone_number": "+16502532222",
+            "template_id": str(template.id),
+            "personalisation": {" Name": "Jo"},
+        }
+        for x in range(2):
+            create_sample_notification(notify_db, notify_db_session, service=service)
+        auth_header = create_authorization_header(service_id=template.service_id)
+
+        with set_config_values(notify_api, {"FF_SPIKE_SMS_DAILY_LIMIT": True, "REDIS_ENABLED": True}):
+            response = client.post(
+                path="/v2/notifications/sms",
+                data=json.dumps(data),
+                headers=[("Content-Type", "application/json"), auth_header],
+            )
+        assert response.status_code == 201
+
+    def test_post_sms_not_enough_fragments_left(self, notify_api, client, notify_db, notify_db_session, mocker):
+        mocker.patch("app.sms_normal.publish")
+        service = create_service(sms_daily_limit=10, message_limit=100)
+        template = create_sample_template(notify_db, notify_db_session, content=500 * "a", service=service, template_type="sms")
+        data = {
+            "phone_number": "+16502532222",
+            "template_id": str(template.id),
+            "personalisation": {" Name": "Jo"},
+        }
+        for x in range(7):
+            create_sample_notification(notify_db, notify_db_session, service=service)
+        auth_header = create_authorization_header(service_id=template.service_id)
+
+        with set_config_values(notify_api, {"FF_SPIKE_SMS_DAILY_LIMIT": True, "REDIS_ENABLED": True}):
+            response = client.post(
+                path="/v2/notifications/sms",
+                data=json.dumps(data),
+                headers=[("Content-Type", "application/json"), auth_header],
+            )
+        assert response.status_code == 429
+
+    def test_post_sms_not_enough_fragments_left_FF_SPIKE_SMS_DAILY_LIMIT_false(
+        self, notify_api, client, notify_db, notify_db_session, mocker
+    ):
+        mocker.patch("app.sms_normal.publish")
+        service = create_service(sms_daily_limit=10, message_limit=100)
+        template = create_sample_template(notify_db, notify_db_session, content=500 * "a", service=service, template_type="sms")
+        data = {
+            "phone_number": "+16502532222",
+            "template_id": str(template.id),
+            "personalisation": {" Name": "Jo"},
+        }
+        for x in range(7):
+            create_sample_notification(notify_db, notify_db_session, service=service)
+        auth_header = create_authorization_header(service_id=template.service_id)
+
+        with set_config_values(notify_api, {"FF_SPIKE_SMS_DAILY_LIMIT": False, "REDIS_ENABLED": True}):
+            response = client.post(
+                path="/v2/notifications/sms",
+                data=json.dumps(data),
+                headers=[("Content-Type", "application/json"), auth_header],
+            )
+        assert response.status_code == 201
 
 
 class TestBulkSend:


### PR DESCRIPTION
# Summary | Résumé

https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/cds-snc/notification-planning/931

Check if there's enough fragments left in the `/sms` send

# Test instructions | Instructions pour tester la modification

- Set your SMS limit to 1
- Send a 2 part `/sms`
- should get an error message

# Release Instructions | Instructions pour le déploiement

None.


