### PR TITLE
fix: docker-scan workflow permissions

### DIFF
--- a/.github/workflows/docker-vulnerability-scan.yml
+++ b/.github/workflows/docker-vulnerability-scan.yml
@@ -6,8 +6,9 @@ on:
     - cron: "0 4 * * *"
 
 permissions:
-  id-token: write   # This is required for requesting the OIDC JWT
-  contents: read    # This is required for actions/checkout
+  id-token: write        # This is required for requesting the OIDC JWT
+  contents: read         # This is required for actions/checkout
+  security-events: write # This is required for the docker-scan action
 
 jobs:
   docker-vulnerability-scan-k8s:


### PR DESCRIPTION
# Summary
Update the Docker vulnerability scan action to allow write to the security events of the repo. This allows the scan results to be published.

This is required after the change to OIDC roles which narrowed the workflow permissions.