### PR TITLE
feat: Salesforce Engagement create

### DIFF
--- a/app/clients/salesforce/salesforce_account.py
+++ b/app/clients/salesforce/salesforce_account.py
@@ -1,0 +1,42 @@
+from typing import Optional
+
+from simple_salesforce import Salesforce
+
+from .salesforce_utils import query_one, query_param_sanitize
+
+
+def get_account_name_from_org(organisation_notes: str) -> str:
+    """Given a service's organisation notes, returns the Account name
+    which is the first segment of the organisation notes before the `>` character.
+    If the notes do not contain a `>` character, the entire notes are returned.
+
+    TODO: This could be improved by explicitly passing the selected Account name
+    to the API from Admin rather than parsing it out of the organisation notes.
+
+    Args:
+        organisation_notes (str): The service's organisation notes
+
+    Returns:
+        str: The Account name
+    """
+    if isinstance(organisation_notes, str) and ">" in organisation_notes:
+        return organisation_notes.split(">")[0].strip()
+    return organisation_notes
+
+
+def get_account_id_from_name(session: Salesforce, account_name: str, generic_account_id: str) -> Optional[str]:
+    """Returns the Account ID for the given Account Name.  If no match is found, a generic
+    Account not found ID is returned.
+
+    Args:
+        session (Salesforce): Salesforce session for the operation.
+        account_name (str): Account name to lookup the ID for.
+        generic_account_id (str): Generic Account ID to return if no match is found.
+
+    Returns:
+        Optional[str]: The matching Account ID or a generic Account ID if no match is found.
+    """
+    account_name_sanitized = query_param_sanitize(account_name)
+    query = f"SELECT Id FROM Account where Name = '{account_name_sanitized}' OR CDS_AccountNameFrench__c = '{account_name_sanitized}' LIMIT 1"
+    result = query_one(session, query)
+    return result.get("Id") if result else generic_account_id

--- a/app/clients/salesforce/salesforce_client.py
+++ b/app/clients/salesforce/salesforce_client.py
@@ -4,10 +4,15 @@ from typing import TYPE_CHECKING, Optional
 
 from simple_salesforce import Salesforce
 
-from . import salesforce_auth, salesforce_contact
+from . import (
+    salesforce_account,
+    salesforce_auth,
+    salesforce_contact,
+    salesforce_engagement,
+)
 
 if TYPE_CHECKING:
-    from app.models import User
+    from app.models import Service, User
 
 
 class SalesforceClient:
@@ -17,20 +22,54 @@ class SalesforceClient:
         self.password = app.config["SALESFORCE_PASSWORD"]
         self.security_token = app.config["SALESFORCE_SECURITY_TOKEN"]
         self.domain = app.config["SALESFORCE_DOMAIN"]
+        self.generic_account_id = app.config["SALESFORCE_GENERIC_ACCOUNT_ID"]
 
     #
     # Authentication
     #
     def get_session(self) -> Salesforce:
+        """Returns an authenticated Salesforce session.
+
+        Returns:
+            Salesforce: The authenticated Salesforce session.
+        """
         return salesforce_auth.get_session(self.client_id, self.username, self.password, self.security_token, self.domain)
 
     def end_session(self, session: Salesforce):
+        """Revokes a Salesforce session.
+
+        Args:
+            session (Salesforce): The Salesforce session to revoke.
+        """
         salesforce_auth.end_session(session)
 
     #
     # Contacts
     #
     def contact_create(self, user: User, account_id: Optional[str] = None):
+        """Creates a Salesforce Contact for the given Notify user
+
+        Args:
+            user (User): The Notify user to create a Salesforce Contact for.
+            account_id (Optional[str], optional): Salesforce Account ID to use for the Contact. Defaults to None.
+        """
         session = self.get_session()
         salesforce_contact.create(session, user, account_id)
