### PR TITLE
Add redis calls during process_ses_results

### DIFF
--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -4,9 +4,10 @@ from flask import current_app, json
 from notifications_utils.statsd_decorators import statsd
 from sqlalchemy.orm.exc import NoResultFound
 
-from app import notify_celery, statsd_client
+from app import bounce_rate_client, notify_celery, statsd_client
 from app.config import QueueNames
 from app.dao import notifications_dao
+from app.models import NOTIFICATION_HARD_BOUNCE, NOTIFICATION_PERMANENT_FAILURE
 from app.notifications.callbacks import _check_and_queue_callback_task
 from app.notifications.notifications_ses_callback import (
     _check_and_queue_complaint_callback_task,
@@ -76,6 +77,11 @@ def process_ses_results(self, response):
             )
 
         statsd_client.incr("callback.ses.{}".format(notification_status))
+
+        # Record bounces and notifications in Redis
+        if notification_status == NOTIFICATION_PERMANENT_FAILURE:
+            bounce_rate_client.set_sliding_hard_bounce(notification.service_id)
+        bounce_rate_client.set_sliding_notifications(notification.service_id)
 
         if notification.sent_at:
             statsd_client.timing_with_dates("callback.ses.elapsed-time", datetime.utcnow(), notification.sent_at)

--- a/tests/app/celery/test_process_ses_receipts_tasks.py
+++ b/tests/app/celery/test_process_ses_receipts_tasks.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import pytest
 from freezegun import freeze_time
 
-from app import signer_complaint, statsd_client
+from app import signer_complaint, statsd_client, bounce_rate_client
 from app.aws.mocks import ses_complaint_callback
 from app.celery.process_ses_receipts_tasks import process_ses_results
 from app.celery.research_mode_tasks import (
@@ -161,6 +161,7 @@ def test_ses_callback_does_not_call_send_delivery_status_if_no_db_entry(
     notify_db, notify_db_session, sample_email_template, mocker
 ):
     with freeze_time("2001-01-01T12:00:00"):
+
         send_mock = mocker.patch("app.celery.service_callback_tasks.send_delivery_status_to_service.apply_async")
         notification = create_sample_notification(
             notify_db,
@@ -354,3 +355,48 @@ class TestBounceRates:
         assert process_ses_results(ses_soft_bounce_callback(reference="ref", bounce_subtype=bounce_subtype))
         assert get_notification_by_id(notification.id).feedback_type == NOTIFICATION_SOFT_BOUNCE
         assert get_notification_by_id(notification.id).feedback_subtype == expected_subtype
+
+    @pytest.mark.parametrize(
+        "bounce_subtype, expected_subtype",
+        [
+            ("General", NOTIFICATION_HARD_GENERAL),
+            ("NoEmail", NOTIFICATION_HARD_NOEMAIL),
+            ("Suppressed", NOTIFICATION_HARD_SUPPRESSED),
+            ("OnAccountSuppressionList", NOTIFICATION_HARD_ONACCOUNTSUPPRESSIONLIST),
+        ],
+    )
+    def test_ses_callback_should_add_two_redis_keys_when_delivery_receipt_is_hard_bounce(
+        self, sample_email_template, mocker, bounce_subtype, expected_subtype
+    ):
+        mocker.patch("app.bounce_rate_client.set_sliding_hard_bounce")
+        mocker.patch("app.bounce_rate_client.set_sliding_notifications")
+
+        notification = save_notification(create_notification(template=sample_email_template, reference="ref", status="delivered"))
+
+        assert process_ses_results(ses_hard_bounce_callback(reference="ref", bounce_subtype=bounce_subtype))
+
+        bounce_rate_client.set_sliding_hard_bounce.assert_called_with(notification.service_id)
+        bounce_rate_client.set_sliding_notifications.assert_called_with(notification.service_id)
+
+    @pytest.mark.parametrize(
+        "bounce_subtype, expected_subtype",
+        [
+            ("General", NOTIFICATION_SOFT_GENERAL),
+            ("MailboxFull", NOTIFICATION_SOFT_MAILBOXFULL),
+            ("MessageTooLarge", NOTIFICATION_SOFT_MESSAGETOOLARGE),
+            ("ContentRejected", NOTIFICATION_SOFT_CONTENTREJECTED),
+            ("AttachmentRejected", NOTIFICATION_SOFT_ATTACHMENTREJECTED),
+        ],
+    )
+    def test_ses_callback_should_add_one_redis_key_when_delivery_receipt_is_soft_bounce(
+        self, sample_email_template, mocker, bounce_subtype, expected_subtype
+    ):
+        mocker.patch("app.bounce_rate_client.set_sliding_hard_bounce")
+        mocker.patch("app.bounce_rate_client.set_sliding_notifications")
+
+        notification = save_notification(create_notification(template=sample_email_template, reference="ref", status="delivered"))
+
+        assert process_ses_results(ses_soft_bounce_callback(reference="ref", bounce_subtype=bounce_subtype))
+
+        bounce_rate_client.set_sliding_hard_bounce.assert_not_called()
+        bounce_rate_client.set_sliding_notifications.assert_called_with(notification.service_id)


### PR DESCRIPTION

If the notification is a permanent failure add to the sliding_hard_bounce:{service_id} and sliding_notifications:{service_id} keys
If the notification is a soft bounce, only add to sliding_notifications:{service_id}

# Summary | Résumé
This PR adds calls to the `bounce_rate_client` during the `process_ses_receipts_task`.

If the notification is a permanent failure add a member to the sliding_hard_bounce:{service_id} and sliding_notifications:{service_id} keys
If the notification is a soft bounce, only add to sliding_notifications:{service_id}

# Test instructions | Instructions pour tester la modification
Testing must be done post-merge to main as locally setting up callbacks to the celery task locally is burdensome.

### Soft bounce / Successful delivery path
1. Send an email to a valid recipient. Take note of the `service_id` doing the send.
2. Connect to Redis via the `redis-cli` and run `zrange sliding_notifications:<service_id here> 0 -1` and `zrange sliding_hard_bounce:<service_id here> 0 -1`.
3. A soft bounce or successful delivery should only add to `sliding_notifications:{service_id}`

### Hard bounce path
1. send and email to an invalid recipient. Take note of the `service_id` doing the send.
2. Connect to Redis via the `redis-cli` and run `zrange sliding_notifications:{service_id} 0 -1` and `zrange sliding_hard_bounce:{service_id} 0 -1`. 
3. A hard bounce should add to both `sliding_notifications:{service_id}` and sliding_hard_bounce:{service_id}


