### PR TITLE
Rename Rate limit function and add a docstring

### DIFF
--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -62,7 +62,13 @@ from app.v2.errors import (
 NEAR_DAILY_LIMIT_PERCENTAGE = 80 / 100
 
 
-def check_service_over_api_rate_limit(service: Service, api_key: ApiKey):
+def check_service_over_api_rate_limit_and_update_rate(service: Service, api_key: ApiKey):
+    """This function:
+    - adds the current timestamp to the api rate limit key in Redis
+    - expires old data from outside the `interval`
+    - checks if the service is over the api rate limit in the `interval`
+    - raises an error if the service is over the api rate limit
+    """
     if current_app.config["API_RATE_LIMIT_ENABLED"] and current_app.config["REDIS_ENABLED"]:
         cache_key = rate_limit_cache_key(service.id, api_key.key_type)
         rate_limit = service.rate_limit
@@ -163,7 +169,7 @@ def check_sms_limit_increment_redis_send_warnings_if_needed(service: Service, re
 
 
 def check_rate_limiting(service: Service, api_key: ApiKey):
-    check_service_over_api_rate_limit(service, api_key)
+    check_service_over_api_rate_limit_and_update_rate(service, api_key)
     check_service_over_daily_message_limit(api_key.key_type, service)
 
 

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -20,7 +20,7 @@ from app.notifications.validators import (
     check_reply_to,
     check_service_email_reply_to_id,
     check_service_letter_contact_id,
-    check_service_over_api_rate_limit,
+    check_service_over_api_rate_limit_and_update_rate,
     check_service_over_bounce_rate,
     check_service_over_daily_message_limit,
     check_service_sms_sender_id,
@@ -500,7 +500,7 @@ def test_that_when_exceed_rate_limit_request_fails(notify_db, notify_db_session,
         service = create_sample_service(notify_db, notify_db_session, restricted=True)
         api_key = create_sample_api_key(notify_db, notify_db_session, service=service, key_type=api_key_type)
         with pytest.raises(RateLimitError) as e:
-            check_service_over_api_rate_limit(service, api_key)
+            check_service_over_api_rate_limit_and_update_rate(service, api_key)
 
         assert app.redis_store.exceeded_rate_limit.called_with(
             "{}-{}".format(str(service.id), api_key.key_type), service.rate_limit, 60
@@ -520,7 +520,7 @@ def test_that_when_not_exceeded_rate_limit_request_succeeds(notify_db, notify_db
         service = create_sample_service(notify_db, notify_db_session, restricted=True)
         api_key = create_sample_api_key(notify_db, notify_db_session, service=service, key_type="normal")
 
-        check_service_over_api_rate_limit(service, api_key)
+        check_service_over_api_rate_limit_and_update_rate(service, api_key)
         assert app.redis_store.exceeded_rate_limit.called_with("{}-{}".format(str(service.id), api_key.key_type), 3000, 60)
 
 
@@ -534,7 +534,7 @@ def test_should_not_rate_limit_if_limiting_is_disabled(notify_db, notify_db_sess
         service = create_sample_service(notify_db, notify_db_session, restricted=True)
         api_key = create_sample_api_key(notify_db, notify_db_session, service=service)
 
-        check_service_over_api_rate_limit(service, api_key)
+        check_service_over_api_rate_limit_and_update_rate(service, api_key)
         assert not app.redis_store.exceeded_rate_limit.called
 
 


### PR DESCRIPTION
# Summary | Résumé

Rename Rate limit function and add a docstring to reduce confusion about what this function is doing.