### PR TITLE
feat: add service "go live" use case to Salesforce

### DIFF
--- a/app/clients/salesforce/salesforce_client.py
+++ b/app/clients/salesforce/salesforce_client.py
@@ -103,19 +103,18 @@ class SalesforceClient:
         salesforce_engagement.create(session, service, {}, account_id, contact_id)
         self.end_session(session)
 
-    def engagement_update_stage(self, service: Service, user: User, stage_name: str) -> None:
-        """Updates the stage of a Salesforce Engagement for the given Notify service.  The Engagement
+    def engagement_update(self, service: Service, user: User, field_updates: dict[str, str]) -> None:
+        """Updates a Salesforce Engagement for the given Notify service.  The Engagement
         will be associated with the Notify user that triggers the stage update.
 
         Args:
             service (Service): Notify Service to update an Engagement for.
             user (User): Notify User creating the service.
-            stage_name (str): New stage to set.
+            field_updates (dict[str, str]): The fields to update on the Engagement.
         """
         session = self.get_session()
         account_id, contact_id = self.contact_update_account_id(session, service, user)
-        stage_update = {"StageName": stage_name}
-        salesforce_engagement.update(session, service, stage_update, account_id, contact_id)
+        salesforce_engagement.update(session, service, field_updates, account_id, contact_id)
         self.end_session(session)
 
     def engagement_close(self, service: Service) -> None:

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -16,10 +16,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 
 from app import redis_store, salesforce_client
-from app.clients.salesforce.salesforce_engagement import (
-    ENGAGEMENT_STAGE_ACTIVATION,
-    ENGAGEMENT_STAGE_LIVE,
-)
+from app.clients.salesforce.salesforce_engagement import ENGAGEMENT_STAGE_LIVE
 from app.config import QueueNames
 from app.dao import fact_notification_status_dao, notifications_dao
 from app.dao.api_key_dao import (
@@ -275,7 +272,6 @@ def update_service(service_id):
     fetched_service = dao_fetch_service_by_id(service_id)
     # Capture the status change here as Marshmallow changes this later
     service_going_live = fetched_service.restricted and not req_json.get("restricted", True)
-    service_requested_go_live = not service_going_live and req_json.get("go_live_user")
     message_limit_changed = fetched_service.message_limit != req_json.get("message_limit", fetched_service.message_limit)
     sms_limit_changed = fetched_service.sms_daily_limit != req_json.get("sms_daily_limit", fetched_service.sms_daily_limit)
     current_data = dict(service_schema.dump(fetched_service).data.items())
@@ -308,7 +304,7 @@ def update_service(service_id):
     if service_going_live:
         _warn_services_users_about_going_live(service_id, current_data)
 
-    if current_app.config["FF_SALESFORCE_CONTACT"] and (service_going_live or service_requested_go_live):
+    if service_going_live and current_app.config["FF_SALESFORCE_CONTACT"]:
         try:
             # Two scenarios, if there is a user that has requested to go live, we will use that user
             # to create a Contact/Engagment pair between Notify and Salesforce.
@@ -319,8 +315,7 @@ def update_service(service_id):
             else:
                 user = dao_fetch_service_creator(service.id)
 
-            stage_name = ENGAGEMENT_STAGE_LIVE if service_going_live else ENGAGEMENT_STAGE_ACTIVATION
-            salesforce_client.engagement_update_stage(service, user, stage_name)
+            salesforce_client.engagement_update(service, user, {"StageName": ENGAGEMENT_STAGE_LIVE})
         except Exception as e:
             current_app.logger.exception(e)
 

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from app import salesforce_client
 from app.clients.freshdesk import Freshdesk
+from app.clients.salesforce.salesforce_engagement import ENGAGEMENT_STAGE_ACTIVATION
 from app.config import Config, QueueNames
 from app.dao.fido2_key_dao import (
     create_fido2_session,
@@ -461,6 +462,15 @@ def send_contact_request(user_id):
     except NoResultFound:
         # This is perfectly normal if get_user_by_email raises
         pass
+
+    # Update the engagement stage in Salesforce for go live requests
+    if contact.is_go_live_request and current_app.config["FF_SALESFORCE_CONTACT"]:
+        try:
+            engagement_updates = {"StageName": ENGAGEMENT_STAGE_ACTIVATION, "Description": contact.main_use_case}
+            service = dao_fetch_service_by_id(contact.service_id)
+            salesforce_client.engagement_update(service, user, engagement_updates)
+        except Exception as e:
+            current_app.logger.exception(e)
 
     status_code = Freshdesk(contact).send_ticket()
     return jsonify({"status_code": status_code}), 204

--- a/tests/app/clients/test_salesforce_client.py
+++ b/tests/app/clients/test_salesforce_client.py
@@ -114,7 +114,7 @@ def test_engagement_create(mocker, salesforce_client):
     mock_end_session.assert_called_once_with("session")
 
 
-def test_engagement_update_stage(mocker, salesforce_client):
+def test_engagement_update(mocker, salesforce_client):
     mock_get_session = mocker.patch.object(salesforce_client, "get_session", return_value="session")
     mock_contact_update_account_id = mocker.patch.object(
         salesforce_client, "contact_update_account_id", return_value=("account_id", "contact_id")
@@ -124,11 +124,13 @@ def test_engagement_update_stage(mocker, salesforce_client):
     mock_service = mocker.MagicMock()
     mock_service.organisation_notes = "account_name > service_name"
 
-    salesforce_client.engagement_update_stage(mock_service, "user", "live")
+    salesforce_client.engagement_update(mock_service, "user", {"StageName": "live", "Description": "would be oh so nice"})
 
     mock_get_session.assert_called_once()
     mock_contact_update_account_id.assert_called_once_with("session", mock_service, "user")
-    mock_update.assert_called_once_with("session", mock_service, {"StageName": "live"}, "account_id", "contact_id")
+    mock_update.assert_called_once_with(
+        "session", mock_service, {"StageName": "live", "Description": "would be oh so nice"}, "account_id", "contact_id"
+    )
     mock_end_session.assert_called_once_with("session")
 
 


### PR DESCRIPTION
# Summary
Update the Salesforce Engagement for a service with the "go live" use case from the request.  This will be added to the Engagement's description.

# Related
- cds-snc/platform-core-services#310