### PR TITLE
fix: OIDC role used for docker vuln scan

### DIFF
--- a/.github/workflows/docker-vulnerability-scan.yml
+++ b/.github/workflows/docker-vulnerability-scan.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Configure credentials to Notify account using OIDC
         uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
         with:
-          role-to-assume: arn:aws:iam::239043911459:role/notification-api-apply
+          role-to-assume: arn:aws:iam::${{ secrets.PRODUCTION_API_LAMBDA_ECR_ACCOUNT }}:role/notification-api-apply
           role-session-name: NotifyApiGitHubActions
           aws-region: "ca-central-1"
 


### PR DESCRIPTION
# Summary
Update to use the OIDC role in the same account as the ECR image being scanned.