### PR TITLE
Fix bug where template redaction for P/Ts is flaky

### DIFF
--- a/app/dao/templates_dao.py
+++ b/app/dao/templates_dao.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 from datetime import datetime
-from typing import Optional, Tuple, Union
+from typing import Tuple, Union
 
 from flask import current_app
 from notifications_utils.clients.redis import template_version_cache_key
@@ -21,13 +21,13 @@ from app.models import (
 
 @transactional
 @version_class(VersionOptions(Template, history_class=TemplateHistory))
-def dao_create_template(template, template_id: Optional[uuid.UUID] = None):
+def dao_create_template(template, redact_personalisation=False):
     # must be set now so version history model can use same id
-    template.id = uuid.uuid4() if not template_id else template_id
+    template.id = uuid.uuid4()
 
     redacted_dict = {
         "template": template,
-        "redact_personalisation": False,
+        "redact_personalisation": redact_personalisation,
     }
     if template.created_by:
         redacted_dict.update({"updated_by": template.created_by})

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -96,15 +96,8 @@ def create_template(service_id):
 
     check_reply_to(service_id, new_template.reply_to, new_template.template_type)
 
-    template_id = uuid.uuid4()
-    dao_create_template(new_template, template_id=template_id)
-
-    if service_owned_by_a_province_or_territory(service_id):
-        try:
-            fetched_template = dao_get_template_by_id_and_service_id(template_id=template_id, service_id=service_id)
-            dao_redact_template(fetched_template, template_json["created_by"])
-        except NoResultFound:
-            current_app.logger.error(f"Template not found for redaction. service_id: {service_id}, template_id: {template_id}")
+    redact_personalisation = service_owned_by_a_province_or_territory(service_id)
+    dao_create_template(new_template, redact_personalisation=redact_personalisation)
 
     return jsonify(data=template_schema.dump(new_template).data), 201
 

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -61,8 +61,8 @@ def validate_parent_folder(template_json):
 def should_template_be_redacted(organisation: Organisation) -> bool:
     try:
         return organisation.organisation_type == "province_or_territory"
-    except Exception as e:
-        current_app.logger.error(f"Error checking organisation_type: {e}")
+    except AttributeError:
+        current_app.logger.info(f"Service has no linked organisation")
         return False
 
 

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -62,7 +62,7 @@ def should_template_be_redacted(organisation: Organisation) -> bool:
     try:
         return organisation.organisation_type == "province_or_territory"
     except AttributeError:
-        current_app.logger.info(f"Service has no linked organisation")
+        current_app.logger.info("Service has no linked organisation")
         return False
 
 

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -1,5 +1,4 @@
 import base64
-import uuid
 from io import BytesIO
 
 import botocore

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -11,7 +11,6 @@ from requests import post as requests_post
 from sqlalchemy.orm.exc import NoResultFound
 
 from app.dao.notifications_dao import get_notification_by_id
-from app.dao.organisation_dao import dao_get_organisation_by_service_id
 from app.dao.services_dao import dao_fetch_service_by_id
 from app.dao.template_folder_dao import dao_get_template_folder_by_id_and_service_id
 from app.dao.templates_dao import (
@@ -27,7 +26,7 @@ from app.dao.templates_dao import (
 )
 from app.errors import InvalidRequest, register_errors
 from app.letters.utils import get_letter_pdf
-from app.models import LETTER_TYPE, SECOND_CLASS, SMS_TYPE, Service, Template
+from app.models import LETTER_TYPE, SECOND_CLASS, SMS_TYPE, Organisation, Template
 from app.notifications.validators import check_reply_to, service_has_permission
 from app.schema_validation import validate
 from app.schemas import template_history_schema, template_schema
@@ -59,12 +58,11 @@ def validate_parent_folder(template_json):
         return None
 
 
-def service_owned_by_a_province_or_territory(service: Service) -> bool:
+def should_template_be_redacted(organisation: Organisation) -> bool:
     try:
-        return service.organisation.organisation_type == "province_or_territory"
+        return organisation.organisation_type == "province_or_territory"
     except Exception as e:
-        # service has no organisation
-        current_app.logger.error(f"Can't get organisation: {e}")
+        current_app.logger.error(f"Error checking organisation_type: {e}")
         return False
 
 
@@ -73,6 +71,7 @@ def create_template(service_id):
     fetched_service = dao_fetch_service_by_id(service_id=service_id)
     # permissions needs to be placed here otherwise marshmallow will interfere with versioning
     permissions = fetched_service.permissions
+    organisation = fetched_service.organisation
     template_json = validate(request.get_json(), post_create_template_schema)
     folder = validate_parent_folder(template_json=template_json)
     new_template = Template.from_json(template_json, folder)
@@ -95,7 +94,7 @@ def create_template(service_id):
 
     check_reply_to(service_id, new_template.reply_to, new_template.template_type)
 
-    redact_personalisation = service_owned_by_a_province_or_territory(fetched_service)
+    redact_personalisation = should_template_be_redacted(organisation)
     dao_create_template(new_template, redact_personalisation=redact_personalisation)
 
     return jsonify(data=template_schema.dump(new_template).data), 201

--- a/tests/app/dao/test_templates_dao.py
+++ b/tests/app/dao/test_templates_dao.py
@@ -53,8 +53,7 @@ def test_create_template(sample_service, sample_user, template_type, subject, re
     assert dao_get_all_templates_for_service(sample_service.id)[0].name == "Sample Template"
     assert dao_get_all_templates_for_service(sample_service.id)[0].process_type == "normal"
     assert (
-        dao_get_all_templates_for_service(sample_service.id)[0].template_redacted.redact_personalisation
-        == redact_personalisation
+        dao_get_all_templates_for_service(sample_service.id)[0].template_redacted.redact_personalisation == redact_personalisation
     )
 
 

--- a/tests/app/dao/test_templates_dao.py
+++ b/tests/app/dao/test_templates_dao.py
@@ -52,11 +52,10 @@ def test_create_template(sample_service, sample_user, template_type, subject, re
     assert len(dao_get_all_templates_for_service(sample_service.id)) == 1
     assert dao_get_all_templates_for_service(sample_service.id)[0].name == "Sample Template"
     assert dao_get_all_templates_for_service(sample_service.id)[0].process_type == "normal"
-    if redact_personalisation:
-        assert (
-            dao_get_all_templates_for_service(sample_service.id)[0].template_redacted.redact_personalisation
-            == redact_personalisation
-        )
+    assert (
+        dao_get_all_templates_for_service(sample_service.id)[0].template_redacted.redact_personalisation
+        == redact_personalisation
+    )
 
 
 def test_create_template_creates_redact_entry(sample_service):

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -94,7 +94,9 @@ def test_should_create_a_new_template_for_a_service(client, sample_user, templat
     assert sorted(json_resp["data"]) == sorted(template_schema.dump(template).data)
 
 
-def test_create_a_new_template_for_a_service_adds_folder_relationship(client, sample_service):
+def test_create_a_new_template_for_a_service_adds_folder_relationship(client, sample_service, mocker):
+    # mocker.patch("app.template.rest.service_owned_by_a_province_or_territory", return_value=False)
+
     parent_folder = create_template_folder(service=sample_service, name="parent folder")
 
     data = {
@@ -115,7 +117,7 @@ def test_create_a_new_template_for_a_service_adds_folder_relationship(client, sa
     )
     assert response.status_code == 201
     template = Template.query.filter(Template.name == "my template").first()
-    assert template.folder == parent_folder
+    # assert template.folder == parent_folder
 
 
 @pytest.mark.parametrize(

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -113,7 +113,7 @@ def test_create_a_new_template_for_a_service_adds_folder_relationship(client, sa
     )
     assert response.status_code == 201
     template = Template.query.filter(Template.name == "my template").first()
-    # assert template.folder == parent_folder
+    assert template.folder == parent_folder
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Summary | Résumé

After testing creating new templates on staging for P/T services, I observed that the templates were not always auto-redacted and I found `Template not found for redaction.` in the logs. This is logged when we try to fetch the template by id, and we get a `NoResultFound` error: https://github.com/cds-snc/notification-api/blob/main/app/template/rest.py#L106

This indicated that the template has not been created in the db yet and that is causing the redaction to fail. Instead, we can just set the `redact_personalisation` property to `True` when we create the template, and that seems to work.

I removed the optional `tempate_id` argument from `create_template`, since I had added that in the original PR for this feature and it is no longer needed: https://github.com/cds-snc/notification-api/pull/1873

# Test instructions | Instructions pour tester la modification


Local test:
- run this branch of notification-api locally, and the main branch of notification-admin locally
- log in as a platform admin and create a new organisation "Province of Ontario"
- go to the settings page for this new org and set it as type "Provincial or Territorial Government"
- create a new service
- visit the service's settings page and set the org as "Province of Ontario"
- create a new template for the service and save it
- observe that the template page shows the text "Recipients' information will be redacted from system"
