### PR TITLE
Add the warning email trigger to the csv send via admin codepath

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -75,7 +75,7 @@ from app.notifications.process_notifications import (
 )
 from app.notifications.validators import (
     check_service_over_daily_message_limit,
-    check_service_over_daily_sms_limit,
+    check_service_over_daily_sms_limit_and_warn,
 )
 from app.types import VerifiedNotification
 from app.utils import get_csv_max_rows
@@ -306,7 +306,7 @@ def save_smss(self, service_id: Optional[str], signed_notifications: List[Signed
     current_app.logger.info(f"Sending following sms notifications to AWS: {notification_id_queue.keys()}")
     for notification_obj in saved_notifications:
         try:
-            check_service_over_daily_sms_limit(KEY_TYPE_NORMAL, service)
+            check_service_over_daily_sms_limit_and_warn(KEY_TYPE_NORMAL, service)
         except (LiveServiceTooManySMSRequestsError, TrialServiceTooManyRequestsError):
             # if notification would put service over limit, don't add it to the queue
             continue

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -23,11 +23,8 @@ from app.models import (
     JOB_STATUS_CANCELLED,
     JOB_STATUS_PENDING,
     JOB_STATUS_SCHEDULED,
-    KEY_TYPE_NORMAL,
     LETTER_TYPE,
-    SMS_TYPE,
 )
-from app.notifications.validators import check_service_over_daily_sms_limit
 from app.schemas import (
     job_schema,
     notification_with_template_schema,
@@ -145,10 +142,6 @@ def create_job(service_id):
 
     if errors:
         raise InvalidRequest(errors, status_code=400)
-
-    # trigger warning emails (this codepath is for CSV send via Admin site)
-    if template.template_type == SMS_TYPE and current_app.config["FF_SPIKE_SMS_DAILY_LIMIT"]:
-        check_service_over_daily_sms_limit(KEY_TYPE_NORMAL, service)
 
     data.update({"template_version": template.version})
 

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -23,8 +23,11 @@ from app.models import (
     JOB_STATUS_CANCELLED,
     JOB_STATUS_PENDING,
     JOB_STATUS_SCHEDULED,
+    KEY_TYPE_NORMAL,
     LETTER_TYPE,
+    SMS_TYPE,
 )
+from app.notifications.validators import check_service_over_daily_sms_limit
 from app.schemas import (
     job_schema,
     notification_with_template_schema,
@@ -142,6 +145,10 @@ def create_job(service_id):
 
     if errors:
         raise InvalidRequest(errors, status_code=400)
+
+    # trigger warning emails (this codepath is for CSV send via Admin site)
+    if template.template_type == SMS_TYPE and current_app.config["FF_SPIKE_SMS_DAILY_LIMIT"]:
+        check_service_over_daily_sms_limit(KEY_TYPE_NORMAL, service)
 
     data.update({"template_version": template.version})
 

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -99,7 +99,7 @@ def check_service_over_daily_message_limit(key_type: ApiKeyType, service: Servic
     counter_name="rate_limit.live_service_daily_sms",
     exception=LiveServiceTooManySMSRequestsError,
 )
-def check_service_over_daily_sms_limit(key_type: ApiKeyType, service: Service):
+def check_service_over_daily_sms_limit_and_warn(key_type: ApiKeyType, service: Service):
     if current_app.config["FF_SPIKE_SMS_DAILY_LIMIT"] and key_type != KEY_TYPE_TEST and current_app.config["REDIS_ENABLED"]:
         fragments_sent = fetch_daily_sms_fragment_count(service.id)
         warn_about_daily_sms_limit(service, fragments_sent)
@@ -109,7 +109,7 @@ def check_rate_limiting(service: Service, api_key: ApiKey, template_type: Templa
     check_service_over_api_rate_limit(service, api_key)
     check_service_over_daily_message_limit(api_key.key_type, service)
     if template_type == "sms":
-        check_service_over_daily_sms_limit(api_key.key_type, service)
+        check_service_over_daily_sms_limit_and_warn(api_key.key_type, service)
 
 
 def warn_about_daily_message_limit(service: Service, messages_sent):

--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -33,7 +33,7 @@ from app.notifications.process_notifications import (
 from app.notifications.validators import (
     check_service_has_permission,
     check_service_over_daily_message_limit,
-    check_service_over_daily_sms_limit,
+    check_service_over_daily_sms_limit_and_warn,
     validate_and_format_recipient,
     validate_template,
 )
@@ -63,7 +63,7 @@ def send_one_off_notification(service_id, post_data):
 
     check_service_over_daily_message_limit(KEY_TYPE_NORMAL, service)
     if template.template_type == "sms":
-        check_service_over_daily_sms_limit(KEY_TYPE_NORMAL, service)
+        check_service_over_daily_sms_limit_and_warn(KEY_TYPE_NORMAL, service)
 
     validate_and_format_recipient(
         send_to=post_data["to"],

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -75,7 +75,7 @@ from app.notifications.validators import (
     check_service_can_schedule_notification,
     check_service_email_reply_to_id,
     check_service_has_permission,
-    check_service_over_daily_sms_limit,
+    check_service_over_daily_sms_limit_and_warn,
     check_service_sms_sender_id,
     validate_and_format_recipient,
     validate_template,
@@ -153,7 +153,7 @@ def post_bulk():
     check_service_has_permission(template.template_type, authenticated_service.permissions)
 
     if template.template_type == "sms" and check_sms_limit:
-        check_service_over_daily_sms_limit(api_user.key_type, authenticated_service)
+        check_service_over_daily_sms_limit_and_warn(api_user.key_type, authenticated_service)
         fragments_sent = fetch_daily_sms_fragment_count(authenticated_service.id)
         remaining_messages = authenticated_service.sms_daily_limit - fragments_sent
     else:

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -20,7 +20,7 @@ from app.notifications.validators import (
     check_service_letter_contact_id,
     check_service_over_api_rate_limit,
     check_service_over_daily_message_limit,
-    check_service_over_daily_sms_limit,
+    check_service_over_daily_sms_limit_and_warn,
     check_service_sms_sender_id,
     check_sms_content_char_count,
     check_template_is_active,
@@ -91,7 +91,7 @@ class TestCheckDailyLimits:
 
         if limit_type == "sms":
             with set_config(notify_api, "FF_SPIKE_SMS_DAILY_LIMIT", True):
-                check_service_over_daily_sms_limit(key_type, sample_service)
+                check_service_over_daily_sms_limit_and_warn(key_type, sample_service)
         else:
             check_service_over_daily_message_limit(key_type, sample_service)
         app.notifications.validators.redis_store.set.assert_not_called()
@@ -109,7 +109,7 @@ class TestCheckDailyLimits:
         mocker.patch("app.notifications.validators.services_dao")
         if limit_type == "sms":
             with set_config(notify_api, "FF_SPIKE_SMS_DAILY_LIMIT", True):
-                check_service_over_daily_sms_limit(key_type, sample_service)
+                check_service_over_daily_sms_limit_and_warn(key_type, sample_service)
         else:
             check_service_over_daily_message_limit(key_type, sample_service)
             app.notifications.validators.redis_store.set.assert_not_called()
@@ -121,7 +121,7 @@ class TestCheckDailyLimits:
 
         if limit_type == "sms":
             with set_config(notify_api, "FF_SPIKE_SMS_DAILY_LIMIT", True):
-                check_service_over_daily_sms_limit("test", sample_service)
+                check_service_over_daily_sms_limit_and_warn("test", sample_service)
         else:
             check_service_over_daily_message_limit("test", sample_service)
         assert not app.notifications.validators.redis_store.mock_calls
@@ -141,7 +141,7 @@ class TestCheckDailyLimits:
 
             if limit_type == "sms":
                 with set_config(notify_api, "FF_SPIKE_SMS_DAILY_LIMIT", True):
-                    check_service_over_daily_sms_limit(key_type, sample_service)
+                    check_service_over_daily_sms_limit_and_warn(key_type, sample_service)
             else:
                 check_service_over_daily_message_limit(key_type, sample_service)
 
@@ -154,7 +154,7 @@ class TestCheckDailyLimits:
             db_mock = mocker.patch("app.notifications.validators.services_dao")
             check_service_over_daily_message_limit("normal", sample_service)
             with set_config(notify_api, "FF_SPIKE_SMS_DAILY_LIMIT", True):
-                check_service_over_daily_sms_limit("normal", sample_service)
+                check_service_over_daily_sms_limit_and_warn("normal", sample_service)
 
             assert db_mock.method_calls == []
 
@@ -182,7 +182,7 @@ class TestCheckDailyLimits:
             if limit_type == "sms":
                 with pytest.raises(TooManySMSRequestsError) as e:
                     with set_config(notify_api, "FF_SPIKE_SMS_DAILY_LIMIT", True):
-                        check_service_over_daily_sms_limit(key_type, service)
+                        check_service_over_daily_sms_limit_and_warn(key_type, service)
                 assert e.value.message == "Exceeded SMS daily sending limit of 4 fragments"
             else:
                 with pytest.raises(TooManyRequestsError) as e:
@@ -225,7 +225,7 @@ class TestCheckDailyLimits:
 
             if limit_type == "sms":
                 with set_config(notify_api, "FF_SPIKE_SMS_DAILY_LIMIT", True):
-                    check_service_over_daily_sms_limit("normal", service)
+                    check_service_over_daily_sms_limit_and_warn("normal", service)
             else:
                 check_service_over_daily_message_limit("normal", service)
 
@@ -266,7 +266,7 @@ class TestCheckDailyLimits:
             if limit_type == "sms":
                 with pytest.raises(TooManySMSRequestsError) as e:
                     with set_config(notify_api, "FF_SPIKE_SMS_DAILY_LIMIT", True):
-                        check_service_over_daily_sms_limit("normal", service)
+                        check_service_over_daily_sms_limit_and_warn("normal", service)
                     assert e.value.message == "Exceeded SMS daily sending limit of 5 fragments"
             else:
                 with pytest.raises(TooManyRequestsError) as e:
@@ -301,7 +301,7 @@ class TestCheckDailyLimits:
 
             with pytest.raises(TooManySMSRequestsError) as e:
                 with set_config(notify_api, "FF_SPIKE_SMS_DAILY_LIMIT", True):
-                    check_service_over_daily_sms_limit(key_type, service)
+                    check_service_over_daily_sms_limit_and_warn(key_type, service)
             assert e.value.status_code == 429
             assert e.value.message == "Exceeded SMS daily sending limit of 4 fragments"
             assert e.value.fields == []
@@ -337,7 +337,7 @@ class TestCheckDailyLimits:
         if limit_type == "sms":
             with pytest.raises(TooManySMSRequestsError):
                 with set_config(notify_api, "FF_SPIKE_SMS_DAILY_LIMIT", True):
-                    check_service_over_daily_sms_limit("normal", service)
+                    check_service_over_daily_sms_limit_and_warn("normal", service)
         else:
             with pytest.raises(TooManyRequestsError):
                 check_service_over_daily_message_limit("normal", service)
@@ -355,7 +355,7 @@ class TestCheckDailyLimits:
         service = create_sample_service(notify_db, notify_db_session, restricted=True, limit=4, sms_limit=4)
         check_service_over_daily_message_limit("normal", service)
         with set_config(notify_api, "FF_SPIKE_SMS_DAILY_LIMIT", True):
-            check_service_over_daily_sms_limit("normal", service)
+            check_service_over_daily_sms_limit_and_warn("normal", service)
         # Then
         app_statsd.statsd_client.incr.assert_not_called()
 

--- a/tests/app/service/test_send_one_off_notification.py
+++ b/tests/app/service/test_send_one_off_notification.py
@@ -268,7 +268,7 @@ def test_send_one_off_notification_raises_if_over_sms_daily_limit(notify_db_sess
     service = create_service(message_limit=0)
     template = create_template(service=service)
     mocker.patch(
-        "app.service.send_notification.check_service_over_daily_sms_limit",
+        "app.service.send_notification.check_service_over_daily_sms_limit_and_warn",
         side_effect=TooManyRequestsError(1),
     )
 


### PR DESCRIPTION
# Summary | Résumé

This to fix a bug Jimmy found where the SMS Limit related warning emails were not being triggered for a send via the Admin site.

The check we were performing (`check_if_request_would_put_service_over_daily_sms_limit`) did not include the logic to send the warning emails. I switched it to the other check function that is responsible for sending these emails:  `check_service_over_daily_sms_limit`.

# Test instructions | Instructions pour tester la modification

See bug card.
