### PR TITLE
Fix 500 error when `scheduled_for` time contains a timezone offset

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -36,9 +36,10 @@ def _validate_positive_number(value, msg="Not a positive integer"):
         raise ValidationError(msg)
 
 
-def _validate_datetime_not_too_far_in_future(dte):
+def _validate_datetime_not_too_far_in_future(dte: datetime):
     max_hours = current_app.config["JOBS_MAX_SCHEDULE_HOURS_AHEAD"]
-    if dte > datetime.utcnow() + timedelta(hours=max_hours):
+    max_schedule_time = datetime.utcnow() + timedelta(hours=max_hours)
+    if dte.timestamp() > max_schedule_time.timestamp():
         msg = f"Date cannot be more than {max_hours} hours in the future"
         raise ValidationError(msg)
 
@@ -48,18 +49,8 @@ def _validate_not_in_future(dte, msg="Date cannot be in the future"):
         raise ValidationError(msg)
 
 
-def _validate_not_in_past(dte, msg="Date cannot be in the past"):
-    if dte < date.today():
-        raise ValidationError(msg)
-
-
-def _validate_datetime_not_in_future(dte, msg="Date cannot be in the future"):
-    if dte > datetime.utcnow():
-        raise ValidationError(msg)
-
-
-def _validate_datetime_not_in_past(dte, msg="Date cannot be in the past"):
-    if dte < datetime.utcnow():
+def _validate_datetime_not_in_past(dte: datetime, msg="Date cannot be in the past"):
+    if dte.timestamp() < datetime.utcnow().timestamp():
         raise ValidationError(msg)
 
 


### PR DESCRIPTION
# Summary | Résumé

This PR:
- makes the validator functions for the marshmallow `JobSchema` work for timezone-aware and timezone-naive times, since these both have a `.timestamp()` method that converts a datetime to a number of seconds since Jan 1, 1970 UTC time: https://docs.python.org/3/library/datetime.html#datetime.datetime.timestamp
- removes some unused validator functions that looked like they contained the same bug

# Test instructions | Instructions pour tester la modification

1. check out the `main` branch and run locally
2. send an api request to `http://host.docker.internal:6011/v2/notifications/bulk` with the following data:
```
{'name': 'send 22',
 'scheduled_for': '2023-07-25T19:34:43-05:00',
 'rows': [['email address'], ['success@simulator.amazonses.com']],
 'template_id': 'your-template-id'}
```
3. observe that you get a 500 error back
4. check out this branch and run locally
5. observe that you get a "success" status back
6. open a Postgres client and look at the jobs table
7. observe that the job is scheduled for `2023-07-26 00:34:43`, which is the correct timezone-naive UTC version of  `scheduled_for`