### PR TITLE
Fix bounce rate logging

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -173,7 +173,7 @@ def check_service_over_bounce_rate(service_id: str):
     bounce_rate = bounce_rate_client.get_bounce_rate(service_id)
     bounce_rate_status = bounce_rate_client.check_bounce_rate_status(service_id)
     debug_data = bounce_rate_client.get_debug_data(service_id)
-    current_app.logger.info(
+    current_app.logger.info(f"Service id: {service_id} Bounce Rate: {bounce_rate} Bounce Status: {bounce_rate_status}, Debug Data: {debug_data}")
         f"Service id: {service_id} Bounce Rate: {bounce_rate} Bounce Status: {bounce_rate_status}, Debug Data: {debug_data}"
     )
     if bounce_rate_status == BounceRateStatus.CRITICAL.value:

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -173,7 +173,7 @@ def check_service_over_bounce_rate(service_id: str):
     bounce_rate = bounce_rate_client.get_bounce_rate(service_id)
     bounce_rate_status = bounce_rate_client.check_bounce_rate_status(service_id)
     debug_data = bounce_rate_client.get_debug_data(service_id)
-    current_app.logger.info(f"Service id: {service_id} Bounce Rate: {bounce_rate} Bounce Status: {bounce_rate_status}, Debug Data: {debug_data}")
+    current_app.logger.info(
         f"Service id: {service_id} Bounce Rate: {bounce_rate} Bounce Status: {bounce_rate_status}, Debug Data: {debug_data}"
     )
     if bounce_rate_status == BounceRateStatus.CRITICAL.value:

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -167,21 +167,20 @@ def check_for_malware_errors(document_download_response_code, notification):
 
 
 def check_service_over_bounce_rate(service_id: str):
-    current_app.logger.info(f"Entered check_service_over_bounce_rate with service_id {service_id}")
     if not current_app.config["FF_BOUNCE_RATE_V1"]:
         return
 
     bounce_rate = bounce_rate_client.get_bounce_rate(service_id)
     bounce_rate_status = bounce_rate_client.check_bounce_rate_status(service_id)
     debug_data = bounce_rate_client.get_debug_data(service_id)
-    current_app.logger.info(f"Bounce Rate: {bounce_rate} Bounce Status: {bounce_rate_status}, Debug Data: {debug_data}")
+    current_app.logger.debug(f"Bounce Rate: {bounce_rate} Bounce Status: {bounce_rate_status}, Debug Data: {debug_data}")
     if bounce_rate_status == BounceRateStatus.CRITICAL.value:
         # TODO: Bounce Rate V2, raise a BadRequestError when bounce rate meets or exceeds critical threshold
