### PR TITLE
fix: handle cases where no organisation notes

### DIFF
--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -469,7 +469,7 @@ def send_contact_request(user_id):
             engagement_updates = {"StageName": ENGAGEMENT_STAGE_ACTIVATION, "Description": contact.main_use_case}
             service = dao_fetch_service_by_id(contact.service_id)
             salesforce_client.engagement_update(service, user, engagement_updates)
-            contact.department_org_name = service.organisation_notes
+            contact.department_org_name = service.organisation_notes if service.organisation_notes else "Unknown"
         except Exception as e:
             current_app.logger.exception(e)
 

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -918,6 +918,39 @@ def test_send_contact_request_go_live(client, sample_service, mocker):
     )
 
 
+@pytest.mark.parametrize(
+    "organisation_notes, department_org_name",
+    [
+        ("TBS > CDS", "TBS > CDS"),
+        (None, "Unknown"),
+    ],
+)
+def test_send_contact_request_go_live_with_org_notes(organisation_notes, department_org_name, client, sample_service, mocker):
+    sample_user = sample_service.users[0]
+    sample_service.organisation_notes = organisation_notes
+    data = {
+        "name": sample_user.name,
+        "email_address": sample_user.email_address,
+        "main_use_case": "I want to send emails",
+        "support_type": "go_live_request",
+        "service_id": str(sample_service.id),
+    }
+    mock_contact_request = mocker.MagicMock()
+    mocker.patch("app.user.rest.ContactRequest", return_value=mock_contact_request)
+    mocker.patch("app.user.rest.dao_fetch_service_by_id", return_value=sample_service)
+    mocker.patch("app.user.rest.Freshdesk.send_ticket", return_value=201)
+    mocker.patch("app.user.rest.get_user_by_email", return_value=sample_user)
+    mocker.patch("app.user.rest.salesforce_client")
+
+    resp = client.post(
+        url_for("user.send_contact_request", user_id=str(sample_user.id)),
+        data=json.dumps(data),
+        headers=[("Content-Type", "application/json"), create_authorization_header()],
+    )
+    assert resp.status_code == 204
+    mock_contact_request.department_org_name = department_org_name
+
+
 def test_send_branding_request(client, sample_service, mocker):
     sample_user = sample_service.users[0]
     post_data = {

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -948,7 +948,7 @@ def test_send_contact_request_go_live_with_org_notes(organisation_notes, departm
         headers=[("Content-Type", "application/json"), create_authorization_header()],
     )
     assert resp.status_code == 204
-    mock_contact_request.department_org_name = department_org_name
+    assert mock_contact_request.department_org_name == department_org_name
 
 
 def test_send_branding_request(client, sample_service, mocker):


### PR DESCRIPTION
# Summary
Update the `go live` contact request to handle the case where a service does not have `organisation_notes` specified.  This will be the case for all services created before the Salesforce integration was turned on.

Currently this missing `organisation_notes` column is breaking the `go live` request flow and preventing the Freshdesk ticket from being created.

# Related
- #1817
