### PR TITLE
Pin waffles to a version

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -61,7 +61,7 @@ jobs:
       run: |
         cp -f .env.example .env
     - name: Checks for new endpoints against AWS WAF rules
-      uses: cds-snc/notification-utils/.github/actions/waffles@main
+      uses: cds-snc/notification-utils/.github/actions/waffles@49.1.0
       with:
         app-loc: '/github/workspace'
         app-libs: '/github/workspace/env/site-packages'


### PR DESCRIPTION
# Summary | Résumé

API is having the same issue as what occurred yesterday in `notification-admin`: https://github.com/cds-snc/notification-admin/pull/1408 

# Test instructions | Instructions pour tester la modification

CI should now pass.