### PR TITLE
feat: Salesforce Engagement go live flow

### DIFF
--- a/app/clients/salesforce/salesforce_account.py
+++ b/app/clients/salesforce/salesforce_account.py
@@ -36,7 +36,9 @@ def get_account_id_from_name(session: Salesforce, account_name: str, generic_acc
     Returns:
         Optional[str]: The matching Account ID or a generic Account ID if no match is found.
     """
-    account_name_sanitized = query_param_sanitize(account_name)
-    query = f"SELECT Id FROM Account where Name = '{account_name_sanitized}' OR CDS_AccountNameFrench__c = '{account_name_sanitized}' LIMIT 1"
-    result = query_one(session, query)
+    result = None
+    if isinstance(account_name, str) and account_name.strip() != "":
+        account_name_sanitized = query_param_sanitize(account_name)
+        query = f"SELECT Id FROM Account where Name = '{account_name_sanitized}' OR CDS_AccountNameFrench__c = '{account_name_sanitized}' LIMIT 1"
+        result = query_one(session, query)
     return result.get("Id") if result else generic_account_id

--- a/app/clients/salesforce/salesforce_contact.py
+++ b/app/clients/salesforce/salesforce_contact.py
@@ -92,5 +92,8 @@ def get_contact_by_user_id(session: Salesforce, user_id: str) -> Optional[dict[s
     Returns:
         Optional[dict[str, str]]: Salesforce Contact details or None if can't be found
     """
-    query = f"SELECT Id, FirstName, LastName, AccountId FROM Contact WHERE CDS_Contact_ID__c = '{query_param_sanitize(user_id)}' LIMIT 1"
-    return query_one(session, query)
+    result = None
+    if isinstance(user_id, str) and user_id:
+        query = f"SELECT Id, FirstName, LastName, AccountId FROM Contact WHERE CDS_Contact_ID__c = '{query_param_sanitize(user_id)}' LIMIT 1"
+        result = query_one(session, query)
+    return result

--- a/app/clients/salesforce/salesforce_contact.py
+++ b/app/clients/salesforce/salesforce_contact.py
@@ -93,7 +93,7 @@ def get_contact_by_user_id(session: Salesforce, user_id: str) -> Optional[dict[s
         Optional[dict[str, str]]: Salesforce Contact details or None if can't be found
     """
     result = None
-    if isinstance(user_id, str) and user_id:
+    if isinstance(user_id, str) and user_id.strip():
         query = f"SELECT Id, FirstName, LastName, AccountId FROM Contact WHERE CDS_Contact_ID__c = '{query_param_sanitize(user_id)}' LIMIT 1"
         result = query_one(session, query)
     return result

--- a/app/clients/salesforce/salesforce_engagement.py
+++ b/app/clients/salesforce/salesforce_engagement.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from flask import current_app
 from simple_salesforce import Salesforce
 
-from .salesforce_utils import parse_result
+from .salesforce_utils import parse_result, query_one, query_param_sanitize
 
 if TYPE_CHECKING:
     from app.models import Service
@@ -75,3 +75,58 @@ def create(
     except Exception as ex:
         current_app.logger.error(f"Salesforce Engagement create failed: {ex}")
     return engagement_id
+
+
+def update_stage(
+    session: Salesforce, service: Service, stage_name: str, account_id: Optional[str], contact_id: Optional[str]
+) -> Optional[str]:
+    """Update an Engagement's stage.  If the Engagement does not
+    exist, it is created.
+
+    Args:
+        session (Salesforce): Salesforce session to perform the operation.
+        service (Service): The service's details for the engagement.
+        stage_name (str): The service's stage name.
+        account_id (Optional[str]): Salesforce Account ID to associate with the Engagement.
+        contact_id (Optional[str]): Salesforce Contact ID to associate with the Engagement.
+
+    Returns:
+        Optional[str]: Updated Engagement ID or None if the operation failed.
+    """
+    engagement_id = None
+    try:
+        engagement = get_engagement_by_service_id(session, str(service.id))
+
+        # Existing Engagement, update the stage name
+        if engagement:
+            result = session.Opportunity.update(
+                engagement.get("Id"),
+                {"StageName": stage_name},
+                headers={"Sforce-Duplicate-Rule-Header": "allowSave=true"},
+            )
+            is_updated = parse_result(result, f"Salesforce Engagement update '{service}'")
+            engagement_id = engagement.get("Id") if is_updated else None
+        # Create the Engagement.  This handles Notify services that were created before Salesforce was added.
+        else:
+            engagement_id = create(session, service, stage_name, account_id, contact_id)
+
+    except Exception as ex:
+        current_app.logger.error(f"Salesforce Engagement update failed: {ex}")
+    return engagement_id
+
+
+def get_engagement_by_service_id(session: Salesforce, service_id: str) -> Optional[dict[str, Any]]:
+    """Retrieve a Salesforce Engagement by a Notify service ID
+
+    Args:
+        session (Salesforce): Salesforce session to perform the operation.
+        service_id (str): Notify service ID
+
+    Returns:
+        Optional[dict[str, str]]: Salesforce Engagement details or None if can't be found
+    """
+    result = None
+    if isinstance(service_id, str) and service_id:
+        query = f"SELECT Id, Name, ContactId, AccountId FROM Opportunity where CDS_Opportunity_Number__c = '{query_param_sanitize(service_id)}' LIMIT 1"
+        result = query_one(session, query)
+    return result

--- a/app/clients/salesforce/salesforce_engagement.py
+++ b/app/clients/salesforce/salesforce_engagement.py
@@ -126,7 +126,7 @@ def get_engagement_by_service_id(session: Salesforce, service_id: str) -> Option
         Optional[dict[str, str]]: Salesforce Engagement details or None if can't be found
     """
     result = None
-    if isinstance(service_id, str) and service_id:
+    if isinstance(service_id, str) and service_id.strip():
         query = f"SELECT Id, Name, ContactId, AccountId FROM Opportunity where CDS_Opportunity_Number__c = '{query_param_sanitize(service_id)}' LIMIT 1"
         result = query_one(session, query)
     return result

--- a/tests/app/clients/test_salesforce_account.py
+++ b/tests/app/clients/test_salesforce_account.py
@@ -32,3 +32,11 @@ def test_get_account_id_from_name_generic(mocker, notify_api):
         mock_query_one.assert_called_with(
             mock_session, "SELECT Id FROM Account where Name = 'l\\'account' OR CDS_AccountNameFrench__c = 'l\\'account' LIMIT 1"
         )
+
+
+def test_get_account_id_from_name_blank(mocker, notify_api):
+    mock_session = mocker.MagicMock()
+    with notify_api.app_context():
+        assert get_account_id_from_name(mock_session, None, "generic_account_id") == "generic_account_id"
+        assert get_account_id_from_name(mock_session, "", "generic_account_id") == "generic_account_id"
+        assert get_account_id_from_name(mock_session, "     ", "generic_account_id") == "generic_account_id"

--- a/tests/app/clients/test_salesforce_contact.py
+++ b/tests/app/clients/test_salesforce_contact.py
@@ -79,7 +79,7 @@ def test_update_account_id_new(mocker, notify_api, user):
         mock_create.assert_called_with(mock_session, user, "potatoes")
 
 
-def test_get_contact_by_user_id(mocker, notify_api, user):
+def test_get_contact_by_user_id(mocker, notify_api):
     with notify_api.app_context():
         mock_session = mocker.MagicMock()
         mock_query_one = mocker.patch.object(salesforce_contact, "query_one", return_value={"Id": "42"})
@@ -88,3 +88,11 @@ def test_get_contact_by_user_id(mocker, notify_api, user):
         mock_query_one.assert_called_with(
             mock_session, "SELECT Id, FirstName, LastName, AccountId FROM Contact WHERE CDS_Contact_ID__c = '2' LIMIT 1"
         )
+
+
+def test_get_contact_by_user_id_blank(mocker, notify_api):
+    with notify_api.app_context():
+        mock_session = mocker.MagicMock()
+        assert get_contact_by_user_id(mock_session, None) is None
+        assert get_contact_by_user_id(mock_session, "") is None
+        assert get_contact_by_user_id(mock_session, "       ") is None

--- a/tests/app/clients/test_salesforce_engagement.py
+++ b/tests/app/clients/test_salesforce_engagement.py
@@ -1,7 +1,11 @@
 import pytest
 
 from app.clients.salesforce import salesforce_engagement
-from app.clients.salesforce.salesforce_engagement import create
+from app.clients.salesforce.salesforce_engagement import (
+    create,
+    get_engagement_by_service_id,
+    update_stage,
+)
 from app.models import Service
 
 
@@ -70,3 +74,60 @@ def test_create_no_engagement(mocker, notify_api, service):
         assert create(mock_session, service, "lambas", None, None) is None
         mock_session.Opportunity.create.assert_not_called()
         mock_session.OpportunityLineItem.create.assert_not_called()
+
+
+def test_update_stage_existing(mocker, notify_api, service):
+    with notify_api.app_context():
+        mock_session = mocker.MagicMock()
+        mock_get_engagement_by_service_id = mocker.patch.object(
+            salesforce_engagement, "get_engagement_by_service_id", return_value={"Id": "42"}
+        )
+        mock_session.Opportunity.update.return_value = {"success": True, "Id": "42"}
+
+        assert update_stage(mock_session, service, "potatoes", None, None) == "42"
+
+        mock_session.Opportunity.update.assert_called_with(
+            "42", {"StageName": "potatoes"}, headers={"Sforce-Duplicate-Rule-Header": "allowSave=true"}
+        )
+        mock_get_engagement_by_service_id.assert_called_with(mock_session, "3")
+
+
+def test_update_stage_new(mocker, notify_api, service):
+    with notify_api.app_context():
+        mock_session = mocker.MagicMock()
+        mock_get_engagement_by_service_id = mocker.patch.object(
+            salesforce_engagement, "get_engagement_by_service_id", return_value=None
+        )
+        mock_create = mocker.patch.object(salesforce_engagement, "create", return_value="42")
+
+        assert update_stage(mock_session, service, "potatoes", "account_id", "contact_id") == "42"
+
+        mock_get_engagement_by_service_id.assert_called_with(mock_session, "3")
+        mock_create.assert_called_with(mock_session, service, "potatoes", "account_id", "contact_id")
+
+
+def test_update_stage_failed(mocker, notify_api, service):
+    with notify_api.app_context():
+        mock_session = mocker.MagicMock()
+        mocker.patch.object(salesforce_engagement, "get_engagement_by_service_id", return_value={"Id": "42"})
+        mock_session.Opportunity.update.return_value = {"success": False}
+        assert update_stage(mock_session, service, "potatoes", "account_id", "contact_id") is None
+
+
+def test_get_engagement_by_service_id(mocker, notify_api):
+    with notify_api.app_context():
+        mock_session = mocker.MagicMock()
+        mock_query_one = mocker.patch.object(salesforce_engagement, "query_one", return_value={"Id": "42"})
+
+        assert get_engagement_by_service_id(mock_session, "2") == {"Id": "42"}
+        mock_query_one.assert_called_with(
+            mock_session, "SELECT Id, Name, ContactId, AccountId FROM Opportunity where CDS_Opportunity_Number__c = '2' LIMIT 1"
+        )
+
+
+def test_get_engagement_by_service_id_blank(mocker, notify_api):
+    with notify_api.app_context():
+        mock_session = mocker.MagicMock()
+        assert get_engagement_by_service_id(mock_session, None) is None
+        assert get_engagement_by_service_id(mock_session, "") is None
+        assert get_engagement_by_service_id(mock_session, "       ") is None


### PR DESCRIPTION
## Summary
Update the Salesforce Engagement stage as a Notify service goes through the `go live` flow.

This involves setting the Engagement stage to `Activiation` when the request to go live is made.  Once the service is set as live, the Engagement stage is then set to `Live`.

## Test instructions
### With env var `FF_SALESFORCE_CONTACT = True`
1. Login and create a new service.
1. Check Salesforce and expect to see a new Engagement with `stage = Trial`
1. Request for the service to go live.
1. Check Salesforce and expect the service Engagement to have `stage = Activation`
1. Set the service as live.
1. Check Salesforce and expect the service Engagement to have `stage = Live`

### With env var `FF_SALESFORCE_CONTACT = False`
1. Repeat the above Notify steps and expect no Salesforce Engagement creation or stage updates.

## Related
- cds-snc/platform-core-services#285