### PR TITLE
Add the `organisation_notes` column

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -542,6 +542,7 @@ class Service(BaseModel, Versioned):
     go_live_user = db.relationship("User", foreign_keys=[go_live_user_id])
     go_live_at = db.Column(db.DateTime, nullable=True)
     sending_domain = db.Column(db.String(255), nullable=True, unique=False)
+    organisation_notes = db.Column(db.String(255), nullable=True, unique=False)
 
     organisation_id = db.Column(UUID(as_uuid=True), db.ForeignKey("organisation.id"), index=True, nullable=True)
     organisation = db.relationship("Organisation", backref="services")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -224,6 +224,7 @@ class ServiceSchema(BaseSchema):
     override_flag = False
     letter_contact_block = fields.Method(serialize="get_letter_contact")
     go_live_at = field_for(models.Service, "go_live_at", format="%Y-%m-%d %H:%M:%S.%f")
+    organisation_notes = field_for(models.Service, "organisation_notes")
 
     def get_letter_logo_filename(self, service):
         return service.letter_branding and service.letter_branding.filename

--- a/migrations/versions/0429_add_organisation_notes.py
+++ b/migrations/versions/0429_add_organisation_notes.py
@@ -1,0 +1,32 @@
+"""
+
+Revision ID: 0429_add_organisation_notes
+Revises: 0428_add_bounce_type_known
+Create Date: 2023-03-09 16:02:27.798584
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0429_add_organisation_notes"
+down_revision = "0428_add_bounce_type_known"
+
+user = "postgres"
+timeout = 1200  # in seconds, i.e. 20 minutes
+default = 1
+
+
+def upgrade():
+    op.add_column(
+        "services",
+        sa.Column("organisation_notes", sa.String(), nullable=True),
+    )
+    op.add_column(
+        "services_history",
+        sa.Column("organisation_notes", sa.String(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("services", "organisation_notes")
+    op.drop_column("services_history", "organisation_notes")


### PR DESCRIPTION
# Summary | Résumé

This PR adds a new column `organisation_notes` to the `services` and `services_history` tables. This column will eventually contain strings entered by users creating new trial services. The `organisation_notes` string will be the combination of strings entered on this page:

<img width="400" alt="Screen Shot 2023-03-07 at 12 00 45 PM" src="https://user-images.githubusercontent.com/5498428/223494393-22778e1b-3457-4424-aa6a-10f24ce85bf4.png">

I am thinking they will be combined like this: `"parent_organisation_name > child_organisation name"` but that is not set in stone.

This data would then be pulled from the db and inserted into the freshdesk ticket if/when the service requests to go live.

The `organisation_notes` column is `nullable` so we can merge this change before the rest of the admin code is ready. I tested this code locally with the `main` branch of notification-admin - new services are created successfully with `NULL`s in the `organisation_notes` column. 

# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their
review | Voici une suggestion de liste de vérification comprenant des questions
que les réviseurs pourraient poser pendant leur examen :


- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne
      une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une
      fonctionnalité existante?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une
      modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des
      préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de
      façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de
      risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README
      setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce
      changement (fichier README, etc.)?
