### PR TITLE
Bump utils version 5.3.0 -> 5.3.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2454,7 +2454,7 @@ requests = ">=2.0.0"
 
 [[package]]
 name = "notifications-utils"
-version = "50.3.0"
+version = "50.3.1"
 description = "Shared python code for Notification - Provides logging utils etc."
 category = "main"
 optional = false
@@ -2488,8 +2488,8 @@ werkzeug = "2.2.3"
 [package.source]
 type = "git"
 url = "https://github.com/cds-snc/notifier-utils.git"
-reference = "50.3.0"
-resolved_reference = "323ab8cc7887fa5ba02f4780410f5ffdaf68ac92"
+reference = "50.3.1"
+resolved_reference = "ccd25bb205b7291e5ffe3331d7206fbcf0af999e"
 
 [[package]]
 name = "ordered-set"
@@ -4179,4 +4179,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10.9"
-content-hash = "6c3aa9456daf93bac1d5d5e81d65e71c05947d2e5c7301404d42c027df158603"
+content-hash = "d00f03ae35b2ec91d1a79e97033fa690ccd600f1da7029db1c16d65655a9feb2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ Werkzeug = "2.2.3"
 MarkupSafe = "2.1.2"
 # REVIEW: v2 is using sha512 instead of sha1 by default (in v1)
 itsdangerous = "2.1.2"
-notifications-utils = {git = "https://github.com/cds-snc/notifier-utils.git", rev = "50.3.0"}
+notifications-utils = {git = "https://github.com/cds-snc/notifier-utils.git", rev = "50.3.1"}
 
 # rsa = "4.9  # awscli 1.22.38 depends on rsa<4.8
 typing-extensions = "4.5.0"


### PR DESCRIPTION
# Summary | Résumé
Bump utils version 5.3.0 -> 5.3.1. This PR should resolve issues with failing WAF rules check on https://github.com/cds-snc/notification-api/pull/1837