+        self.end_session(session)
+
+    #
+    # Engagements
+    #
+    def engagement_create(self, service: Service, user: User):
+        """Creates a Salesforce Engagement for the given Notify service
+
+        Args:
+            service (Service): Notify Service to create an Engagement for.
+            user (User): Notify User creating the service.
+        """
+        session = self.get_session()
+        account_name = salesforce_account.get_account_name_from_org(service.organisation_notes)
+        account_id = salesforce_account.get_account_id_from_name(session, account_name, self.generic_account_id)
+        contact_id = salesforce_contact.update_account_id(session, user, account_id)
+        salesforce_engagement.create(session, service, salesforce_engagement.ENGAGEMENT_STAGE_TRIAL, account_id, contact_id)
         self.end_session(session)

--- a/app/clients/salesforce/salesforce_contact.py
+++ b/app/clients/salesforce/salesforce_contact.py
@@ -1,17 +1,22 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import TYPE_CHECKING, Optional
 
 from flask import current_app
 from simple_salesforce import Salesforce
 
-from .salesforce_utils import get_name_parts, parse_result
+from .salesforce_utils import (
+    get_name_parts,
+    parse_result,
+    query_one,
+    query_param_sanitize,
+)
 
 if TYPE_CHECKING:
     from app.models import User
 
 
-def create(session: Salesforce, user: User, account_id: Optional[str]) -> Tuple[bool, Optional[str]]:
+def create(session: Salesforce, user: User, account_id: Optional[str]) -> Optional[str]:
     """Create a Salesforce Contact from the given Notify User
 
     Args:
@@ -20,9 +25,8 @@ def create(session: Salesforce, user: User, account_id: Optional[str]) -> Tuple[
         account_id (str | None, optional): ID of the Account to associate the Contact with.
 
     Returns:
-        Tuple[bool, Optional[str]]: Success indicator and the ID of the new Contact
+        Optional[str]: Newly created Contact ID or None if the operation failed.
     """
-    is_created = False
     contact_id = None
     try:
         name_parts = get_name_parts(user.name)
@@ -37,9 +41,56 @@ def create(session: Salesforce, user: User, account_id: Optional[str]) -> Tuple[
             },
             headers={"Sforce-Duplicate-Rule-Header": "allowSave=true"},
         )
-        is_created = parse_result(result, f"Salesforce Contact create for '{user.email_address}'")
+        parse_result(result, f"Salesforce Contact create for '{user.email_address}'")
         contact_id = result.get("id")
 
     except Exception as ex:
         current_app.logger.error(f"Salesforce Contact create failed: {ex}")
-    return (is_created, contact_id)
+    return contact_id
+
+
+def update_account_id(session: Salesforce, user: User, account_id: Optional[str]) -> Optional[str]:
+    """Update the Account ID of a Contact.  If the Contact does not
+    exist, it is created.
+
+    Args:
+        session (Salesforce): Salesforce session used to perform the operation.
+        user (User): Notify User object for the linked Contact to update
+        account_id (str): ID of the Salesforce Account
+
+    Returns:
+         contact_id (str): ID of the updated Contact or None if the operation failed
+    """
+    contact_id = None
+    try:
+        contact = get_contact_by_user_id(session, str(user.id))
+
+        # Existing contact, update the AccountID
+        if contact:
+            result = session.Contact.update(
+                contact.get("Id"), {"AccountId": account_id}, headers={"Sforce-Duplicate-Rule-Header": "allowSave=true"}
+            )
+            parse_result(result, f"Salesforce Contact update '{user.email_address}' with account ID '{account_id}'")
+            contact_id = contact.get("Id")
+        # Create the new contact
+        else:
+            contact_id = create(session, user, account_id)
+
+    except Exception as ex:
+        current_app.logger.error(f"Salesforce Contact update failed: {ex}")
+    return contact_id
+
+
+def get_contact_by_user_id(session: Salesforce, user_id: str) -> Optional[dict[str, str]]:
+    """Retrieve a Salesforce Contact by their Notify user ID.  If
+    they can't be found, `None` is returned.
+
+    Args:
+        session (Salesforce): Salesforce session used to perform the operation.
+        user_id (str): Notify user ID.
+
+    Returns:
+        Optional[dict[str, str]]: Salesforce Contact details or None if can't be found
+    """
+    query = f"SELECT Id, FirstName, LastName, AccountId FROM Contact WHERE CDS_Contact_ID__c = '{query_param_sanitize(user_id)}' LIMIT 1"
+    return query_one(session, query)

