### PR TITLE
Create a new backend-specific feature flag for bounce rate

### DIFF
--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -79,7 +79,7 @@ def process_ses_results(self, response):
         statsd_client.incr("callback.ses.{}".format(notification_status))
 
         # Record bounces and notifications in Redis
-        if current_app.config["FF_BOUNCE_RATE_V1"]:
+        if current_app.config["FF_BOUNCE_RATE_BACKEND"]:
             if notification_status == NOTIFICATION_PERMANENT_FAILURE:
                 bounce_rate_client.set_sliding_hard_bounce(notification.service_id, str(notification.id))
                 current_app.logger.info(

--- a/app/config.py
+++ b/app/config.py
@@ -515,7 +515,7 @@ class Config(object):
     FF_SALESFORCE_CONTACT = env.bool("FF_SALESFORCE_CONTACT", False)
 
     # Feature flags for bounce rate
-    FF_BOUNCE_RATE_V1 = env.bool("FF_BOUNCE_RATE_V1", False)
+    FF_BOUNCE_RATE_BACKEND = env.bool("FF_BOUNCE_RATE_BACKEND", False)
     # Timestamp in epoch milliseconds to seed the bounce rate. We will seed data for (24, the below config) included.
     FF_BOUNCE_RATE_SEED_EPOCH_MS = os.getenv("FF_BOUNCE_RATE_SEED_EPOCH_MS", False)
 
@@ -614,7 +614,7 @@ class Test(Development):
     API_HOST_NAME = "http://localhost:6011"
 
     TEMPLATE_PREVIEW_API_HOST = "http://localhost:9999"
-    FF_BOUNCE_RATE_V1 = True
+    FF_BOUNCE_RATE_BACKEND = True
 
 
 class Production(Config):

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -167,7 +167,7 @@ def check_for_malware_errors(document_download_response_code, notification):
 
 
 def check_service_over_bounce_rate(service_id: str):
-    if not current_app.config["FF_BOUNCE_RATE_V1"]:
+    if not current_app.config["FF_BOUNCE_RATE_BACKEND"]:
         return
 
     bounce_rate = bounce_rate_client.get_bounce_rate(service_id)
@@ -278,7 +278,7 @@ def send_email_to_provider(notification: Notification):
                 reply_to_address=validate_and_format_email_address(email_reply_to) if email_reply_to else None,
                 attachments=attachments,
             )
-            if current_app.config["FF_BOUNCE_RATE_V1"]:
+            if current_app.config["FF_BOUNCE_RATE_BACKEND"]:
                 check_service_over_bounce_rate(service.id)
                 bounce_rate_client.set_sliding_notifications(service.id, str(notification.id))
                 current_app.logger.info(f"Setting total notifications for service {service.id} in REDIS")

--- a/app/models.py
+++ b/app/models.py
@@ -1758,7 +1758,7 @@ class Notification(BaseModel):
 
     @property
     def formatted_status(self):
-        if current_app.config["FF_BOUNCE_RATE_V1"]:
+        if current_app.config["FF_BOUNCE_RATE_BACKEND"]:
 
             def _getStatusByBounceSubtype():
                 """Return the status of a notification based on the bounce sub type"""
@@ -1802,7 +1802,7 @@ class Notification(BaseModel):
             }[self.template.template_type].get(self.status, self.status)
 
         # -----------------
