### PR TITLE
Report exception after first SMS sending retry only

### DIFF
--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -101,10 +101,14 @@ def _deliver_sms(self, notification_id):
         _check_and_queue_callback_task(notification)
     except Exception:
         try:
-            current_app.logger.exception("SMS notification delivery for id: {} failed".format(notification_id))
             if self.request.retries == 0:
+                # Retry immediately, especially as a common failure is for the database data
+                # replication to be delayed. The immediate retry likely succeeds in these scenarios.
                 self.retry(queue=QueueNames.RETRY, countdown=0)
             else:
+                # Once the previous retry failed, log the exception and this time,
+                # retry with the default delay.
+                current_app.logger.exception("SMS notification delivery for id: {} failed".format(notification_id))
                 self.retry(queue=QueueNames.RETRY)
         except self.MaxRetriesExceededError:
             message = (


### PR DESCRIPTION
# Summary | Résumé

This is to reduce alarms fatigue with our errors.

Do not log the exception right away when a SMS failure occurs but only after the first retry. That is because most likely error that happens at this stage is the db data replication did not propagate yet and could not find the notification. By retrying immediately as it is setup at the moment, it usually succeeds on second try. But prior to this change, the logging statement would trigger our alarms even though the 2nd attemps most likely succeed.

If there is other type of errors, an immediate retry following another failure will then log the exception and raise the alarms as usual.

# Test instructions | Instructions pour tester la modification

This will have to be monitored via the logs, upon celery SMS sending failures.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their
review | Voici une suggestion de liste de vérification comprenant des questions
que les réviseurs pourraient poser pendant leur examen :


- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne
      une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une
      fonctionnalité existante?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une
      modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des
      préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de
      façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de
      risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README
      setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce
      changement (fichier README, etc.)?