--- a/app/clients/salesforce/salesforce_engagement.py
+++ b/app/clients/salesforce/salesforce_engagement.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional
+
+from flask import current_app
+from simple_salesforce import Salesforce
+
+from .salesforce_utils import parse_result
+
+if TYPE_CHECKING:
+    from app.models import Service
+
+ENGAGEMENT_PRODUCT = "GC Notify"
+ENGAGEMENT_TEAM = "Platform"
+ENGAGEMENT_TYPE = "New Business"
+ENGAGEMENT_STAGE_ACTIVATION = "Activation"
+ENGAGEMENT_STAGE_LIVE = "Live"
+ENGAGEMENT_STAGE_TRIAL = "Trial Account"
+
+
+def create(
+    session: Salesforce, service: Service, stage_name: str, account_id: Optional[str], contact_id: Optional[str]
+) -> Optional[str]:
+    """Create a Salesforce Engagement for the given Notify service
+
+    Args:
+        session (Salesforce): Salesforce session to perform the operation.
+        service (Service): The service's details for the engagement.
+        stage_name (str): The service's stage name.
+        account_id (Optional[str]): Salesforce Account ID to associate with the Engagement.
+        contact_id (Optional[str]): Salesforce Contact ID to associate with the Engagement.
+
+    Returns:
+       Optional[str]: Newly created Engagement ID or None if the operation failed.
+    """
+    engagement_id = None
+    try:
+        if account_id and contact_id:
+            result = session.Opportunity.create(
+                {
+                    "Name": service.name,
+                    "AccountId": account_id,
+                    "ContactId": contact_id,
+                    "CDS_Opportunity_Number__c": str(service.id),
+                    "StageName": stage_name,
+                    "CloseDate": datetime.today().strftime("%Y-%m-%d"),
+                    "RecordTypeId": current_app.config["SALESFORCE_ENGAGEMENT_RECORD_TYPE"],
+                    "Type": ENGAGEMENT_TYPE,
+                    "CDS_Lead_Team__c": ENGAGEMENT_TEAM,
+                    "Product_to_Add__c": ENGAGEMENT_PRODUCT,
+                },
+                headers={"Sforce-Duplicate-Rule-Header": "allowSave=true"},
+            )
+            parse_result(result, f"Salesforce Engagement create for service ID {service.id}")
+            engagement_id = result.get("id")
+
+            # Create the Product association
+            if engagement_id:
+                result = session.OpportunityLineItem.create(
+                    {
+                        "OpportunityId": engagement_id,
+                        "PricebookEntryId": current_app.config["SALESFORCE_ENGAGEMENT_STANDARD_PRICEBOOK_ID"],
+                        "Product2Id": current_app.config["SALESFORCE_ENGAGEMENT_PRODUCT_ID"],
+                        "Quantity": 1,
+                        "UnitPrice": 0,
+                    },
+                    headers={"Sforce-Duplicate-Rule-Header": "allowSave=true"},
+                )
+                parse_result(result, f"Salesforce Engagement OpportunityLineItem create for service ID {service.id}")
+        else:
+            current_app.logger.error(
+                f"Salesforce Engagement create failed: missing Account ID '{account_id}' or Contact ID '{contact_id}' for service ID {service.id}"
+            )
+    except Exception as ex:
+        current_app.logger.error(f"Salesforce Engagement create failed: {ex}")
+    return engagement_id

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -15,7 +15,7 @@ from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 
-from app import redis_store
+from app import redis_store, salesforce_client
 from app.clients.zendesk_sell import ZenDeskSell
 from app.config import QueueNames
 from app.dao import fact_notification_status_dao, notifications_dao
