### PR TITLE
Fix/smoke test running with poetry

### DIFF
--- a/.devcontainer/scripts/notify-dev-entrypoint.sh
+++ b/.devcontainer/scripts/notify-dev-entrypoint.sh
@@ -25,8 +25,8 @@ echo -e "complete -F __start_kubectl k" >> ~/.zshrc
 
 # Smoke test
 # requires adding files .env_staging and .env_prod to the root of the project
-echo -e "alias smoke-staging='cd /workspace && cp .env_smoke_staging tests_smoke/.env && make smoke-test'" >> ~/.zshrc
-echo -e "alias smoke-prod='cd /workspace && cp .env_smoke_prod tests_smoke/.env && make smoke-test'" >> ~/.zshrc
+echo -e "alias smoke-staging='cd /workspace && cp .env_smoke_staging tests_smoke/.env && poetry run make smoke-test'" >> ~/.zshrc
+echo -e "alias smoke-prod='cd /workspace && cp .env_smoke_prod tests_smoke/.env && poetry run make smoke-test'" >> ~/.zshrc
 
 cd /workspace
 

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ format:
 
 .PHONY: smoke-test
 smoke-test:
-	cd tests_smoke && poetry run python smoke_test.py
+	cd tests_smoke && python smoke_test.py
 
 .PHONY: run
 run:


### PR DESCRIPTION
# Summary | Résumé

This PR updates the makefile to run the smoke tests without refering to poetry and the devconatiner script to run them using poetry.
