### PR TITLE
feat: add timeout to Salesforce API requests

### DIFF
--- a/app/clients/salesforce/salesforce_auth.py
+++ b/app/clients/salesforce/salesforce_auth.py
@@ -2,12 +2,14 @@ import requests
 from flask import current_app
 from simple_salesforce import Salesforce
 
+SALESFORCE_TIMEOUT_SECONDS = 10
+
 
 class TimeoutAdapter(requests.adapters.HTTPAdapter):
     """Custom adapter to add a timeout to Salesforce API requests"""
 
     def send(self, *args, **kwargs):
-        kwargs["timeout"] = 10
+        kwargs["timeout"] = SALESFORCE_TIMEOUT_SECONDS
         return super().send(*args, **kwargs)
 
 

--- a/app/clients/salesforce/salesforce_auth.py
+++ b/app/clients/salesforce/salesforce_auth.py
@@ -1,5 +1,14 @@
+import requests
 from flask import current_app
 from simple_salesforce import Salesforce
+
+
+class TimeoutAdapter(requests.adapters.HTTPAdapter):
+    """Custom adapter to add a timeout to Salesforce API requests"""
+
+    def send(self, *args, **kwargs):
+        kwargs["timeout"] = 10
+        return super().send(*args, **kwargs)
 
 
 def get_session(client_id: str, username: str, password: str, security_token: str, domain: str) -> Salesforce:
@@ -17,12 +26,18 @@ def get_session(client_id: str, username: str, password: str, security_token: st
     """
     session = None
     try:
+        # Add a timeout to Salesforce API requests
+        requests_session = requests.Session()
+        requests_session.mount("https://", TimeoutAdapter())
+        requests_session.mount("http://", TimeoutAdapter())
+
         session = Salesforce(
             client_id=client_id,
             username=username,
             password=password,
             security_token=security_token,
             domain=domain,
+            session=requests_session,
         )
     except Exception as ex:
         current_app.logger.error(f"Salesforce login failed: {ex}")

--- a/tests/app/clients/test_salesforce_auth.py
+++ b/tests/app/clients/test_salesforce_auth.py
@@ -1,3 +1,5 @@
+from unittest.mock import call
+
 from simple_salesforce.exceptions import SalesforceAuthenticationFailed
 
 from app.clients.salesforce import salesforce_auth
@@ -7,9 +9,20 @@ from app.clients.salesforce.salesforce_auth import end_session, get_session
 def test_get_session(mocker, notify_api):
     with notify_api.app_context():
         mock_salesforce = mocker.patch.object(salesforce_auth, "Salesforce", return_value="session")
+        mock_timeout_adapter = mocker.patch.object(salesforce_auth, "TimeoutAdapter", return_value="timeout_adapter")
+        mock_requests = mocker.patch.object(salesforce_auth, "requests")
+        mock_requests.Session.return_value = mocker.MagicMock()
         assert get_session("client_id", "username", "password", "security_token", "domain") == mock_salesforce.return_value
         mock_salesforce.assert_called_with(
-            client_id="client_id", username="username", password="password", security_token="security_token", domain="domain"
+            client_id="client_id",
+            username="username",
+            password="password",
+            security_token="security_token",
+            domain="domain",
+            session=mock_requests.Session.return_value,
+        )
+        mock_requests.Session.return_value.mount.assert_has_calls(
+            [call("https://", mock_timeout_adapter.return_value), call("http://", mock_timeout_adapter.return_value)]
         )
 
 


### PR DESCRIPTION
# Summary
Update the Salesforce API requests to timeout after 10 seconds. This will prevent excessive waiting for Notify users if the Salesforce API is unresponsive.