### PR TITLE
Populate Freshdesk organisation in "go live" requests using `service.organisation_notes`

### DIFF
--- a/app/clients/freshdesk.py
+++ b/app/clients/freshdesk.py
@@ -29,11 +29,13 @@ class Freshdesk(object):
                 ]
             )
         elif self.contact.is_go_live_request():
+            # the ">" character breaks rendering for the freshdesk preview in slack
+            department_org_name = self.contact.department_org_name.replace(">", "/")
             message = "<br>".join(
                 [
                     f"{self.contact.service_name} just requested to go live.",
                     "",
-                    f"- Department/org: {self.contact.department_org_name}",
+                    f"- Department/org: {department_org_name}",
                     f"- Intended recipients: {self.contact.intended_recipients}",
                     f"- Purpose: {self.contact.main_use_case}",
                     f"- Notification types: {self.contact.notification_types}",

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -464,11 +464,12 @@ def send_contact_request(user_id):
         pass
 
     # Update the engagement stage in Salesforce for go live requests
-    if contact.is_go_live_request and current_app.config["FF_SALESFORCE_CONTACT"]:
+    if contact and contact.is_go_live_request and current_app.config["FF_SALESFORCE_CONTACT"]:
         try:
             engagement_updates = {"StageName": ENGAGEMENT_STAGE_ACTIVATION, "Description": contact.main_use_case}
             service = dao_fetch_service_by_id(contact.service_id)
             salesforce_client.engagement_update(service, user, engagement_updates)
+            contact.department_org_name = service.organisation_notes
         except Exception as e:
             current_app.logger.exception(e)
 


### PR DESCRIPTION
# Summary | Résumé

Populate Freshdesk organisation in "go live" requests using `service.organisation_notes`