### PR TITLE
add smoke test to dev container

### DIFF
--- a/.devcontainer/scripts/notify-dev-entrypoint.sh
+++ b/.devcontainer/scripts/notify-dev-entrypoint.sh
@@ -23,6 +23,11 @@ echo -e "alias k-prod='aws eks --region ca-central-1 update-kubeconfig --name no
 echo -e "source <(kubectl completion zsh)" >> ~/.zshrc
 echo -e "complete -F __start_kubectl k" >> ~/.zshrc
 
+# Smoke test
+# requires files .env_staging and .env_prod to the root of the project
+echo -e "alias smoke-staging='cd /workspace && cp .env_smoke_staging tests_smoke/.env && make smoke-test'" >> ~/.zshrc
+echo -e "alias smoke-prod='cd /workspace && cp .env_smoke_prod tests_smoke/.env && make smoke-test'" >> ~/.zshrc
+
 cd /workspace 
 
 # Warm up git index prior to display status in prompt else it will 

--- a/.devcontainer/scripts/notify-dev-entrypoint.sh
+++ b/.devcontainer/scripts/notify-dev-entrypoint.sh
@@ -24,7 +24,7 @@ echo -e "source <(kubectl completion zsh)" >> ~/.zshrc
 echo -e "complete -F __start_kubectl k" >> ~/.zshrc
 
 # Smoke test
-# requires files .env_staging and .env_prod to the root of the project
+# requires adding files .env_staging and .env_prod to the root of the project
 echo -e "alias smoke-staging='cd /workspace && cp .env_smoke_staging tests_smoke/.env && make smoke-test'" >> ~/.zshrc
 echo -e "alias smoke-prod='cd /workspace && cp .env_smoke_prod tests_smoke/.env && make smoke-test'" >> ~/.zshrc
 

--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ target/
 environment.sh
 .envrc
 .env
+.env_*
 .env.lambda
 
 celerybeat-schedule


### PR DESCRIPTION
# Summary | Résumé

- You need to add smoke test env files from Lastpass to the project root (`.env_smoke_staging` and `.env_smoke_prod`)
- from a devcontainer terminal can now run the alias `smoke-staging` or `smoke-prod`

