### PR TITLE
fix/do not log email address

### DIFF
--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -59,7 +59,10 @@ def deliver_email(self, notification_id):
             raise NoResultFound()
         send_to_providers.send_email_to_provider(notification)
     except InvalidEmailError as e:
-        current_app.logger.info(f"Cannot send notification {notification_id}, got an invalid email address: {str(e)}.")
+        if not notification.to.isascii():
+            current_app.logger.info(f"Cannot send notification {notification_id} (has a non-ascii email address): {str(e)}")
+        else:
+            current_app.logger.info(f"Cannot send notification {notification_id}, got an invalid email address: {str(e)}.")
         update_notification_status_by_id(notification_id, NOTIFICATION_TECHNICAL_FAILURE)
         _check_and_queue_callback_task(notification)
     except InvalidUrlException:

--- a/app/clients/email/aws_ses.py
+++ b/app/clients/email/aws_ses.py
@@ -105,7 +105,7 @@ class AwsSesClient(EmailClient):
 
             # http://docs.aws.amazon.com/ses/latest/DeveloperGuide/api-error-codes.html
             if e.response["Error"]["Code"] == "InvalidParameterValue":
-                raise InvalidEmailError('email: "{}" message: "{}"'.format(to_addresses[0], e.response["Error"]["Message"]))
+                raise InvalidEmailError(f'message: "{e.response["Error"]["Message"]}"')
             else:
                 self.statsd_client.incr("clients.ses.error")
                 raise AwsSesClientException(str(e))

--- a/tests/app/clients/test_aws_ses.py
+++ b/tests/app/clients/test_aws_ses.py
@@ -197,7 +197,6 @@ def test_send_email_raises_bad_email_as_InvalidEmailError(mocker):
         )
 
     assert "some error message from amazon" in str(excinfo.value)
-    assert "definitely@invalid_email.com" in str(excinfo.value)
 
 
 def test_send_email_raises_other_errs_as_AwsSesClientException(mocker):


### PR DESCRIPTION
# Summary | Résumé

- stop logging the email address when there's a problem
- if there is a problem, check if the email address contains non-ascii characters.

# Test instructions | Instructions pour tester la modification

- Add "+é" to the local part of your CDS email address (before the @) and try to send.
- should see the new error logged and not the email address.
