### PR TITLE
Add ticket info logging when creating freshdesk tickets

### DIFF
--- a/app/clients/freshdesk.py
+++ b/app/clients/freshdesk.py
@@ -104,7 +104,8 @@ class Freshdesk(object):
                     timeout=5,
                 )
                 response.raise_for_status()
-
+                if response.status_code == 201:
+                    current_app.logger.info(f"Created Freshdesk ticket for service: {self.contact.service_id} type: {self.contact.support_type}")
                 return response.status_code
             else:
                 return 201

--- a/app/clients/freshdesk.py
+++ b/app/clients/freshdesk.py
@@ -105,7 +105,9 @@ class Freshdesk(object):
                 )
                 response.raise_for_status()
                 if response.status_code == 201:
-                    current_app.logger.info(f"Created Freshdesk ticket for service: {self.contact.service_id} type: {self.contact.support_type}")
+                    current_app.logger.info(
+                        f"Created Freshdesk ticket for service: {self.contact.service_id} type: {self.contact.support_type}"
+                    )
                 return response.status_code
             else:
                 return 201


### PR DESCRIPTION
# Summary | Résumé
This PR adds logging when we send Freshdesk tickets so we can better track them when troubleshooting Freshdesk related issues.