-        # remove this code when FF_BOUNCE_RATE_V1 is removed
+        # remove this code when FF_BOUNCE_RATE_BACKEND is removed
         # -----------------
         return {
             "email": {

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -161,7 +161,7 @@ def post_bulk():
     max_rows = current_app.config["CSV_MAX_ROWS"]
     check_sms_limit = current_app.config["FF_SPIKE_SMS_DAILY_LIMIT"]
     epoch_seeding_bounce = current_app.config["FF_BOUNCE_RATE_SEED_EPOCH_MS"]
-    bounce_rate_v1 = current_app.config["FF_BOUNCE_RATE_V1"]
+    bounce_rate_v1 = current_app.config["FF_BOUNCE_RATE_BACKEND"]
     if bounce_rate_v1 and epoch_seeding_bounce:
         _seed_bounce_data(epoch_seeding_bounce, str(authenticated_service.id))
 
@@ -253,7 +253,7 @@ def post_notification(notification_type: NotificationType):
     else:
         abort(404)
 
-    bounce_rate_v1 = current_app.config["FF_BOUNCE_RATE_V1"]
+    bounce_rate_v1 = current_app.config["FF_BOUNCE_RATE_BACKEND"]
     epoch_seeding_bounce = current_app.config["FF_BOUNCE_RATE_SEED_EPOCH_MS"]
     if bounce_rate_v1 and epoch_seeding_bounce:
         _seed_bounce_data(epoch_seeding_bounce, str(authenticated_service.id))

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -1445,7 +1445,7 @@ def app_statsd(mocker):
 
 @pytest.fixture(scope="function")
 def app_bounce_rate_client(mocker):
-    current_app.config["FF_BOUNCE_RATE_V1"] = True
+    current_app.config["FF_BOUNCE_RATE_BACKEND"] = True
     current_app.bounce_rate_client = mocker.Mock()
     return current_app
 

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -1168,7 +1168,7 @@ class TestMalware:
 
 class TestBounceRate:
     def test_send_email_should_use_service_reply_to_email(self, sample_service, sample_email_template, mocker, notify_api):
-        with set_config_values(notify_api, {"FF_BOUNCE_RATE_V1": True}):
+        with set_config_values(notify_api, {"FF_BOUNCE_RATE_BACKEND": True}):
             mocker.patch("app.aws_ses_client.send_email", return_value="reference")
             mocker.patch("app.bounce_rate_client.set_sliding_notifications")
             db_notification = save_notification(create_notification(template=sample_email_template, reply_to_text="foo@bar.com"))

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1577,7 +1577,7 @@ def test_get_all_notifications_for_service_formatted_for_csv(client, sample_temp
     assert resp["notifications"][0]["template_name"] == sample_template.name
     assert resp["notifications"][0]["template_type"] == notification.notification_type
 
-    if current_app.config["FF_BOUNCE_RATE_V1"]:
+    if current_app.config["FF_BOUNCE_RATE_BACKEND"]:
         assert resp["notifications"][0]["status"] == "In transit"
     else:
         assert resp["notifications"][0]["status"] == "Sending"

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -126,7 +126,7 @@ def test_notification_for_csv_returns_correct_job_row_number(sample_job):
     assert serialized["row_number"] == 1
 
 
-# This test needs to be removed when FF_BOUNCE_RATE_V1 is removed
+# This test needs to be removed when FF_BOUNCE_RATE_BACKEND is removed
 @freeze_time("2016-01-30 12:39:58.321312")
 @pytest.mark.parametrize(
     "template_type, status, expected_status",
@@ -145,7 +145,7 @@ def test_notification_for_csv_returns_correct_job_row_number(sample_job):
     ],
 )
 def test_notification_for_csv_returns_formatted_status(sample_service, template_type, status, expected_status):
-    if not current_app.config["FF_BOUNCE_RATE_V1"]:
+    if not current_app.config["FF_BOUNCE_RATE_BACKEND"]:
         template = create_template(sample_service, template_type=template_type)
         notification = save_notification(create_notification(template, status=status))
 
@@ -175,7 +175,7 @@ def test_notification_for_csv_returns_formatted_status(sample_service, template_
 def test_notification_for_csv_returns_formatted_status_ff_bouncerate(
     sample_service, template_type, status, feedback_subtype, expected_status
 ):
-    if current_app.config["FF_BOUNCE_RATE_V1"]:
+    if current_app.config["FF_BOUNCE_RATE_BACKEND"]:
         template = create_template(sample_service, template_type=template_type)
         notification = save_notification(create_notification(template, status=status))
         if feedback_subtype:


### PR DESCRIPTION
# Summary | Résumé

Create a new backend-specific feature flag for bounce rate. The purpose of this is so we can turn this on independently of the frontend, and start to collect data in Redis and log the bounce rate. There should be no user-visible changes related to this. 

This is to start populated data in Redis to enable us to display data from Redis in the UI for those services that have the bounce rate feature turned on: https://github.com/cds-snc/notification-admin/pull/1554 

# Test instructions | Instructions pour tester la modification

CI should pass, should be no visible changes.

# Release Instructions | Instructions pour le déploiement

We will need a follow up PR to turn this feature flag on in Staging.