### PR TITLE
fix: Salesforce Contact one word names

### DIFF
--- a/app/clients/salesforce/salesforce_client.py
+++ b/app/clients/salesforce/salesforce_client.py
@@ -66,8 +66,8 @@ class SalesforceClient:
         session = self.get_session()
         name_parts = salesforce_utils.get_name_parts(user.name)
         user_updates = {
-            "FirstName": name_parts["first"] if name_parts["first"] else user.name,
-            "LastName": name_parts["last"] if name_parts["last"] else "",
+            "FirstName": name_parts["first"],
+            "LastName": name_parts["last"],
             "Email": user.email_address,
         }
         salesforce_contact.update(session, user, user_updates)

--- a/app/clients/salesforce/salesforce_contact.py
+++ b/app/clients/salesforce/salesforce_contact.py
@@ -31,8 +31,8 @@ def create(session: Salesforce, user: User, field_updates: dict[str, Optional[st
     try:
         name_parts = get_name_parts(user.name)
         field_default_values = {
-            "FirstName": name_parts["first"] if name_parts["first"] else user.name,
-            "LastName": name_parts["last"] if name_parts["last"] else "",
+            "FirstName": name_parts["first"],
+            "LastName": name_parts["last"],
             "Title": "created by Notify API",
             "CDS_Contact_ID__c": str(user.id),
             "Email": user.email_address,

--- a/app/clients/salesforce/salesforce_utils.py
+++ b/app/clients/salesforce/salesforce_utils.py
@@ -4,22 +4,25 @@ from flask import current_app
 from simple_salesforce import Salesforce
 
 
-def get_name_parts(full_name: str) -> dict[str, Optional[str]]:
+def get_name_parts(full_name: str) -> dict[str, str]:
     """
     Splits a space separated fullname into first and last
-    name parts.  If the name cannot be split, the first and
-    last segments will be set to None.
+    name parts.  If the name cannot be split, the first name will
+    be blank and the last name will be set to the passed in full name.
+
+    This is because Salesforce requires a last name but allows the
+    last name to be blank.
 
     Args:
         full_name (str): The space seperated full name
 
     Returns:
-        dict[str, Optional[str]]: The first and last name parts
+        dict[str, str]: The first and last name parts
     """
     name_parts = full_name.split()
     return {
-        "first": name_parts[0] if len(name_parts) > 0 else None,
-        "last": " ".join(name_parts[1:]) if len(name_parts) > 1 else None,
+        "first": name_parts[0] if len(name_parts) > 1 else "",
+        "last": " ".join(name_parts[1:]) if len(name_parts) > 1 else full_name,
     }
 
 

--- a/tests/app/clients/test_salesforce_contact.py
+++ b/tests/app/clients/test_salesforce_contact.py
@@ -57,6 +57,31 @@ def test_create_custom(mocker, notify_api, user):
         )
 
 
+def test_create_one_name(mocker, notify_api):
+    with notify_api.app_context():
+        mock_session = mocker.MagicMock()
+        mock_session.Contact.create.return_value = {"success": True, "id": "42"}
+        mock_user = User(
+            **{
+                "id": 3,
+                "name": "Gandalf",
+                "email_address": "gandalf@fellowship.ca",
+                "platform_admin": False,
+            }
+        )
+        assert create(mock_session, mock_user, {}) == "42"
+        mock_session.Contact.create.assert_called_with(
+            {
+                "FirstName": "",
+                "LastName": "Gandalf",
+                "Title": "created by Notify API",
+                "CDS_Contact_ID__c": "3",
+                "Email": "gandalf@fellowship.ca",
+            },
+            headers={"Sforce-Duplicate-Rule-Header": "allowSave=true"},
+        )
+
+
 def test_create_failed(mocker, notify_api, user):
     with notify_api.app_context():
         mock_session = mocker.MagicMock()

--- a/tests/app/clients/test_salesforce_utils.py
+++ b/tests/app/clients/test_salesforce_utils.py
@@ -8,8 +8,8 @@ from app.clients.salesforce.salesforce_utils import (
 
 def test_get_name_parts():
     assert get_name_parts("Frodo Baggins") == {"first": "Frodo", "last": "Baggins"}
-    assert get_name_parts("Smaug") == {"first": "Smaug", "last": None}
-    assert get_name_parts("") == {"first": None, "last": None}
+    assert get_name_parts("Smaug") == {"first": "", "last": "Smaug"}
+    assert get_name_parts("") == {"first": "", "last": ""}
     assert get_name_parts("Gandalf The Grey") == {"first": "Gandalf", "last": "The Grey"}
 
 


### PR DESCRIPTION
# Summary
Fix the Salesforce Contact create if the Notify user's name is only one word.  Salesforce requires the `LastName` field to be set, but the `FirstName` field is optional.

# Related
- Closes cds-snc/platform-core-services#308