### PR TITLE
Fix for missing org notes

### DIFF
--- a/app/clients/freshdesk.py
+++ b/app/clients/freshdesk.py
@@ -38,12 +38,13 @@ class Freshdesk(object):
             )
         elif self.contact.is_go_live_request():
             # the ">" character breaks rendering for the freshdesk preview in slack
-            department_org_name = self.contact.department_org_name.replace(">", "/")
+            if self.contact.department_org_name:
+                self.contact.department_org_name = self.contact.department_org_name.replace(">", "/")
             message = "<br>".join(
                 [
                     f"{self.contact.service_name} just requested to go live.",
                     "",
-                    f"- Department/org: {department_org_name}",
+                    f"- Department/org: {self.contact.department_org_name}",
                     f"- Intended recipients: {self.contact.intended_recipients}",
                     f"- Purpose: {self.contact.main_use_case}",
                     f"- Notification types: {self.contact.notification_types}",

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -472,12 +472,11 @@ def send_contact_request(user_id):
 
             if not service.organisation_notes:
                 # the service was created before we started requesting the organisation name at creation time
-                if contact.department_org_name:
-                    # If the service doesn't have an organisation name, but the contact form does, update the service
-                    service.organisation_notes = contact.department_org_name
-                else:
+                if not contact.department_org_name:
                     # this shouldn't happen, but if it does, we don't want to leave the service with no organisation name
-                    service.organisation_notes = "Unknown"
+                    contact.department_org_name = "Unknown"
+                # fall back on the organisation name collected from the go live request
+                service.organisation_notes = contact.department_org_name
                 dao_update_service(service)
             else:
                 # this is the normal case, where the service has an organisation name collected when it was created

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -27,7 +27,7 @@ from app.dao.fido2_key_dao import (
 from app.dao.login_event_dao import list_login_events, save_login_event
 from app.dao.permissions_dao import permission_dao
 from app.dao.service_user_dao import dao_get_service_user, dao_update_service_user
-from app.dao.services_dao import dao_fetch_service_by_id
+from app.dao.services_dao import dao_fetch_service_by_id, dao_update_service
 from app.dao.template_folder_dao import dao_get_template_folder_by_id_and_service_id
 from app.dao.templates_dao import dao_get_template_by_id
 from app.dao.users_dao import (
@@ -469,7 +469,20 @@ def send_contact_request(user_id):
             engagement_updates = {"StageName": ENGAGEMENT_STAGE_ACTIVATION, "Description": contact.main_use_case}
             service = dao_fetch_service_by_id(contact.service_id)
             salesforce_client.engagement_update(service, user, engagement_updates)
-            contact.department_org_name = service.organisation_notes if service.organisation_notes else "Unknown"
+            
+            if not service.organisation_notes:
+                # the service was created before we started requesting the organisation name at creation time
+                if contact.department_org_name:
+                    # If the service doesn't have an organisation name, but the contact form does, update the service
+                    service.organisation_notes = contact.department_org_name
+                else:
+                    # this shouldn't happen, but if it does, we don't want to leave the service with no organisation name
+                    service.organisation_notes = "Unknown"
+                dao_update_service(service)
+            else:
+                # this is the normal case, where the service has an organisation name collected when it was created
+                contact.department_org_name = service.organisation_notes
+
         except Exception as e:
             current_app.logger.exception(e)
 

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -469,7 +469,7 @@ def send_contact_request(user_id):
             engagement_updates = {"StageName": ENGAGEMENT_STAGE_ACTIVATION, "Description": contact.main_use_case}
             service = dao_fetch_service_by_id(contact.service_id)
             salesforce_client.engagement_update(service, user, engagement_updates)
-            
+
             if not service.organisation_notes:
                 # the service was created before we started requesting the organisation name at creation time
                 if contact.department_org_name:

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -938,9 +938,11 @@ def test_send_contact_request_go_live_with_org_notes(organisation_notes, departm
     mock_contact_request = mocker.MagicMock()
     mocker.patch("app.user.rest.ContactRequest", return_value=mock_contact_request)
     mocker.patch("app.user.rest.dao_fetch_service_by_id", return_value=sample_service)
+    mocker.patch("app.user.rest.dao_update_service")
     mocker.patch("app.user.rest.Freshdesk.send_ticket", return_value=201)
     mocker.patch("app.user.rest.get_user_by_email", return_value=sample_user)
     mocker.patch("app.user.rest.salesforce_client")
+    mock_contact_request.department_org_name = None
 
     resp = client.post(
         url_for("user.send_contact_request", user_id=str(sample_user.id)),


### PR DESCRIPTION
# Summary | Résumé

This adds some functionality I missed to cover the case where a service requests to go live that was created before the CRM integration feature was launched.

I tested using the following steps:
1. run this locally and connect a locally running `notification-admin` with `FF_SALESFORCE_CONTACT=False`
2. create a trial service 
3. change `FF_SALESFORCE_CONTACT=True` and restart `notification-admin`
4. go through the "go live" request process
5. observe that you are asked to enter an organisation name on the first step
6. make the go live request
7. this freshdesk ticket was created, displaying the organisation I entered at step 5 and no errors occurred: https://cds-snc.freshdesk.com/a/tickets/14961
