### PR TITLE
Update bounce rate queries to use `feedback_type`

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -35,6 +35,7 @@ from app.models import (
     LETTER_TYPE,
     NOTIFICATION_CREATED,
     NOTIFICATION_DELIVERED,
+    NOTIFICATION_HARD_BOUNCE,
     NOTIFICATION_PENDING,
     NOTIFICATION_PENDING_VIRUS_CHECK,
     NOTIFICATION_PERMANENT_FAILURE,
@@ -786,7 +787,7 @@ def overall_bounce_rate_for_day(min_emails_sent=1000, default_time=datetime.utcn
         db.session.query(
             Notification.service_id.label("service_id"),
             func.count(Notification.id).label("total_emails"),
-            func.count().filter(Notification.status == NOTIFICATION_PERMANENT_FAILURE).label("hard_bounces"),
+            func.count().filter(Notification.feedback_type == NOTIFICATION_HARD_BOUNCE).label("hard_bounces"),
         )
         .filter(Notification.created_at.between(twenty_four_hours_ago, default_time))  # this value is the `[bounce-rate-window]`
         .group_by(Notification.service_id)
@@ -816,7 +817,7 @@ def service_bounce_rate_for_day(service_id, min_emails_sent=1000, default_time=d
     query = (
         db.session.query(
             func.count(Notification.id).label("total_emails"),
-            func.count().filter(Notification.status == NOTIFICATION_PERMANENT_FAILURE).label("hard_bounces"),
+            func.count().filter(Notification.feedback_type == NOTIFICATION_HARD_BOUNCE).label("hard_bounces"),
         )
         .filter(Notification.created_at.between(twenty_four_hours_ago, default_time))  # this value is the `[bounce-rate-window]`
         .filter(Notification.service_id == service_id)

--- a/tests/app/dao/notification_dao/test_notification_dao_bounce_rate.py
+++ b/tests/app/dao/notification_dao/test_notification_dao_bounce_rate.py
@@ -35,7 +35,9 @@ class TestBounceRate:
     def test_bounce_rate_all_service(self, sample_email_template, sample_job):
         assert Notification.query.count() == 0
 
-        data_1 = _notification_json(sample_email_template, job_id=sample_job.id, status="permanent-failure", feedback_type=NOTIFICATION_HARD_BOUNCE)
+        data_1 = _notification_json(
+            sample_email_template, job_id=sample_job.id, status="permanent-failure", feedback_type=NOTIFICATION_HARD_BOUNCE
+        )
         data_2 = _notification_json(sample_email_template, job_id=sample_job.id, status="created")
 
         notification_1 = Notification(**data_1)
@@ -54,7 +56,9 @@ class TestBounceRate:
     def test_bounce_rate_single_service(self, sample_email_template, sample_job):
         assert Notification.query.count() == 0
 
-        data_1 = _notification_json(sample_email_template, job_id=sample_job.id, status="permanent-failure", feedback_type=NOTIFICATION_HARD_BOUNCE)
+        data_1 = _notification_json(
+            sample_email_template, job_id=sample_job.id, status="permanent-failure", feedback_type=NOTIFICATION_HARD_BOUNCE
+        )
         data_2 = _notification_json(sample_email_template, job_id=sample_job.id, status="created")
 
         notification_1 = Notification(**data_1)
@@ -72,7 +76,9 @@ class TestBounceRate:
     def test_bounce_rate_single_service_no_result(self, sample_service_full_permissions, sample_email_template, sample_job):
         assert Notification.query.count() == 0
 
-        data_1 = _notification_json(sample_email_template, job_id=sample_job.id, status="permanent-failure", feedback_type=NOTIFICATION_HARD_BOUNCE)
+        data_1 = _notification_json(
+            sample_email_template, job_id=sample_job.id, status="permanent-failure", feedback_type=NOTIFICATION_HARD_BOUNCE
+        )
         data_2 = _notification_json(sample_email_template, job_id=sample_job.id, status="created")
 
         notification_1 = Notification(**data_1)

--- a/tests/app/dao/notification_dao/test_notification_dao_bounce_rate.py
+++ b/tests/app/dao/notification_dao/test_notification_dao_bounce_rate.py
@@ -5,10 +5,10 @@ from app.dao.notifications_dao import (
     overall_bounce_rate_for_day,
     service_bounce_rate_for_day,
 )
-from app.models import KEY_TYPE_NORMAL, Notification
+from app.models import KEY_TYPE_NORMAL, NOTIFICATION_HARD_BOUNCE, Notification
 
 
-def _notification_json(sample_template, job_id=None, id=None, status=None):
+def _notification_json(sample_template, job_id=None, id=None, status=None, feedback_type=None):
     data = {
         "to": "hello@world.com",
         "service": sample_template.service,
@@ -26,6 +26,8 @@ def _notification_json(sample_template, job_id=None, id=None, status=None):
         data.update({"id": id})
     if status:
         data.update({"status": status})
+    if feedback_type:
+        data.update({"feedback_type": feedback_type})
     return data
 
 
@@ -33,7 +35,7 @@ class TestBounceRate:
     def test_bounce_rate_all_service(self, sample_email_template, sample_job):
         assert Notification.query.count() == 0
 
-        data_1 = _notification_json(sample_email_template, job_id=sample_job.id, status="permanent-failure")
+        data_1 = _notification_json(sample_email_template, job_id=sample_job.id, status="permanent-failure", feedback_type=NOTIFICATION_HARD_BOUNCE)
         data_2 = _notification_json(sample_email_template, job_id=sample_job.id, status="created")
 
         notification_1 = Notification(**data_1)
@@ -52,7 +54,7 @@ class TestBounceRate:
     def test_bounce_rate_single_service(self, sample_email_template, sample_job):
         assert Notification.query.count() == 0
 
-        data_1 = _notification_json(sample_email_template, job_id=sample_job.id, status="permanent-failure")
+        data_1 = _notification_json(sample_email_template, job_id=sample_job.id, status="permanent-failure", feedback_type=NOTIFICATION_HARD_BOUNCE)
         data_2 = _notification_json(sample_email_template, job_id=sample_job.id, status="created")
 
         notification_1 = Notification(**data_1)
@@ -70,7 +72,7 @@ class TestBounceRate:
     def test_bounce_rate_single_service_no_result(self, sample_service_full_permissions, sample_email_template, sample_job):
         assert Notification.query.count() == 0
 
-        data_1 = _notification_json(sample_email_template, job_id=sample_job.id, status="permanent-failure")
+        data_1 = _notification_json(sample_email_template, job_id=sample_job.id, status="permanent-failure", feedback_type=NOTIFICATION_HARD_BOUNCE)
         data_2 = _notification_json(sample_email_template, job_id=sample_job.id, status="created")
 
         notification_1 = Notification(**data_1)


### PR DESCRIPTION
This PR updates the bounce rate queries to use `feedback_type = 'hard-bounce'` instead of relying on `notification_status` like we needed to before this point.