### PR TITLE
New celery task for marking jobs as complete

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -16,7 +16,7 @@ from app import (
     sms_priority,
     zendesk_client,
 )
-from app.celery.tasks import process_job, save_emails, save_smss
+from app.celery.tasks import job_complete, process_job, save_emails, save_smss
 from app.config import QueueNames, TaskNames
 from app.dao.invited_org_user_dao import (
     delete_org_invitations_created_more_than_two_days_ago,
@@ -27,6 +27,7 @@ from app.dao.notifications_dao import (
     dao_get_scheduled_notifications,
     dao_old_letters_with_created_status,
     dao_precompiled_letters_still_pending_virus_check,
+    get_notification_count_for_job,
     is_delivery_slow_for_provider,
     notifications_not_yet_sent,
     set_scheduled_notification_to_processed,
@@ -58,6 +59,33 @@ def run_scheduled_jobs():
             current_app.logger.info("Job ID {} added to process job queue".format(job.id))
     except SQLAlchemyError:
         current_app.logger.exception("Failed to run scheduled jobs")
+        raise
+
+
+@notify_celery.task(name="mark-jobs-complete")
+@statsd(namespace="tasks")
+def mark_jobs_complete():
+    # query for jobs that are in progress
+    jobs_in_progress: tuple[Job] = (
+        Job.query.filter(
+            Job.job_status == JOB_STATUS_IN_PROGRESS,
+        )
+        .order_by(Job.processing_started)
+        .all()
+    )
+
+    try:
+        for job in jobs_in_progress:
+            # check if all notifications for that job are sent
+            notification_count = get_notification_count_for_job(job.id, job.service_id)
+
+            # if so, mark job as complete
+            if notification_count >= job.notification_count:
+                job_complete(job)
+                current_app.logger.info(f"Job ID {str(job.id)} marked as complete")
+
+    except SQLAlchemyError:
+        current_app.logger.exception("Failed to mark jobs complete")
         raise
 
 

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -66,7 +66,7 @@ def run_scheduled_jobs():
 @statsd(namespace="tasks")
 def mark_jobs_complete():
     # query for jobs that are in progress
-    jobs_in_progress: tuple[Job] = (
+    jobs_in_progress = (
         Job.query.filter(
             Job.job_status == JOB_STATUS_IN_PROGRESS,
         )
@@ -77,7 +77,7 @@ def mark_jobs_complete():
     try:
         for job in jobs_in_progress:
             # check if all notifications for that job are sent
-            notification_count = get_notification_count_for_job(job.id, job.service_id)
+            notification_count = get_notification_count_for_job(job.service_id, job.id)
 
             # if so, mark job as complete
             if notification_count >= job.notification_count:

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -133,7 +133,6 @@ def process_job(job_id):
         )
 
 
-
 def job_complete(job: Job, resumed=False, start=None):
     job.job_status = JOB_STATUS_FINISHED
 
@@ -657,7 +656,6 @@ def process_incomplete_job(job_id):
                 )
                 first_row = []
             break
-
 
 
 def choose_database_queue(process_type: str, research_mode: bool, notifications_count: int) -> str:

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -132,7 +132,6 @@ def process_job(job_id):
             metrics_logger, 1, notification_type=db_template.template_type, priority=db_template.process_type
         )
 
-    job_complete(job, start=start)
 
 
 def job_complete(job: Job, resumed=False, start=None):
@@ -659,7 +658,6 @@ def process_incomplete_job(job_id):
                 first_row = []
             break
 
-    job_complete(job, resumed=True)
 
 
 def choose_database_queue(process_type: str, research_mode: bool, notifications_count: int) -> str:

--- a/app/config.py
+++ b/app/config.py
@@ -310,6 +310,11 @@ class Config(object):
             "schedule": timedelta(minutes=66),
             "options": {"queue": QueueNames.PERIODIC},
         },
