### PR TITLE
fix: Salesforce engagement field maxlengths

### DIFF
--- a/app/clients/salesforce/salesforce_engagement.py
+++ b/app/clients/salesforce/salesforce_engagement.py
@@ -55,7 +55,7 @@ def create(
             }
             field_values = field_default_values | field_updates
             result = session.Opportunity.create(
-                field_values,
+                engagement_maxlengths(field_values),
                 headers={"Sforce-Duplicate-Rule-Header": "allowSave=true"},
             )
             parse_result(result, f"Salesforce Engagement create for service ID {service.id}")
@@ -106,7 +106,7 @@ def update(
         if engagement:
             result = session.Opportunity.update(
                 engagement.get("Id"),
-                field_updates,
+                engagement_maxlengths(field_updates),
                 headers={"Sforce-Duplicate-Rule-Header": "allowSave=true"},
             )
             is_updated = parse_result(result, f"Salesforce Engagement update '{service}' with '{field_updates}'")
@@ -208,3 +208,21 @@ def get_engagement_contact_role(
         query = f"SELECT Id, OpportunityId, ContactId FROM OpportunityContactRole WHERE OpportunityId = '{query_param_sanitize(engagement_id)}' AND ContactId = '{query_param_sanitize(contact_id)}' LIMIT 1"
         result = query_one(session, query)
     return result
+
+
+def engagement_maxlengths(fields: dict[str, str]) -> dict[str, str]:
+    """Given a dictionary of Engagement fields to update, truncate the values to the maximum length allowed by Salesforce.
+
+    Args:
+        field_updates (dict[str, str]): Engagement fields to check
+
+    Returns:
+        dict[str, str]: Field updates with values truncated to the maximum length allowed by Salesforce
+    """
+    maxlengths = {
+        "Name": 120,
+    }
+    for field_name, maxlength in maxlengths.items():
+        if field_name in fields:
+            fields[field_name] = fields[field_name][:maxlength]
+    return fields

--- a/tests/app/clients/test_salesforce_engagement.py
+++ b/tests/app/clients/test_salesforce_engagement.py
@@ -5,6 +5,7 @@ from app.clients.salesforce.salesforce_engagement import (
     contact_role_add,
     contact_role_delete,
     create,
+    engagement_maxlengths,
     get_engagement_by_service_id,
     get_engagement_contact_role,
     update,
@@ -265,3 +266,12 @@ def test_get_engagement_contact_role_blank(mocker, notify_api):
         assert get_engagement_contact_role(mock_session, "1", None) is None
         assert get_engagement_contact_role(mock_session, "", "2") is None
         assert get_engagement_contact_role(mock_session, "3", "       ") is None
+
+
+def test_engagement_maxlengths():
+    assert engagement_maxlengths({"foo": "bar"}) == {"foo": "bar"}
+    assert engagement_maxlengths({"foo": "bar", "bam": "baz"}) == {"foo": "bar", "bam": "baz"}
+    assert engagement_maxlengths({"Name": "this name is short enough"}) == {"Name": "this name is short enough"}
+    assert engagement_maxlengths({"Name": f"this name is not short enough {150 * 'x'}"}) == {
+        "Name": f"this name is not short enough {90 * 'x'}"
+    }


### PR DESCRIPTION
# Summary
Update the Salesforce engagement code so that it checks if field values are above the maximum allowed length.  If they are the field values are truncated to the maxlength.

# Tests
1. Create a Notify service with a name over 120 characters in length.  Expect to see a Salesforce Engagement created with a name that is 120 characters long.
2. Update an existing Notify service name to be longer than 120 characters in length.  Expect to see the Salesforce Engagement updated with a name that is 120 characters long.

# Related
- https://github.com/cds-snc/platform-core-services/issues/389