### PR TITLE
Fix/tweak resigning

### DIFF
--- a/app/dao/api_key_dao.py
+++ b/app/dao/api_key_dao.py
@@ -13,10 +13,11 @@ from app.models import ApiKey
 
 
 @transactional
-def resign_api_keys(unsafe: bool = False):
+def resign_api_keys(resign: bool, unsafe: bool = False):
     """Resign the _secret column of the api_keys table with (potentially) a new key.
 
     Args:
+        resign (bool): whether to resign the api keys
         unsafe (bool, optional): resign regardless of whether the unsign step fails with a BadSignature.
         Defaults to False.
 
@@ -24,10 +25,12 @@ def resign_api_keys(unsafe: bool = False):
         e: BadSignature if the unsign step fails and unsafe is False.
     """
     rows = ApiKey.query.all()  # noqa
-    current_app.logger.info(f"Resigning {len(rows)} api keys")
+    current_app.logger.info(f"Total of {len(rows)} api keys")
 
+    rows_to_update = []
     for row in rows:
         try:
+            old_signature = row._secret
             unsigned_secret = getattr(row, "secret")  # unsign the secret
         except BadSignature as e:
             if unsafe:
@@ -36,7 +39,16 @@ def resign_api_keys(unsafe: bool = False):
                 current_app.logger.error(f"BadSignature for api_key {row.id}, using verify_unsafe instead")
                 raise e
         setattr(row, "secret", unsigned_secret)  # resigns the api key secret with (potentially) a new signing secret
-    db.session.bulk_save_objects(rows)
+        if old_signature != row._secret:
+            rows_to_update.append(row)
+        if not resign:
+            row._secret = old_signature  # reset the signature to the old value
+    
+    if resign:
+        current_app.logger.info(f"Resigning {len(rows_to_update)} api keys")
+        db.session.bulk_save_objects(rows)
+    elif not resign:
+        current_app.logger.info(f"{len(rows_to_update)} api keys need resigning")
 
 
 @transactional

--- a/app/dao/api_key_dao.py
+++ b/app/dao/api_key_dao.py
@@ -26,8 +26,8 @@ def resign_api_keys(resign: bool, unsafe: bool = False):
     """
     rows = ApiKey.query.all()  # noqa
     current_app.logger.info(f"Total of {len(rows)} api keys")
-
     rows_to_update = []
+
     for row in rows:
         try:
             old_signature = row._secret
@@ -43,7 +43,7 @@ def resign_api_keys(resign: bool, unsafe: bool = False):
             rows_to_update.append(row)
         if not resign:
             row._secret = old_signature  # reset the signature to the old value
-    
+
     if resign:
         current_app.logger.info(f"Resigning {len(rows_to_update)} api keys")
         db.session.bulk_save_objects(rows)

--- a/app/dao/inbound_sms_dao.py
+++ b/app/dao/inbound_sms_dao.py
@@ -24,7 +24,7 @@ def resign_inbound_sms(resign: bool, unsafe: bool = False):
         e: BadSignature if the unsign step fails and unsafe is False.
     """
     rows = InboundSms.query.all()  # noqa
-    current_app.logger.info(f"Total of {len(rows)} api keys")
+    current_app.logger.info(f"Total of {len(rows)} inbound sms")
     rows_to_update = []
 
     for row in rows:

--- a/app/dao/inbound_sms_dao.py
+++ b/app/dao/inbound_sms_dao.py
@@ -11,10 +11,12 @@ from app.utils import midnight_n_days_ago
 
 
 @transactional
-def resign_inbound_sms(unsafe: bool = False):
+def resign_inbound_sms(resign: bool, unsafe: bool = False):
     """Resign the _content column of the inbound_sms table with (potentially) a new key.
 
     Args:
+
+        resign (bool): whether to resign the inbound sms
         unsafe (bool, optional): resign regardless of whether the unsign step fails with a BadSignature.
         Defaults to False.
 
@@ -22,10 +24,12 @@ def resign_inbound_sms(unsafe: bool = False):
         e: BadSignature if the unsign step fails and unsafe is False.
     """
     rows = InboundSms.query.all()  # noqa
