### PR TITLE
Update dev container extensions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,11 +4,9 @@
 	"service": "dev",
 	"workspaceFolder": "/workspace",
 	"shutdownAction": "stopCompose",
-
 	"remoteEnv": {
 		"PATH": "/home/vscode/.local/bin:${containerEnv:PATH}" // give our installed Python modules precedence
 	},
-
 	"settings": {
 		"[python]": {
 			"editor.formatOnSave": true
@@ -19,7 +17,6 @@
 		"python.linting.pylintPath": "/usr/local/bin/pylint",
 		"python.pythonPath": "/usr/local/bin/python",
 	},
-
 	"features": {
 		"docker-from-docker": {
 			"version": "latest",
@@ -31,11 +28,10 @@
 			"minikube": "none"
 		}
 	},
-
 	"extensions": [
 		"donjayamanne.python-extension-pack",
 		"ms-azuretools.vscode-docker",
-		"ms-python.vscode-pylance",
+		"ms-python.python",
 		"eamodio.gitlens",
 		"wholroyd.jinja",
 		"pmbenjamin.vscode-snyk",
@@ -48,9 +44,8 @@
 		"mtxr.sqltools",
 		"mtxr.sqltools-driver-pg",
 		"bungcip.better-toml",
+		"matangover.mypy"
 	],
-
 	"postCreateCommand": "notify-dev-entrypoint.sh",
-
 	"remoteUser": "vscode"
 }


### PR DESCRIPTION
# Summary | Résumé

`Pylance` is now the default python formatter in VS code so we can change to that. And adding the `mypy` extension will hopefully make the type hints in the editor work better. 