### PR TITLE
Use a different redis cluster for publishing new POSTs

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -108,19 +108,19 @@ def create_app(application, config=None):
     flask_redis_publish.init_app(application)
     redis_store.init_app(application)
 
-    sms_bulk.init_app(flask_redis, metrics_logger)
-    sms_normal.init_app(flask_redis, metrics_logger)
-    sms_priority.init_app(flask_redis, metrics_logger)
-    email_bulk.init_app(flask_redis, metrics_logger)
-    email_normal.init_app(flask_redis, metrics_logger)
-    email_priority.init_app(flask_redis, metrics_logger)
-
     sms_bulk_publish.init_app(flask_redis_publish, metrics_logger)
     sms_normal_publish.init_app(flask_redis_publish, metrics_logger)
     sms_priority_publish.init_app(flask_redis_publish, metrics_logger)
     email_bulk_publish.init_app(flask_redis_publish, metrics_logger)
     email_normal_publish.init_app(flask_redis_publish, metrics_logger)
     email_priority_publish.init_app(flask_redis_publish, metrics_logger)
+
+    sms_bulk.init_app(flask_redis, metrics_logger)
+    sms_normal.init_app(flask_redis, metrics_logger)
+    sms_priority.init_app(flask_redis, metrics_logger)
+    email_bulk.init_app(flask_redis, metrics_logger)
+    email_normal.init_app(flask_redis, metrics_logger)
+    email_priority.init_app(flask_redis, metrics_logger)
 
     register_blueprint(application)
     register_v2_blueprints(application)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -47,6 +47,7 @@ signer = CryptoSigner()
 zendesk_client = ZendeskClient()
 statsd_client = StatsdClient()
 flask_redis = FlaskRedis()
+flask_redis_publish = FlaskRedis(config_prefix="REDIS_PUBLISH")
 redis_store = RedisClient()
 metrics_logger = MetricsLogger()
 # TODO: Rework instantiation to decouple redis_store.redis_store and pass it in.\
@@ -66,6 +67,13 @@ sms_priority = RedisQueue("sms", process_type="priority")
 email_bulk = RedisQueue("email", process_type="bulk")
 email_normal = RedisQueue("email", process_type="normal")
 email_priority = RedisQueue("email", process_type="priority")
+
+sms_bulk_publish = RedisQueue("sms", process_type="bulk")
+sms_normal_publish = RedisQueue("sms", process_type="normal")
+sms_priority_publish = RedisQueue("sms", process_type="priority")
+email_bulk_publish = RedisQueue("email", process_type="bulk")
+email_normal_publish = RedisQueue("email", process_type="normal")
+email_priority_publish = RedisQueue("email", process_type="priority")
 
 
 def create_app(application, config=None):
@@ -97,6 +105,7 @@ def create_app(application, config=None):
     clients.init_app(sms_clients=[aws_sns_client], email_clients=[aws_ses_client])
 
     flask_redis.init_app(application)
+    flask_redis_publish.init_app(application)
     redis_store.init_app(application)
 
     sms_bulk.init_app(flask_redis, metrics_logger)
@@ -105,6 +114,13 @@ def create_app(application, config=None):
     email_bulk.init_app(flask_redis, metrics_logger)
     email_normal.init_app(flask_redis, metrics_logger)
     email_priority.init_app(flask_redis, metrics_logger)
+
+    sms_bulk_publish.init_app(flask_redis_publish, metrics_logger)
+    sms_normal_publish.init_app(flask_redis_publish, metrics_logger)
+    sms_priority_publish.init_app(flask_redis_publish, metrics_logger)
+    email_bulk_publish.init_app(flask_redis_publish, metrics_logger)
+    email_normal_publish.init_app(flask_redis_publish, metrics_logger)
+    email_priority_publish.init_app(flask_redis_publish, metrics_logger)
 
     register_blueprint(application)
     register_v2_blueprints(application)

--- a/app/config.py
+++ b/app/config.py
@@ -149,6 +149,7 @@ class Config(object):
 
     # URL of redis instance
     REDIS_URL = os.getenv("REDIS_URL")
+    REDIS_PUBLISH_URL = os.getenv("REDIS_PUBLISH_URL", REDIS_URL)
     REDIS_ENABLED = env.bool("REDIS_ENABLED", False)
     EXPIRE_CACHE_TEN_MINUTES = 600
     EXPIRE_CACHE_EIGHT_DAYS = 8 * 24 * 60 * 60

