### PR TITLE
Revert "sign with DANGEROUS_SALT for now (#1799)"

### DIFF
--- a/app/encryption.py
+++ b/app/encryption.py
@@ -34,7 +34,7 @@ class CryptoSigner:
         self.dangerous_salt = app.config.get("DANGEROUS_SALT")
 
     def sign(self, to_sign: str | NotificationDictToSign) -> str | bytes:
-        return self.serializer.dumps(to_sign, salt=self.dangerous_salt)
+        return self.serializer.dumps(to_sign, salt=self.salt)
 
     # TODO: get rid of this after everything is signed with the new salts
     # This is only needed where we look things up by the signed value:

--- a/tests/app/test_encryption.py
+++ b/tests/app/test_encryption.py
@@ -25,7 +25,6 @@ class TestEncryption:
         with pytest.raises(BadSignature):
             signer2.verify(signer1.sign("this"))
 
-    @pytest.mark.skip(reason="temporariily using dangerous salt for all signing")
     def should_not_verify_content_signed_with_different_salts(self, notify_api):
         signer1 = CryptoSigner()
         signer2 = CryptoSigner()


### PR DESCRIPTION
This reverts commit 7d91af1e075930904a2bca202ae6b7f1e33d82ef.

# Summary | Résumé

Now that prod has the "verify with old or new salt" code, we can change the signing code back to using the new salt.

# Test instructions | Instructions pour tester la modification

Should be no differences.

In particular, should be able to view both old notifications and new ones and send using new or old api keys.