-        current_app.logger.info(
+        current_app.logger.warning(
             f"Service: {service_id} has met or exceeded a critical bounce rate threshold of 10%. Bounce rate: {bounce_rate}"
         )
     elif bounce_rate_status == BounceRateStatus.WARNING.value:
-        current_app.logger.info(
+        current_app.logger.warning(
             f"Service: {service_id} has met or exceeded a warning bounce rate threshold of 5%. Bounce rate: {bounce_rate}"
         )
 

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -173,7 +173,9 @@ def check_service_over_bounce_rate(service_id: str):
     bounce_rate = bounce_rate_client.get_bounce_rate(service_id)
     bounce_rate_status = bounce_rate_client.check_bounce_rate_status(service_id)
     debug_data = bounce_rate_client.get_debug_data(service_id)
-    current_app.logger.debug(f"Bounce Rate: {bounce_rate} Bounce Status: {bounce_rate_status}, Debug Data: {debug_data}")
+    current_app.logger.info(
+        f"Service id: {service_id} Bounce Rate: {bounce_rate} Bounce Status: {bounce_rate_status}, Debug Data: {debug_data}"
+    )
     if bounce_rate_status == BounceRateStatus.CRITICAL.value:
         # TODO: Bounce Rate V2, raise a BadRequestError when bounce rate meets or exceeds critical threshold
         current_app.logger.warning(

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -35,7 +35,6 @@ from app.models import (
     SMS_TYPE,
     ApiKey,
     ApiKeyType,
-    BounceRateStatus,
     NotificationType,
     Permission,
     Service,
@@ -286,24 +285,6 @@ def service_can_send_to_recipient(send_to, key_type: ApiKeyType, service: Servic
                 "Can’t send to this recipient when service is in trial mode " f'– see {get_document_url("en", "keys.html#live")}'
             )
         raise BadRequestError(message=message, status_code=400)
-
-
-def check_service_over_bounce_rate(service_id: str):
-    current_app.logger.info(f"Entered check_service_over_bounce_rate with service_id {service_id}")
-    if current_app.config["FF_BOUNCE_RATE_V1"]:
-        bounce_rate = bounce_rate_client.get_bounce_rate(service_id)
-        bounce_rate_status = bounce_rate_client.check_bounce_rate_status(service_id)
-        debug_data = bounce_rate_client.get_debug_data(service_id)
-        current_app.logger.info(f"Bounce Rate: {bounce_rate} Bounce Status: {bounce_rate_status}, Debug Data: {debug_data}")
-        if bounce_rate_status == BounceRateStatus.CRITICAL.value:
-            # TODO: Bounce Rate V2, raise a BadRequestError when bounce rate meets or exceeds critical threshold
-            current_app.logger.info(
-                f"Service: {service_id} has met or exceeded a critical bounce rate threshold of 10%. Bounce rate: {bounce_rate}"
-            )
-        elif bounce_rate_status == BounceRateStatus.WARNING.value:
-            current_app.logger.info(
-                f"Service: {service_id} has met or exceeded a warning bounce rate threshold of 5%. Bounce rate: {bounce_rate}"
-            )
 
 
 def service_has_permission(notify_type, permissions: list[Permission]):

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -20,7 +20,7 @@ from notifications_utils.recipients import (
 from notifications_utils.statsd_decorators import statsd_catch
 from sqlalchemy.orm.exc import NoResultFound
 
-from app import bounce_rate_client, redis_store
+from app import redis_store
 from app.dao import services_dao, templates_dao
 from app.dao.service_email_reply_to_dao import dao_get_reply_to_by_id
 from app.dao.service_letter_contact_dao import dao_get_letter_contact_by_id

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -76,7 +76,6 @@ from app.notifications.validators import (
     check_service_can_schedule_notification,
     check_service_email_reply_to_id,
     check_service_has_permission,
-    check_service_over_bounce_rate,
     check_service_sms_sender_id,
     check_sms_limit_increment_redis_send_warnings_if_needed,
     validate_and_format_recipient,
@@ -178,7 +177,6 @@ def post_bulk():
         remaining_messages = authenticated_service.sms_daily_limit - fragments_sent
     else:
         current_app.logger.info(f"[post_notifications.post_bulk()] Checking bounce rate for service: {authenticated_service.id}")
-        check_service_over_bounce_rate(authenticated_service.id)
         remaining_messages = authenticated_service.message_limit - fetch_todays_total_message_count(authenticated_service.id)
 
     form["validated_sender_id"] = validate_sender_id(template, form.get("reply_to_id"))
@@ -247,10 +245,6 @@ def post_notification(notification_type: NotificationType):
         )
 
     if notification_type == EMAIL_TYPE:
-        current_app.logger.info(
-            f"[post_notifications.post_notification()]Checking bounce rate for service: {authenticated_service.id}"
-        )
-        check_service_over_bounce_rate(authenticated_service.id)
         form = validate(request_json, post_email_request)
     elif notification_type == SMS_TYPE:
         form = validate(request_json, post_sms_request)

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -31,6 +31,7 @@ from app.models import (
     KEY_TYPE_NORMAL,
     KEY_TYPE_TEAM,
     KEY_TYPE_TEST,
+    BounceRateStatus,
     EmailBranding,
     Notification,
     Service,
@@ -1176,3 +1177,28 @@ class TestBounceRate:
                 db_notification,
             )
             app.bounce_rate_client.set_sliding_notifications.assert_called_once_with(sample_service.id, str(db_notification.id))
+
+    def test_check_service_over_bounce_rate_critical(self, mocker, fake_uuid):
+        mocker.patch("app.bounce_rate_client.check_bounce_rate_status", return_value=BounceRateStatus.CRITICAL.value)
+        mocker.patch("app.bounce_rate_client.get_bounce_rate", return_value=current_app.config["BR_CRITICAL_PERCENTAGE"])
+        mock_logger = mocker.patch("app.notifications.validators.current_app.logger.info")
+        send_to_providers.check_service_over_bounce_rate(fake_uuid)
+        mock_logger.assert_called_once_with(
+            f"Service: {fake_uuid} has met or exceeded a critical bounce rate threshold of 10%. Bounce rate: {current_app.config['BR_CRITICAL_PERCENTAGE']}"
+        )
+
+    def test_check_service_over_bounce_rate_warning(self, mocker, fake_uuid):
+        mocker.patch("app.bounce_rate_client.check_bounce_rate_status", return_value=BounceRateStatus.WARNING.value)
+        mocker.patch("app.bounce_rate_client.get_bounce_rate", return_value=current_app.config["BR_WARNING_PERCENTAGE"])
+        mock_logger = mocker.patch("app.notifications.validators.current_app.logger.info")
+        send_to_providers.check_service_over_bounce_rate(fake_uuid)
+        mock_logger.assert_called_once_with(
+            f"Service: {fake_uuid} has met or exceeded a warning bounce rate threshold of 5%. Bounce rate: {current_app.config['BR_WARNING_PERCENTAGE']}"
+        )
+
+    def test_check_service_over_bounce_rate_normal(self, mocker, fake_uuid):
+        mocker.patch("app.bounce_rate_client.check_bounce_rate_status", return_value=BounceRateStatus.NORMAL.value)
+        mocker.patch("app.bounce_rate_client.get_bounce_rate", return_value=0.0)
+        mock_logger = mocker.patch("app.notifications.validators.current_app.logger.info")
+        assert send_to_providers.check_service_over_bounce_rate(fake_uuid) is None
+        mock_logger.assert_not_called()

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -6,6 +6,7 @@ from unittest.mock import ANY, MagicMock, call
 import pytest
 from flask import current_app
 from notifications_utils.recipients import validate_and_format_phone_number
+from pytest_mock import MockFixture
 from requests import HTTPError
 
 import app
@@ -1178,27 +1179,30 @@ class TestBounceRate:
             )
             app.bounce_rate_client.set_sliding_notifications.assert_called_once_with(sample_service.id, str(db_notification.id))
 
-    def test_check_service_over_bounce_rate_critical(self, mocker, fake_uuid):
-        mocker.patch("app.bounce_rate_client.check_bounce_rate_status", return_value=BounceRateStatus.CRITICAL.value)
-        mocker.patch("app.bounce_rate_client.get_bounce_rate", return_value=current_app.config["BR_CRITICAL_PERCENTAGE"])
-        mock_logger = mocker.patch("app.notifications.validators.current_app.logger.info")
-        send_to_providers.check_service_over_bounce_rate(fake_uuid)
-        mock_logger.assert_called_once_with(
-            f"Service: {fake_uuid} has met or exceeded a critical bounce rate threshold of 10%. Bounce rate: {current_app.config['BR_CRITICAL_PERCENTAGE']}"
-        )
+    def test_check_service_over_bounce_rate_critical(self, mocker: MockFixture, notify_api, fake_uuid):
+        with notify_api.app_context():
+            mocker.patch("app.bounce_rate_client.check_bounce_rate_status", return_value=BounceRateStatus.CRITICAL.value)
+            mocker.patch("app.bounce_rate_client.get_bounce_rate", return_value=current_app.config["BR_CRITICAL_PERCENTAGE"])
+            mock_logger = mocker.patch("app.delivery.send_to_providers.current_app.logger.warning")
+            send_to_providers.check_service_over_bounce_rate(fake_uuid)
+            mock_logger.assert_called_once_with(
+                f"Service: {fake_uuid} has met or exceeded a critical bounce rate threshold of 10%. Bounce rate: {current_app.config['BR_CRITICAL_PERCENTAGE']}"
+            )
 
-    def test_check_service_over_bounce_rate_warning(self, mocker, fake_uuid):
-        mocker.patch("app.bounce_rate_client.check_bounce_rate_status", return_value=BounceRateStatus.WARNING.value)
-        mocker.patch("app.bounce_rate_client.get_bounce_rate", return_value=current_app.config["BR_WARNING_PERCENTAGE"])
-        mock_logger = mocker.patch("app.notifications.validators.current_app.logger.info")
-        send_to_providers.check_service_over_bounce_rate(fake_uuid)
-        mock_logger.assert_called_once_with(
-            f"Service: {fake_uuid} has met or exceeded a warning bounce rate threshold of 5%. Bounce rate: {current_app.config['BR_WARNING_PERCENTAGE']}"
-        )
+    def test_check_service_over_bounce_rate_warning(self, mocker: MockFixture, notify_api, fake_uuid):
+        with notify_api.app_context():
+            mocker.patch("app.bounce_rate_client.check_bounce_rate_status", return_value=BounceRateStatus.WARNING.value)
+            mocker.patch("app.bounce_rate_client.get_bounce_rate", return_value=current_app.config["BR_WARNING_PERCENTAGE"])
+            mock_logger = mocker.patch("app.notifications.validators.current_app.logger.warning")
+            send_to_providers.check_service_over_bounce_rate(fake_uuid)
+            mock_logger.assert_called_once_with(
+                f"Service: {fake_uuid} has met or exceeded a warning bounce rate threshold of 5%. Bounce rate: {current_app.config['BR_WARNING_PERCENTAGE']}"
+            )
 
-    def test_check_service_over_bounce_rate_normal(self, mocker, fake_uuid):
-        mocker.patch("app.bounce_rate_client.check_bounce_rate_status", return_value=BounceRateStatus.NORMAL.value)
-        mocker.patch("app.bounce_rate_client.get_bounce_rate", return_value=0.0)
-        mock_logger = mocker.patch("app.notifications.validators.current_app.logger.info")
-        assert send_to_providers.check_service_over_bounce_rate(fake_uuid) is None
-        mock_logger.assert_not_called()
+    def test_check_service_over_bounce_rate_normal(self, mocker: MockFixture, notify_api, fake_uuid):
+        with notify_api.app_context():
+            mocker.patch("app.bounce_rate_client.check_bounce_rate_status", return_value=BounceRateStatus.NORMAL.value)
+            mocker.patch("app.bounce_rate_client.get_bounce_rate", return_value=0.0)
+            mock_logger = mocker.patch("app.notifications.validators.current_app.logger.warning")
+            assert send_to_providers.check_service_over_bounce_rate(fake_uuid) is None
+            mock_logger.assert_not_called()

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -14,7 +14,6 @@ from app.models import (
     LETTER_TYPE,
     SMS_TYPE,
     ApiKeyType,
-    BounceRateStatus,
 )
 from app.notifications.validators import (
     check_reply_to,

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -21,7 +21,6 @@ from app.notifications.validators import (
     check_service_email_reply_to_id,
     check_service_letter_contact_id,
     check_service_over_api_rate_limit_and_update_rate,
-    check_service_over_bounce_rate,
     check_service_over_daily_message_limit,
     check_service_sms_sender_id,
     check_sms_content_char_count,
@@ -618,37 +617,6 @@ def test_check_service_sms_sender_id_where_sms_sender_is_not_found(sample_servic
         check_service_sms_sender_id(sample_service.id, fake_uuid, SMS_TYPE)
     assert e.value.status_code == 400
     assert e.value.message == "sms_sender_id {} does not exist in database for service id {}".format(fake_uuid, sample_service.id)
-
-
-@pytest.mark.skip(reason="Disable temporarily to test logging")
-def test_check_service_over_bounce_rate_critical(mocker, fake_uuid):
-    mocker.patch("app.bounce_rate_client.check_bounce_rate_status", return_value=BounceRateStatus.CRITICAL.value)
-    mocker.patch("app.bounce_rate_client.get_bounce_rate", return_value=current_app.config["BR_CRITICAL_PERCENTAGE"])
-    mock_logger = mocker.patch("app.notifications.validators.current_app.logger.info")
-    check_service_over_bounce_rate(fake_uuid)
-    mock_logger.assert_called_once_with(
-        f"Service: {fake_uuid} has met or exceeded a critical bounce rate threshold of 10%. Bounce rate: {current_app.config['BR_CRITICAL_PERCENTAGE']}"
-    )
-
-
-@pytest.mark.skip(reason="Disable temporarily to test logging")
-def test_check_service_over_bounce_rate_warning(mocker, fake_uuid):
-    mocker.patch("app.bounce_rate_client.check_bounce_rate_status", return_value=BounceRateStatus.WARNING.value)
-    mocker.patch("app.bounce_rate_client.get_bounce_rate", return_value=current_app.config["BR_WARNING_PERCENTAGE"])
-    mock_logger = mocker.patch("app.notifications.validators.current_app.logger.info")
-    check_service_over_bounce_rate(fake_uuid)
-    mock_logger.assert_called_once_with(
-        f"Service: {fake_uuid} has met or exceeded a warning bounce rate threshold of 5%. Bounce rate: {current_app.config['BR_WARNING_PERCENTAGE']}"
-    )
-
-
-@pytest.mark.skip(reason="Disable temporarily to test logging")
-def test_check_service_over_bounce_rate_normal(mocker, fake_uuid):
-    mocker.patch("app.bounce_rate_client.check_bounce_rate_status", return_value=BounceRateStatus.NORMAL.value)
-    mocker.patch("app.bounce_rate_client.get_bounce_rate", return_value=0.0)
-    mock_logger = mocker.patch("app.notifications.validators.current_app.logger.info")
-    assert check_service_over_bounce_rate(fake_uuid) is None
-    mock_logger.assert_not_called()
 
 
 def test_check_service_letter_contact_id_where_letter_contact_id_is_none():

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -1013,7 +1013,6 @@ class TestSendingDocuments:
         template = create_template(service=service, template_type="email", content=content)
 
         statsd_mock = mocker.patch("app.v2.notifications.post_notifications.statsd_client")
-        mocker.patch("app.notifications.validators.check_service_over_bounce_rate")
         mock_publish = mocker.patch("app.email_normal_publish.publish")
         document_download_mock = mocker.patch("app.v2.notifications.post_notifications.document_download_client.upload_document")
         document_response = document_download_response({"sending_method": sending_method, "mime_type": "text/plain"})
@@ -1087,7 +1086,6 @@ class TestSendingDocuments:
         template = create_template(service=service, template_type="email", content=content)
 
         mocker.patch("app.v2.notifications.post_notifications.statsd_client")
-        mocker.patch("app.notifications.validators.check_service_over_bounce_rate")
         document_download_mock = mocker.patch("app.v2.notifications.post_notifications.document_download_client.upload_document")
         document_response = document_download_response({"sending_method": sending_method, "mime_type": "text/plain"})
         document_download_mock.return_value = document_response
@@ -1148,7 +1146,6 @@ class TestSendingDocuments:
         template = create_template(service=service, template_type="email", content=template_content)
 
         mocker.patch("app.v2.notifications.post_notifications.statsd_client")
-        mocker.patch("app.notifications.validators.check_service_over_bounce_rate")
         document_download_mock = mocker.patch("app.v2.notifications.post_notifications.document_download_client.upload_document")
         document_response = document_download_response({"sending_method": sending_method, "mime_type": "text/plain"})
         document_download_mock.return_value = document_response


### PR DESCRIPTION
# Summary | Résumé

Moved the bounce rate check to `send_to_providers.py` in celery. This allows us to call it from one place, and when we later suspend the service from here, it should work since we do not send to the provider if the service is suspended.

# Test instructions | Instructions pour tester la modification

Tests should pass, we can QA the logs in Staging.

