### PR TITLE
Provide a direct link to the failed run when failure

### DIFF
--- a/.github/workflows/build_and_push_performance_test.yml
+++ b/.github/workflows/build_and_push_performance_test.yml
@@ -74,5 +74,5 @@ jobs:
       - name: Notify Slack channel if this job failed
         if: ${{ failure() }}
         run: |
-          json="{'text':'<!here> CI is failing in <https://github.com/cds-snc/notification-api/|notification-api> !'}"
+          json="{'text':'<!here> CI is failing in <https://github.com/cds-snc/notification-api/actions/runs/${GITHUB_RUN_ID}|notification-api> !'}"
           curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -99,5 +99,5 @@ jobs:
     - name: Notify Slack channel if this job failed
       if: ${{ failure() }}
       run: |
-        json="{'text':'<!here> CI is failing in <https://github.com/cds-snc/notification-api/|notification-api> !'}"
+        json="{'text':'<!here> CI is failing in <https://github.com/cds-snc/notification-api/actions/runs/${GITHUB_RUN_ID}|notification-api> !'}"
         curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/lambda_production.yml
+++ b/.github/workflows/lambda_production.yml
@@ -63,5 +63,5 @@ jobs:
       - name: Notify Slack channel if this job failed
         if: ${{ failure() }}
         run: |
-          json="{'text':'<!here> CI is failing in <https://github.com/cds-snc/notification-api/|notification-api> !'}"
+          json="{'text':'<!here> CI is failing in <https://github.com/cds-snc/notification-api/actions/runs/${GITHUB_RUN_ID}|notification-api> !'}"
           curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/lambda_staging.yml
+++ b/.github/workflows/lambda_staging.yml
@@ -67,5 +67,5 @@ jobs:
       - name: Notify Slack channel if this job failed
         if: ${{ failure() }}
         run: |
-          json="{'text':'<!here> CI is failing in <https://github.com/cds-snc/notification-api/|notification-api> !'}"
+          json="{'text':'<!here> CI is failing in <https://github.com/cds-snc/notification-api/actions/runs/${GITHUB_RUN_ID}|notification-api> !'}"
           curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -27,5 +27,5 @@ jobs:
       - name: Notify Slack channel if this performance test job fails
         if: ${{ failure() && github.ref == 'refs/heads/main' }}
         run: |
-          json="{'text':'Scheduled CI Performance testing failed: <https://github.com/cds-snc/notification-api/actions|GitHub actions>'}"
+          json="{'text':'Scheduled CI Performance testing failed: <https://github.com/cds-snc/notification-api/actions/runs/${GITHUB_RUN_ID}|GitHub actions>'}"
           curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -77,5 +77,5 @@ jobs:
     - name: Notify Slack channel if this job fails
       if: ${{ failure() && github.ref == 'refs/heads/main' }}
       run: |
-        json="{'text':'Scheduled CI testing failed: <https://github.com/cds-snc/notification-api/actions|GitHub actions>'}"
+        json="{'text':'Scheduled CI testing failed: <https://github.com/cds-snc/notification-api/actions/runs/${GITHUB_RUN_ID}|GitHub actions>'}"
         curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
# Summary | Résumé

If we have a failure during the execution of the `build_and_push_performance_test` GitHub action, we notify Slack with a link to the repository. This PR changes the link to refer to the failed run ID directly so that we do not have to search through our actions manually.

# Test instructions | Instructions pour tester la modification

Make the perf workflow fail and notice the link in the Slack notification.

It`s possible it might not work. If that does not, we can replicate the strategy adopted for the URL shortener:
https://github.com/cds-snc/url-shortener/blob/main/.github/workflows/workflow_failure.yml


