### PR TITLE
Update the /bulk endpoint sms limit checking to use the shared logic

### DIFF
--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -35,10 +35,7 @@ from app.clients.document_download import DocumentDownloadError
 from app.config import QueueNames, TaskNames
 from app.dao.jobs_dao import dao_create_job
 from app.dao.notifications_dao import update_notification_status_by_reference
-from app.dao.services_dao import (
-    fetch_todays_total_message_count,
-    fetch_todays_total_sms_count,
-)
+from app.dao.services_dao import fetch_todays_total_message_count
 from app.dao.templates_dao import get_precompiled_letter_template
 from app.encryption import NotificationDictToSign
 from app.letters.utils import upload_letter_pdf
@@ -78,6 +75,7 @@ from app.notifications.validators import (
     check_service_can_schedule_notification,
     check_service_email_reply_to_id,
     check_service_has_permission,
+    check_service_over_daily_sms_limit,
     check_service_sms_sender_id,
     validate_and_format_recipient,
     validate_template,
@@ -85,8 +83,8 @@ from app.notifications.validators import (
 )
 from app.schema_validation import validate
 from app.schemas import job_schema
-from app.sms_fragment_utils import fetch_daily_sms_fragment_count
 from app.service.utils import safelisted_members
+from app.sms_fragment_utils import fetch_daily_sms_fragment_count
 from app.v2.errors import BadRequestError
 from app.v2.notifications import v2_notification_blueprint
 from app.v2.notifications.create_response import (

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -85,6 +85,7 @@ from app.notifications.validators import (
 )
 from app.schema_validation import validate
 from app.schemas import job_schema
+from app.sms_fragment_utils import fetch_daily_sms_fragment_count
 from app.service.utils import safelisted_members
 from app.v2.errors import BadRequestError
 from app.v2.notifications import v2_notification_blueprint
@@ -154,7 +155,9 @@ def post_bulk():
     check_service_has_permission(template.template_type, authenticated_service.permissions)
 
     if template.template_type == "sms" and check_sms_limit:
-        remaining_messages = authenticated_service.sms_daily_limit - fetch_todays_total_sms_count(authenticated_service.id)
+        check_service_over_daily_sms_limit(api_user.key_type, authenticated_service)
+        fragments_sent = fetch_daily_sms_fragment_count(authenticated_service.id)
+        remaining_messages = authenticated_service.sms_daily_limit - fragments_sent
     else:
         remaining_messages = authenticated_service.message_limit - fetch_todays_total_message_count(authenticated_service.id)
 

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -1901,7 +1901,9 @@ class TestBulkSend:
         messages_count_mock = mocker.patch(
             "app.v2.notifications.post_notifications.fetch_todays_total_message_count", return_value=9
         )
-        messages_count_mock = mocker.patch("app.v2.notifications.post_notifications.fetch_daily_sms_fragment_count", return_value=9)
+        messages_count_mock = mocker.patch(
+            "app.v2.notifications.post_notifications.fetch_daily_sms_fragment_count", return_value=9
+        )
         data = {
             "name": "job_name",
             "template_id": template.id,

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -1933,7 +1933,7 @@ class TestBulkSend:
         service = create_service(sms_daily_limit=10, message_limit=100)
         template = create_sample_template(notify_db, notify_db_session, content=500 * "a", service=service, template_type="sms")
         mocker.patch("app.v2.notifications.post_notifications.fetch_todays_total_message_count", return_value=9)
-        mocker.patch("app.v2.notifications.post_notifications.fetch_todays_total_sms_count", return_value=9)
+        mocker.patch("app.dao.services_dao.fetch_todays_total_sms_count", return_value=9)
         data = {
             "name": "job_name",
             "template_id": template.id,
@@ -1962,7 +1962,7 @@ class TestBulkSend:
         service = create_service(sms_daily_limit=10, message_limit=100)
         template = create_sample_template(notify_db, notify_db_session, content=500 * "a", service=service, template_type="sms")
         mocker.patch("app.v2.notifications.post_notifications.fetch_todays_total_message_count", return_value=9)
-        mocker.patch("app.v2.notifications.post_notifications.fetch_todays_total_sms_count", return_value=9)
+        mocker.patch("app.dao.services_dao.fetch_todays_total_sms_count", return_value=9)
         job_id = str(uuid.uuid4())
         mocker.patch("app.v2.notifications.post_notifications.upload_job_to_s3", return_value=job_id)
         mocker.patch("app.v2.notifications.post_notifications.process_job.apply_async")

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -1933,7 +1933,7 @@ class TestBulkSend:
         service = create_service(sms_daily_limit=10, message_limit=100)
         template = create_sample_template(notify_db, notify_db_session, content=500 * "a", service=service, template_type="sms")
         mocker.patch("app.v2.notifications.post_notifications.fetch_todays_total_message_count", return_value=9)
-        mocker.patch("app.dao.services_dao.fetch_todays_total_sms_count", return_value=9)
+        mocker.patch("app.v2.notifications.post_notifications.fetch_daily_sms_fragment_count", return_value=9)
         data = {
             "name": "job_name",
             "template_id": template.id,
@@ -1962,7 +1962,7 @@ class TestBulkSend:
         service = create_service(sms_daily_limit=10, message_limit=100)
         template = create_sample_template(notify_db, notify_db_session, content=500 * "a", service=service, template_type="sms")
         mocker.patch("app.v2.notifications.post_notifications.fetch_todays_total_message_count", return_value=9)
-        mocker.patch("app.dao.services_dao.fetch_todays_total_sms_count", return_value=9)
+        mocker.patch("app.v2.notifications.post_notifications.fetch_daily_sms_fragment_count", return_value=9)
         job_id = str(uuid.uuid4())
         mocker.patch("app.v2.notifications.post_notifications.upload_job_to_s3", return_value=job_id)
         mocker.patch("app.v2.notifications.post_notifications.process_job.apply_async")

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -1901,7 +1901,7 @@ class TestBulkSend:
         messages_count_mock = mocker.patch(
             "app.v2.notifications.post_notifications.fetch_todays_total_message_count", return_value=9
         )
-        messages_count_mock = mocker.patch("app.v2.notifications.post_notifications.fetch_todays_total_sms_count", return_value=9)
+        messages_count_mock = mocker.patch("app.v2.notifications.post_notifications.fetch_daily_sms_fragment_count", return_value=9)
         data = {
             "name": "job_name",
             "template_id": template.id,


### PR DESCRIPTION
# Summary | Résumé

Update the /bulk endpoint sms limit checking to use the shared logic.

This is a fix for a bug @andrewleith found where post requests to /bulk were not failing even though he had submitted more sms fragments for sending than his limit allowed. These SMS were stuck in sending. 

