### PR TITLE
Fix failing migration in staging/prod

### DIFF
--- a/migrations/versions/0428_add_bounce_type_known.py
+++ b/migrations/versions/0428_add_bounce_type_known.py
@@ -17,7 +17,7 @@ from alembic import op
 def upgrade():
     # prevent from being executed in a transaction block
     op.execute("COMMIT")
-    
+
     op.execute("ALTER TYPE notification_feedback_types ADD VALUE 'unknown-bounce'")
     op.execute("ALTER TYPE notification_feedback_subtypes ADD VALUE 'unknown-bounce-subtype'")
 

--- a/migrations/versions/0428_add_bounce_type_known.py
+++ b/migrations/versions/0428_add_bounce_type_known.py
@@ -15,6 +15,9 @@ from alembic import op
 
 # option 1
 def upgrade():
+    # prevent from being executed in a transaction block
+    op.execute("COMMIT")
+    
     op.execute("ALTER TYPE notification_feedback_types ADD VALUE 'unknown-bounce'")
     op.execute("ALTER TYPE notification_feedback_subtypes ADD VALUE 'unknown-bounce-subtype'")
 


### PR DESCRIPTION
This PR updates the `ALTER TYPE` migration (0428_add_bounce_type_known) to prevent this error happening in postgres 11.17:
```
 psycopg2.errors.ActiveSqlTransaction: ALTER TYPE ... ADD cannot run inside a transaction block 
```