-    current_app.logger.info(f"Resigning {len(rows)} inbound sms")
+    current_app.logger.info(f"Total of {len(rows)} api keys")
+    rows_to_update = []
 
     for row in rows:
         try:
+            old_signature = row._content
             unsigned_content = getattr(row, "content")  # unsign the content
         except BadSignature as e:
             if unsafe:
@@ -34,7 +38,16 @@ def resign_inbound_sms(unsafe: bool = False):
                 current_app.logger.error(f"BadSignature for inbound_sms {row.id}")
                 raise e
         setattr(row, "content", unsigned_content)  # resigns the content with (potentially) a new signing secret
-    db.session.bulk_save_objects(rows)
+        if old_signature != row._content:
+            rows_to_update.append(row)
+        if not resign:
+            row._content = old_signature  # reset the signature to the old value
+
+    if resign:
+        current_app.logger.info(f"Resigning {len(rows_to_update)} inbound sms")
+        db.session.bulk_save_objects(rows)
+    elif not resign:
+        current_app.logger.info(f"{len(rows_to_update)} inbound sms need resigning")
 
 
 @transactional

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -57,6 +57,7 @@ from app.utils import (
     midnight_n_days_ago,
 )
 
+
 @transactional
 def _resign_notifications_chunk(chunk_offset: int, chunk_size: int, resign: bool, unsafe: bool) -> int:
     rows = Notification.query.order_by(Notification.created_at).slice(chunk_offset, chunk_offset + chunk_size).all()
