### PR TITLE
feat: close engagement when service deleted

### DIFF
--- a/app/clients/salesforce/salesforce_account.py
+++ b/app/clients/salesforce/salesforce_account.py
@@ -4,23 +4,31 @@ from simple_salesforce import Salesforce
 
 from .salesforce_utils import query_one, query_param_sanitize
 
+ORG_NOTES_ORG_NAME_INDEX = 0
+ORG_NOTES_OTHER_NAME_INDEX = 1
 
-def get_account_name_from_org(organisation_notes: str) -> str:
-    """Given a service's organisation notes, returns the Account name
-    which is the first segment of the organisation notes before the `>` character.
-    If the notes do not contain a `>` character, the entire notes are returned.
+
+def get_org_name_from_notes(organisation_notes: str, name_index: int = ORG_NOTES_ORG_NAME_INDEX) -> str:
+    """Given a service's organisation notes, returns either the organisation name or
+    organisation other name.  The organisation notes structure is as follows:
+
+    ORG_NAME > ORG_OTHER_NAME
+
+    If the `>` character is not found, the entire organisation notes is returned.
 
     TODO: This could be improved by explicitly passing the selected Account name
     to the API from Admin rather than parsing it out of the organisation notes.
 
     Args:
         organisation_notes (str): The service's organisation notes
+        name_index (int): The index of the name to return.  Defaults to 0 (organisation name).
 
     Returns:
-        str: The Account name
+        str: The organisation name or organisation other name.
     """
-    if isinstance(organisation_notes, str) and ">" in organisation_notes:
-        return organisation_notes.split(">")[0].strip()
+    note_parts = organisation_notes.split(">") if isinstance(organisation_notes, str) else []
+    if len(note_parts) > name_index:
+        return note_parts[name_index].strip()
     return organisation_notes
 
 

--- a/app/clients/salesforce/salesforce_engagement.py
+++ b/app/clients/salesforce/salesforce_engagement.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Optional
 from flask import current_app
 from simple_salesforce import Salesforce
 
+from .salesforce_account import ORG_NOTES_OTHER_NAME_INDEX, get_org_name_from_notes
 from .salesforce_utils import parse_result, query_one, query_param_sanitize
 
 if TYPE_CHECKING:
@@ -15,19 +16,20 @@ ENGAGEMENT_PRODUCT = "GC Notify"
 ENGAGEMENT_TEAM = "Platform"
 ENGAGEMENT_TYPE = "New Business"
 ENGAGEMENT_STAGE_ACTIVATION = "Activation"
+ENGAGEMENT_STAGE_CLOSED = "Closed"
 ENGAGEMENT_STAGE_LIVE = "Live"
 ENGAGEMENT_STAGE_TRIAL = "Trial Account"
 
 
 def create(
-    session: Salesforce, service: Service, stage_name: str, account_id: Optional[str], contact_id: Optional[str]
+    session: Salesforce, service: Service, field_updates: dict[str, str], account_id: Optional[str], contact_id: Optional[str]
 ) -> Optional[str]:
     """Create a Salesforce Engagement for the given Notify service
 
     Args:
         session (Salesforce): Salesforce session to perform the operation.
         service (Service): The service's details for the engagement.
-        stage_name (str): The service's stage name.
+        field_updates (Optional[dict[str, str]]): Custom values used to override any default values.
         account_id (Optional[str]): Salesforce Account ID to associate with the Engagement.
         contact_id (Optional[str]): Salesforce Contact ID to associate with the Engagement.
 
