### PR TITLE
Adjust Salesforce timeout to 3s

### DIFF
--- a/app/clients/salesforce/salesforce_auth.py
+++ b/app/clients/salesforce/salesforce_auth.py
@@ -2,7 +2,7 @@ import requests
 from flask import current_app
 from simple_salesforce import Salesforce
 
-SALESFORCE_TIMEOUT_SECONDS = 10
+SALESFORCE_TIMEOUT_SECONDS = 3
 
 
 class TimeoutAdapter(requests.adapters.HTTPAdapter):


### PR DESCRIPTION
# Summary | Résumé

This will ensure Notify users don't wait too long for trial service creation, etc if the Salesforce API goes down.