--- a/app/config.py
+++ b/app/config.py
@@ -545,6 +545,7 @@ class Development(Config):
 
     SQLALCHEMY_DATABASE_URI = os.getenv("SQLALCHEMY_DATABASE_URI", "postgresql://postgres@localhost/notification_api")
     REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+    REDIS_PUBLISH_URL = os.getenv("REDIS_PUBLISH_URL", "redis://localhost:6379/0")
 
     ANTIVIRUS_ENABLED = env.bool("ANTIVIRUS_ENABLED", False)
 

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -17,14 +17,14 @@ from app import (
     authenticated_service,
     create_uuid,
     document_download_client,
-    email_bulk,
-    email_normal,
-    email_priority,
+    email_bulk_publish,
+    email_normal_publish,
+    email_priority_publish,
     notify_celery,
     signer,
-    sms_bulk,
-    sms_normal,
-    sms_priority,
+    sms_bulk_publish,
+    sms_normal_publish,
+    sms_priority_publish,
     statsd_client,
 )
 from app.aws.s3 import upload_job_to_s3
@@ -314,18 +314,18 @@ def triage_notification_to_queues(notification_type: NotificationType, signed_no
     """
     if notification_type == SMS_TYPE:
         if template.process_type == PRIORITY:
-            sms_priority.publish(signed_notification_data)
+            sms_priority_publish.publish(signed_notification_data)
         elif template.process_type == NORMAL:
-            sms_normal.publish(signed_notification_data)
+            sms_normal_publish.publish(signed_notification_data)
         elif template.process_type == BULK:
-            sms_bulk.publish(signed_notification_data)
+            sms_bulk_publish.publish(signed_notification_data)
     elif notification_type == EMAIL_TYPE:
         if template.process_type == PRIORITY:
-            email_priority.publish(signed_notification_data)
+            email_priority_publish.publish(signed_notification_data)
         elif template.process_type == NORMAL:
-            email_normal.publish(signed_notification_data)
+            email_normal_publish.publish(signed_notification_data)
         elif template.process_type == BULK:
-            email_bulk.publish(signed_notification_data)
+            email_bulk_publish.publish(signed_notification_data)
 
 
 def process_sms_or_email_notification(

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -62,7 +62,7 @@ def rows_to_csv(rows):
 class TestSingleEndpointSucceeds:
     @pytest.mark.parametrize("reference", [None, "reference_from_client"])
     def test_post_sms_notification_returns_201(self, notify_api, client, sample_template_with_placeholders, mocker, reference):
-        mock_publish = mocker.patch("app.sms_normal.publish")
+        mock_publish = mocker.patch("app.sms_normal_publish.publish")
         data = {
             "phone_number": "+16502532222",
             "template_id": str(sample_template_with_placeholders.id),
@@ -106,7 +106,7 @@ class TestSingleEndpointSucceeds:
         self, notify_api, client, sample_template_with_placeholders, mocker
     ):
         sms_sender = create_service_sms_sender(service=sample_template_with_placeholders.service, sms_sender="6502532222")
-        mock_publish = mocker.patch("app.sms_normal.publish")
+        mock_publish = mocker.patch("app.sms_normal_publish.publish")
         data = {
             "phone_number": "+16502532222",
             "template_id": str(sample_template_with_placeholders.id),
@@ -132,7 +132,7 @@ class TestSingleEndpointSucceeds:
     def test_post_sms_notification_uses_inbound_number_as_sender(self, notify_api, client, notify_db_session, mocker):
         service = create_service_with_inbound_number(inbound_number="1")
         template = create_template(service=service, content="Hello (( Name))\nYour thing is due soon")
-        mock_publish = mocker.patch("app.sms_normal.publish")
+        mock_publish = mocker.patch("app.sms_normal_publish.publish")
         data = {
             "phone_number": "+16502532222",
             "template_id": str(template.id),
@@ -158,7 +158,7 @@ class TestSingleEndpointSucceeds:
         self, notify_api, client, sample_template_with_placeholders, mocker
     ):
         sms_sender = create_service_sms_sender(service=sample_template_with_placeholders.service, sms_sender="123456")
-        mock_publish = mocker.patch("app.sms_normal.publish")
+        mock_publish = mocker.patch("app.sms_normal_publish.publish")
         data = {
             "phone_number": "+16502532222",
             "template_id": str(sample_template_with_placeholders.id),
@@ -189,7 +189,7 @@ class TestSingleEndpointSucceeds:
         client,
         mocker,
     ):
-        mocker.patch("app.sms_normal.publish")
+        mocker.patch("app.sms_normal_publish.publish")
 
         data = {"phone_number": "+20-12-1234-1234", "template_id": sample_template.id}
         auth_header = create_authorization_header(service_id=sample_service.id)
@@ -204,7 +204,7 @@ class TestSingleEndpointSucceeds:
         assert response.headers["Content-type"] == "application/json"
 
     def test_post_sms_should_publish_supplied_sms_number(self, notify_api, client, sample_template_with_placeholders, mocker):
-        mock_publish = mocker.patch("app.sms_normal.publish")
+        mock_publish = mocker.patch("app.sms_normal_publish.publish")
 
         data = {
             "phone_number": "+16502532222",
@@ -229,7 +229,7 @@ class TestSingleEndpointSucceeds:
 
     @pytest.mark.parametrize("reference", [None, "reference_from_client"])
     def test_post_email_notification_returns_201(notify_api, client, sample_email_template_with_placeholders, mocker, reference):
-        mock_publish = mocker.patch("app.email_normal.publish")
+        mock_publish = mocker.patch("app.email_normal_publish.publish")
         data = {
             "email_address": sample_email_template_with_placeholders.service.users[0].email_address,
             "template_id": sample_email_template_with_placeholders.id,
@@ -273,7 +273,7 @@ class TestSingleEndpointSucceeds:
 
     def test_post_email_notification_with_valid_reply_to_id_returns_201(self, notify_api, client, sample_email_template, mocker):
         reply_to_email = create_reply_to_email(sample_email_template.service, "test@test.com")
-        mock_publish = mocker.patch("app.email_normal.publish")
+        mock_publish = mocker.patch("app.email_normal_publish.publish")
         data = {
             "email_address": sample_email_template.service.users[0].email_address,
             "template_id": sample_email_template.id,
@@ -643,7 +643,7 @@ class TestPostNotificationsErrors:
         assert "ValidationError" in resp_json["errors"][0]["error"]
 
     def test_post_email_notification_with_invalid_reply_to_id_returns_400(self, client, sample_email_template, mocker, fake_uuid):
-        mocker.patch("app.email_normal.publish")
+        mocker.patch("app.email_normal_publish.publish")
         data = {
             "email_address": sample_email_template.service.users[0].email_address,
             "template_id": sample_email_template.id,
@@ -672,7 +672,7 @@ class TestPostNotificationsErrors:
             is_default=False,
             archived=True,
         )
-        mocker.patch("app.email_normal.publish")
+        mocker.patch("app.email_normal_publish.publish")
         data = {
             "email_address": "test@test.com",
             "template_id": sample_email_template.id,
@@ -704,7 +704,7 @@ class TestPostNotificationsErrors:
     def test_post_email_notification_with_personalisation_too_large(
         self, notify_api, client, sample_email_template_with_placeholders, mocker, personalisation_size, expected_success
     ):
-        mocked = mocker.patch("app.email_normal.publish")
+        mocked = mocker.patch("app.email_normal_publish.publish")
 
         data = {
             "email_address": sample_email_template_with_placeholders.service.users[0].email_address,
@@ -781,7 +781,7 @@ class TestPostNotificationsErrors:
 def test_should_not_persist_or_send_notification_if_simulated_recipient(
     client, recipient, notification_type, sample_email_template, sample_template, mocker
 ):
-    mock_publish = mocker.patch("app.{}_normal.publish".format(notification_type))
+    mock_publish = mocker.patch("app.{}_normal_publish.publish".format(notification_type))
 
     if notification_type == "sms":
         data = {"phone_number": recipient, "template_id": str(sample_template.id)}
@@ -820,7 +820,7 @@ def test_send_notification_uses_appropriate_queue_according_to_template_process_
     send_to,
     process_type,
 ):
-    mock_publish = mocker.patch("app.{}_{}.publish".format(notification_type, process_type))
+    mock_publish = mocker.patch("app.{}_{}_publish.publish".format(notification_type, process_type))
 
     sample = create_template(
         service=sample_service,
@@ -861,7 +861,7 @@ class TestRestrictedServices:
         service.users = [user]
         template = create_template(service=service, template_type=notification_type)
         create_api_key(service=service, key_type="team")
-        redis_publish = mocker.patch(f"app.{notification_type}_normal.publish")
+        redis_publish = mocker.patch(f"app.{notification_type}_normal_publish.publish")
         data = {
             to_key: to,
             "template_id": template.id,
@@ -1011,7 +1011,7 @@ class TestSendingDocuments:
         template = create_template(service=service, template_type="email", content=content)
 
         statsd_mock = mocker.patch("app.v2.notifications.post_notifications.statsd_client")
-        mock_publish = mocker.patch("app.email_normal.publish")
+        mock_publish = mocker.patch("app.email_normal_publish.publish")
         document_download_mock = mocker.patch("app.v2.notifications.post_notifications.document_download_client.upload_document")
         document_response = document_download_response({"sending_method": sending_method, "mime_type": "text/plain"})
         document_download_mock.return_value = document_response
@@ -1076,7 +1076,7 @@ class TestSendingDocuments:
     def test_post_notification_with_document_too_large(
         self, notify_api, client, notify_db_session, mocker, filename, sending_method, attachment_size, expected_success
     ):
-        mocked = mocker.patch("app.email_normal.publish")
+        mocked = mocker.patch("app.email_normal_publish.publish")
         service = create_service(service_permissions=[EMAIL_TYPE, UPLOAD_DOCUMENT])
         content = "See attached file."
         if sending_method == "link":
@@ -1135,7 +1135,7 @@ class TestSendingDocuments:
     def test_post_notification_with_too_many_documents(
         self, notify_api, client, notify_db_session, mocker, sending_method, attachment_number, expected_success
     ):
-        mocked = mocker.patch("app.email_normal.publish")
+        mocked = mocker.patch("app.email_normal_publish.publish")
         service = create_service(service_permissions=[EMAIL_TYPE, UPLOAD_DOCUMENT])
         template_content = "See attached file.\n"
         if sending_method == "link":
@@ -1401,7 +1401,7 @@ class TestSendingDocuments:
         service = create_service(service_permissions=[EMAIL_TYPE, UPLOAD_DOCUMENT])
         template = create_template(service=service, template_type="email", content="Document: ((document))")
 
-        mocker.patch("app.email_normal.publish")
+        mocker.patch("app.email_normal_publish.publish")
         document_download_mock = mocker.patch("app.v2.notifications.post_notifications.document_download_client")
         document_download_mock.get_upload_url.return_value = "https://document-url"
 
@@ -1428,7 +1428,7 @@ class TestSendingDocuments:
         service = create_service(service_permissions=[EMAIL_TYPE])
         template = create_template(service=service, template_type="email", content="Document: ((document))")
 
-        mocker.patch("app.email_normal.publish")
+        mocker.patch("app.email_normal_publish.publish")
         document_download_mock = mocker.patch("app.v2.notifications.post_notifications.document_download_client")
         document_download_mock.upload_document.return_value = document_download_response()
 
@@ -1450,7 +1450,7 @@ class TestSendingDocuments:
 
 class TestSMSSendFragments:
     def test_post_sms_enough_fragments_left(self, notify_api, client, notify_db, notify_db_session, mocker):
-        mocker.patch("app.sms_normal.publish")
+        mocker.patch("app.sms_normal_publish.publish")
         service = create_service(sms_daily_limit=10, message_limit=100)
         template = create_sample_template(notify_db, notify_db_session, content=500 * "a", service=service, template_type="sms")
         data = {
@@ -1471,7 +1471,7 @@ class TestSMSSendFragments:
         assert response.status_code == 201
 
     def test_post_sms_not_enough_fragments_left(self, notify_api, client, notify_db, notify_db_session, mocker):
-        mocker.patch("app.sms_normal.publish")
+        mocker.patch("app.sms_normal_publish.publish")
         service = create_service(sms_daily_limit=10, message_limit=100)
         template = create_sample_template(notify_db, notify_db_session, content=500 * "a", service=service, template_type="sms")
         data = {
@@ -1494,7 +1494,7 @@ class TestSMSSendFragments:
     def test_post_sms_not_enough_fragments_left_FF_SPIKE_SMS_DAILY_LIMIT_false(
         self, notify_api, client, notify_db, notify_db_session, mocker
     ):
-        mocker.patch("app.sms_normal.publish")
+        mocker.patch("app.sms_normal_publish.publish")
         service = create_service(sms_daily_limit=10, message_limit=100)
         template = create_sample_template(notify_db, notify_db_session, content=500 * "a", service=service, template_type="sms")
         data = {
@@ -1526,7 +1526,7 @@ class TestSMSFragmentCounter:
         self, notify_api, client, notify_db, notify_db_session, mocker, key_type
     ):
         # test setup
-        mocker.patch("app.sms_normal.publish")
+        mocker.patch("app.sms_normal_publish.publish")
         increment_todays_requested_sms_count = mocker.patch("app.notifications.validators.increment_todays_requested_sms_count")
 
         def __send_sms():
@@ -1573,7 +1573,7 @@ class TestSMSFragmentCounter:
         self, notify_api, client, notify_db, notify_db_session, mocker, key_type
     ):
         # test setup
-        mocker.patch("app.sms_normal.publish")
+        mocker.patch("app.sms_normal_publish.publish")
         mocker.patch("app.v2.notifications.post_notifications.create_bulk_job", return_value=str(uuid.uuid4()))
         increment_todays_requested_sms_count = mocker.patch("app.notifications.validators.increment_todays_requested_sms_count")
 
@@ -1617,7 +1617,7 @@ class TestSMSFragmentCounter:
     @pytest.mark.parametrize("key_type", [KEY_TYPE_TEST, KEY_TYPE_NORMAL, KEY_TYPE_TEAM])
     def test_API_BULK_post_sms_with_mixed_numbers(self, notify_api, client, notify_db, notify_db_session, mocker, key_type):
         # test setup
-        mocker.patch("app.sms_normal.publish")
+        mocker.patch("app.sms_normal_publish.publish")
         mocker.patch("app.v2.notifications.post_notifications.create_bulk_job", return_value=str(uuid.uuid4()))
         increment_todays_requested_sms_count = mocker.patch("app.notifications.validators.increment_todays_requested_sms_count")
 
@@ -1667,7 +1667,7 @@ class TestSMSFragmentCounter:
         self, notify_api, client, notify_db, notify_db_session, mocker
     ):
         # test setup
-        mocker.patch("app.sms_normal.publish")
+        mocker.patch("app.sms_normal_publish.publish")
         mocker.patch("app.service.send_notification.send_notification_to_queue")
         increment_todays_requested_sms_count = mocker.patch("app.notifications.validators.increment_todays_requested_sms_count")
 
@@ -1711,7 +1711,7 @@ class TestSMSFragmentCounter:
         self, notify_api, client, notify_db, notify_db_session, mocker, expected_status_code, phone_numbers
     ):
         # test setup
-        mocker.patch("app.sms_normal.publish")
+        mocker.patch("app.sms_normal_publish.publish")
         mocker.patch("app.service.send_notification.send_notification_to_queue")
         mocker.patch("app.celery.tasks.process_job.apply_async")
         mocker.patch(
@@ -1758,7 +1758,7 @@ class TestEmailsAndLimitsForSMSFragments:
     # API
     def test_API_ONEOFF_sends_warning_emails_and_blocks_sends(self, notify_api, client, notify_db, notify_db_session, mocker):
         # test setup
-        mocker.patch("app.sms_normal.publish")
+        mocker.patch("app.sms_normal_publish.publish")
         send_warning_email = mocker.patch("app.notifications.validators.send_near_sms_limit_email")
         send_limit_reached_email = mocker.patch("app.notifications.validators.send_sms_limit_reached_email")
 
@@ -1797,7 +1797,7 @@ class TestEmailsAndLimitsForSMSFragments:
 
     def test_API_ONEOFF_cant_hop_over_limit_using_3_fragment_sms(self, notify_api, client, notify_db, notify_db_session, mocker):
         # test setup
-        mocker.patch("app.sms_normal.publish")
+        mocker.patch("app.sms_normal_publish.publish")
         send_warning_email = mocker.patch("app.notifications.validators.send_near_sms_limit_email")
 
         def __send_sms():
@@ -1831,7 +1831,7 @@ class TestEmailsAndLimitsForSMSFragments:
 
     def test_API_BULK_sends_warning_emails_and_blocks_sends(self, notify_api, client, notify_db, notify_db_session, mocker):
         # test setup
-        mocker.patch("app.sms_normal.publish")
+        mocker.patch("app.sms_normal_publish.publish")
         mocker.patch("app.v2.notifications.post_notifications.create_bulk_job", return_value=str(uuid.uuid4()))
         send_warning_email = mocker.patch("app.notifications.validators.send_near_sms_limit_email")
         send_limit_reached_email = mocker.patch("app.notifications.validators.send_sms_limit_reached_email")
@@ -1874,7 +1874,7 @@ class TestEmailsAndLimitsForSMSFragments:
 
     def test_API_BULK_cant_hop_over_limit_1_fragment(self, notify_api, client, notify_db, notify_db_session, mocker):
         # test setup
-        mocker.patch("app.sms_normal.publish")
+        mocker.patch("app.sms_normal_publish.publish")
         mocker.patch("app.v2.notifications.post_notifications.create_bulk_job", return_value=str(uuid.uuid4()))
         send_warning_email = mocker.patch("app.notifications.validators.send_near_sms_limit_email")
         send_limit_reached_email = mocker.patch("app.notifications.validators.send_sms_limit_reached_email")
@@ -1920,7 +1920,7 @@ class TestEmailsAndLimitsForSMSFragments:
 
     def test_API_BULK_cant_hop_over_limit_2_fragment(self, notify_api, client, notify_db, notify_db_session, mocker):
         # test setup
-        mocker.patch("app.sms_normal.publish")
+        mocker.patch("app.sms_normal_publish.publish")
         mocker.patch("app.v2.notifications.post_notifications.create_bulk_job", return_value=str(uuid.uuid4()))
         send_warning_email = mocker.patch("app.notifications.validators.send_near_sms_limit_email")
 
@@ -1963,7 +1963,7 @@ class TestEmailsAndLimitsForSMSFragments:
     # ADMIN
     def test_ADMIN_ONEOFF_sends_warning_emails_and_blocks_sends(self, notify_api, client, notify_db, notify_db_session, mocker):
         # test setup
-        mocker.patch("app.sms_normal.publish")
+        mocker.patch("app.sms_normal_publish.publish")
 
         mocker.patch("app.service.send_notification.send_notification_to_queue")
         send_warning_email = mocker.patch("app.notifications.validators.send_near_sms_limit_email")
@@ -2008,7 +2008,7 @@ class TestEmailsAndLimitsForSMSFragments:
         self, notify_api, client, notify_db, notify_db_session, mocker
     ):
         # test setup
-        mocker.patch("app.sms_normal.publish")
+        mocker.patch("app.sms_normal_publish.publish")
 
         mocker.patch("app.service.send_notification.send_notification_to_queue")
         send_warning_email = mocker.patch("app.notifications.validators.send_near_sms_limit_email")
@@ -2046,7 +2046,7 @@ class TestEmailsAndLimitsForSMSFragments:
 
     def test_ADMIN_CSV_sends_warning_emails_and_blocks_sends(self, notify_api, client, notify_db, notify_db_session, mocker):
         # test setup
-        mocker.patch("app.sms_normal.publish")
+        mocker.patch("app.sms_normal_publish.publish")
         mocker.patch("app.service.send_notification.send_notification_to_queue")
         mocker.patch("app.celery.tasks.process_job.apply_async")
         mocker.patch(
@@ -2101,7 +2101,7 @@ class TestEmailsAndLimitsForSMSFragments:
 
     def test_ADMIN_CSV_cant_hop_over_limit_using_1_fragment_sms(self, notify_api, client, notify_db, notify_db_session, mocker):
         # test setup
-        mocker.patch("app.sms_normal.publish")
+        mocker.patch("app.sms_normal_publish.publish")
         mocker.patch("app.service.send_notification.send_notification_to_queue")
         mocker.patch("app.celery.tasks.process_job.apply_async")
 
@@ -2157,7 +2157,7 @@ class TestEmailsAndLimitsForSMSFragments:
 
     def test_ADMIN_CSV_cant_hop_over_limit_using_2_fragment_sms(self, notify_api, client, notify_db, notify_db_session, mocker):
         # test setup
-        mocker.patch("app.sms_normal.publish")
+        mocker.patch("app.sms_normal_publish.publish")
         mocker.patch("app.service.send_notification.send_notification_to_queue")
         mocker.patch("app.celery.tasks.process_job.apply_async")
 
@@ -2836,7 +2836,7 @@ class TestBulkSend:
         }
 
     def test_post_bulk_with_too_large_sms_fails(self, client, notify_db, notify_db_session, mocker):
-        mocker.patch("app.sms_normal.publish")
+        mocker.patch("app.sms_normal_publish.publish")
         mocker.patch("app.v2.notifications.post_notifications.create_bulk_job", return_value=str(uuid.uuid4()))
 
         service = create_service(sms_daily_limit=10, message_limit=100)
@@ -2868,7 +2868,7 @@ class TestBulkSend:
     def test_post_bulk_with_too_large_sms_fail_and_shows_correct_row(
         self, client, notify_db, notify_db_session, mocker, row_data, failure_row
     ):
-        mocker.patch("app.sms_normal.publish")
+        mocker.patch("app.sms_normal_publish.publish")
         mocker.patch("app.v2.notifications.post_notifications.create_bulk_job", return_value=str(uuid.uuid4()))
 
         service = create_service(sms_daily_limit=10, message_limit=100)
@@ -2897,9 +2897,9 @@ class TestBulkSend:
 class TestBatchPriorityLanes:
     @pytest.mark.parametrize("process_type", ["bulk", "normal", "priority"])
     def test_sms_each_queue_is_used(self, notify_api, client, service_factory, mocker, process_type):
-        mock_redisQueue_SMS_BULK = mocker.patch("app.sms_bulk.publish")
-        mock_redisQueue_SMS_NORMAL = mocker.patch("app.sms_normal.publish")
-        mock_redisQueue_SMS_PRIORITY = mocker.patch("app.sms_priority.publish")
+        mock_redisQueue_SMS_BULK = mocker.patch("app.sms_bulk_publish.publish")
+        mock_redisQueue_SMS_NORMAL = mocker.patch("app.sms_normal_publish.publish")
+        mock_redisQueue_SMS_PRIORITY = mocker.patch("app.sms_priority_publish.publish")
 
         service = service_factory.get("one")
         template = create_template(service=service, content="Hello (( Name))\nYour thing is due soon", process_type=process_type)
@@ -2928,9 +2928,9 @@ class TestBatchPriorityLanes:
 
     @pytest.mark.parametrize("process_type", ["bulk", "normal", "priority"])
     def test_email_each_queue_is_used(self, notify_api, client, mocker, service_factory, process_type):
-        mock_redisQueue_EMAIL_BULK = mocker.patch("app.email_bulk.publish")
-        mock_redisQueue_EMAIL_NORMAL = mocker.patch("app.email_normal.publish")
-        mock_redisQueue_EMAIL_PRIORITY = mocker.patch("app.email_priority.publish")
+        mock_redisQueue_EMAIL_BULK = mocker.patch("app.email_bulk_publish.publish")
+        mock_redisQueue_EMAIL_NORMAL = mocker.patch("app.email_normal_publish.publish")
+        mock_redisQueue_EMAIL_PRIORITY = mocker.patch("app.email_priority_publish.publish")
 
         service = service_factory.get("one")
         template = create_template(


### PR DESCRIPTION
# Summary | Résumé

We want to write to one redis instance and read from another. This will be used for the redis upgrade.

# Local Testing
- created a new redis container in the devcontainer (basically just copy the one that's there and change the name and port)
- set both URLs to point to the old one. Verify that Notify still works.
- turn off the beat worker. new POSTs just pile up in the inbox since there's nothing moving them to an inflight.
- stop everything. set `REDIS_PUBLISH_URL` to the new container. Run everything. 
  - old redis gets the inbox processed and sent.
  - new POSTs pile up in inbox on new redis
- stop everything. Set both URLs to new redis. restart everything
  - new inbox gets processed and sent
  - new POSTs get sent
  - nothing goes into old redis  