@@ -260,6 +260,8 @@ def create_service():
     try:
         # try-catch; just in case, we don't want to error here
         ZenDeskSell().send_create_service(valid_service, user)
+        if current_app.config["FF_SALESFORCE_CONTACT"]:
+            salesforce_client.engagement_create(valid_service, user)
     except Exception as e:
         current_app.logger.exception(e)
 

--- a/tests/app/clients/test_salesforce_account.py
+++ b/tests/app/clients/test_salesforce_account.py
@@ -1,0 +1,34 @@
+from app.clients.salesforce import salesforce_account
+from app.clients.salesforce.salesforce_account import (
+    get_account_id_from_name,
+    get_account_name_from_org,
+)
+
+
+def test_get_account_name_from_org():
+    assert get_account_name_from_org("Account Name 1 > Service Name") == "Account Name 1"
+    assert get_account_name_from_org("Account Name 2") == "Account Name 2"
+    assert get_account_name_from_org("Account Name 3 >") == "Account Name 3"
+    assert get_account_name_from_org("Account Name 4 > Service Name > Team Name") == "Account Name 4"
+    assert get_account_name_from_org(None) is None
+
+
+def test_get_account_id_from_name(mocker, notify_api):
+    mock_session = mocker.MagicMock()
+    mock_query_one = mocker.patch.object(salesforce_account, "query_one", return_value={"Id": "account_id"})
+    with notify_api.app_context():
+        assert get_account_id_from_name(mock_session, "Account Name", "generic_account_id") == "account_id"
+        mock_query_one.assert_called_with(
+            mock_session,
+            "SELECT Id FROM Account where Name = 'Account Name' OR CDS_AccountNameFrench__c = 'Account Name' LIMIT 1",
+        )
+
+
+def test_get_account_id_from_name_generic(mocker, notify_api):
+    mock_session = mocker.MagicMock()
+    mock_query_one = mocker.patch.object(salesforce_account, "query_one", return_value=None)
+    with notify_api.app_context():
+        assert get_account_id_from_name(mock_session, "l'account", "generic_account_id") == "generic_account_id"
+        mock_query_one.assert_called_with(
+            mock_session, "SELECT Id FROM Account where Name = 'l\\'account' OR CDS_AccountNameFrench__c = 'l\\'account' LIMIT 1"
+        )

--- a/tests/app/clients/test_salesforce_client.py
+++ b/tests/app/clients/test_salesforce_client.py
@@ -1,6 +1,11 @@
 import pytest
 
-from app.clients.salesforce import salesforce_auth, salesforce_contact
+from app.clients.salesforce import (
+    salesforce_account,
+    salesforce_auth,
+    salesforce_contact,
+    salesforce_engagement,
+)
 from app.clients.salesforce.salesforce_client import SalesforceClient
 
 
@@ -14,6 +19,7 @@ def salesforce_client(client, mocker):
             "SALESFORCE_PASSWORD": "somepassword",
             "SALESFORCE_SECURITY_TOKEN": "somesecuritytoken",
             "SALESFORCE_DOMAIN": "test",
+            "SALESFORCE_GENERIC_ACCOUNT_ID": "someaccountid",
         }
     )
     client.init_app(current_app)
@@ -41,4 +47,28 @@ def test_contact_create(mocker, salesforce_client):
 
     mock_get_session.assert_called_once()
     mock_create.assert_called_once_with("session", "user", "account_id")
