### PR TITLE
fix: go live contact check for service ID

### DIFF
--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -466,10 +466,13 @@ def send_contact_request(user_id):
     # Update the engagement stage in Salesforce for go live requests
     if contact and contact.is_go_live_request and current_app.config["FF_SALESFORCE_CONTACT"]:
         try:
-            engagement_updates = {"StageName": ENGAGEMENT_STAGE_ACTIVATION, "Description": contact.main_use_case}
-            service = dao_fetch_service_by_id(contact.service_id)
-            salesforce_client.engagement_update(service, user, engagement_updates)
-            contact.department_org_name = service.organisation_notes
+            if contact.service_id:
+                engagement_updates = {"StageName": ENGAGEMENT_STAGE_ACTIVATION, "Description": contact.main_use_case}
+                service = dao_fetch_service_by_id(contact.service_id)
+                salesforce_client.engagement_update(service, user, engagement_updates)
+                contact.department_org_name = service.organisation_notes
+            else:
+                current_app.logger.error(f"Missing service_id for go live request with contact: {contact}")
         except Exception as e:
             current_app.logger.exception(e)
 


### PR DESCRIPTION
# Summary
Update the `go live` contact request to check for a service ID.  If one does not exist, log the contact details so we can start to troubleshoot how contact requests are ending up in this code path.