+        "mark-jobs-complete": {
+            "task": "mark-jobs-complete",
+            "schedule": crontab(),
+            "options": {"queue": QueueNames.PERIODIC},
+        },
         "check-job-status": {
             "task": "check-job-status",
             "schedule": crontab(),

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -283,6 +283,11 @@ def get_notifications_for_job(service_id, job_id, filter_dict=None, page=1, page
 
 
 @statsd(namespace="dao")
+def get_notification_count_for_job(service_id, job_id):
+    return Notification.query.filter_by(service_id=service_id, job_id=job_id).count()
+
+
+@statsd(namespace="dao")
 def get_notification_with_personalisation(service_id, notification_id, key_type):
     filter_dict = {"service_id": service_id, "id": notification_id}
     if key_type:

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -18,6 +18,7 @@ from app.celery.scheduled_tasks import (
     check_templated_letter_state,
     delete_invitations,
     delete_verify_codes,
+    mark_jobs_complete,
     recover_expired_notifications,
     replay_created_notifications,
     run_scheduled_jobs,
@@ -594,3 +595,27 @@ class TestRecoverExpiredNotification:
         email_bulk.assert_called_once()
         email_normal.assert_called_once()
         email_priority.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "notification_count_in_job, notification_count_in_db, expected_status",
+    [
+        [3, 0, JOB_STATUS_IN_PROGRESS],
+        [3, 1, JOB_STATUS_IN_PROGRESS],
+        [3, 3, JOB_STATUS_FINISHED],
+        [3, 10, JOB_STATUS_FINISHED],
+    ],
+)
+def test_mark_jobs_complete(sample_template, notification_count_in_job, notification_count_in_db, expected_status):
+    job = create_job(
+        template=sample_template,
+        notification_count=notification_count_in_job,
+        created_at=datetime.utcnow() - timedelta(minutes=1),
+        processing_started=datetime.utcnow() - timedelta(minutes=1),
+        job_status=JOB_STATUS_IN_PROGRESS,
+    )
+    for _ in range(notification_count_in_db):
+        save_notification(create_notification(template=sample_template, job=job))
+
+    mark_jobs_complete()
+    assert job.job_status == expected_status

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -25,6 +25,7 @@ from app.dao.notifications_dao import (
     dao_update_notifications_by_reference,
     delete_notifications_older_than_retention_by_type,
     get_notification_by_id,
+    get_notification_count_for_job,
     get_notification_for_job,
     get_notification_with_personalisation,
     get_notifications_for_job,
@@ -75,6 +76,7 @@ def test_should_have_decorated_notifications_dao_functions():
     assert dao_update_notification.__wrapped__.__name__ == "dao_update_notification"  # noqa
     assert update_notification_status_by_reference.__wrapped__.__name__ == "update_notification_status_by_reference"  # noqa
     assert get_notification_for_job.__wrapped__.__name__ == "get_notification_for_job"  # noqa
+    assert get_notification_count_for_job.__wrapped__.__name__ == "get_notification_count_for_job"  # noqa
     assert get_notifications_for_job.__wrapped__.__name__ == "get_notifications_for_job"  # noqa
     assert get_notification_with_personalisation.__wrapped__.__name__ == "get_notification_with_personalisation"  # noqa
     assert get_notifications_for_service.__wrapped__.__name__ == "get_notifications_for_service"  # noqa
@@ -566,6 +568,17 @@ def test_get_all_notifications_for_job(sample_job):
 
     notifications_from_db = get_notifications_for_job(sample_job.service.id, sample_job.id).items
     assert len(notifications_from_db) == 5
+
+
+def test_get_notification_count_for_job(sample_job):
+    for i in range(0, 7):
+        try:
+            save_notification(create_notification(template=sample_job.template, job=sample_job))
+        except IntegrityError:
+            pass
+
+    notification_count_from_db = get_notification_count_for_job(sample_job.service.id, sample_job.id)
+    assert notification_count_from_db == 7
 
 
 def test_get_all_notifications_for_job_by_status(sample_job):


### PR DESCRIPTION
# Summary | Résumé

This PR:
- removes the `job_complete` calls from `process_job` and `process_incomplete_job` since these calls were happening before all notifications had been added to the db, and update the associate tests
- adds a new periodic celery task that runs every minute called `mark-jobs-complete`. This queries for "in progress" jobs and checks if the notifications for that job exist in the notifications table yet. If the do exist, the job is marked "complete"
- tests for `mark_jobs_complete`
- adds a new function to `notifications_dao.py` called `get_notification_count_for_job`, as well as tests for this

# Test instructions | Instructions pour tester la modification

1. Run `./scripts/run_celery_purge.sh` locally
2. run notification-api locally using this branch (`fix/celery-task-job-complete`), also run celery
3. point notification-admin to your local api and run it locally too
4. open a Postgres client like Postico and connect to your local db, open the `jobs` table
5. send a bulk job via the api of maybe 10 emails (needs to be via api because CSV upload doesn't work locally)
6. refresh the `jobs` table in Postico and observe that a new row has appeared for the job you just sent via API
7. observe that the `job_status` column is set to either `pending` or `in progress`
8. wait 1 minute
9. refresh the `jobs` table and observe that `job_status` now has a value of `finished`