### PR TITLE
Revert "Improve api and callback status messages"

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1781,9 +1781,6 @@ class Notification(BaseModel):
                     "sending": "In transit",
                     "created": "In transit",
                     "sent": "Delivered",
-                    "pending": "In transit",
-                    "pending-virus-check": "In transit",
-                    "pii-check-failed": "Exceeds Protected A",
                 },
                 "sms": {
                     "failed": "Failed",
@@ -1793,7 +1790,6 @@ class Notification(BaseModel):
                     "delivered": "Delivered",
                     "sending": "In transit",
                     "created": "In transit",
-                    "pending": "In transit",
                     "sent": "Sent",
                 },
                 "letter": {
@@ -1909,7 +1905,7 @@ class Notification(BaseModel):
             "line_6": None,
             "postcode": None,
             "type": self.notification_type,
-            "status": self.get_letter_status() if self.notification_type == LETTER_TYPE else self.formatted_status,
+            "status": self.get_letter_status() if self.notification_type == LETTER_TYPE else self.status,
             "provider_response": self.provider_response,
             "template": template_dict,
             "body": self.content,

--- a/app/notifications/callbacks.py
+++ b/app/notifications/callbacks.py
@@ -21,7 +21,7 @@ def create_delivery_status_callback_data(notification, service_callback_api):
         "notification_id": str(notification.id),
         "notification_client_reference": notification.client_reference,
         "notification_to": notification.to,
-        "notification_status": notification.formatted_status,
+        "notification_status": notification.status,
         "notification_provider_response": notification.provider_response,
         "notification_created_at": notification.created_at.strftime(DATETIME_FORMAT),
         "notification_updated_at": notification.updated_at.strftime(DATETIME_FORMAT) if notification.updated_at else None,

--- a/tests/app/notifications/test_callbacks.py
+++ b/tests/app/notifications/test_callbacks.py
@@ -29,7 +29,7 @@ def test_create_delivery_status_callback_data(
         "notification_id": str(notification.id),
         "notification_provider_response": notification.provider_response,
         "notification_sent_at": notification.sent_at.strftime(DATETIME_FORMAT),
-        "notification_status": notification.formatted_status,
+        "notification_status": notification.status,
         "notification_to": notification.to,
         "notification_type": notification.notification_type,
         "notification_updated_at": notification.updated_at,

--- a/tests/app/v2/notifications/test_get_notifications.py
+++ b/tests/app/v2/notifications/test_get_notifications.py
@@ -61,7 +61,7 @@ def test_get_notification_by_id_returns_200(client, billable_units, provider, sa
         "line_6": None,
         "postcode": None,
         "type": "{}".format(sample_notification.notification_type),
-        "status": "{}".format(sample_notification.formatted_status),
+        "status": "{}".format(sample_notification.status),
         "provider_response": sample_notification.provider_response,
         "template": expected_template_response,
         "created_at": sample_notification.created_at.strftime(DATETIME_FORMAT),
@@ -115,7 +115,7 @@ def test_get_notification_by_id_with_placeholders_returns_200(client, sample_ema
         "line_6": None,
         "postcode": None,
         "type": "{}".format(sample_notification.notification_type),
-        "status": "{}".format(sample_notification.formatted_status),
+        "status": "{}".format(sample_notification.status),
         "provider_response": sample_notification.provider_response,
         "template": expected_template_response,
         "created_at": sample_notification.created_at.strftime(DATETIME_FORMAT),
@@ -317,7 +317,7 @@ def test_get_all_notifications_except_job_notifications_returns_200(client, samp
     assert len(json_response["notifications"]) == 2
 
     assert json_response["notifications"][0]["id"] == str(notification.id)
-    assert json_response["notifications"][0]["status"] == "In transit"
+    assert json_response["notifications"][0]["status"] == "created"
     assert json_response["notifications"][0]["template"] == {
         "id": str(notification.template.id),
         "uri": notification.template.get_link(),
@@ -349,7 +349,7 @@ def test_get_all_notifications_with_include_jobs_arg_returns_200(client, sample_
     assert len(json_response["notifications"]) == 2
 
     assert json_response["notifications"][0]["id"] == str(notification.id)
-    assert json_response["notifications"][0]["status"] == notification.formatted_status
+    assert json_response["notifications"][0]["status"] == notification.status
     assert json_response["notifications"][0]["phone_number"] == notification.to
     assert json_response["notifications"][0]["type"] == notification.template.template_type
     assert not json_response["notifications"][0]["scheduled_for"]
@@ -393,7 +393,7 @@ def test_get_all_notifications_filter_by_template_type(client, sample_service):
     assert len(json_response["notifications"]) == 1
 
     assert json_response["notifications"][0]["id"] == str(notification.id)
-    assert json_response["notifications"][0]["status"] == "In transit"
+    assert json_response["notifications"][0]["status"] == "created"
     assert json_response["notifications"][0]["template"] == {
         "id": str(email_template.id),
         "uri": notification.template.get_link(),
@@ -439,7 +439,7 @@ def test_get_all_notifications_filter_by_single_status(client, sample_template):
     assert len(json_response["notifications"]) == 1
 
     assert json_response["notifications"][0]["id"] == str(notification.id)
-    assert json_response["notifications"][0]["status"] == "In transit"
+    assert json_response["notifications"][0]["status"] == "pending"
 
 
 def test_get_all_notifications_filter_by_status_invalid_status(client, sample_notification):


### PR DESCRIPTION
Reverts cds-snc/notification-api#1870 while we address updating the API documentation, and restore the notification status, and add the formatted status message as a separate new property to avoid breaking any client integrations.