### PR TITLE
fix: take service name into account when checking sms message length

### DIFF
--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -317,8 +317,10 @@ def validate_and_format_recipient(
         return validate_and_format_email_address(email_address=send_to)
 
 
-def check_sms_content_char_count(content_count):
-    if content_count > SMS_CHAR_COUNT_LIMIT:
+def check_sms_content_char_count(content_count, service_name):
+    if (
+        content_count + len(service_name) + 2 > SMS_CHAR_COUNT_LIMIT
+    ):  # the +2 is to account for the ': ' that is added to the service name
         message = "Content for template has a character count greater than the limit of {}".format(SMS_CHAR_COUNT_LIMIT)
         raise BadRequestError(message=message)
 
@@ -343,7 +345,7 @@ def validate_template(template_id, personalisation, service: Service, notificati
 
     template_with_content: Template = create_content_for_notification(template, personalisation)
     if template.template_type == SMS_TYPE:
-        check_sms_content_char_count(template_with_content.content_count)
+        check_sms_content_char_count(template_with_content.content_count, service.name)
 
     check_content_is_not_blank(template_with_content)
 

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -444,15 +444,31 @@ def test_service_can_send_to_recipient_fails_when_mobile_number_is_not_on_team(n
     assert e.value.fields == []
 
 
-@pytest.mark.parametrize("char_count", [612, 0, 494, 200])
+@pytest.mark.parametrize("char_count", [610, 0, 494, 200])
 def test_check_sms_content_char_count_passes(char_count, notify_api):
-    assert check_sms_content_char_count(char_count) is None
+    assert check_sms_content_char_count(char_count, "") is None
 
 
 @pytest.mark.parametrize("char_count", [613, 700, 6000])
 def test_check_sms_content_char_count_fails(char_count, notify_api):
     with pytest.raises(BadRequestError) as e:
-        check_sms_content_char_count(char_count)
+        check_sms_content_char_count(char_count, "")
+    assert e.value.status_code == 400
+    assert e.value.message == "Content for template has a character count greater than the limit of {}".format(
+        SMS_CHAR_COUNT_LIMIT
+    )
+    assert e.value.fields == []
+
+
+@pytest.mark.parametrize("char_count", [603, 0, 494, 200])
+def test_check_sms_content_char_count_passes_with_svc_name(char_count, notify_api):
+    assert check_sms_content_char_count(char_count, "service") is None
+
+
+@pytest.mark.parametrize("char_count", [606, 700, 6000])
+def test_check_sms_content_char_count_fails_with_svc_name(char_count, notify_api):
+    with pytest.raises(BadRequestError) as e:
+        check_sms_content_char_count(char_count, "service")
     assert e.value.status_code == 400
     assert e.value.message == "Content for template has a character count greater than the limit of {}".format(
         SMS_CHAR_COUNT_LIMIT


### PR DESCRIPTION
# Summary | Résumé

This PR updates the sms validator which checks the overall message length to include the length of service name which we always append to every sms message.