### PR TITLE
Fix expired inflight metric

### DIFF
--- a/app/aws/metrics.py
+++ b/app/aws/metrics.py
@@ -92,6 +92,7 @@ def put_batch_saving_expiry_metric(metrics_logger: MetricsLogger, queue: RedisQu
         metrics_logger.put_metric("batch_saving_inflight", count, "Count")
         metrics_logger.set_dimensions({"expired": "True", "notification_type": queue._suffix, "priority": queue._process_type})
         metrics_logger.flush()
+        metrics_logger.put_metric("batch_saving_inflight", count, "Count")
         metrics_logger.set_dimensions({"expired": "True", "notification_type": "any", "priority": "any"})
         metrics_logger.flush()
     except ClientError as e:


### PR DESCRIPTION
# Summary | Résumé

[This](https://github.com/cds-snc/notification-api/pull/1894) didn't work - I think because we already flushed() the metric, we need to use a new one.

# Test instructions | Instructions pour tester la modification

try it again on staging...