@@ -37,19 +39,23 @@ def create(
     engagement_id = None
     try:
         if account_id and contact_id:
+            # Default Engagement values, which can be overridden by passing in field_updates
+            field_default_values = {
+                "Name": service.name,
+                "AccountId": account_id,
+                "ContactId": contact_id,
+                "CDS_Opportunity_Number__c": str(service.id),
+                "Notify_Organization_Other__c": get_org_name_from_notes(service.organisation_notes, ORG_NOTES_OTHER_NAME_INDEX),
+                "CloseDate": datetime.today().strftime("%Y-%m-%d"),
+                "RecordTypeId": current_app.config["SALESFORCE_ENGAGEMENT_RECORD_TYPE"],
+                "StageName": ENGAGEMENT_STAGE_TRIAL,
+                "Type": ENGAGEMENT_TYPE,
+                "CDS_Lead_Team__c": ENGAGEMENT_TEAM,
+                "Product_to_Add__c": ENGAGEMENT_PRODUCT,
+            }
+            field_values = field_default_values | field_updates
             result = session.Opportunity.create(
-                {
-                    "Name": service.name,
-                    "AccountId": account_id,
-                    "ContactId": contact_id,
-                    "CDS_Opportunity_Number__c": str(service.id),
-                    "StageName": stage_name,
-                    "CloseDate": datetime.today().strftime("%Y-%m-%d"),
-                    "RecordTypeId": current_app.config["SALESFORCE_ENGAGEMENT_RECORD_TYPE"],
-                    "Type": ENGAGEMENT_TYPE,
-                    "CDS_Lead_Team__c": ENGAGEMENT_TEAM,
-                    "Product_to_Add__c": ENGAGEMENT_PRODUCT,
-                },
+                field_values,
                 headers={"Sforce-Duplicate-Rule-Header": "allowSave=true"},
             )
             parse_result(result, f"Salesforce Engagement create for service ID {service.id}")
@@ -77,16 +83,15 @@ def create(
     return engagement_id
 
 
-def update_stage(
-    session: Salesforce, service: Service, stage_name: str, account_id: Optional[str], contact_id: Optional[str]
+def update(
+    session: Salesforce, service: Service, field_updates: dict[str, str], account_id: Optional[str], contact_id: Optional[str]
 ) -> Optional[str]:
-    """Update an Engagement's stage.  If the Engagement does not
-    exist, it is created.
+    """Update an Engagement.  If the Engagement does not exist, it is created.
 
     Args:
         session (Salesforce): Salesforce session to perform the operation.
         service (Service): The service's details for the engagement.
-        stage_name (str): The service's stage name.
+        field_updates (dict[str, str]): The engagement fields to update.
         account_id (Optional[str]): Salesforce Account ID to associate with the Engagement.
         contact_id (Optional[str]): Salesforce Contact ID to associate with the Engagement.
 
@@ -101,14 +106,14 @@ def update_stage(
         if engagement:
             result = session.Opportunity.update(
                 engagement.get("Id"),
-                {"StageName": stage_name},
+                field_updates,
                 headers={"Sforce-Duplicate-Rule-Header": "allowSave=true"},
             )
             is_updated = parse_result(result, f"Salesforce Engagement update '{service}'")
             engagement_id = engagement.get("Id") if is_updated else None
         # Create the Engagement.  This handles Notify services that were created before Salesforce was added.
         else:
-            engagement_id = create(session, service, stage_name, account_id, contact_id)
+            engagement_id = create(session, service, field_updates, account_id, contact_id)
 
     except Exception as ex:
         current_app.logger.error(f"Salesforce Engagement update failed: {ex}")

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -701,6 +701,11 @@ def archive_service(service_id):
 
     if service.active:
         dao_archive_service(service.id)
+        if current_app.config["FF_SALESFORCE_CONTACT"]:
+            try:
+                salesforce_client.engagement_close(service)
+            except Exception as e:
+                current_app.logger.exception(e)
 
     return "", 204
 

--- a/tests/app/clients/test_salesforce_account.py
+++ b/tests/app/clients/test_salesforce_account.py
@@ -1,16 +1,19 @@
 from app.clients.salesforce import salesforce_account
 from app.clients.salesforce.salesforce_account import (
+    ORG_NOTES_ORG_NAME_INDEX,
+    ORG_NOTES_OTHER_NAME_INDEX,
     get_account_id_from_name,
-    get_account_name_from_org,
+    get_org_name_from_notes,
 )
 
 
-def test_get_account_name_from_org():
-    assert get_account_name_from_org("Account Name 1 > Service Name") == "Account Name 1"
-    assert get_account_name_from_org("Account Name 2") == "Account Name 2"
-    assert get_account_name_from_org("Account Name 3 >") == "Account Name 3"
-    assert get_account_name_from_org("Account Name 4 > Service Name > Team Name") == "Account Name 4"
-    assert get_account_name_from_org(None) is None
+def test_get_org_name_from_notes():
+    assert get_org_name_from_notes("Account Name 1 > Service Name", ORG_NOTES_ORG_NAME_INDEX) == "Account Name 1"
+    assert get_org_name_from_notes("Account Name 2 > Another service Name") == "Account Name 2"
+    assert get_org_name_from_notes("Account Name 3 > Some service", ORG_NOTES_OTHER_NAME_INDEX) == "Some service"
+    assert get_org_name_from_notes("Account Name 4 > Service Name > Team Name", 2) == "Team Name"
+    assert get_org_name_from_notes(None) is None
+    assert get_org_name_from_notes(">") == ""
 
 
 def test_get_account_id_from_name(mocker, notify_api):

--- a/tests/app/clients/test_salesforce_client.py
+++ b/tests/app/clients/test_salesforce_client.py
@@ -52,7 +52,7 @@ def test_contact_create(mocker, salesforce_client):
 
 def test_contact_update_account_id(mocker, salesforce_client):
     mock_get_account_name_from_org = mocker.patch.object(
-        salesforce_account, "get_account_name_from_org", return_value="account_name"
+        salesforce_account, "get_org_name_from_notes", return_value="account_name"
     )
     mock_get_account_id_from_name = mocker.patch.object(salesforce_account, "get_account_id_from_name", return_value="account_id")
     mock_update_account_id = mocker.patch.object(salesforce_contact, "update_account_id", return_value="contact_id")
@@ -81,9 +81,7 @@ def test_engagement_create(mocker, salesforce_client):
 
     mock_get_session.assert_called_once()
     mock_contact_update_account_id.assert_called_once_with("session", mock_service, "user")
-    mock_create.assert_called_once_with(
-        "session", mock_service, salesforce_engagement.ENGAGEMENT_STAGE_TRIAL, "account_id", "contact_id"
-    )
+    mock_create.assert_called_once_with("session", mock_service, {}, "account_id", "contact_id")
     mock_end_session.assert_called_once_with("session")
 
 
@@ -92,7 +90,7 @@ def test_engagement_update_stage(mocker, salesforce_client):
     mock_contact_update_account_id = mocker.patch.object(
         salesforce_client, "contact_update_account_id", return_value=("account_id", "contact_id")
     )
-    mock_update_stage = mocker.patch.object(salesforce_engagement, "update_stage")
+    mock_update = mocker.patch.object(salesforce_engagement, "update")
     mock_end_session = mocker.patch.object(salesforce_client, "end_session")
     mock_service = mocker.MagicMock()
     mock_service.organisation_notes = "account_name > service_name"
@@ -101,5 +99,43 @@ def test_engagement_update_stage(mocker, salesforce_client):
 
     mock_get_session.assert_called_once()
     mock_contact_update_account_id.assert_called_once_with("session", mock_service, "user")
-    mock_update_stage.assert_called_once_with("session", mock_service, "live", "account_id", "contact_id")
+    mock_update.assert_called_once_with("session", mock_service, {"StageName": "live"}, "account_id", "contact_id")
+    mock_end_session.assert_called_once_with("session")
+
+
+def test_engagement_close(mocker, salesforce_client):
+    mock_get_session = mocker.patch.object(salesforce_client, "get_session", return_value="session")
+    mock_get_engagement_by_service_id = mocker.patch.object(
+        salesforce_engagement, "get_engagement_by_service_id", return_value="engagement_id"
+    )
+    mock_update = mocker.patch.object(salesforce_engagement, "update")
+    mock_end_session = mocker.patch.object(salesforce_client, "end_session")
+    mock_service = mocker.MagicMock()
+    mock_service.id = "service_id"
+
+    salesforce_client.engagement_close(mock_service)
+
+    mock_get_session.assert_called_once()
+    mock_get_engagement_by_service_id.assert_called_once_with("session", mock_service.id)
+    mock_update.assert_called_once_with(
+        "session", mock_service, {"CDS_Close_Reason__c": "Trial deleted by user", "StageName": "Closed"}, None, None
+    )
+    mock_end_session.assert_called_once_with("session")
+
+
+def test_engagement_close_no_engagement(mocker, salesforce_client):
+    mock_get_session = mocker.patch.object(salesforce_client, "get_session", return_value="session")
+    mock_get_engagement_by_service_id = mocker.patch.object(
+        salesforce_engagement, "get_engagement_by_service_id", return_value=None
+    )
+    mock_update = mocker.patch.object(salesforce_engagement, "update")
+    mock_end_session = mocker.patch.object(salesforce_client, "end_session")
+    mock_service = mocker.MagicMock()
+    mock_service.id = "service_id"
+
+    salesforce_client.engagement_close(mock_service)
+
+    mock_get_session.assert_called_once()
+    mock_get_engagement_by_service_id.assert_called_once_with("session", mock_service.id)
+    mock_update.assert_not_called()
     mock_end_session.assert_called_once_with("session")


### PR DESCRIPTION
# Summary 
Add Salesforce integration that closes an Engagement if a linked Notify Service is deleted.

Update the Engagement create operation to include the other organisation name if it is provided.