### PR TITLE
Implement email character limit for the send notifications endpoint

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,7 +67,7 @@ jobs:
       run: |
         cp -f .env.example .env
     - name: Checks for new endpoints against AWS WAF rules
-      uses: cds-snc/notification-utils/.github/actions/waffles@deea67992424aae324aa597058d56a7813c4c0ea # 50.3.2
+      uses: cds-snc/notification-utils/.github/actions/waffles@51.0.2
       with:
         app-loc: '/github/workspace'
         app-libs: '/github/workspace/env/site-packages'

--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -1,5 +1,4 @@
 from flask import Blueprint, current_app, jsonify, request
-from notifications_utils import SMS_CHAR_COUNT_LIMIT
 from notifications_utils.recipients import get_international_phone_info
 
 from app import api_user, authenticated_service
@@ -194,8 +193,10 @@ def create_template_object_for_notification(template, personalisation) -> Templa
         errors = {"template": [message]}
         raise InvalidRequest(errors, status_code=400)
 
-    if template_object.template_type == SMS_TYPE and template_object.content_count > SMS_CHAR_COUNT_LIMIT:
-        message = "Content has a character count greater than the limit of {}".format(SMS_CHAR_COUNT_LIMIT)
+    if template_object.template_type not in [SMS_TYPE, EMAIL_TYPE]:
+        return template_object
+    if template_object.is_message_too_long():
+        message = f"Content has a character count greater than the limit of {template_object.CHAR_COUNT_LIMIT}"
         errors = {"content": [message]}
         raise InvalidRequest(errors, status_code=400)
     return template_object


### PR DESCRIPTION
# Summary | Résumé

This PR adds a check to the `send_notification` endpoint (`/notifications/<string:notification_type>`) to return a 400 error a user tries to send an email that exceeds the new character limit (including personalisation content)

# Test instructions | Instructions pour tester la modification

TBD