### PR TITLE
Fix bug where simulated email/sms sent via the API with a team key was not working

### DIFF
--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -10,6 +10,7 @@ from app.dbsetup import RoutingSQLAlchemy
 from app.models import (
     EMAIL_TYPE,
     INTERNATIONAL_SMS_TYPE,
+    KEY_TYPE_TEAM,
     LETTER_TYPE,
     SMS_TYPE,
     ApiKeyType,
@@ -378,6 +379,12 @@ def test_service_can_send_to_recipient_passes_for_safelisted_recipient_passes(no
     assert service_can_send_to_recipient("some_other_email@test.com", "team", sample_service) is None
     create_sample_service_safelist(notify_db, notify_db_session, mobile_number="6502532222")
     assert service_can_send_to_recipient("6502532222", "team", sample_service) is None
+
+
+def test_service_can_send_to_recipient_passes_for_simulated_recipients(notify_db, notify_db_session):
+    live_service = create_sample_service(notify_db, notify_db_session, service_name="live", restricted=False)
+    assert service_can_send_to_recipient(current_app.config["SIMULATED_EMAIL_ADDRESSES"][0], KEY_TYPE_TEAM, live_service) is None
+    assert service_can_send_to_recipient(current_app.config["SIMULATED_SMS_NUMBERS"][0], KEY_TYPE_TEAM, live_service) is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Summary | Résumé
Sending simulated SMS and Email notifications while using a team api key was returning a 400 error.

# Test instructions | Instructions pour tester la modification
Create a service, add a Team API Key, and email and SMS templates. Hit `/v2/notifications/[sms|email] with the Team API Key. Observe that the request will now succeed.

# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their
review | Voici une suggestion de liste de vérification comprenant des questions
que les réviseurs pourraient poser pendant leur examen :


- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne
      une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une
      fonctionnalité existante?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une
      modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des
      préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de
      façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de
      risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README
      setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce
      changement (fichier README, etc.)?
