### PR TITLE
`mark-jobs-complete` should also run on jobs with the error status

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -65,17 +65,17 @@ def run_scheduled_jobs():
 @notify_celery.task(name="mark-jobs-complete")
 @statsd(namespace="tasks")
 def mark_jobs_complete():
-    # query for jobs that are in progress
-    jobs_in_progress = (
+    # query for jobs that are not yet complete
+    jobs_not_complete = (
         Job.query.filter(
-            Job.job_status == JOB_STATUS_IN_PROGRESS,
+            Job.job_status.in_([JOB_STATUS_IN_PROGRESS, JOB_STATUS_ERROR])
         )
         .order_by(Job.processing_started)
         .all()
     )
 
     try:
-        for job in jobs_in_progress:
+        for job in jobs_not_complete:
             # check if all notifications for that job are sent
             notification_count = get_notification_count_for_job(job.service_id, job.id)
 

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -67,11 +67,7 @@ def run_scheduled_jobs():
 def mark_jobs_complete():
     # query for jobs that are not yet complete
     jobs_not_complete = (
-        Job.query.filter(
-            Job.job_status.in_([JOB_STATUS_IN_PROGRESS, JOB_STATUS_ERROR])
-        )
-        .order_by(Job.processing_started)
-        .all()
+        Job.query.filter(Job.job_status.in_([JOB_STATUS_IN_PROGRESS, JOB_STATUS_ERROR])).order_by(Job.processing_started).all()
     )
 
     try:

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -598,21 +598,25 @@ class TestRecoverExpiredNotification:
 
 
 @pytest.mark.parametrize(
-    "notification_count_in_job, notification_count_in_db, expected_status",
+    "notification_count_in_job, notification_count_in_db, initial_status, expected_status",
     [
-        [3, 0, JOB_STATUS_IN_PROGRESS],
-        [3, 1, JOB_STATUS_IN_PROGRESS],
-        [3, 3, JOB_STATUS_FINISHED],
-        [3, 10, JOB_STATUS_FINISHED],
+        [3, 0, JOB_STATUS_IN_PROGRESS, JOB_STATUS_IN_PROGRESS],
+        [3, 1, JOB_STATUS_IN_PROGRESS, JOB_STATUS_IN_PROGRESS],
+        [3, 1, JOB_STATUS_ERROR, JOB_STATUS_ERROR],
+        [3, 3, JOB_STATUS_ERROR, JOB_STATUS_FINISHED],
+        [3, 3, JOB_STATUS_IN_PROGRESS, JOB_STATUS_FINISHED],
+        [3, 10, JOB_STATUS_IN_PROGRESS, JOB_STATUS_FINISHED],
     ],
 )
-def test_mark_jobs_complete(sample_template, notification_count_in_job, notification_count_in_db, expected_status):
+def test_mark_jobs_complete(
+    sample_template, notification_count_in_job, notification_count_in_db, initial_status, expected_status
+):
     job = create_job(
         template=sample_template,
         notification_count=notification_count_in_job,
         created_at=datetime.utcnow() - timedelta(minutes=1),
         processing_started=datetime.utcnow() - timedelta(minutes=1),
-        job_status=JOB_STATUS_IN_PROGRESS,
+        job_status=initial_status,
     )
     for _ in range(notification_count_in_db):
         save_notification(create_notification(template=sample_template, job=job))


### PR DESCRIPTION
# Summary | Résumé

For jobs that are not complete after 2 hours, the `job_status` gets updated to `error` here: https://github.com/cds-snc/notification-api/blob/main/app/celery/scheduled_tasks.py#L192.

Those jobs are then set to `process-incomplete-jobs` and the remaining rows are added to the `notifications` table. Once all the rows are added to the notifications table, these jobs can be marked `complete`.
