### PR TITLE
fix: poetry-ize perf test docker image

### DIFF
--- a/tests-perf/ops/Dockerfile
+++ b/tests-perf/ops/Dockerfile
@@ -1,20 +1,35 @@
 FROM python:3.10-alpine3.16@sha256:b2d1f7c5ef2aad57f135104240e91c5327d9c414a58517f1080d55ed6a7a591d
 
 ENV PYTHONDONTWRITEBYTECODE 1
+ENV POETRY_VERSION "1.3.2"
+ENV APP_VENV="/app/.venv"
+ENV POETRY_HOME="/opt/poetry"
+ENV POETRY_VERSION="1.3.2"
+ENV POETRY_VIRTUALENVS_CREATE="false"
+ENV PATH="${APP_VENV}/bin:${POETRY_HOME}/bin:$PATH"
 
 RUN apk add --no-cache bash build-base git libtool cmake autoconf automake gcc musl-dev postgresql-dev g++ libexecinfo-dev make libffi-dev libmagic libcurl curl-dev rust cargo && rm -rf /var/cache/apk/*
 
-# update pip
-RUN python -m pip install wheel
-RUN python -m pip install --upgrade pip
-
 RUN set -ex && mkdir /app
-
 WORKDIR /app
 
-COPY . /app
+# Install poetry and isolate it in it's own venv
+RUN python -m venv ${POETRY_HOME} \
+    && ${POETRY_HOME}/bin/pip3 install poetry==${POETRY_VERSION}
 
-RUN set -ex && pip3 install -r requirements_for_test.txt
+COPY pyproject.toml poetry.lock /app/
+
+RUN python -m venv ${APP_VENV} \
+    && . ${APP_VENV}/bin/activate \
+    && poetry install \
+    && poetry add wheel
+
+COPY . /app/
+
+RUN . ${APP_VENV}/bin/activate \
+    && make generate-version-file
+
+
 RUN echo "fs.file-max = 100000" >> /etc/sysctl.conf
 
 ENTRYPOINT [ "bin/execute_and_publish_performance_test.sh" ]


### PR DESCRIPTION
# Summary | Résumé

Docker image for perf test hadn't been poetry-ized and would fail to build, causing our ci pipeline to fail

Pretty much copy-pasted what we do in the app Dockerfile.

# Test instructions | Instructions pour tester la modification

can build locally with `docker build -t perf-tests . -f tests-perf/ops/Dockerfile`


