### PR TITLE
Add celery worker make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,49 +7,65 @@ APP_VERSION_FILE = app/version.py
 GIT_BRANCH ?= $(shell git symbolic-ref --short HEAD 2> /dev/null || echo "detached")
 GIT_COMMIT ?= $(shell git rev-parse HEAD)
 
-.PHONY: help generate-version-file test freeze-requirements test-requirements coverage clean format smoke-test run run-celery run-celery-clean run-celery-beat run-celery-perge
-
+.PHONY: help
 help:
 	@cat $(MAKEFILE_LIST) | grep -E '^[a-zA-Z_-]+:.*?## .*$$' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
+.PHONY: generate-version-file
 generate-version-file: ## Generates the app version file
 	@printf "__commit_sha__ = \"${GIT_COMMIT}\"\n__time__ = \"${DATE}\"\n" > ${APP_VERSION_FILE}
 
+.PHONY: test
 test: generate-version-file ## Run tests
 	./scripts/run_tests.sh
 
+.PHONY: freeze-requirements
 freeze-requirements:
 	poetry lock --no-update
 
+.PHONY: test-requirements
 test-requirements:
 	poetry lock --check
 
+.PHONY: coverage
 coverage: venv ## Create coverage report
 	. venv/bin/activate && coveralls
 
+.PHONY: clean
 clean:
 	rm -rf node_modules cache target venv .coverage build tests/.cache
 
+.PHONY: format
 format:
 	poetry run isort .
 	poetry run black --config pyproject.toml .
 	poetry run flake8 .
 	poetry run mypy .
 
+.PHONY: smoke-test
 smoke-test:
 	cd tests_smoke && poetry run python smoke_test.py
 
+.PHONY: run
 run: ## Run the web app
 	flask run -p 6011 --host=0.0.0.0
 
+.PHONY: run-celery
 run-celery: ## Run the celery workers
 	./scripts/run_celery.sh
 
+.PHONY: run-celery-clean
 run-celery-clean: ## Run the celery workers but filter out common scheduled tasks
 	./scripts/run_celery.sh 2>&1 >/dev/null | grep -Ev 'beat|in-flight-to-inbox|run-scheduled-jobs|check-job-status'
 
+.PHONY: run-celery-sms
+run-celery-sms: ## run the celery workers for sms from dedicated numbers
+	./scripts/run_celery_sms.sh
+
+.PHONY: run-celery-beat
 run-celery-beat: ## Run the celery beat
 	./scripts/run_celery_beat.sh
 
-run-celery-perge: ## Purge the celery queues
+.PHONY: run-celery-purge
+run-celery-purge: ## Purge the celery queues
 	./scripts/run_celery_purge.sh

--- a/Makefile
+++ b/Makefile
@@ -7,44 +7,49 @@ APP_VERSION_FILE = app/version.py
 GIT_BRANCH ?= $(shell git symbolic-ref --short HEAD 2> /dev/null || echo "detached")
 GIT_COMMIT ?= $(shell git rev-parse HEAD)
 
-.PHONY: help
+.PHONY: help generate-version-file test freeze-requirements test-requirements coverage clean format smoke-test run run-celery run-celery-clean run-celery-beat run-celery-perge
+
 help:
 	@cat $(MAKEFILE_LIST) | grep -E '^[a-zA-Z_-]+:.*?## .*$$' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: generate-version-file
 generate-version-file: ## Generates the app version file
 	@printf "__commit_sha__ = \"${GIT_COMMIT}\"\n__time__ = \"${DATE}\"\n" > ${APP_VERSION_FILE}
 
-.PHONY: test
 test: generate-version-file ## Run tests
 	./scripts/run_tests.sh
 
-.PHONY: freeze-requirements
 freeze-requirements:
 	poetry lock --no-update
 
-.PHONY: test-requirements
+test-requirements:
 	poetry lock --check
 
-.PHONY: coverage
 coverage: venv ## Create coverage report
 	. venv/bin/activate && coveralls
 
-.PHONY: clean
 clean:
 	rm -rf node_modules cache target venv .coverage build tests/.cache
 
-.PHONY: format
 format:
 	poetry run isort .
 	poetry run black --config pyproject.toml .
 	poetry run flake8 .
 	poetry run mypy .
 
-.PHONY: smoke-test
 smoke-test:
 	cd tests_smoke && poetry run python smoke_test.py
 
-.PHONY: run
-run:
+run: ## Run the web app
 	flask run -p 6011 --host=0.0.0.0
+
+run-celery: ## Run the celery workers
+	./scripts/run_celery.sh
+
+run-celery-clean: ## Run the celery workers but filter out common scheduled tasks
+	./scripts/run_celery.sh 2>&1 >/dev/null | grep -Ev 'beat|in-flight-to-inbox|run-scheduled-jobs|check-job-status'
+
+run-celery-beat: ## Run the celery beat
+	./scripts/run_celery_beat.sh
+
+run-celery-perge: ## Purge the celery queues
+	./scripts/run_celery_purge.sh


### PR DESCRIPTION
# Summary | Résumé

Add some make targets for running the celery scripts to make local running a little easier.

# Test instructions | Instructions pour tester la modification

Run the celery workers with `make run-celery-beat` and either `make run-celery` or `make run-celery-clean`
