### PR TITLE
feat: sync Salesforce Engagement ContactRoles

### DIFF
--- a/app/clients/salesforce/salesforce_client.py
+++ b/app/clients/salesforce/salesforce_client.py
@@ -132,3 +132,27 @@ class SalesforceClient:
             }
             salesforce_engagement.update(session, service, close_update, None, None)
         self.end_session(session)
+
+    def engagement_add_contact_role(self, service: Service, user: User) -> None:
+        """Adds a Salesforce ContactRole to an Engagement.
+
+        Args:
+            service (Service): Notify Service that will have its Engagement's ContactRoles updated.
+            user (User): Notify User being added as a ContactRole.
+        """
+        session = self.get_session()
+        account_id, contact_id = self.contact_update_account_id(session, service, user)
+        salesforce_engagement.contact_role_add(session, service, account_id, contact_id)
+        self.end_session(session)
+
+    def engagement_delete_contact_role(self, service: Service, user: User) -> None:
+        """Deletes a Salesforce ContactRole from an Engagement.
+
+        Args:
+            service (Service): Notify Service that will have its Engagement's ContactRoles updated.
+            user (User): Notify User being deleted as a ContactRole.
+        """
+        session = self.get_session()
+        account_id, contact_id = self.contact_update_account_id(session, service, user)
+        salesforce_engagement.contact_role_delete(session, service, account_id, contact_id)
+        self.end_session(session)

