### PR TITLE
Daily Email Limits - Add limits to redis

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -447,11 +447,11 @@ def fetch_todays_total_sms_count(service_id):
     return 0 if result is None or result.sum_billable_units is None else result.sum_billable_units
 
 
-def fetch_service_email_limit(service_id):
+def fetch_service_email_limit(service_id: uuid.UUID) -> int:
     return Service.query.get(service_id).message_limit
 
 
-def fetch_todays_total_email_count(service_id: str) -> int:
+def fetch_todays_total_email_count(service_id: uuid.UUID) -> int:
     midnight = get_midnight(datetime.now(tz=pytz.utc))
     result = (
         db.session.query(func.count(Notification).label("total_email_notifications"))

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -447,6 +447,25 @@ def fetch_todays_total_sms_count(service_id):
     return 0 if result is None or result.sum_billable_units is None else result.sum_billable_units
 
 
+def fetch_service_email_limit(service_id):
+    return Service.query.get(service_id).message_limit
+
+
+def fetch_todays_total_email_count(service_id: str) -> int:
+    midnight = get_midnight(datetime.now(tz=pytz.utc))
+    result = (
+        db.session.count((Notification).label("total_email_notifications"))
+        .filter(
+            Notification.service_id == service_id,
+            Notification.key_type != KEY_TYPE_TEST,
+            Notification.created_at > midnight,
+            Notification.notification_type == "email",
+        )
+        .first()
+    )
+    return 0 if result is None else result.total_email_notifications
+
+
 def _stats_for_service_query(service_id):
     return (
         db.session.query(

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -454,7 +454,7 @@ def fetch_service_email_limit(service_id):
 def fetch_todays_total_email_count(service_id: str) -> int:
     midnight = get_midnight(datetime.now(tz=pytz.utc))
     result = (
-        db.session.count((Notification).label("total_email_notifications"))
+        db.session.query(func.count(Notification).label("total_email_notifications"))
         .filter(
             Notification.service_id == service_id,
             Notification.key_type != KEY_TYPE_TEST,

--- a/app/email_limit_utils.py
+++ b/app/email_limit_utils.py
@@ -5,9 +5,8 @@ from flask import current_app
 from notifications_utils.clients.redis import email_daily_count_cache_key
 
 from app import redis_store
-from app.dao.services_dao import (
-    fetch_todays_total_email_count,
-)
+from app.dao.services_dao import fetch_todays_total_email_count
+
 
 def fetch_todays_email_count(service_id: UUID) -> int:
     if not current_app.config["REDIS_ENABLED"]:

--- a/app/email_limit_utils.py
+++ b/app/email_limit_utils.py
@@ -1,0 +1,30 @@
+from datetime import timedelta
+from uuid import UUID
+
+from flask import current_app
+from notifications_utils.clients.redis import email_daily_count_cache_key
+
+from app import redis_store
+from app.dao.services_dao import (
+    fetch_todays_total_email_count,
+)
+
+def fetch_todays_email_count(service_id: UUID) -> int:
+    if not current_app.config["REDIS_ENABLED"]:
+        return fetch_todays_total_email_count(service_id)
+
+    cache_key = email_daily_count_cache_key(service_id)
+    total_email_count = redis_store.get(cache_key)
+    if total_email_count is None:
+        total_email_count = fetch_todays_total_email_count(service_id)
+        redis_store.set(cache_key, total_email_count, ex=int(timedelta(hours=2).total_seconds()))
+    return int(total_email_count)
+
+
+def increment_todays_email_count(service_id: UUID, increment_by: int) -> None:
+    if not current_app.config["REDIS_ENABLED"]:
+        return
+
+    fetch_todays_email_count(service_id)  # to make sure it's set in redis
+    cache_key = email_daily_count_cache_key(service_id)
+    redis_store.incrby(cache_key, increment_by)

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -38,7 +38,6 @@ from app.dao.services_dao import (
     dao_update_service,
     delete_service_and_all_associated_db_objects,
     fetch_service_email_limit,
-    fetch_todays_total_email_count,
     fetch_todays_total_message_count,
     fetch_todays_total_sms_count,
     get_services_by_partial_name,

--- a/tests/app/test_email_limit_utils.py
+++ b/tests/app/test_email_limit_utils.py
@@ -1,0 +1,48 @@
+import pytest
+from notifications_utils.clients.redis import email_daily_count_cache_key
+
+from app.email_limit_utils import (
+    fetch_todays_email_count,
+)
+from tests.conftest import set_config
+
+
+@pytest.mark.parametrize("redis_value,db_value,expected_result", [(None, 5, 5), ("3", 5, 3)])
+def test_fetch_todays_requested_sms_count(client, mocker, sample_service, redis_value, db_value, expected_result):
+    cache_key = sms_daily_count_cache_key(sample_service.id)
+    mocker.patch("app.redis_store.get", lambda x: redis_value if x == cache_key else None)
+    mocked_set = mocker.patch("app.redis_store.set")
+    mocker.patch("app.sms_fragment_utils.fetch_todays_total_sms_count", return_value=db_value)
+    mocker.patch("app.dao.users_dao.user_can_be_archived", return_value=False)
+
+    with set_config(client.application, "REDIS_ENABLED", True):
+        actual_result = fetch_todays_requested_sms_count(sample_service.id)
+
+        assert actual_result == expected_result
+        if redis_value is None:
+            assert mocked_set.called_once_with(
+                cache_key,
+                db_value,
+            )
+        else:
+            mocked_set.assert_not_called()
+
+
+@pytest.mark.parametrize("redis_value,db_value,increment_by", [(None, 5, 5), ("3", 5, 3)])
+def test_increment_todays_requested_sms_count(mocker, sample_service, redis_value, db_value, increment_by):
+    cache_key = sms_daily_count_cache_key(sample_service.id)
+    mocker.patch("app.redis_store.get", lambda x: redis_value if x == cache_key else None)
+    mocked_set = mocker.patch("app.redis_store.set")
+    mocked_incrby = mocker.patch("app.redis_store.incrby")
+    mocker.patch("app.sms_fragment_utils.fetch_todays_requested_sms_count", return_value=db_value)
+
+    increment_todays_requested_sms_count(sample_service.id, increment_by)
+
+    assert mocked_incrby.called_once_with(cache_key, increment_by)
+    if redis_value is None:
+        assert mocked_set.called_once_with(
+            cache_key,
+            db_value,
+        )
+    else:
+        mocked_set.assert_not_called()

--- a/tests/app/test_email_limit_utils.py
+++ b/tests/app/test_email_limit_utils.py
@@ -1,24 +1,42 @@
 import pytest
 from notifications_utils.clients.redis import email_daily_count_cache_key
 
-from app.email_limit_utils import (
-    fetch_todays_email_count,
-)
+from app.email_limit_utils import fetch_todays_email_count, increment_todays_email_count
 from tests.conftest import set_config
 
 
-@pytest.mark.parametrize("redis_value,db_value,expected_result", [(None, 5, 5), ("3", 5, 3)])
-def test_fetch_todays_requested_sms_count(client, mocker, sample_service, redis_value, db_value, expected_result):
-    cache_key = sms_daily_count_cache_key(sample_service.id)
-    mocker.patch("app.redis_store.get", lambda x: redis_value if x == cache_key else None)
-    mocked_set = mocker.patch("app.redis_store.set")
-    mocker.patch("app.sms_fragment_utils.fetch_todays_total_sms_count", return_value=db_value)
-    mocker.patch("app.dao.users_dao.user_can_be_archived", return_value=False)
+class TestEmailLimits:
+    @pytest.mark.parametrize("redis_value, db_value, expected_result", [(None, 5, 5), ("3", 5, 3)])
+    def test_fetch_todays_requested_email_count(self, client, mocker, sample_service, redis_value, db_value, expected_result):
+        cache_key = email_daily_count_cache_key(sample_service.id)
+        mocker.patch("app.redis_store.get", lambda x: redis_value if x == cache_key else None)
+        mocked_set = mocker.patch("app.redis_store.set")
+        mocker.patch("app.email_limit_utils.fetch_todays_total_email_count", return_value=db_value)
+        # mocker.patch("app.dao.users_dao.user_can_be_archived", return_value=False)
 
-    with set_config(client.application, "REDIS_ENABLED", True):
-        actual_result = fetch_todays_requested_sms_count(sample_service.id)
+        with set_config(client.application, "REDIS_ENABLED", True):
+            actual_result = fetch_todays_email_count(sample_service.id)
 
-        assert actual_result == expected_result
+            assert actual_result == expected_result
+            if redis_value is None:
+                assert mocked_set.called_once_with(
+                    cache_key,
+                    db_value,
+                )
+            else:
+                mocked_set.assert_not_called()
+
+    @pytest.mark.parametrize("redis_value, db_value, increment_by", [(None, 5, 5), ("3", 5, 3)])
+    def test_increment_todays_requested_email_count(self, mocker, sample_service, redis_value, db_value, increment_by):
+        cache_key = email_daily_count_cache_key(sample_service.id)
+        mocker.patch("app.redis_store.get", lambda x: redis_value if x == cache_key else None)
+        mocked_set = mocker.patch("app.redis_store.set")
+        mocked_incrby = mocker.patch("app.redis_store.incrby")
+        mocker.patch("app.email_limit_utils.fetch_todays_email_count", return_value=db_value)
+
+        increment_todays_email_count(sample_service.id, increment_by)
+
+        assert mocked_incrby.called_once_with(cache_key, increment_by)
         if redis_value is None:
             assert mocked_set.called_once_with(
                 cache_key,
@@ -26,23 +44,3 @@ def test_fetch_todays_requested_sms_count(client, mocker, sample_service, redis_
             )
         else:
             mocked_set.assert_not_called()
-
-
-@pytest.mark.parametrize("redis_value,db_value,increment_by", [(None, 5, 5), ("3", 5, 3)])
-def test_increment_todays_requested_sms_count(mocker, sample_service, redis_value, db_value, increment_by):
-    cache_key = sms_daily_count_cache_key(sample_service.id)
-    mocker.patch("app.redis_store.get", lambda x: redis_value if x == cache_key else None)
-    mocked_set = mocker.patch("app.redis_store.set")
-    mocked_incrby = mocker.patch("app.redis_store.incrby")
-    mocker.patch("app.sms_fragment_utils.fetch_todays_requested_sms_count", return_value=db_value)
-
-    increment_todays_requested_sms_count(sample_service.id, increment_by)
-
-    assert mocked_incrby.called_once_with(cache_key, increment_by)
-    if redis_value is None:
-        assert mocked_set.called_once_with(
-            cache_key,
-            db_value,
-        )
-    else:
-        mocked_set.assert_not_called()


### PR DESCRIPTION
# Summary | Résumé

First updates for email daily limits. This PR puts the daily service limit into redis.
We also add a func to find the number of emails sent in a day. Added tests for the above functionality as well.