### PR TITLE
Task/bounce

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -13,6 +13,7 @@ from flask_migrate import Migrate
 from flask_redis import FlaskRedis
 from notifications_utils import logging, request_helper
 from notifications_utils.clients.redis.redis_client import RedisClient
+from notifications_utils.clients.redis.bounce_rate import RedisBounceRate
 from notifications_utils.clients.statsd.statsd_client import StatsdClient
 from notifications_utils.clients.zendesk.zendesk_client import ZendeskClient
 from werkzeug.exceptions import HTTPException as WerkzeugHTTPException
@@ -49,6 +50,7 @@ statsd_client = StatsdClient()
 flask_redis = FlaskRedis()
 flask_redis_publish = FlaskRedis(config_prefix="REDIS_PUBLISH")
 redis_store = RedisClient()
+bounce_rate_client = RedisBounceRate(redis_store)
 metrics_logger = MetricsLogger()
 # TODO: Rework instantiation to decouple redis_store.redis_store and pass it in.\
 email_queue = RedisQueue("email")

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -12,8 +12,8 @@ from flask_marshmallow import Marshmallow
 from flask_migrate import Migrate
 from flask_redis import FlaskRedis
 from notifications_utils import logging, request_helper
-from notifications_utils.clients.redis.redis_client import RedisClient
 from notifications_utils.clients.redis.bounce_rate import RedisBounceRate
+from notifications_utils.clients.redis.redis_client import RedisClient
 from notifications_utils.clients.statsd.statsd_client import StatsdClient
 from notifications_utils.clients.zendesk.zendesk_client import ZendeskClient
 from werkzeug.exceptions import HTTPException as WerkzeugHTTPException

--- a/app/config.py
+++ b/app/config.py
@@ -492,6 +492,9 @@ class Config(object):
 
     FF_SALESFORCE_CONTACT = env.bool("FF_SALESFORCE_CONTACT", False)
 
+    # Feature flags for bounce rate
+    FF_BOUNCE_RATE_V1 = env.bool("FF_BOUNCE_RATE_V1", False)
+
     @classmethod
     def get_sensitive_config(cls) -> list[str]:
         "List of config keys that contain sensitive information"

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -258,7 +258,7 @@ def send_email_to_provider(notification: Notification):
             )
             if current_app.config["FF_BOUNCE_RATE_V1"]:
                 bounce_rate_client.set_total_notifications(service.id)
-                current_app.info(f"Setting total notifications for service {service.id} in REDIS")
+                current_app.logger.info(f"Setting total notifications for service {service.id} in REDIS")
             current_app.logger.info(f"Notification id {notification.id} HAS BEEN SENT")
             notification.reference = reference
             update_notification_to_sending(notification, provider)

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -16,7 +16,7 @@ from notifications_utils.template import (
     SMSMessageTemplate,
 )
 
-from app import clients, document_download_client, statsd_client
+from app import bounce_rate_client, clients, document_download_client, statsd_client
 from app.celery.research_mode_tasks import send_email_response, send_sms_response
 from app.config import Config
 from app.dao.notifications_dao import dao_update_notification
@@ -256,6 +256,7 @@ def send_email_to_provider(notification: Notification):
                 reply_to_address=validate_and_format_email_address(email_reply_to) if email_reply_to else None,
                 attachments=attachments,
             )
+            bounce_rate_client.set_total_notifications(service.id)
             notification.reference = reference
             update_notification_to_sending(notification, provider)
         current_app.logger.info(f"Notification id {notification.id} status in sending")

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -256,7 +256,10 @@ def send_email_to_provider(notification: Notification):
                 reply_to_address=validate_and_format_email_address(email_reply_to) if email_reply_to else None,
                 attachments=attachments,
             )
-            bounce_rate_client.set_total_notifications(service.id)
+            if current_app.config["FF_BOUNCE_RATE_V1"]:
+                bounce_rate_client.set_total_notifications(service.id)
+                current_app.info(f"Setting total notifications for service {service.id} in REDIS")
+            current_app.logger.info(f"Notification id {notification.id} HAS BEEN SENT")
             notification.reference = reference
             update_notification_to_sending(notification, provider)
         current_app.logger.info(f"Notification id {notification.id} status in sending")

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -146,7 +146,7 @@ def test_should_send_personalised_template_to_correct_email_provider_and_persist
 
     mocker.patch("app.aws_ses_client.send_email", return_value="reference")
     statsd_mock = mocker.patch("app.delivery.send_to_providers.statsd_client")