@@ -64,8 +65,8 @@ def _resign_notifications_chunk(chunk_offset: int, chunk_size: int, resign: bool
 
     rows_to_update = []
     for row in rows:
-        old_personalisation = row._personalisation
-        if old_personalisation:
+        old_signature = row._personalisation
+        if old_signature:
             try:
                 unsigned_personalisation = getattr(row, "personalisation")  # unsign the personalisation
             except BadSignature as e:
@@ -77,21 +78,21 @@ def _resign_notifications_chunk(chunk_offset: int, chunk_size: int, resign: bool
         setattr(
             row, "personalisation", unsigned_personalisation
         )  # resigns the personalisation with (potentially) a new signing secret
-        if old_personalisation != row._personalisation:
+        if old_signature != row._personalisation:
             rows_to_update.append(row)
         if not resign:
-            row._personalisation = old_personalisation  # reset the signature to the old value
-        
+            row._personalisation = old_signature  # reset the signature to the old value
+
     if resign and len(rows_to_update) > 0:
         current_app.logger.info(f"Resigning {len(rows_to_update)} notifications")
         db.session.bulk_save_objects(rows)
     elif len(rows_to_update) > 0:
         current_app.logger.info(f"{len(rows_to_update)} notifications need resigning")
-    
+
     return len(rows_to_update)
 
 
-def resign_notifications(chunk_size: int, resign: bool, unsafe: bool = False):
+def resign_notifications(chunk_size: int, resign: bool, unsafe: bool = False) -> int:
     """Resign the _personalisation column of the notifications table with (potentially) a new key.
 
     Args:
@@ -100,10 +101,13 @@ def resign_notifications(chunk_size: int, resign: bool, unsafe: bool = False):
         unsafe (bool, optional): resign regardless of whether the unsign step fails with a BadSignature. Defaults to False.
         max_update_size(int, -1): max number of rows to update at once, -1 for no limit. Defautls to -1.
 
+    Returns:
+        int: number of notifications that were resigned or need to be resigned.
+
     Raises:
         e: BadSignature if the unsign step fails and unsafe is False.
     """
-    
+
     total_notifications = Notification.query.count()
     current_app.logger.info(f"Total of {total_notifications} notifications")
     num_old_signatures = 0
@@ -111,11 +115,12 @@ def resign_notifications(chunk_size: int, resign: bool, unsafe: bool = False):
     for chunk_offset in range(0, total_notifications, chunk_size):
         num_old_signatures_in_chunk = _resign_notifications_chunk(chunk_offset, chunk_size, resign, unsafe)
         num_old_signatures += num_old_signatures_in_chunk
-    
+
     if resign:
         current_app.logger.info(f"Overall, {num_old_signatures} notifications were resigned")
     else:
         current_app.logger.info(f"Overall, {num_old_signatures} notifications need resigning")
+    return num_old_signatures
 
 
 @statsd(namespace="dao")

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -57,23 +57,15 @@ from app.utils import (
     midnight_n_days_ago,
 )
 
-
 @transactional
-def resign_notifications(unsafe: bool = False):
-    """Resign the _personalisation column of the notifications table with (potentially) a new key.
+def _resign_notifications_chunk(chunk_offset: int, chunk_size: int, resign: bool, unsafe: bool) -> int:
+    rows = Notification.query.order_by(Notification.created_at).slice(chunk_offset, chunk_offset + chunk_size).all()
+    current_app.logger.info(f"Processing chunk {chunk_offset} to {chunk_offset + len(rows) - 1}")
 
-    Args:
-        unsafe (bool, optional): resign regardless of whether the unsign step fails with a BadSignature.
-        Defaults to False.
-
-    Raises:
-        e: BadSignature if the unsign step fails and unsafe is False.
-    """
-    rows = Notification.query.all()  # noqa
-    current_app.logger.info(f"Resigning {len(rows)} notifications")
-
+    rows_to_update = []
     for row in rows:
-        if row._personalisation:
+        old_personalisation = row._personalisation
+        if old_personalisation:
             try:
                 unsigned_personalisation = getattr(row, "personalisation")  # unsign the personalisation
             except BadSignature as e:
@@ -85,7 +77,45 @@ def resign_notifications(unsafe: bool = False):
         setattr(
             row, "personalisation", unsigned_personalisation
         )  # resigns the personalisation with (potentially) a new signing secret
-    db.session.bulk_save_objects(rows)
+        if old_personalisation != row._personalisation:
+            rows_to_update.append(row)
+        if not resign:
+            row._personalisation = old_personalisation  # reset the signature to the old value
+        
+    if resign and len(rows_to_update) > 0:
+        current_app.logger.info(f"Resigning {len(rows_to_update)} notifications")
+        db.session.bulk_save_objects(rows)
+    elif len(rows_to_update) > 0:
+        current_app.logger.info(f"{len(rows_to_update)} notifications need resigning")
+    
+    return len(rows_to_update)
+
+
+def resign_notifications(chunk_size: int, resign: bool, unsafe: bool = False):
+    """Resign the _personalisation column of the notifications table with (potentially) a new key.
+
+    Args:
+        chunk_size (int): number of rows to update at once.
+        resign (bool): resign the notifications.
+        unsafe (bool, optional): resign regardless of whether the unsign step fails with a BadSignature. Defaults to False.
+        max_update_size(int, -1): max number of rows to update at once, -1 for no limit. Defautls to -1.
+
+    Raises:
+        e: BadSignature if the unsign step fails and unsafe is False.
+    """
+    
+    total_notifications = Notification.query.count()
+    current_app.logger.info(f"Total of {total_notifications} notifications")
+    num_old_signatures = 0
+
+    for chunk_offset in range(0, total_notifications, chunk_size):
+        num_old_signatures_in_chunk = _resign_notifications_chunk(chunk_offset, chunk_size, resign, unsafe)
+        num_old_signatures += num_old_signatures_in_chunk
+    
+    if resign:
+        current_app.logger.info(f"Overall, {num_old_signatures} notifications were resigned")
+    else:
+        current_app.logger.info(f"Overall, {num_old_signatures} notifications need resigning")
 
 
 @statsd(namespace="dao")

--- a/scripts/resign_database.py
+++ b/scripts/resign_database.py
@@ -24,6 +24,7 @@ from app.dao.api_key_dao import resign_api_keys  # noqa: E402
 from app.dao.inbound_sms_dao import resign_inbound_sms  # noqa: E402
 from app.dao.notifications_dao import resign_notifications  # noqa: E402
 from app.dao.service_callback_api_dao import resign_service_callbacks  # noqa: E402
+from flask import current_app
 
 
 def resign_all(chunk: int, resign: bool, unsafe: bool):
@@ -32,7 +33,7 @@ def resign_all(chunk: int, resign: bool, unsafe: bool):
     resign_service_callbacks(resign, unsafe)
     resign_notifications(chunk, resign, unsafe)
     if not resign:
-        print("This is a preview, fields have not been changed. To resign fields, run with --resign flag")
+        current_app.logger.info("NOTE: this is a preview, fields have not been changed. To resign fields, run with --resign flag")
 
 
 if __name__ == "__main__":

--- a/scripts/resign_database.py
+++ b/scripts/resign_database.py
@@ -27,10 +27,12 @@ from app.dao.service_callback_api_dao import resign_service_callbacks  # noqa: E
 
 
 def resign_all(chunk:int, resign: bool, unsafe: bool):
-    resign_api_keys(unsafe)
-    resign_inbound_sms(unsafe)
-    resign_service_callbacks(unsafe)
+    resign_api_keys(resign, unsafe)
+    resign_inbound_sms(resign, unsafe)
+    resign_service_callbacks(resign, unsafe)
     resign_notifications(chunk, resign, unsafe)
+    if not resign:
+        print(f"This is a preview, fields have not been changed. To resign fields, run with --resign flag")
 
 
 if __name__ == "__main__":

--- a/scripts/resign_database.py
+++ b/scripts/resign_database.py
@@ -26,13 +26,13 @@ from app.dao.notifications_dao import resign_notifications  # noqa: E402
 from app.dao.service_callback_api_dao import resign_service_callbacks  # noqa: E402
 
 
-def resign_all(chunk:int, resign: bool, unsafe: bool):
+def resign_all(chunk: int, resign: bool, unsafe: bool):
     resign_api_keys(resign, unsafe)
     resign_inbound_sms(resign, unsafe)
     resign_service_callbacks(resign, unsafe)
     resign_notifications(chunk, resign, unsafe)
     if not resign:
-        print(f"This is a preview, fields have not been changed. To resign fields, run with --resign flag")
+        print("This is a preview, fields have not been changed. To resign fields, run with --resign flag")
 
 
 if __name__ == "__main__":

--- a/scripts/resign_database.py
+++ b/scripts/resign_database.py
@@ -26,16 +26,18 @@ from app.dao.notifications_dao import resign_notifications  # noqa: E402
 from app.dao.service_callback_api_dao import resign_service_callbacks  # noqa: E402
 
 
-def resign_all(unsafe: bool = False):
+def resign_all(chunk:int, resign: bool, unsafe: bool):
     resign_api_keys(unsafe)
     resign_inbound_sms(unsafe)
     resign_service_callbacks(unsafe)
-    resign_notifications(unsafe)
+    resign_notifications(chunk, resign, unsafe)
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--unsafe", default=False, action='store_true', help="resign notifications that have a bad signature")
+    parser.add_argument("--chunk", default=25000, type=int, help="size of chunks of notifications to resign at a time (default 25000)")
+    parser.add_argument("--resign", default=False, action='store_true', help="resign columns (default false)")
+    parser.add_argument("--unsafe", default=False, action='store_true', help="ignore bad signatures (default false)")
     args = parser.parse_args()
 
     load_dotenv()
@@ -43,4 +45,4 @@ if __name__ == "__main__":
     create_app(application)
     application.app_context().push()
 
-    resign_all(args.unsafe)
+    resign_all(args.chunk, args.resign, args.unsafe)

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -1803,20 +1803,52 @@ class TestBulkInsertNotifications:
 
 
 class TestResigning:
-    def test_resign_notifications_resigns_with_new_key(self, sample_template_with_placeholders):
+    # @pytest.mark.parametrize("resign", [True, False])
+    # def test_resign_notifications_resigns_or_previews(self, resign, sample_template_with_placeholders):
+    #     from app import signer_personalisation
+
+    #     with set_signer_secret_key(signer_personalisation, ["k1", "k2"]):
+    #         initial_notification = create_notification(sample_template_with_placeholders, personalisation={"Name": "test"})
+    #         save_notification(initial_notification)
+    #         personalisation = initial_notification.personalisation
+    #         _personalisation = initial_notification._personalisation
+
+    #     with set_signer_secret_key(signer_personalisation, ["k2", "k3"]):
+    #         resign_notifications(chunk_size=10, resign=resign)
+    #         notification = Notification.query.get(initial_notification.id)
+    #         assert notification.personalisation == personalisation  # unsigned value is the same
+    #         if resign:
+    #             assert notification._personalisation != _personalisation  # signature is different
+    #         else:
+    #             assert notification._personalisation == _personalisation  # signature is the same
+
+    @pytest.mark.parametrize("resign,chunk_size", [(True, 2), (False, 2), (True, 10), (False, 10)])
+    def test_resign_notifications_resigns_or_previews(self, resign, chunk_size, sample_template_with_placeholders):
         from app import signer_personalisation
 
         with set_signer_secret_key(signer_personalisation, ["k1", "k2"]):
-            initial_notification = create_notification(sample_template_with_placeholders, personalisation={"Name": "test"})
-            save_notification(initial_notification)
-            personalisation = initial_notification.personalisation
-            _personalisation = initial_notification._personalisation
+
+            initial_notifications = [
+                create_notification(sample_template_with_placeholders, personalisation={"Name": "test"}) for _ in range(5)
+            ]
+            personalisations = [n.personalisation for n in initial_notifications]
+            _personalisations = [n._personalisation for n in initial_notifications]
+            for notification in initial_notifications:
+                save_notification(notification)
 
         with set_signer_secret_key(signer_personalisation, ["k2", "k3"]):
-            resign_notifications()
-            notification = Notification.query.get(initial_notification.id)
-            assert notification.personalisation == personalisation  # unsigned value is the same
-            assert notification._personalisation != _personalisation  # signature is different
+            resign_notifications(chunk_size=chunk_size, resign=resign)
+
+            notifications = [Notification.query.get(n.id) for n in initial_notifications]
+            assert [n.personalisation for n in notifications] == personalisations  # unsigned values are the same
+            if resign:
+                for (
+                    notification,
+                    _personalisation,
+                ) in zip(notifications, _personalisations):
+                    assert notification._personalisation != _personalisation  # signature is different
+            else:
+                assert [n._personalisation for n in notifications] == _personalisations  # signatures are the same
 
     def test_resign_notifications_fails_if_cannot_verify_signatures(self, sample_template_with_placeholders):
         from app import signer_personalisation
@@ -1827,7 +1859,7 @@ class TestResigning:
 
         with set_signer_secret_key(signer_personalisation, ["k3"]):
             with pytest.raises(BadSignature):
-                resign_notifications()
+                resign_notifications(chunk_size=10, resign=True)
 
     def test_resign_notifications_unsafe_resigns_with_new_key(self, sample_template_with_placeholders):
         from app import signer_personalisation
@@ -1839,7 +1871,7 @@ class TestResigning:
             _personalisation = initial_notification._personalisation
 
         with set_signer_secret_key(signer_personalisation, ["k3"]):
-            resign_notifications(unsafe=True)
+            resign_notifications(chunk_size=10, resign=True, unsafe=True)
             notification = Notification.query.get(initial_notification.id)
             assert notification.personalisation == personalisation  # unsigned value is the same
             assert notification._personalisation != _personalisation  # signature is different

--- a/tests/app/dao/test_api_key_dao.py
+++ b/tests/app/dao/test_api_key_dao.py
@@ -166,6 +166,20 @@ def test_should_not_return_revoked_api_keys_older_than_7_days(sample_service, da
 
 
 class TestResigning:
+    
+    def test_resign_api_keys_previews_only(self, sample_service):
+        from app import signer_api_key
+
+        with set_signer_secret_key(signer_api_key, ["k1", "k2"]):
+            initial_key = create_api_key(service=sample_service)
+            _secret = initial_key._secret
+
+        with set_signer_secret_key(signer_api_key, ["k2", "k3"]):
+            resign_api_keys(resign=False)
+            api_key = ApiKey.query.get(initial_key.id)
+            assert api_key._secret == _secret  # signature is the same
+
+
     def test_resign_api_keys_resigns_with_new_key(self, sample_service):
         from app import signer_api_key
 
@@ -175,7 +189,7 @@ class TestResigning:
             _secret = initial_key._secret
 
         with set_signer_secret_key(signer_api_key, ["k2", "k3"]):
-            resign_api_keys()
+            resign_api_keys(resign=True)
             api_key = ApiKey.query.get(initial_key.id)
             assert api_key.secret == secret  # unsigned value is the same
             assert api_key._secret != _secret  # signature is different
@@ -188,7 +202,7 @@ class TestResigning:
 
         with set_signer_secret_key(signer_api_key, "k3"):
             with pytest.raises(BadSignature):
-                resign_api_keys()
+                resign_api_keys(resign=True)
 
     def test_resign_api_keys_unsafe_resigns_with_new_key(self, sample_service):
         from app import signer_api_key
@@ -199,7 +213,7 @@ class TestResigning:
             _secret = initial_key._secret
 
         with set_signer_secret_key(signer_api_key, ["k3"]):
-            resign_api_keys(unsafe=True)
+            resign_api_keys(resign=True, unsafe=True)
             api_key = ApiKey.query.get(initial_key.id)
             assert api_key.secret == secret  # unsigned value is the same
             assert api_key._secret != _secret  # signature is different

--- a/tests/app/dao/test_api_key_dao.py
+++ b/tests/app/dao/test_api_key_dao.py
@@ -166,21 +166,8 @@ def test_should_not_return_revoked_api_keys_older_than_7_days(sample_service, da
 
 
 class TestResigning:
-    
-    def test_resign_api_keys_previews_only(self, sample_service):
-        from app import signer_api_key
-
-        with set_signer_secret_key(signer_api_key, ["k1", "k2"]):
-            initial_key = create_api_key(service=sample_service)
-            _secret = initial_key._secret
-
-        with set_signer_secret_key(signer_api_key, ["k2", "k3"]):
-            resign_api_keys(resign=False)
-            api_key = ApiKey.query.get(initial_key.id)
-            assert api_key._secret == _secret  # signature is the same
-
-
-    def test_resign_api_keys_resigns_with_new_key(self, sample_service):
+    @pytest.mark.parametrize("resign", [True, False])
+    def test_resign_api_keys_resigns_or_previews(self, resign, sample_service):
         from app import signer_api_key
 
         with set_signer_secret_key(signer_api_key, ["k1", "k2"]):
@@ -189,10 +176,13 @@ class TestResigning:
             _secret = initial_key._secret
 
         with set_signer_secret_key(signer_api_key, ["k2", "k3"]):
-            resign_api_keys(resign=True)
+            resign_api_keys(resign=resign)
             api_key = ApiKey.query.get(initial_key.id)
             assert api_key.secret == secret  # unsigned value is the same
-            assert api_key._secret != _secret  # signature is different
+            if resign:
+                assert api_key._secret != _secret  # signature is different
+            else:
+                assert api_key._secret == _secret  # signature is the same
 
     def test_resign_api_keys_fails_if_cannot_verify_signatures(self, sample_service):
         from app import signer_api_key


### PR DESCRIPTION
# Summary | Résumé

Make some tweaks to the database resigning code. Basically add options:
```
  --chunk CHUNK  size of chunks of notifications to resign at a time (default 25000)
  --resign       resign columns (default false)
```
where 
- `chunk` is used to process the notifications in batches. Each batch is its own transaction. If some batches are successfully resigned and then the code crashes, that's fine (it's ok for some parts of the database to be signed with the old key and some with the new key)
- by default the script just says how many rows need resigning. the `--resign` parameter tells the script to actually resign.

# Test instructions | Instructions pour tester la modification

Can run locally with changing SECRET_KEY to give it something that needs resigning. Note that if you switch your secret key from `k1,k2` to `k2,k1` everything will pass verification but be resigned.

Real test will be in staging...

# Release Instructions | Instructions pour le déploiement

None.

> Necessary steps to perform before and after the deployment of these changes.
> For example, emptying the cache on a feature that changes the cache data
> structure in Redis could be mentioned.

---

> Étapes nécessaires à exécuter avant et après le déploiement des changements
> introduits par cette proposition. Par exemple, vider la cache suite à des
> changements modifiant une structure de données de la cache pourrait être
> mentionné.

# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their
review | Voici une suggestion de liste de vérification comprenant des questions
que les réviseurs pourraient poser pendant leur examen :


- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne
      une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une
      fonctionnalité existante?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une
      modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des
      préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de
      façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de
      risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README
      setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce
      changement (fichier README, etc.)?
