### PR TITLE
Fix for bug where `redis_client.active=False` for the running app

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -57,7 +57,7 @@ statsd_client = StatsdClient()
 flask_redis = FlaskRedis()
 flask_redis_publish = FlaskRedis(config_prefix="REDIS_PUBLISH")
 redis_store = RedisClient()
-bounce_rate_client = RedisBounceRate(RedisClient())
+bounce_rate_client = RedisBounceRate(redis_store)
 metrics_logger = MetricsLogger()
 # TODO: Rework instantiation to decouple redis_store.redis_store and pass it in.\
 email_queue = RedisQueue("email")


### PR DESCRIPTION
# Summary | Résumé

This is a bug fix for an issue where methods on the `BounceRateClient` were not actually saving things to Redis because they were failing this `if` check: https://github.com/cds-snc/notification-utils/blob/main/notifications_utils/clients/redis/redis_client.py#L140

We need to initialize the `BounceRateClient` with `redis_store` since that is what we are calling `.init_app()` on here: https://github.com/cds-snc/notification-api/blob/main/app/__init__.py#L130

and that sets `self.active = True`.
