### PR TITLE
Remove SENDGRID_API_KEY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,6 @@ MLWR_HOST=''
 MLWR_USER=''
 MLWR_KEY=''
 
-SENDGRID_API_KEY=
-
 NOTIFICATION_QUEUE_PREFIX='notification-canada-ca'
 
 FLASK_APP=application.py


### PR DESCRIPTION
# Summary | Résumé

Removes unreferenced `SENDGRID_API_KEY` from .env.example that was missed in https://github.com/cds-snc/notification-api/pull/1291.