### PR TITLE
chore(renovate): update config to ignore requirements.txt

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>cds-snc/renovate-config"
+  ],
+  "ignorePaths": [
+    "requirements.txt"
   ]
 }


### PR DESCRIPTION
# Summary | Résumé

This PR updates renovate to only do its magic to `requirements-app.txt` and `requirements_for_test.app` and not to touch `requirements.txt` anymore.

We will update that file via `make freeze-requirements` that will come in another PR.