### PR TITLE
fix: contact is `go live` request if condition

### DIFF
--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -464,15 +464,12 @@ def send_contact_request(user_id):
         pass
 
     # Update the engagement stage in Salesforce for go live requests
-    if contact and contact.is_go_live_request and current_app.config["FF_SALESFORCE_CONTACT"]:
+    if contact and contact.is_go_live_request() and current_app.config["FF_SALESFORCE_CONTACT"]:
         try:
-            if contact.service_id:
-                engagement_updates = {"StageName": ENGAGEMENT_STAGE_ACTIVATION, "Description": contact.main_use_case}
-                service = dao_fetch_service_by_id(contact.service_id)
-                salesforce_client.engagement_update(service, user, engagement_updates)
-                contact.department_org_name = service.organisation_notes
-            else:
-                current_app.logger.error(f"Missing service_id for go live request with contact: {contact}")
+            engagement_updates = {"StageName": ENGAGEMENT_STAGE_ACTIVATION, "Description": contact.main_use_case}
+            service = dao_fetch_service_by_id(contact.service_id)
+            salesforce_client.engagement_update(service, user, engagement_updates)
+            contact.department_org_name = service.organisation_notes
         except Exception as e:
             current_app.logger.exception(e)
 

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -834,6 +834,7 @@ def test_send_contact_request_no_live_service(client, sample_user, mocker):
     }
 
     mocked_freshdesk = mocker.patch("app.user.rest.Freshdesk.send_ticket", return_value=201)
+    mocked_salesforce_client = mocker.patch("app.user.rest.salesforce_client")
 
     resp = client.post(
         url_for("user.send_contact_request", user_id=str(sample_user.id)),
@@ -843,6 +844,7 @@ def test_send_contact_request_no_live_service(client, sample_user, mocker):
     assert resp.status_code == 204
 
     mocked_freshdesk.assert_called_once_with()
+    mocked_salesforce_client.engagement_update.assert_not_called()
 
     contact = ContactRequest(**data)
     contact.tags = ["z_skip_opsgenie", "z_skip_urgent_escalation"]
@@ -856,6 +858,7 @@ def test_send_contact_request_with_live_service(client, sample_service, mocker):
         "support_type": "ask_question",
     }
     mocked_freshdesk = mocker.patch("app.user.rest.Freshdesk.send_ticket", return_value=201)
+    mocked_salesforce_client = mocker.patch("app.user.rest.salesforce_client")
 
     resp = client.post(
         url_for("user.send_contact_request", user_id=str(sample_user.id)),
@@ -864,6 +867,7 @@ def test_send_contact_request_with_live_service(client, sample_service, mocker):
     )
     assert resp.status_code == 204
     mocked_freshdesk.assert_called_once_with()
+    mocked_salesforce_client.engagement_update.assert_not_called()
 
 
 def test_send_contact_request_demo(client, sample_user, mocker):
@@ -873,6 +877,7 @@ def test_send_contact_request_demo(client, sample_user, mocker):
         "support_type": "demo",
     }
     mocked_freshdesk = mocker.patch("app.user.rest.Freshdesk.send_ticket", return_value=201)
+    mocked_salesforce_client = mocker.patch("app.user.rest.salesforce_client")
 
     resp = client.post(
         url_for("user.send_contact_request", user_id=str(sample_user.id)),
@@ -882,6 +887,7 @@ def test_send_contact_request_demo(client, sample_user, mocker):
     assert resp.status_code == 204
 
     mocked_freshdesk.assert_called_once_with()
+    mocked_salesforce_client.engagement_update.assert_not_called()
     contact = ContactRequest(**data)
     contact.tags = ["z_skip_opsgenie", "z_skip_urgent_escalation"]
 
@@ -921,6 +927,7 @@ def test_send_branding_request(client, sample_service, mocker):
         "filename": "branding_url",
     }
     mocked_freshdesk = mocker.patch("app.user.rest.Freshdesk.send_ticket", return_value=201)
+    mocked_salesforce_client = mocker.patch("app.user.rest.salesforce_client")
 
     resp = client.post(
         url_for("user.send_branding_request", user_id=str(sample_user.id)),
@@ -929,6 +936,7 @@ def test_send_branding_request(client, sample_service, mocker):
     )
     assert resp.status_code == 204
     mocked_freshdesk.assert_called_once_with()
+    mocked_salesforce_client.engagement_update.assert_not_called()
 
 
 def test_send_user_confirm_new_email_returns_204(client, sample_user, change_email_confirmation_template, mocker):


### PR DESCRIPTION
# Summary
Update the check for contact `go live` request to properly call the model's method.  Also updates the unit tests to assert that the Salesforce client method is not invoked for other contact types.

# Related
- cds-snc/platform-core-services#313