### PR TITLE
Add `province_or_territory` organisation type

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1782,9 +1782,6 @@ class Notification(BaseModel):
                     "sending": "In transit",
                     "created": "In transit",
                     "sent": "Delivered",
-                    "pending": "In transit",
-                    "pending-virus-check": "In transit",
-                    "pii-check-failed": "Exceeds Protected A",
                 },
                 "sms": {
                     "failed": "Failed",
@@ -1794,7 +1791,6 @@ class Notification(BaseModel):
                     "delivered": "Delivered",
                     "sending": "In transit",
                     "created": "In transit",
-                    "pending": "In transit",
                     "sent": "Sent",
                 },
                 "letter": {
@@ -1910,7 +1906,7 @@ class Notification(BaseModel):
             "line_6": None,
             "postcode": None,
             "type": self.notification_type,
-            "status": self.get_letter_status() if self.notification_type == LETTER_TYPE else self.formatted_status,
+            "status": self.get_letter_status() if self.notification_type == LETTER_TYPE else self.status,
             "provider_response": self.provider_response,
             "template": template_dict,
             "body": self.content,

--- a/app/models.py
+++ b/app/models.py
@@ -389,6 +389,7 @@ class Domain(BaseModel):
 
 ORGANISATION_TYPES = [
     "central",
+    "province_or_territory",
     "local",
     "nhs_central",
     "nhs_local",
@@ -1781,6 +1782,9 @@ class Notification(BaseModel):
                     "sending": "In transit",
                     "created": "In transit",
                     "sent": "Delivered",
+                    "pending": "In transit",
+                    "pending-virus-check": "In transit",
+                    "pii-check-failed": "Exceeds Protected A",
                 },
                 "sms": {
                     "failed": "Failed",
@@ -1790,6 +1794,7 @@ class Notification(BaseModel):
                     "delivered": "Delivered",
                     "sending": "In transit",
                     "created": "In transit",
+                    "pending": "In transit",
                     "sent": "Sent",
                 },
                 "letter": {
@@ -1905,7 +1910,7 @@ class Notification(BaseModel):
             "line_6": None,
             "postcode": None,
             "type": self.notification_type,
-            "status": self.get_letter_status() if self.notification_type == LETTER_TYPE else self.status,
+            "status": self.get_letter_status() if self.notification_type == LETTER_TYPE else self.formatted_status,
             "provider_response": self.provider_response,
             "template": template_dict,
             "body": self.content,

--- a/migrations/versions/0431_add_pt_organisation_type.py
+++ b/migrations/versions/0431_add_pt_organisation_type.py
@@ -1,0 +1,24 @@
+"""
+
+Revision ID: 0431_add_pt_organisation_type
+Revises: 0430_add_contact_form_email
+Create Date: 2023-05-30 00:00:00
+
+"""
+
+from alembic import op
+
+revision = "0431_add_pt_organisation_type"
+down_revision = "0430_add_contact_form_email"
+
+def upgrade():
+    op.execute(
+        f"""
+        INSERT INTO organisation_types (name, is_crown, annual_free_sms_fragment_limit) 
+        VALUES ('province_or_territory', null, 250000)
+    """
+    )
+
+
+def downgrade():
+    op.execute("DELETE FROM organisation_types WHERE name = 'province_or_territory'")

--- a/migrations/versions/0431_add_pt_organisation_type.py
+++ b/migrations/versions/0431_add_pt_organisation_type.py
@@ -11,6 +11,7 @@ from alembic import op
 revision = "0431_add_pt_organisation_type"
 down_revision = "0430_add_contact_form_email"
 
+
 def upgrade():
     op.execute(
         f"""

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -172,7 +172,6 @@ def test_create_service_with_organisation(notify_db_session):
         ("test@nhs.uk", "central"),
         ("test@example.nhs.uk", "central"),
         ("TEST@NHS.UK", "central"),
-        ("test@ontario.ca", "province_or_territory"),
     ),
 )
 @pytest.mark.parametrize(

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -172,6 +172,7 @@ def test_create_service_with_organisation(notify_db_session):
         ("test@nhs.uk", "central"),
         ("test@example.nhs.uk", "central"),
         ("TEST@NHS.UK", "central"),
+        ("test@ontario.ca", "province_or_territory"),
     ),
 )
 @pytest.mark.parametrize(

--- a/tests/app/organisation/test_rest.py
+++ b/tests/app/organisation/test_rest.py
@@ -230,7 +230,7 @@ def test_post_create_organisation_existing_name_raises_400(admin_request, sample
             },
             (
                 "organisation_type foo is not one of "
-                "[central, local, nhs_central, nhs_local, nhs_gp, emergency_service, school_or_college, other]"
+                "[central, province_or_territory, local, nhs_central, nhs_local, nhs_gp, emergency_service, school_or_college, other]"
             ),
         ),
     ),


### PR DESCRIPTION
# Summary | Résumé

Add `province_or_territory` organisation type.

This will allow us to identify if a service is for a P/T or not, and apply some different rules for template redaction and data retention. 

We'll also need to add it in notification-admin before we are able to set this type for an organisation.

# Test instructions | Instructions pour tester la modification

Tests should pass, new row should be visible in the `organisation_types` table.