+    mock_end_session.assert_called_once_with("session")
+
+
+def test_engagement_create(mocker, salesforce_client):
+    mock_get_session = mocker.patch.object(salesforce_client, "get_session", return_value="session")
+    mock_get_account_name_from_org = mocker.patch.object(
+        salesforce_account, "get_account_name_from_org", return_value="account_name"
+    )
+    mock_get_account_id_from_name = mocker.patch.object(salesforce_account, "get_account_id_from_name", return_value="account_id")
+    mock_update_account_id = mocker.patch.object(salesforce_contact, "update_account_id", return_value="contact_id")
+    mock_create = mocker.patch.object(salesforce_engagement, "create")
+    mock_end_session = mocker.patch.object(salesforce_client, "end_session")
+    mock_service = mocker.MagicMock()
+    mock_service.organisation_notes = "account_name > service_name"
+
+    salesforce_client.engagement_create(mock_service, "user")
+
+    mock_get_session.assert_called_once()
+    mock_get_account_name_from_org.assert_called_once_with(mock_service.organisation_notes)
+    mock_get_account_id_from_name.assert_called_once_with("session", "account_name", "someaccountid")
+    mock_update_account_id.assert_called_once_with("session", "user", "account_id")
+    mock_create.assert_called_once_with(
+        "session", mock_service, salesforce_engagement.ENGAGEMENT_STAGE_TRIAL, "account_id", "contact_id"
+    )
     mock_end_session.assert_called_once_with("session")

--- a/tests/app/clients/test_salesforce_contact.py
+++ b/tests/app/clients/test_salesforce_contact.py
@@ -1,6 +1,11 @@
 import pytest
 
-from app.clients.salesforce.salesforce_contact import create
+from app.clients.salesforce import salesforce_contact
+from app.clients.salesforce.salesforce_contact import (
+    create,
+    get_contact_by_user_id,
+    update_account_id,
+)
 from app.models import User
 
 
@@ -20,7 +25,7 @@ def test_create(mocker, notify_api, user):
     with notify_api.app_context():
         mock_session = mocker.MagicMock()
         mock_session.Contact.create.return_value = {"success": True, "id": "42"}
