### PR TITLE
fix: check FF before sending sms limit changed email

### DIFF
--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -337,7 +337,7 @@ def _warn_service_users_about_message_limit_changed(service_id, data):
 def _warn_service_users_about_sms_limit_changed(service_id, data):
     send_notification_to_service_users(
         service_id=service_id,
-        template_id=current_app.config["DAILY_SMS_LIMIT_UPDATED_TEMPLATE_ID"]
+        template_id=current_app.config["DAILY_SMS_LIMIT_UPDATED_TEMPLATE_ID"],
         personalisation={
             "service_name": data["name"],
             "message_limit_en": "{:,}".format(data["sms_daily_limit"]),

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -298,7 +298,7 @@ def update_service(service_id):
     if sms_limit_changed:
         redis_store.delete(near_sms_daily_limit_cache_key(service_id))
         redis_store.delete(over_sms_daily_limit_cache_key(service_id))
-        if not fetched_service.restricted:
+        if not fetched_service.restricted and current_app.config["FF_SPIKE_SMS_DAILY_LIMIT"]:
             _warn_service_users_about_sms_limit_changed(service_id, current_data)
 
     if service_going_live:
@@ -338,8 +338,6 @@ def _warn_service_users_about_sms_limit_changed(service_id, data):
     send_notification_to_service_users(
         service_id=service_id,
         template_id=current_app.config["DAILY_SMS_LIMIT_UPDATED_TEMPLATE_ID"]
-        if current_app.config["FF_SPIKE_SMS_DAILY_LIMIT"]
-        else current_app.config["DAILY_LIMIT_UPDATED_TEMPLATE_ID"],
         personalisation={
             "service_name": data["name"],
             "message_limit_en": "{:,}".format(data["sms_daily_limit"]),


### PR DESCRIPTION
# Summary | Résumé

https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/cds-snc/notification-planning/949

We are sending the "sms limit updated" email when users go live in prod.

# Test instructions | Instructions pour tester la modification

Tested locally:
- set `FF_SPIKE_SMS_DAILY_LIMIT` to false
- create a service, make it live
-  verify I don't get the "can send 1000 messages" email.

# Release Instructions | Instructions pour le déploiement

None.
