### PR TITLE
Add check to CI to ensure poetry.lock is consistent with pyproject.toml

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,6 +35,8 @@ jobs:
       env:
         POETRY_VERSION: "1.3.2"
       run: pip install poetry==${POETRY_VERSION} && poetry --version
+    - name: Check poetry.lock aligns with pyproject.toml
+      run: poetry lock --check
     - name: Install requirements
       run: poetry install --with test
     - name: Run tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry.dependencies]
 python = "~3.10.9"
 apig-wsgi = "2.15.0"
-boto = "2.48.0"
+boto = "2.49.0"
 cffi = "1.15.1"
 celery = {extras = ["sqs"], version = "5.2.7"}
 docopt = "0.6.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry.dependencies]
 python = "~3.10.9"
 apig-wsgi = "2.15.0"
-boto = "2.49.0"
+boto = "2.48.0"
 cffi = "1.15.1"
 celery = {extras = ["sqs"], version = "5.2.7"}
 docopt = "0.6.2"


### PR DESCRIPTION
# Summary | Résumé
Current we do not have safe guards in place to prevent an outdated `poetry.lock` file from being committed to main. When this occurs it can lead to our dev containers running into issues. This PR adds a check during the test CI job to ensure that the lock file is up to date and consistent with `pyproject.toml`.