-        assert create(mock_session, user, "potatoes") == (True, "42")
+        assert create(mock_session, user, "potatoes") == "42"
         mock_session.Contact.create.assert_called_with(
             {
                 "FirstName": "Samwise",
@@ -38,11 +43,48 @@ def test_create_failed(mocker, notify_api, user):
     with notify_api.app_context():
         mock_session = mocker.MagicMock()
         mock_session.Contact.create.return_value = {"success": False}
-        assert create(mock_session, user, None) == (False, None)
+        assert create(mock_session, user, None) is None
 
 
 def test_create_exception(mocker, notify_api, user):
     with notify_api.app_context():
         mock_session = mocker.MagicMock()
         mock_session.Contact.create.side_effect = Exception()
-        assert create(mock_session, user, None) == (False, None)
+        assert create(mock_session, user, None) is None
+
+
+def test_update_account_id_existing(mocker, notify_api, user):
+    with notify_api.app_context():
+        mock_session = mocker.MagicMock()
+        mock_get_contact_by_user_id = mocker.patch.object(salesforce_contact, "get_contact_by_user_id", return_value={"Id": "42"})
+        mock_session.Contact.update.return_value = {"success": True, "Id": "42"}
+
+        assert update_account_id(mock_session, user, "potatoes") == "42"
+
+        mock_session.Contact.update.assert_called_with(
+            "42", {"AccountId": "potatoes"}, headers={"Sforce-Duplicate-Rule-Header": "allowSave=true"}
+        )
+        mock_get_contact_by_user_id.assert_called_with(mock_session, "2")
+
+
+def test_update_account_id_new(mocker, notify_api, user):
+    with notify_api.app_context():
+        mock_session = mocker.MagicMock()
+        mock_get_contact_by_user_id = mocker.patch.object(salesforce_contact, "get_contact_by_user_id", return_value=None)
+        mock_create = mocker.patch.object(salesforce_contact, "create", return_value="42")
+
+        assert update_account_id(mock_session, user, "potatoes") == "42"
+
+        mock_get_contact_by_user_id.assert_called_with(mock_session, "2")
+        mock_create.assert_called_with(mock_session, user, "potatoes")
+
+
+def test_get_contact_by_user_id(mocker, notify_api, user):
+    with notify_api.app_context():
+        mock_session = mocker.MagicMock()
+        mock_query_one = mocker.patch.object(salesforce_contact, "query_one", return_value={"Id": "42"})
+
+        assert get_contact_by_user_id(mock_session, "2") == {"Id": "42"}
+        mock_query_one.assert_called_with(
+            mock_session, "SELECT Id, FirstName, LastName, AccountId FROM Contact WHERE CDS_Contact_ID__c = '2' LIMIT 1"
+        )

--- a/tests/app/clients/test_salesforce_engagement.py
+++ b/tests/app/clients/test_salesforce_engagement.py
@@ -1,0 +1,72 @@
+import pytest
+
+from app.clients.salesforce import salesforce_engagement
+from app.clients.salesforce.salesforce_engagement import create
+from app.models import Service
+
+
+@pytest.fixture
+def service():
+    return Service(
+        **{
+            "id": 3,
+            "name": "The Fellowship",
+        }
+    )
+
+
+def test_create(mocker, notify_api, service):
+    with notify_api.app_context():
+        mock_session = mocker.MagicMock()
+        mock_session.Opportunity.create.return_value = {"success": True, "id": "9"}
+        mock_datetime = mocker.patch.object(salesforce_engagement, "datetime")
+        mock_datetime.today.return_value.strftime.return_value = "1970-01-01"
+        notify_api.config["SALESFORCE_ENGAGEMENT_RECORD_TYPE"] = "hobbitsis"
+        notify_api.config["SALESFORCE_ENGAGEMENT_STANDARD_PRICEBOOK_ID"] = "the ring"
+        notify_api.config["SALESFORCE_ENGAGEMENT_PRODUCT_ID"] = "my precious"
+
+        assert create(mock_session, service, "lambas", "123", "456") == "9"
+
+        mock_session.Opportunity.create.assert_called_with(
+            {
+                "Name": "The Fellowship",
+                "AccountId": "123",
+                "ContactId": "456",
+                "CDS_Opportunity_Number__c": "3",
+                "StageName": "lambas",
+                "CloseDate": "1970-01-01",
+                "RecordTypeId": "hobbitsis",
+                "Type": salesforce_engagement.ENGAGEMENT_TYPE,
+                "CDS_Lead_Team__c": salesforce_engagement.ENGAGEMENT_TEAM,
+                "Product_to_Add__c": salesforce_engagement.ENGAGEMENT_PRODUCT,
+            },
+            headers={"Sforce-Duplicate-Rule-Header": "allowSave=true"},
+        )
+
+        mock_session.OpportunityLineItem.create.assert_called_with(
+            {
+                "OpportunityId": "9",
+                "PricebookEntryId": "the ring",
+                "Product2Id": "my precious",
+                "Quantity": 1,
+                "UnitPrice": 0,
+            },
+            headers={"Sforce-Duplicate-Rule-Header": "allowSave=true"},
+        )
+
+
+def test_create_no_engagement_id(mocker, notify_api, service):
+    with notify_api.app_context():
+        mock_session = mocker.MagicMock()
+        mock_session.Opportunity.create.return_value = {"success": False}
+        assert create(mock_session, service, "lambas", "123", "456") is None
+        mock_session.Opportunity.create.assert_called_once()
+        mock_session.OpportunityLineItem.create.assert_not_called()
+
+
+def test_create_no_engagement(mocker, notify_api, service):
+    with notify_api.app_context():
+        mock_session = mocker.MagicMock()
+        assert create(mock_session, service, "lambas", None, None) is None
+        mock_session.Opportunity.create.assert_not_called()
+        mock_session.OpportunityLineItem.create.assert_not_called()


### PR DESCRIPTION
# Summary
Create a Salesforce Engagement when a new Notify service is created.  

The Notify user that creates the Engagement will have their associated Salesforce Contact updated.  If there is not already a Salesforce Contact for the Notify user, one will be created.

# Related
- cds-snc/platform-core-services#282