### PR TITLE
Double number of concurrent celery workers (DO NOT RELEASE TO PROD)

### DIFF
--- a/scripts/run_celery.sh
+++ b/scripts/run_celery.sh
@@ -4,4 +4,4 @@ set -e
 
 echo "Start celery"
 
-celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency=4 -Q database-tasks,-priority-database-tasks.fifo,-normal-database-tasks,-bulk-database-tasks,job-tasks,notify-internal-tasks,periodic-tasks,priority-tasks,normal-tasks,bulk-tasks,reporting-tasks,research-mode-tasks,retry-tasks,send-sms-tasks,send-email-tasks,service-callbacks,delivery-receipts
+celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency=8 -Q database-tasks,-priority-database-tasks.fifo,-normal-database-tasks,-bulk-database-tasks,job-tasks,notify-internal-tasks,periodic-tasks,priority-tasks,normal-tasks,bulk-tasks,reporting-tasks,research-mode-tasks,retry-tasks,send-sms-tasks,send-email-tasks,service-callbacks,delivery-receipts


### PR DESCRIPTION
# Summary | Résumé

Double the number of celery concurrent workers. The current value of `4` was probably selected for the number of CPU cores present on the machines running our workers. But as our workers are probably not CPU bound (we do not do numbers crunching) but most likely bound by the network, we can test with more celery concurrent workers, as these would wait on either some AWS service calls, the database or Redis.

### **This is change should not end in production, this is meant to test the configuration.**

# Test instructions | Instructions pour tester la modification

Testing in a scratch environment might be preferable.

# Release Instructions | Instructions pour le déploiement

### DO NOT RELEASE IN PROD.
