### PR TITLE
Chore/upgrade flask-sqlalchemy 2.4.0

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -234,7 +234,6 @@ def get_notifications_for_service(
     filter_dict=None,
     page=1,
     page_size=None,
-    count_pages=True,
     limit_days=None,
     key_type=None,
     personalisation=False,
@@ -275,7 +274,7 @@ def get_notifications_for_service(
     if personalisation:
         query = query.options(joinedload("template"))
 
-    return query.order_by(desc(Notification.created_at)).paginate(page=page, per_page=page_size, count=count_pages)
+    return query.order_by(desc(Notification.created_at)).paginate(page=page, per_page=page_size)
 
 
 def _filter_query(query, filter_dict=None):

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -490,14 +490,11 @@ def get_all_notifications_for_service(service_id):
     include_from_test_key = data.get("include_from_test_key", False)
     include_one_off = data.get("include_one_off", True)
 
-    count_pages = data.get("count_pages", True)
-
     pagination = notifications_dao.get_notifications_for_service(
         service_id,
         filter_dict=data,
         page=page,
         page_size=page_size,
-        count_pages=count_pages,
         limit_days=limit_days,
         include_jobs=include_jobs,
         include_from_test_key=include_from_test_key,

--- a/poetry.lock
+++ b/poetry.lock
@@ -1250,24 +1250,20 @@ dev = ["coverage", "pre-commit", "pytest", "pytest-mock"]
 tests = ["coverage", "pytest", "pytest-mock"]
 
 [[package]]
-name = "Flask-SQLAlchemy"
-version = "2.3.2.dev20230412"
-description = "Adds SQLAlchemy support to your Flask application"
+name = "flask-sqlalchemy"
+version = "2.4.0"
+description = "Adds SQLAlchemy support to your Flask application."
 category = "main"
 optional = false
-python-versions = "*"
-files = []
-develop = false
+python-versions = ">= 2.7, != 3.0.*, != 3.1.*, != 3.2.*, != 3.3.*"
+files = [
+    {file = "Flask-SQLAlchemy-2.4.0.tar.gz", hash = "sha256:0c9609b0d72871c540a7945ea559c8fdf5455192d2db67219509aed680a3d45a"},
+    {file = "Flask_SQLAlchemy-2.4.0-py2.py3-none-any.whl", hash = "sha256:8631bbea987bc3eb0f72b1f691d47bd37ceb795e73b59ab48586d76d75a7c605"},
+]
 
 [package.dependencies]
 Flask = ">=0.10"
 SQLAlchemy = ">=0.8.0"
-
-[package.source]
-type = "git"
-url = "https://github.com/pallets-eco/flask-sqlalchemy.git"
-reference = "500e732dd1b975a56ab06a46bd1a20a21e682262"
-resolved_reference = "500e732dd1b975a56ab06a46bd1a20a21e682262"
 
 [[package]]
 name = "freezegun"
@@ -4179,4 +4175,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10.9"
-content-hash = "6c3aa9456daf93bac1d5d5e81d65e71c05947d2e5c7301404d42c027df158603"
+content-hash = "c9f4203b999a7b8bc1feffe4fed719c0e3d0c00202315db6ac26134d1d8e9151"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ Flask-Bcrypt = "1.0.1"
 flask-marshmallow = "0.14.0"
 Flask-Migrate = "2.7.0"
 Flask-SQLAlchemy = "2.4.0"
-#git+https://github.com/mitsuhiko/flask-sqlalchemy.git@500e732dd1b975a56ab06a46bd1a20a21e682262#egg=Flask-SQLAlchemy==2.3.2.dev20190108
 Flask = "2.2.3"
 click-datetime = "0.2"
 gevent = "22.10.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ fido2 = "0.9.3"
 Flask-Bcrypt = "1.0.1"
 flask-marshmallow = "0.14.0"
 Flask-Migrate = "2.7.0"
-Flask-SQLAlchemy = { git = "https://github.com/pallets-eco/flask-sqlalchemy.git", rev = "500e732dd1b975a56ab06a46bd1a20a21e682262"}
+Flask-SQLAlchemy = "2.4.0"
 #git+https://github.com/mitsuhiko/flask-sqlalchemy.git@500e732dd1b975a56ab06a46bd1a20a21e682262#egg=Flask-SQLAlchemy==2.3.2.dev20190108
 Flask = "2.2.3"
 click-datetime = "0.2"

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -774,6 +774,7 @@ def test_should_return_notifications_including_one_offs_by_default(sample_user, 
     assert len(include_one_offs_by_default) == 2
 
 
+@pytest.mark.skip(reason="The page_count arg is not supported in our current flask-sqlalchemy")
 def test_should_not_count_pages_when_given_a_flag(sample_user, sample_template):
     save_notification(create_notification(sample_template))
     notification = save_notification(create_notification(sample_template))

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1709,6 +1709,7 @@ def test_get_only_api_created_notifications_for_service(
     assert resp["notifications"][0]["id"] == str(without_job.id)
 
 
+@pytest.mark.skip(reason="The page_count arg is not supported in our current flask-sqlalchemy")
 def test_get_notifications_for_service_without_page_count(
     admin_request,
     sample_job,


### PR DESCRIPTION
# Summary | Résumé

It looks like we haven't upgraded flask-sqlalchemy in 4 years, since someone pinned it to a github sha in order to use an unreleased feature: https://github.com/cds-snc/notification-api/commit/47c403f6ab17a108773c6d0229438c6b9edeb2d3

The feature is the addition of a `count: bool` arg to the `paginate` function. This feature is now live in flask-sqlalchemy 3.0.0, but we haven't been able to take an incremental approach to upgrading to it because we are stuck on this weird, unreleased version of 2.3.2.

We are only setting `count=False` in one place as far as I can tell: https://github.com/cds-snc/notification-admin/blob/main/app/notify_client/notification_api_client.py#L67

And that is on the api page where the most recent notifications (i.e. "page 1") are listed. So this change may make that page load slowly for services with a lot of notifications - we will need to test that. If that is a problem, we could add an argument that would allow the admin to specify how many notifications should be returned in the query.