### PR TITLE
Adding debug stack trace feature to celery tasks

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -315,6 +315,17 @@ def beat_inbox_email_bulk():
         receipt_id_email, list_of_email_notifications = email_bulk.poll()
 
 
+if current_app.config["FF_DEBUG_STACK_TRACE"]:
+
+    @notify_celery.task(name="debug-stack-trace")
+    @statsd(namespace="tasks")
+    def debug_stack_trace():
+        """
+        This function, when enabled, will throw an exception so that we can test multi-line logging
+        """
+        raise Exception("Debugging")
+
+
 @notify_celery.task(name="beat-inbox-email-priority")
 @statsd(namespace="tasks")
 def beat_inbox_email_priority():
@@ -325,6 +336,7 @@ def beat_inbox_email_priority():
     to another list(list#2). The heartbeat will then call a job that saves list#2 to the DB
     and actually sends the email for each notification saved.
     """
+
     receipt_id_email, list_of_email_notifications = email_priority.poll()
 
     while list_of_email_notifications:

--- a/app/config.py
+++ b/app/config.py
@@ -445,6 +445,8 @@ class Config(object):
         # 'options': {'queue': QueueNames.PERIODIC}
         # },
     }
+
+
     CELERY_QUEUES: List[Any] = []
 
     CONTACT_FORM_EMAIL_ADDRESS = os.getenv("CONTACT_FORM_EMAIL_ADDRESS", "helpdesk@cds-snc.ca")
@@ -524,6 +526,18 @@ class Config(object):
     FF_BOUNCE_RATE_BACKEND = env.bool("FF_BOUNCE_RATE_BACKEND", False)
     # Timestamp in epoch milliseconds to seed the bounce rate. We will seed data for (24, the below config) included.
     FF_BOUNCE_RATE_SEED_EPOCH_MS = os.getenv("FF_BOUNCE_RATE_SEED_EPOCH_MS", False)
+
+    # Feature flag for stack trace debugging
+    FF_DEBUG_STACK_TRACE = env.bool("FF_DEBUG_STACK_TRACE", False)
+    if FF_DEBUG_STACK_TRACE: 
+        CELERYBEAT_SCHEDULE.update({
+            "debug-stack-trace": {
+                "task": "debug-stack-trace",
+                "schedule": 10,
+                "options": {"queue": QueueNames.PERIODIC},
+        },
+        }
+    )
 
     @classmethod
     def get_sensitive_config(cls) -> list[str]:

--- a/app/config.py
+++ b/app/config.py
@@ -446,7 +446,6 @@ class Config(object):
         # },
     }
 
-
     CELERY_QUEUES: List[Any] = []
 
     CONTACT_FORM_EMAIL_ADDRESS = os.getenv("CONTACT_FORM_EMAIL_ADDRESS", "helpdesk@cds-snc.ca")
@@ -529,15 +528,16 @@ class Config(object):
 
     # Feature flag for stack trace debugging
     FF_DEBUG_STACK_TRACE = env.bool("FF_DEBUG_STACK_TRACE", False)
-    if FF_DEBUG_STACK_TRACE: 
-        CELERYBEAT_SCHEDULE.update({
-            "debug-stack-trace": {
-                "task": "debug-stack-trace",
-                "schedule": 10,
-                "options": {"queue": QueueNames.PERIODIC},
-        },
-        }
-    )
+    if FF_DEBUG_STACK_TRACE:
+        CELERYBEAT_SCHEDULE.update(
+            {
+                "debug-stack-trace": {
+                    "task": "debug-stack-trace",
+                    "schedule": 10,
+                    "options": {"queue": QueueNames.PERIODIC},
+                },
+            }
+        )
 
     @classmethod
     def get_sensitive_config(cls) -> list[str]:


### PR DESCRIPTION
# Summary | Résumé

I've added a debug stack trace task to celery that can be enabled/disabled using the environment variable FF_DEBUG_STACK_TRACE. 

When enabled, a celery task will be created that will raise an exception in the same manner as @sastels changes to admin.

# Test instructions | Instructions pour tester la modification

- Set FF_DEBUG_STACK_TRACE to true 
- View the celery logs and make sure the stack trace is shown
- Set FF_DEBUG_STACK_TRACE to false
- View the celery logs and make sure the stack trace is not shown, and that the task does not execute at all.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne
      une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une
      fonctionnalité existante?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une
      modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des
      préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de
      façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de
      risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README
      setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce
      changement (fichier README, etc.)?
