### PR TITLE
Fix "test runner" tab in VSCode

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -23,8 +23,8 @@ env =
     D:FF_CLOUDWATCH_METRICS_ENABLED=True
     D:REDIS_URL=redis://localhost:6380
     D:DOCUMENTATION_DOMAIN=documentation.notification.canada.ca
-    D:SQLALCHEMY_DATABASE_URI=postgresql://postgres:postgres@localhost:5432/test_notification_api
-    D:SQLALCHEMY_DATABASE_READER_URI=postgresql://reader:postgres@localhost:5432/test_notification_api
+    SQLALCHEMY_DATABASE_URI=postgresql://postgres:chummy@db/test_notification_api
+    SQLALCHEMY_DATABASE_READER_URI=postgresql://reader:chummy@db/test_notification_api
 
 
 addopts = -v -p no:warnings


### PR DESCRIPTION
# Summary | Résumé

Updating these values in the pytest config fixes local test failures I was seeing and allows me to run the tests using VSCodes "test runner" tab. 

Draft for now since I am not sure if CI will like this change or not.