--- a/app/clients/salesforce/salesforce_engagement.py
+++ b/app/clients/salesforce/salesforce_engagement.py
@@ -120,6 +120,59 @@ def update(
     return engagement_id
 
 
+def contact_role_add(session: Salesforce, service: Service, account_id: Optional[str], contact_id: Optional[str]) -> None:
+    """Adds an Engagement ContactRole based on the provided Notify service and Contact.  If the
+    Engagement does not exist, it is created.
+
+    Args:
+        session (Salesforce): Salesforce session to perform the operation.
+        service (Service): The service's details for the engagement.
+        account_id (Optional[str]): Salesforce Account ID to associate with the Engagement.
+        contact_id (Optional[str]): Salesforce Contact ID for the Engagement's ContactRole.
+
+    Returns:
+        None
+    """
+    try:
+        engagement = get_engagement_by_service_id(session, str(service.id))
+        if engagement:
+            result = session.OpportunityContactRole.create(
+                {"ContactId": contact_id, "OpportunityId": engagement.get("Id")},
+                headers={"Sforce-Duplicate-Rule-Header": "allowSave=true"},
+            )
+        else:
+            result = create(session, service, {}, account_id, contact_id)  # This implicitly creates the ContactRole
+        parse_result(result, f"Salesforce ContactRole add for {contact_id} with '{service.id}'")
+    except Exception as ex:
+        current_app.logger.error(f"SF_ERR Salesforce ContactRole add for {contact_id} with '{service.id}' failed: {ex}")
+
+
+def contact_role_delete(session: Salesforce, service: Service, account_id: Optional[str], contact_id: Optional[str]) -> None:
+    """Deletes an Engagement ContactRole based on the provided Notify service and Salesforce Contact.
+    If the Engagement does not exist, it is created.
+
+    Args:
+        session (Salesforce): Salesforce session to perform the operation.
+        service (Service): The service's details for the engagement.
+        account_id (Optional[str]): Salesforce Account ID to associate with the Engagement.
+        contact_id (Optional[str]): Salesforce Contact ID to remove as a ContactRole.
+
+    Returns:
+        None
+    """
+    try:
+        result = {}
+        engagement = get_engagement_by_service_id(session, str(service.id))
+        engagement_id = engagement.get("Id") if engagement else create(session, service, {}, account_id, contact_id)
+        engagement_contact_role = get_engagement_contact_role(session, engagement_id, contact_id)
+
+        if engagement_contact_role:
+            result = session.OpportunityContactRole.delete(engagement_contact_role.get("Id"))
+        parse_result(result, f"Salesforce ContactRole delete for {contact_id} with '{service.id}'")
+    except Exception as ex:
+        current_app.logger.error(f"SF_ERR Salesforce ContactRole delete for {contact_id} with '{service.id}' failed: {ex}")
+
+
 def get_engagement_by_service_id(session: Salesforce, service_id: str) -> Optional[dict[str, Any]]:
     """Retrieve a Salesforce Engagement by a Notify service ID
 
@@ -133,5 +186,25 @@ def get_engagement_by_service_id(session: Salesforce, service_id: str) -> Option
     result = None
     if isinstance(service_id, str) and service_id.strip():
         query = f"SELECT Id, Name, ContactId, AccountId FROM Opportunity where CDS_Opportunity_Number__c = '{query_param_sanitize(service_id)}' LIMIT 1"
+        result = query_one(session, query)
+    return result
+
+
+def get_engagement_contact_role(
+    session: Salesforce, engagement_id: Optional[str], contact_id: Optional[str]
+) -> Optional[dict[str, Any]]:
+    """Retrieve a Salesforce Engagement ContactRole.
+
+    Args:
+        session (Salesforce): Salesforce session to perform the operation.
+        engagement_id (str): Salesforce Engagement ID
+        contact_id (str): Salesforce Contact ID
+
+    Returns:
+        Optional[dict[str, str]]: Salesforce Engagement ContactRole details or None if can't be found
+    """
+    result = None
+    if isinstance(engagement_id, str) and engagement_id.strip() and isinstance(contact_id, str) and contact_id.strip():
+        query = f"SELECT Id, OpportunityId, ContactId FROM OpportunityContactRole WHERE OpportunityId = '{query_param_sanitize(engagement_id)}' AND ContactId = '{query_param_sanitize(contact_id)}' LIMIT 1"
         result = query_one(session, query)
     return result

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -423,6 +423,13 @@ def add_user_to_service(service_id, user_id):
 
     dao_add_user_to_service(service, user, permissions, folder_permissions)
     data = service_schema.dump(service).data
+
+    if current_app.config["FF_SALESFORCE_CONTACT"]:
+        try:
+            salesforce_client.engagement_add_contact_role(service, user)
+        except Exception as e:
+            current_app.logger.exception(e)
+
     return jsonify(data=data), 201
 
 
@@ -439,6 +446,13 @@ def remove_user_from_service(service_id, user_id):
         raise InvalidRequest(error, status_code=400)
 
     dao_remove_user_from_service(service, user)
+
+    if current_app.config["FF_SALESFORCE_CONTACT"]:
+        try:
+            salesforce_client.engagement_delete_contact_role(service, user)
+        except Exception as e:
+            current_app.logger.exception(e)
+
     return jsonify({}), 204
 
 

--- a/tests/app/clients/test_salesforce_client.py
+++ b/tests/app/clients/test_salesforce_client.py
@@ -170,3 +170,39 @@ def test_engagement_close_no_engagement(mocker, salesforce_client):
     mock_get_engagement_by_service_id.assert_called_once_with("session", mock_service.id)
     mock_update.assert_not_called()
     mock_end_session.assert_called_once_with("session")
+
+
+def test_engagement_add_contact_role(mocker, salesforce_client):
+    mock_get_session = mocker.patch.object(salesforce_client, "get_session", return_value="session")
+    mock_contact_update_account_id = mocker.patch.object(
+        salesforce_client, "contact_update_account_id", return_value=("account_id", "contact_id")
+    )
+    mock_contact_role_add = mocker.patch.object(salesforce_engagement, "contact_role_add")
+    mock_end_session = mocker.patch.object(salesforce_client, "end_session")
+    mock_service = mocker.MagicMock()
+    mock_service.organisation_notes = "account_name > service_name"
+
+    salesforce_client.engagement_add_contact_role(mock_service, "user")
+
+    mock_get_session.assert_called_once()
+    mock_contact_update_account_id.assert_called_once_with("session", mock_service, "user")
+    mock_contact_role_add.assert_called_once_with("session", mock_service, "account_id", "contact_id")
+    mock_end_session.assert_called_once_with("session")
+
+
+def test_engagement_delete_contact_role(mocker, salesforce_client):
+    mock_get_session = mocker.patch.object(salesforce_client, "get_session", return_value="session")
+    mock_contact_update_account_id = mocker.patch.object(
+        salesforce_client, "contact_update_account_id", return_value=("account_id", "contact_id")
+    )
+    mock_contact_role_delete = mocker.patch.object(salesforce_engagement, "contact_role_delete")
+    mock_end_session = mocker.patch.object(salesforce_client, "end_session")
+    mock_service = mocker.MagicMock()
+    mock_service.organisation_notes = "account_name > service_name"
+
+    salesforce_client.engagement_delete_contact_role(mock_service, "user")
+
+    mock_get_session.assert_called_once()
+    mock_contact_update_account_id.assert_called_once_with("session", mock_service, "user")
+    mock_contact_role_delete.assert_called_once_with("session", mock_service, "account_id", "contact_id")
+    mock_end_session.assert_called_once_with("session")

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1475,7 +1475,8 @@ def test_add_unknown_user_to_service_returns404(notify_api, notify_db, notify_db
             assert result["message"] == expected_message
 
 
-def test_remove_user_from_service(notify_db, notify_db_session, client, sample_user_service_permission):
+def test_remove_user_from_service(notify_db, notify_db_session, client, sample_user_service_permission, mocker):
+    mocked_salesforce_client = mocker.patch("app.service.rest.salesforce_client")
     second_user = create_user(email="new@digital.cabinet-office.gov.uk")
     # Simulates successfully adding a user to the service
     second_permission = create_sample_user_service_permission(notify_db, notify_db_session, user=second_user)
@@ -1487,6 +1488,7 @@ def test_remove_user_from_service(notify_db, notify_db_session, client, sample_u
     auth_header = create_authorization_header()
     resp = client.delete(endpoint, headers=[("Content-Type", "application/json"), auth_header])
     assert resp.status_code == 204
+    mocked_salesforce_client.engagement_delete_contact_role.assert_called_with(second_permission.service, second_permission.user)
 
 
 def test_remove_non_existant_user_from_service(client, sample_user_service_permission):


### PR DESCRIPTION
# Summary
Update the Salesforce API so that as Notify service team members are added and removed, associated Engagement ContactRoles are also added or removed for each team member.

# Testing
1. With `FF_SALESFORCE_CONTACT=true`, start the local API and admin.
2. Create a new service as user `A`.
3. Add a new team member to the service (user `B`) with the permission to manage service team members.
4. Accept the invitation and login to Notify with the new team member `B`.
5. In Salesforce, expect to see ContactRoles on the service's Engagement for users `A` and `B`.
6. As user `B` in Notify, remove user `A` from the service.
7. In Salesforce, there should now only be one ContactRole on the Engagement for user `B`.

# Related
- cds-snc/platform-core-services#344