### PR TITLE
Fix/enforce sms limit with prefix sms option

### DIFF
--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -317,10 +317,12 @@ def validate_and_format_recipient(
         return validate_and_format_email_address(email_address=send_to)
 
 
-def check_sms_content_char_count(content_count, service_name):
-    if (
-        content_count + len(service_name) + 2 > SMS_CHAR_COUNT_LIMIT
-    ):  # the +2 is to account for the ': ' that is added to the service name
+def check_sms_content_char_count(content_count, service_name, prefix_sms: bool):
+    content_length = (
+        content_count + len(service_name) + 2 if prefix_sms else content_count
+    )  # the +2 is to account for the ': ' that is added to the service name
+
+    if content_length > SMS_CHAR_COUNT_LIMIT:
         message = "Content for template has a character count greater than the limit of {}".format(SMS_CHAR_COUNT_LIMIT)
         raise BadRequestError(message=message)
 
@@ -345,7 +347,7 @@ def validate_template(template_id, personalisation, service: Service, notificati
 
     template_with_content: Template = create_content_for_notification(template, personalisation)
     if template.template_type == SMS_TYPE:
-        check_sms_content_char_count(template_with_content.content_count, service.name)
+        check_sms_content_char_count(template_with_content.content_count, service.name, service.prefix_sms)
 
     check_content_is_not_blank(template_with_content)
 

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -444,15 +444,15 @@ def test_service_can_send_to_recipient_fails_when_mobile_number_is_not_on_team(n
     assert e.value.fields == []
 
 
-@pytest.mark.parametrize("char_count", [610, 0, 494, 200])
+@pytest.mark.parametrize("char_count", [612, 0, 494, 200])
 def test_check_sms_content_char_count_passes(char_count, notify_api):
-    assert check_sms_content_char_count(char_count, "") is None
+    assert check_sms_content_char_count(char_count, "", False) is None
 
 
 @pytest.mark.parametrize("char_count", [613, 700, 6000])
 def test_check_sms_content_char_count_fails(char_count, notify_api):
     with pytest.raises(BadRequestError) as e:
-        check_sms_content_char_count(char_count, "")
+        check_sms_content_char_count(char_count, "", False)
     assert e.value.status_code == 400
     assert e.value.message == "Content for template has a character count greater than the limit of {}".format(
         SMS_CHAR_COUNT_LIMIT
@@ -462,13 +462,13 @@ def test_check_sms_content_char_count_fails(char_count, notify_api):
 
 @pytest.mark.parametrize("char_count", [603, 0, 494, 200])
 def test_check_sms_content_char_count_passes_with_svc_name(char_count, notify_api):
-    assert check_sms_content_char_count(char_count, "service") is None
+    assert check_sms_content_char_count(char_count, "service", True) is None
 
 
 @pytest.mark.parametrize("char_count", [606, 700, 6000])
 def test_check_sms_content_char_count_fails_with_svc_name(char_count, notify_api):
     with pytest.raises(BadRequestError) as e:
-        check_sms_content_char_count(char_count, "service")
+        check_sms_content_char_count(char_count, "service", True)
     assert e.value.status_code == 400
     assert e.value.message == "Content for template has a character count greater than the limit of {}".format(
         SMS_CHAR_COUNT_LIMIT


### PR DESCRIPTION
# Summary | Résumé

This builds on #1724 and #1725 to take into account the `sms_prefix` setting of a service which controls whether or not the service name is including in the content of an SMS message.

Test scenarios: 
- From a service with `sms_prefix` on, messages whose length are greater than 610 - the length of the service name should provide an error message in both the API and in ADMIN
- From a service with `sms_prefix` off, messages whose length are greater than 612 should provide an error message in both the API and in ADMIN