### PR TITLE
feat: update Salesforce contact if profile changes

### DIFF
--- a/app/clients/salesforce/salesforce_contact.py
+++ b/app/clients/salesforce/salesforce_contact.py
@@ -56,10 +56,10 @@ def update(session: Salesforce, user: User, field_updates: dict[str, Optional[st
     Args:
         session (Salesforce): Salesforce session used to perform the operation.
         user (User): Notify User object for the linked Contact to update
-        field_updates (dict[str, str]): The contact fields to update.
+        field_updates (dict[str, Optional[str]]): The contact fields to update.
 
     Returns:
-         contact_id (str): ID of the updated Contact or None if the operation failed
+        contact_id (Optional[str]): ID of the updated Contact or None if the operation failed
     """
     contact_id = None
     try:

--- a/app/clients/salesforce/salesforce_contact.py
+++ b/app/clients/salesforce/salesforce_contact.py
@@ -16,13 +16,13 @@ if TYPE_CHECKING:
     from app.models import User
 
 
-def create(session: Salesforce, user: User, account_id: Optional[str]) -> Optional[str]:
+def create(session: Salesforce, user: User, field_updates: dict[str, Optional[str]]) -> Optional[str]:
     """Create a Salesforce Contact from the given Notify User
 
     Args:
         session (Salesforce): Salesforce session used to perform the operation.
         user (User): Notify User that has just been activated.
-        account_id (str | None, optional): ID of the Account to associate the Contact with.
+        field_updates (Optional[dict[str, str]]): Custom values used to override any default values.
 
     Returns:
         Optional[str]: Newly created Contact ID or None if the operation failed.
@@ -30,15 +30,16 @@ def create(session: Salesforce, user: User, account_id: Optional[str]) -> Option
     contact_id = None
     try:
         name_parts = get_name_parts(user.name)
+        field_default_values = {
+            "FirstName": name_parts["first"] if name_parts["first"] else user.name,
+            "LastName": name_parts["last"] if name_parts["last"] else "",
+            "Title": "created by Notify API",
+            "CDS_Contact_ID__c": str(user.id),
+            "Email": user.email_address,
+        }
+        field_values = field_default_values | field_updates
         result = session.Contact.create(
-            {
-                "FirstName": name_parts["first"] if name_parts["first"] else user.name,
-                "LastName": name_parts["last"] if name_parts["last"] else "",
-                "Title": "created by Notify API",
-                "CDS_Contact_ID__c": str(user.id),
-                "Email": user.email_address,
-                "AccountId": account_id,
-            },
+            field_values,
             headers={"Sforce-Duplicate-Rule-Header": "allowSave=true"},
         )
         parse_result(result, f"Salesforce Contact create for '{user.email_address}'")
@@ -49,14 +50,13 @@ def create(session: Salesforce, user: User, account_id: Optional[str]) -> Option
     return contact_id
 
 
-def update_account_id(session: Salesforce, user: User, account_id: Optional[str]) -> Optional[str]:
-    """Update the Account ID of a Contact.  If the Contact does not
-    exist, it is created.
+def update(session: Salesforce, user: User, field_updates: dict[str, Optional[str]]) -> Optional[str]:
+    """Update a Contact's details.  If the Contact does not  exist, it is created.
 
     Args:
         session (Salesforce): Salesforce session used to perform the operation.
         user (User): Notify User object for the linked Contact to update
-        account_id (str): ID of the Salesforce Account
+        field_updates (dict[str, str]): The contact fields to update.
 
     Returns:
          contact_id (str): ID of the updated Contact or None if the operation failed
@@ -68,13 +68,13 @@ def update_account_id(session: Salesforce, user: User, account_id: Optional[str]
         # Existing contact, update the AccountID
         if contact:
             result = session.Contact.update(
-                contact.get("Id"), {"AccountId": account_id}, headers={"Sforce-Duplicate-Rule-Header": "allowSave=true"}
+                contact.get("Id"), field_updates, headers={"Sforce-Duplicate-Rule-Header": "allowSave=true"}
             )
-            parse_result(result, f"Salesforce Contact update '{user.email_address}' with account ID '{account_id}'")
+            parse_result(result, f"Salesforce Contact update '{user.email_address}' with '{field_updates}'")
             contact_id = contact.get("Id")
         # Create the new contact
         else:
-            contact_id = create(session, user, account_id)
+            contact_id = create(session, user, field_updates)
 
     except Exception as ex:
         current_app.logger.error(f"Salesforce Contact update failed: {ex}")

--- a/app/clients/salesforce/salesforce_engagement.py
+++ b/app/clients/salesforce/salesforce_engagement.py
@@ -109,7 +109,7 @@ def update(
                 field_updates,
                 headers={"Sforce-Duplicate-Rule-Header": "allowSave=true"},
             )
-            is_updated = parse_result(result, f"Salesforce Engagement update '{service}'")
+            is_updated = parse_result(result, f"Salesforce Engagement update '{service}' with '{field_updates}'")
             engagement_id = engagement.get("Id") if is_updated else None
         # Create the Engagement.  This handles Notify services that were created before Salesforce was added.
         else:

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -178,6 +178,13 @@ def update_user_attribute(user_id):
 
         send_notification_to_queue(saved_notification, False, queue=QueueNames.NOTIFY)
 
+    if current_app.config["FF_SALESFORCE_CONTACT"]:
+        try:
+            updated_user = get_user_by_id(user_id=user_id)
+            salesforce_client.contact_update(updated_user)
+        except Exception as e:
+            current_app.logger.exception(e)
+
     return jsonify(data=user_to_update.serialize()), 200
 
 

--- a/tests/app/clients/test_salesforce_client.py
+++ b/tests/app/clients/test_salesforce_client.py
@@ -7,6 +7,7 @@ from app.clients.salesforce import (
     salesforce_engagement,
 )
 from app.clients.salesforce.salesforce_client import SalesforceClient
+from app.models import User
 
 
 @pytest.fixture(scope="function")
@@ -43,10 +44,38 @@ def test_contact_create(mocker, salesforce_client):
     mock_create = mocker.patch.object(salesforce_contact, "create")
     mock_end_session = mocker.patch.object(salesforce_client, "end_session")
 
-    salesforce_client.contact_create("user", "account_id")
+    salesforce_client.contact_create("user")
 
     mock_get_session.assert_called_once()
-    mock_create.assert_called_once_with("session", "user", "account_id")
+    mock_create.assert_called_once_with("session", "user", {})
+    mock_end_session.assert_called_once_with("session")
+
+
+def test_contact_update(mocker, salesforce_client):
+    mock_get_session = mocker.patch.object(salesforce_client, "get_session", return_value="session")
+    mock_update = mocker.patch.object(salesforce_contact, "update")
+    mock_end_session = mocker.patch.object(salesforce_client, "end_session")
+    mock_user = User(
+        **{
+            "id": 2,
+            "name": "Samwise Gamgee",
+            "email_address": "samwise@fellowship.ca",
+            "platform_admin": False,
+        }
+    )
+
+    salesforce_client.contact_update(mock_user)
+
+    mock_get_session.assert_called_once()
+    mock_update.assert_called_once_with(
+        "session",
+        mock_user,
+        {
+            "FirstName": "Samwise",
+            "LastName": "Gamgee",
+            "Email": "samwise@fellowship.ca",
+        },
+    )
     mock_end_session.assert_called_once_with("session")
 
 
@@ -55,7 +84,7 @@ def test_contact_update_account_id(mocker, salesforce_client):
         salesforce_account, "get_org_name_from_notes", return_value="account_name"
     )
     mock_get_account_id_from_name = mocker.patch.object(salesforce_account, "get_account_id_from_name", return_value="account_id")
-    mock_update_account_id = mocker.patch.object(salesforce_contact, "update_account_id", return_value="contact_id")
+    mock_update = mocker.patch.object(salesforce_contact, "update", return_value="contact_id")
     mock_session = mocker.MagicMock()
     mock_service = mocker.MagicMock()
     mock_service.organisation_notes = "account_name > service_name"
@@ -64,7 +93,7 @@ def test_contact_update_account_id(mocker, salesforce_client):
 
     mock_get_account_name_from_org.assert_called_once_with(mock_service.organisation_notes)
     mock_get_account_id_from_name.assert_called_once_with(mock_session, "account_name", "someaccountid")
-    mock_update_account_id.assert_called_once_with(mock_session, "user", "account_id")
+    mock_update.assert_called_once_with(mock_session, "user", {"AccountId": "account_id"})
 
 
 def test_engagement_create(mocker, salesforce_client):

--- a/tests/app/clients/test_salesforce_contact.py
+++ b/tests/app/clients/test_salesforce_contact.py
@@ -4,7 +4,7 @@ from app.clients.salesforce import salesforce_contact
 from app.clients.salesforce.salesforce_contact import (
     create,
     get_contact_by_user_id,
-    update_account_id,
+    update,
 )
 from app.models import User
 
@@ -25,7 +25,7 @@ def test_create(mocker, notify_api, user):
     with notify_api.app_context():
         mock_session = mocker.MagicMock()
         mock_session.Contact.create.return_value = {"success": True, "id": "42"}
-        assert create(mock_session, user, "potatoes") == "42"
+        assert create(mock_session, user, {}) == "42"
         mock_session.Contact.create.assert_called_with(
             {
                 "FirstName": "Samwise",
@@ -33,7 +33,25 @@ def test_create(mocker, notify_api, user):
                 "Title": "created by Notify API",
                 "CDS_Contact_ID__c": "2",
                 "Email": "samwise@fellowship.ca",
-                "AccountId": "potatoes",
+            },
+            headers={"Sforce-Duplicate-Rule-Header": "allowSave=true"},
+        )
+
+
+def test_create_custom(mocker, notify_api, user):
+    with notify_api.app_context():
+        mock_session = mocker.MagicMock()
+        mock_session.Contact.create.return_value = {"success": True, "id": "42"}
+        assert create(mock_session, user, {"AccountId": "Samwise", "Lambas": "Bread"}) == "42"
+        mock_session.Contact.create.assert_called_with(
+            {
+                "FirstName": "Samwise",
+                "LastName": "Gamgee",
+                "Title": "created by Notify API",
+                "CDS_Contact_ID__c": "2",
+                "Email": "samwise@fellowship.ca",
+                "AccountId": "Samwise",
+                "Lambas": "Bread",
             },
             headers={"Sforce-Duplicate-Rule-Header": "allowSave=true"},
         )
@@ -43,14 +61,14 @@ def test_create_failed(mocker, notify_api, user):
     with notify_api.app_context():
         mock_session = mocker.MagicMock()
         mock_session.Contact.create.return_value = {"success": False}
-        assert create(mock_session, user, None) is None
+        assert create(mock_session, user, {}) is None
 
 
 def test_create_exception(mocker, notify_api, user):
     with notify_api.app_context():
         mock_session = mocker.MagicMock()
         mock_session.Contact.create.side_effect = Exception()
-        assert create(mock_session, user, None) is None
+        assert create(mock_session, user, {}) is None
 
 
 def test_update_account_id_existing(mocker, notify_api, user):
@@ -59,10 +77,10 @@ def test_update_account_id_existing(mocker, notify_api, user):
         mock_get_contact_by_user_id = mocker.patch.object(salesforce_contact, "get_contact_by_user_id", return_value={"Id": "42"})
         mock_session.Contact.update.return_value = {"success": True, "Id": "42"}
 
-        assert update_account_id(mock_session, user, "potatoes") == "42"
+        assert update(mock_session, user, {"AccountId": "potatoes", "Foo": "Bar"}) == "42"
 
         mock_session.Contact.update.assert_called_with(
-            "42", {"AccountId": "potatoes"}, headers={"Sforce-Duplicate-Rule-Header": "allowSave=true"}
+            "42", {"AccountId": "potatoes", "Foo": "Bar"}, headers={"Sforce-Duplicate-Rule-Header": "allowSave=true"}
         )
         mock_get_contact_by_user_id.assert_called_with(mock_session, "2")
 
@@ -73,10 +91,10 @@ def test_update_account_id_new(mocker, notify_api, user):
         mock_get_contact_by_user_id = mocker.patch.object(salesforce_contact, "get_contact_by_user_id", return_value=None)
         mock_create = mocker.patch.object(salesforce_contact, "create", return_value="42")
 
-        assert update_account_id(mock_session, user, "potatoes") == "42"
+        assert update(mock_session, user, {"AccountId": "potatoes", "Bam": "Baz"}) == "42"
 
         mock_get_contact_by_user_id.assert_called_with(mock_session, "2")
-        mock_create.assert_called_with(mock_session, user, "potatoes")
+        mock_create.assert_called_with(mock_session, user, {"AccountId": "potatoes", "Bam": "Baz"})
 
 
 def test_get_contact_by_user_id(mocker, notify_api):


### PR DESCRIPTION
# Summary
Update a Notify user's linked Salesforce Contact if the user profile is updated.

This change also applies the same Salesforce Contact refactor that was made to the Engagements, which will make it easier to support future update requirements.

# Related
- Closes cds-snc/platform-core-services#304