### PR TITLE
Remove unneeded `s3.remove_job_from_s3` logic

### DIFF
--- a/app/aws/s3.py
+++ b/app/aws/s3.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import datetime, timedelta
+from typing import Optional
 
 import botocore
 import pytz
@@ -38,7 +39,7 @@ def get_job_location(service_id, job_id):
     )
 
 
-def upload_job_to_s3(service_id, file_data):
+def upload_job_to_s3(service_id, file_data, expiry: Optional[datetime]=None):
     upload_id = str(uuid.uuid4())
     bucket, location = get_job_location(service_id, upload_id)
     utils_s3upload(
@@ -46,6 +47,7 @@ def upload_job_to_s3(service_id, file_data):
         region=current_app.config["AWS_REGION"],
         bucket_name=bucket,
         file_location=location,
+        expiry=expiry
     )
     return upload_id
 

--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -51,7 +51,6 @@ def remove_letter_csv_files():
 def _remove_csv_files(job_types):
     jobs = dao_get_jobs_older_than_data_retention(notification_types=job_types)
     for job in jobs:
-        s3.remove_job_from_s3(job.service_id, job.id)
         dao_archive_job(job)
         current_app.logger.info("Job ID {} has been removed from s3.".format(job.id))
 

--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -52,7 +52,6 @@ def _remove_csv_files(job_types):
     jobs = dao_get_jobs_older_than_data_retention(notification_types=job_types)
     for job in jobs:
         dao_archive_job(job)
-        current_app.logger.info("Job ID {} has been removed from s3.".format(job.id))
 
 
 @notify_celery.task(name="delete-sms-notifications")

--- a/poetry.lock
+++ b/poetry.lock
@@ -2454,7 +2454,7 @@ requests = ">=2.0.0"
 
 [[package]]
 name = "notifications-utils"
-version = "50.3.2"
+version = "50.3.4"
 description = "Shared python code for Notification - Provides logging utils etc."
 category = "main"
 optional = false
@@ -2488,8 +2488,8 @@ werkzeug = "2.2.3"
 [package.source]
 type = "git"
 url = "https://github.com/cds-snc/notifier-utils.git"
-reference = "50.3.2"
-resolved_reference = "deea67992424aae324aa597058d56a7813c4c0ea"
+reference = "feat/add-expiry-to-s3-upload"
+resolved_reference = "d9b465472a7e71cf1d0f7a0123fd411c2e7a0a21"
 
 [[package]]
 name = "ordered-set"
@@ -4179,4 +4179,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10.9"
-content-hash = "d88febce0f5682f9d532c1cd4a7b19fea8379e2dbab0aea4d39092c6d6fc9527"
+content-hash = "c4875d16cabf74cfa94b0ed8109df51bd5c2ba73f8ea5fc37b9722d3527f6762"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ Werkzeug = "2.2.3"
 MarkupSafe = "2.1.2"
 # REVIEW: v2 is using sha512 instead of sha1 by default (in v1)
 itsdangerous = "2.1.2"
-notifications-utils = {git = "https://github.com/cds-snc/notifier-utils.git", rev = "50.3.2"}
+notifications-utils = {git = "https://github.com/cds-snc/notifier-utils.git", rev = "feat/add-expiry-to-s3-upload"}
 
 # rsa = "4.9  # awscli 1.22.38 depends on rsa<4.8
 typing-extensions = "4.5.0"

--- a/tests/app/celery/test_nightly_tasks.py
+++ b/tests/app/celery/test_nightly_tasks.py
@@ -87,16 +87,12 @@ def test_will_remove_csv_files_for_jobs_older_than_seven_days(notify_db, notify_
 
     create_job(sample_template, created_at=nine_days_one_second_ago, archived=True)
     job1_to_delete = create_job(sample_template, created_at=eight_days_ago)
-    job2_to_delete = create_job(sample_template, created_at=just_under_nine_days)
+    create_job(sample_template, created_at=just_under_nine_days)
     dont_delete_me_1 = create_job(sample_template, created_at=seven_days_ago)
     create_job(sample_template, created_at=just_under_seven_days)
 
     remove_sms_email_csv_files()
 
-    assert s3.remove_job_from_s3.call_args_list == [
-        call(job1_to_delete.service_id, job1_to_delete.id),
-        call(job2_to_delete.service_id, job2_to_delete.id),
-    ]
     assert job1_to_delete.archived is True
     assert dont_delete_me_1.archived is False
 
@@ -121,25 +117,15 @@ def test_will_remove_csv_files_for_jobs_older_than_retention_period(notify_db, n
     eight_days_ago = datetime.utcnow() - timedelta(days=8)
     thirty_one_days_ago = datetime.utcnow() - timedelta(days=31)
 
-    job1_to_delete = create_job(sms_template_service_1, created_at=four_days_ago)
-    job2_to_delete = create_job(email_template_service_1, created_at=eight_days_ago)
+    create_job(sms_template_service_1, created_at=four_days_ago)
+    create_job(email_template_service_1, created_at=eight_days_ago)
     create_job(email_template_service_1, created_at=four_days_ago)
 
     create_job(email_template_service_2, created_at=eight_days_ago)
-    job3_to_delete = create_job(email_template_service_2, created_at=thirty_one_days_ago)
-    job4_to_delete = create_job(sms_template_service_2, created_at=eight_days_ago)
+    create_job(email_template_service_2, created_at=thirty_one_days_ago)
+    create_job(sms_template_service_2, created_at=eight_days_ago)
 
     remove_sms_email_csv_files()
-
-    s3.remove_job_from_s3.assert_has_calls(
-        [
-            call(job1_to_delete.service_id, job1_to_delete.id),
-            call(job2_to_delete.service_id, job2_to_delete.id),
-            call(job3_to_delete.service_id, job3_to_delete.id),
-            call(job4_to_delete.service_id, job4_to_delete.id),
-        ],
-        any_order=True,
-    )
 
 
 @freeze_time("2017-01-01 10:00:00")
@@ -153,14 +139,10 @@ def test_remove_csv_files_filters_by_type(mocker, sample_service):
 
     eight_days_ago = datetime.utcnow() - timedelta(days=8)
 
-    job_to_delete = create_job(template=letter_template, created_at=eight_days_ago)
+    create_job(template=letter_template, created_at=eight_days_ago)
     create_job(template=sms_template, created_at=eight_days_ago)
 
     remove_letter_csv_files()
-
-    assert s3.remove_job_from_s3.call_args_list == [
-        call(job_to_delete.service_id, job_to_delete.id),
-    ]
 
 
 def test_should_call_delete_sms_notifications_more_than_week_in_task(notify_api, mocker):


### PR DESCRIPTION
# Summary | Résumé

Calling `s3.remove_job_from_s3` from the nightly task is unnecessary. We already have a policy on the bucket that all files will expire after 7 days: https://github.com/cds-snc/notification-terraform/blob/main/aws/common/s3.tf#LL17C1-L23C1

This may also have been contributing to our 4am celery errors where memory consumption would spike. 

# Test instructions | Instructions pour tester la modification

Tests should pass in CI. You can try logging in to s3 to verify that files in the `notification-canada-ca-{env}-csv-upload` buckets have the 7 day expiry set.
