### PR TITLE
Change warning and exception logger for retries

### DIFF
--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -76,7 +76,10 @@ def deliver_email(self, notification_id):
     except Exception as e:
         try:
             current_app.logger.warning(f"The exception is {repr(e)}")
-            current_app.logger.exception("RETRY: Email notification {} failed".format(notification_id))
+            if self.request.retries <= 10:
+                current_app.logger.warning("RETRY {}: Email notification {} failed".format(self.request.retries, notification_id))
+            else:
+                current_app.logger.exception("RETRY: Email notification {} failed".format(notification_id))
             self.retry(queue=QueueNames.RETRY)
         except self.MaxRetriesExceededError:
             message = (


### PR DESCRIPTION
# Summary | Résumé

We don't want the API to throw an error for one retry. We will throw a warning when there have been more than 10 retries.

This is from where I assume we have retry data:
https://github.com/celery/celery/blob/main/celery/app/task.py#L704

