### PR TITLE
Make get_notification_count_for_job only pull in sent notifications

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -284,7 +284,7 @@ def get_notifications_for_job(service_id, job_id, filter_dict=None, page=1, page
 
 @statsd(namespace="dao")
 def get_notification_count_for_job(service_id, job_id):
-    return Notification.query.filter_by(service_id=service_id, job_id=job_id).count()
+    return Notification.query.filter_by(service_id=service_id, job_id=job_id, status=NOTIFICATION_SENT).count()
 
 
 @statsd(namespace="dao")

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -615,7 +615,7 @@ def test_mark_jobs_complete(sample_template, notification_count_in_job, notifica
         job_status=JOB_STATUS_IN_PROGRESS,
     )
     for _ in range(notification_count_in_db):
-        save_notification(create_notification(template=sample_template, job=job))
+        save_notification(create_notification(template=sample_template, status="sent", job=job))
 
     mark_jobs_complete()
     assert job.job_status == expected_status

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -573,7 +573,7 @@ def test_get_all_notifications_for_job(sample_job):
 def test_get_notification_count_for_job(sample_job):
     for i in range(0, 7):
         try:
-            save_notification(create_notification(template=sample_job.template, job=sample_job))
+            save_notification(create_notification(template=sample_job.template, status="sent", job=sample_job))
         except IntegrityError:
             pass
 


### PR DESCRIPTION
# Summary | Résumé
This PR makes a small tweak to the behaviour of `get_notification_count_for_job`. Previously we relied on the count of notifications that exist in the DB for a given job simply matching the `Job.notification_count` column. Since a notification can be added to the DB but not yet sent, we should not mark a job complete until the Notifications are sent.

Both the [new work on preventing duplicate notifications](https://github.com/cds-snc/notification-api/pull/1936/files#diff-cca5917c620894fe770faa88835e9e186285d5b91a55fca992eb94d5dc87e635R93) and [`check_job_status`](https://github.com/cds-snc/notification-api/blob/ee209c8ac123b9aec9c751361f4b69c66e9d8ca6/app/celery/scheduled_tasks.py#L161) rely on the job status being `in-progress` to maintain the state of the `in-progress` job and determine if the job needs to be reprocessed or not  respectively.


# Reproduce steps
1. Check out main and do a bulk send
2. Since we cannot receive SES receipts locally, the status of the notifications will remain as `sending`
3. Check the job in the DB and note that the `processing_finished` column is populated and the `job_status` is set to finished. 

# Test instructions | Instructions pour tester la modification 
1. Repeat steps 1 & 2 above
2. Check the Job status for the bulk send you made, and note that the `job_status` and `processing_finished` fields are `in progress` and `null` respectively
3. Set the status of the notifications you sent for that job to `sent`
4. Check the job status again, after some time, the job should be marked as complete as all the rows have been "processed"


