### PR TITLE
Fix for reply to bug

### DIFF
--- a/app/dao/service_email_reply_to_dao.py
+++ b/app/dao/service_email_reply_to_dao.py
@@ -70,7 +70,7 @@ def archive_reply_to_email_address(service_id, reply_to_id):
     if reply_to_archive.is_default:
         non_archived_reply_tos = dao_get_reply_to_by_service_id(service_id)
         if len(non_archived_reply_tos) > 1:
-            # this error should not be displayed in Admin, only if a user manually sends a post request 
+            # this error should not be displayed in Admin, only if a user manually sends a post request
             raise ArchiveValidationError("You cannot delete a default email reply to address if other reply to addresses exist")
         reply_to_archive.is_default = False
 

--- a/app/dao/service_email_reply_to_dao.py
+++ b/app/dao/service_email_reply_to_dao.py
@@ -68,7 +68,11 @@ def archive_reply_to_email_address(service_id, reply_to_id):
     reply_to_archive = ServiceEmailReplyTo.query.filter_by(id=reply_to_id, service_id=service_id).one()
 
     if reply_to_archive.is_default:
-        raise ArchiveValidationError("You cannot delete a default email reply to address")
+        non_archived_reply_tos = dao_get_reply_to_by_service_id(service_id)
+        if len(non_archived_reply_tos) > 1:
+            # this error should not be displayed in Admin, only if a user manually sends a post request 
+            raise ArchiveValidationError("You cannot delete a default email reply to address if other reply to addresses exist")
+        reply_to_archive.is_default = False
 
     reply_to_archive.archived = True
 

--- a/tests/app/dao/test_service_email_reply_to_dao.py
+++ b/tests/app/dao/test_service_email_reply_to_dao.py
@@ -256,14 +256,27 @@ def test_archive_reply_to_email_address_does_not_archive_a_reply_to_for_a_differ
     assert not reply_to.archived
 
 
+# TODO: fix test name
 def test_archive_reply_to_email_address_raises_an_error_if_attempting_to_archive_a_default(
     sample_service,
 ):
-    create_reply_to_email(service=sample_service, email_address="first@address.com", is_default=False)
     default_reply_to = create_reply_to_email(service=sample_service, email_address="first@address.com")
+
+    archive_reply_to_email_address(sample_service.id, default_reply_to.id)
+
+    assert default_reply_to.archived is True
+    assert default_reply_to.updated_at is not None
+
+
+# TODO: fix test name
+def test_archive_reply_to_email_address_raises_an_error_if_attempting_to_archive_a_default_2(
+    sample_service,
+):
+    default_reply_to = create_reply_to_email(service=sample_service, email_address="first@address.com")
+    create_reply_to_email(service=sample_service, email_address="second@address.com", is_default=False)
 
     with pytest.raises(ArchiveValidationError) as e:
         archive_reply_to_email_address(sample_service.id, default_reply_to.id)
 
-    assert "You cannot delete a default email reply to address" in str(e.value)
+    assert "You cannot delete a default email reply to address if other reply to addresses exist" in str(e.value)
     assert not default_reply_to.archived

--- a/tests/app/dao/test_service_email_reply_to_dao.py
+++ b/tests/app/dao/test_service_email_reply_to_dao.py
@@ -256,8 +256,7 @@ def test_archive_reply_to_email_address_does_not_archive_a_reply_to_for_a_differ
     assert not reply_to.archived
 
 
-# TODO: fix test name
-def test_archive_reply_to_email_address_raises_an_error_if_attempting_to_archive_a_default(
+def test_archive_reply_to_email_address_if_default_and_no_other_addresses_exist(
     sample_service,
 ):
     default_reply_to = create_reply_to_email(service=sample_service, email_address="first@address.com")
@@ -268,8 +267,7 @@ def test_archive_reply_to_email_address_raises_an_error_if_attempting_to_archive
     assert default_reply_to.updated_at is not None
 
 
-# TODO: fix test name
-def test_archive_reply_to_email_address_raises_an_error_if_attempting_to_archive_a_default_2(
+def test_archive_reply_to_email_address_raises_an_error_if_default_and_other_addresses_exist(
     sample_service,
 ):
     default_reply_to = create_reply_to_email(service=sample_service, email_address="first@address.com")

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -2851,23 +2851,38 @@ def test_delete_service_reply_to_email_address_archives_an_email_reply_to(sample
     assert reply_to.archived is True
 
 
-def test_delete_service_reply_to_email_address_returns_400_if_archiving_default_reply_to(
+def test_delete_service_reply_to_email_address_archives_default_reply_to_if_no_others_exist(
     admin_request, notify_db_session, sample_service
 ):
     reply_to = create_reply_to_email(service=sample_service, email_address="some@email.com")
 
-    response = admin_request.post(
+    admin_request.post(
         "service.delete_service_reply_to_email_address",
         service_id=sample_service.id,
         reply_to_email_id=reply_to.id,
+    )
+
+    assert reply_to.archived is True
+
+
+def test_delete_service_reply_to_email_address_returns_400_if_archiving_default_reply_to_and_others_exist(
+    admin_request, notify_db_session, sample_service
+):
+    reply_to_1 = create_reply_to_email(service=sample_service, email_address="some_1@email.com")
+    reply_to_2 = create_reply_to_email(service=sample_service, email_address="some_2@email.com")
+
+    response = admin_request.post(
+        "service.delete_service_reply_to_email_address",
+        service_id=sample_service.id,
+        reply_to_email_id=reply_to_1.id,
         _expected_status=400,
     )
 
     assert response == {
-        "message": "You cannot delete a default email reply to address",
+        "message": "You cannot delete a default email reply to address if other reply to addresses exist",
         "result": "error",
     }
-    assert reply_to.archived is False
+    assert reply_to_1.archived is False
 
 
 def test_get_email_reply_to_address(client, notify_db, notify_db_session):

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -2869,7 +2869,7 @@ def test_delete_service_reply_to_email_address_returns_400_if_archiving_default_
     admin_request, notify_db_session, sample_service
 ):
     reply_to_1 = create_reply_to_email(service=sample_service, email_address="some_1@email.com")
-    reply_to_2 = create_reply_to_email(service=sample_service, email_address="some_2@email.com")
+    create_reply_to_email(service=sample_service, email_address="some_2@email.com")
 
     response = admin_request.post(
         "service.delete_service_reply_to_email_address",


### PR DESCRIPTION
# Summary | Résumé

This is the API side of the fix for the reply-to bug and UX issues described on the attached card.

The API no longer returns an error when trying to archive the default reply-to address, as long as it is the only one. This allows the user to return to the initial state, before they entered a reply-to address. This makes adding a reply-to address a "reversible" action and solves that UX problem where they are not warned their action was irreversible.

Trying to delete the default reply-to address will still return an error, if other non-archived reply-tos exist. This is to ensure we don't get into a buggy state. If the user clicks to archive a default reply-to in this case, the Admin should warn them and then assign default to one of their other addresses before the deletion occurs.

# Test instructions | Instructions pour tester la modification

Test that this still works as expected with the current Admin site.

# Release Instructions | Instructions pour le déploiement

This should be released before the admin PR: https://github.com/cds-snc/notification-admin/pull/1398

# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their
review | Voici une suggestion de liste de vérification comprenant des questions
que les réviseurs pourraient poser pendant leur examen :


- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne
      une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une
      fonctionnalité existante?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une
      modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des
      préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de
      façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de
      risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README
      setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce
      changement (fichier README, etc.)?
