### PR TITLE
Set `--concurrency=4` for celery debugger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,7 +66,7 @@ docs/_build/
 # PyBuilder
 target/
 .idea/
-.vscode
+.vscode/settings.json
 
 # Mac
 *.DS_Store

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -39,6 +39,7 @@
                 "worker",
                 "--pidfile",
                 "/tmp/celery.pid",
+                "--concurrency=4",
                 "-l",
                 "DEBUG",
                 "-Q",


### PR DESCRIPTION
# Summary | Résumé

I needed this to debug this PR: https://github.com/cds-snc/notification-api/pull/1912

We probably want to run the celery debugger like this all the time since that is how we are running it in production (I think?).