### PR TITLE
bug fix KeyErrors from AWS sending domain verification

### DIFF
--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -50,9 +50,7 @@ def process_ses_results(self, response):
                 )
                 self.retry(queue=QueueNames.RETRY)
             except self.MaxRetriesExceededError:
-                current_app.logger.warning(
-                    f"notification not found for SES reference: {reference}. Giving up."
-                )
+                current_app.logger.warning(f"notification not found for SES reference: {reference}. Giving up.")
             return
 
         aws_response_dict = get_aws_responses(ses_message)

--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -38,9 +38,6 @@ def process_ses_results(self, response):
             _check_and_queue_complaint_callback_task(*handle_complaint(ses_message))
             return True
 
-        aws_response_dict = get_aws_responses(ses_message)
-
-        notification_status = aws_response_dict["notification_status"]
         reference = ses_message["mail"]["messageId"]
 
         try:
@@ -58,6 +55,8 @@ def process_ses_results(self, response):
                 )
             return
 
+        aws_response_dict = get_aws_responses(ses_message)
+        notification_status = aws_response_dict["notification_status"]
         notifications_dao._update_notification_status(
             notification=notification,
             status=notification_status,

--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -45,13 +45,13 @@ def process_ses_results(self, response):
         except NoResultFound:
             try:
                 current_app.logger.warning(
-                    f"RETRY {self.request.retries}: notification not found for SES reference {reference} (update to {notification_status}). "
+                    f"RETRY {self.request.retries}: notification not found for SES reference {reference}. "
                     f"Callback may have arrived before notification was persisted to the DB. Adding task to retry queue"
                 )
                 self.retry(queue=QueueNames.RETRY)
             except self.MaxRetriesExceededError:
                 current_app.logger.warning(
-                    f"notification not found for SES reference: {reference} (update to {notification_status}). Giving up."
+                    f"notification not found for SES reference: {reference}. Giving up."
                 )
             return
 

--- a/tests/app/celery/test_process_ses_receipts_tasks.py
+++ b/tests/app/celery/test_process_ses_receipts_tasks.py
@@ -154,7 +154,7 @@ def test_ses_callback_should_give_up_after_max_tries(notify_db, mocker):
     mock_logger = mocker.patch("app.celery.process_ses_receipts_tasks.current_app.logger.warning")
 
     assert process_ses_results(ses_notification_callback(reference="ref")) is None
-    mock_logger.assert_called_with("notification not found for SES reference: ref (update to delivered). Giving up.")
+    mock_logger.assert_called_with("notification not found for SES reference: ref. Giving up.")
 
 
 def test_ses_callback_does_not_call_send_delivery_status_if_no_db_entry(


### PR DESCRIPTION
# Summary | Résumé

Getting lots of KeyErrors raised here
https://github.com/cds-snc/notification-api/blob/main/app/notifications/notifications_ses_callback.py#L39

Believe it is because of the recently added new sending domains. AWS does verification calls when you first create them.

This causes us to try to process an AWS response of "AmazonSnsSubscriptionSucceeded" which our code cannot understand so it throws an error.

Note that if these are related to the new sending domains then these are not associated with notifications, and so our system should not be processing them.

This PR moves the query for the associated notification in front of the response parsing, so if there is no related notification we will not do the parsing. This means that in this case we will not get to the parsing code and not throw a KeyError.
