### PR TITLE
Fix GPG error, unpin devcontainer version

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/python:0-3.10@sha256:04cac448e2712a48117db7bd8489adf5357a397e7069a3113c2566ea848dcb76
+FROM mcr.microsoft.com/vscode/devcontainers/python:0-3.10
 
 ARG KUBENS_VERSION="0.9.4"
 ARG OCTANT_VERSION="0.25.1"


### PR DESCRIPTION
# Summary | Résumé
The currently pinned dev container image appears to be out of date, producing a GPG error when building. Unpinning the image resolves this issue.
```
GPG error: https://dl.yarnpkg.com/debian stable InRelease: The following signatures were invalid: EXPKEYSIG 23E7166788B63E1E Yarn Packaging <[yarn@dan.cx](mailto:yarn@dan.cx)>
```