-    bounce_rate_mock = mocker.patch("app.delivery.send_to_providers.bounce_rate_client")
+    mocker.patch("app.delivery.send_to_providers.bounce_rate_client")
 
     send_to_providers.send_email_to_provider(db_notification)
 
@@ -237,6 +237,7 @@ def test_should_respect_custom_sending_domains(sample_service, mocker, sample_em
 
     sample_service.sending_domain = "foo.bar"
     mocker.patch("app.aws_ses_client.send_email", return_value="reference")
+    mocker.patch("app.delivery.send_to_providers.bounce_rate_client")
 
     send_to_providers.send_email_to_provider(db_notification)
 
@@ -473,6 +474,7 @@ def test_send_email_to_provider_should_not_send_to_provider_when_status_is_not_c
 
 def test_send_email_should_use_service_reply_to_email(sample_service, sample_email_template, mocker):
     mocker.patch("app.aws_ses_client.send_email", return_value="reference")
+    mocker.patch("app.delivery.send_to_providers.bounce_rate_client")
 
     db_notification = save_notification(create_notification(template=sample_email_template, reply_to_text="foo@bar.com"))
     create_reply_to_email(service=sample_service, email_address="foo@bar.com")
@@ -494,6 +496,7 @@ def test_send_email_should_use_service_reply_to_email(sample_service, sample_ema
 
 def test_send_email_should_use_default_service_reply_to_email_when_two_are_set(sample_service, sample_email_template, mocker):
     mocker.patch("app.aws_ses_client.send_email", return_value="reference")
+    mocker.patch("app.delivery.send_to_providers.bounce_rate_client")
 
     create_reply_to_email(service=sample_service, email_address="foo@bar.com")
     create_reply_to_email(service=sample_service, email_address="foo_two@bar.com", is_default=False)
@@ -517,6 +520,7 @@ def test_send_email_should_use_default_service_reply_to_email_when_two_are_set(s
 
 def test_send_email_should_use_non_default_service_reply_to_email_when_it_is_set(sample_service, sample_email_template, mocker):
     mocker.patch("app.aws_ses_client.send_email", return_value="reference")
+    mocker.patch("app.delivery.send_to_providers.bounce_rate_client")
 
     create_reply_to_email(service=sample_service, email_address="foo@bar.com")
     create_reply_to_email(service=sample_service, email_address="foo_two@bar.com", is_default=False)
@@ -792,6 +796,7 @@ def test_should_handle_sms_sender_and_prefix_message(
 
 def test_send_email_to_provider_uses_reply_to_from_notification(sample_email_template, mocker):
     mocker.patch("app.aws_ses_client.send_email", return_value="reference")
+    mocker.patch("app.delivery.send_to_providers.bounce_rate_client")
 
     db_notification = save_notification(create_notification(template=sample_email_template, reply_to_text="test@test.com"))
 
@@ -812,6 +817,7 @@ def test_send_email_to_provider_uses_reply_to_from_notification(sample_email_tem
 
 def test_send_email_to_provider_should_format_reply_to_email_address(sample_email_template, mocker):
     mocker.patch("app.aws_ses_client.send_email", return_value="reference")
+    mocker.patch("app.delivery.send_to_providers.bounce_rate_client")
 
     db_notification = save_notification(create_notification(template=sample_email_template, reply_to_text="test@test.com\t"))
 
@@ -842,6 +848,7 @@ def test_send_sms_to_provider_should_format_phone_number(sample_notification, mo
 def test_send_email_to_provider_should_format_email_address(sample_email_notification, mocker):
     sample_email_notification.to = "test@example.com\t"
     send_mock = mocker.patch("app.aws_ses_client.send_email", return_value="reference")
+    mocker.patch("app.delivery.send_to_providers.bounce_rate_client")
 
     send_to_providers.send_email_to_provider(sample_email_notification)
 
@@ -875,6 +882,7 @@ def test_notification_document_with_pdf_attachment(
     expected_filename,
 ):
     template = create_sample_email_template(notify_db, notify_db_session, content="Here is your ((file))")
+    mocker.patch("app.delivery.send_to_providers.bounce_rate_client")
 
     class mock_response:
         status_code = 200
@@ -1015,6 +1023,7 @@ def test_notification_raises_error_if_message_contains_sin_pii_that_passes_luhn(
 
 def test_notification_passes_if_message_contains_sin_pii_that_fails_luhn(sample_email_template_with_html, mocker, notify_api):
     send_mock = mocker.patch("app.aws_ses_client.send_email", return_value="reference")
+    mocker.patch("app.delivery.send_to_providers.bounce_rate_client")
 
     db_notification = save_notification(
         create_notification(
@@ -1033,6 +1042,7 @@ def test_notification_passes_if_message_contains_sin_pii_that_fails_luhn(sample_
 
 def test_notification_passes_if_message_contains_phone_number(sample_email_template_with_html, mocker):
     send_mock = mocker.patch("app.aws_ses_client.send_email", return_value="reference")
+    mocker.patch("app.delivery.send_to_providers.bounce_rate_client")
 
     db_notification = save_notification(
         create_notification(
@@ -1114,6 +1124,7 @@ class TestMalware:
         self, sample_email_template, mocker, status_code_returned, scan_verdict
     ):
         send_mock = mocker.patch("app.aws_ses_client.send_email", return_value="reference")
+        mocker.patch("app.delivery.send_to_providers.bounce_rate_client")
 
         class mock_response:
             status_code = status_code_returned
@@ -1151,3 +1162,17 @@ class TestMalware:
         send_mock.assert_not_called()
 
         assert Notification.query.get(db_notification.id).status == "technical-failure"
+
+
+class TestBounceRate:
+    def test_send_email_should_use_service_reply_to_email(self, sample_service, sample_email_template, mocker):
+        mocker.patch("app.aws_ses_client.send_email", return_value="reference")
+        mocker.patch("app.bounce_rate_client.set_total_notifications")
+        db_notification = save_notification(create_notification(template=sample_email_template, reply_to_text="foo@bar.com"))
+        create_reply_to_email(service=sample_service, email_address="foo@bar.com")
+
+        send_to_providers.send_email_to_provider(
+            db_notification,
+        )
+
+        app.bounce_rate_client.set_total_notifications.assert_called_once_with(sample_service.id)

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -1165,14 +1165,14 @@ class TestMalware:
 
 
 class TestBounceRate:
-    def test_send_email_should_use_service_reply_to_email(self, sample_service, sample_email_template, mocker):
-        mocker.patch("app.aws_ses_client.send_email", return_value="reference")
-        mocker.patch("app.bounce_rate_client.set_total_notifications")
-        db_notification = save_notification(create_notification(template=sample_email_template, reply_to_text="foo@bar.com"))
-        create_reply_to_email(service=sample_service, email_address="foo@bar.com")
+    def test_send_email_should_use_service_reply_to_email(self, sample_service, sample_email_template, mocker, notify_api):
+        with set_config_values(notify_api, {"FF_BOUNCE_RATE_V1": True}):
+            mocker.patch("app.aws_ses_client.send_email", return_value="reference")
+            mocker.patch("app.bounce_rate_client.set_total_notifications")
+            db_notification = save_notification(create_notification(template=sample_email_template, reply_to_text="foo@bar.com"))
+            create_reply_to_email(service=sample_service, email_address="foo@bar.com")
 
-        send_to_providers.send_email_to_provider(
-            db_notification,
-        )
-
-        app.bounce_rate_client.set_total_notifications.assert_called_once_with(sample_service.id)
+            send_to_providers.send_email_to_provider(
+                db_notification,
+            )
+            app.bounce_rate_client.set_total_notifications.assert_called_once_with(sample_service.id)

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -146,6 +146,7 @@ def test_should_send_personalised_template_to_correct_email_provider_and_persist
 
     mocker.patch("app.aws_ses_client.send_email", return_value="reference")
     statsd_mock = mocker.patch("app.delivery.send_to_providers.statsd_client")
+    bounce_rate_mock = mocker.patch("app.delivery.send_to_providers.bounce_rate_client")
 
     send_to_providers.send_email_to_provider(db_notification)
 


### PR DESCRIPTION
# Summary | Résumé

Add total_notifications to Redis in order to calculate bounce rate.

Going to merge this to staging, It was originally reverted: https://github.com/cds-snc/notification-api/pull/1783
we want to see what the issue might be here.