### PR TITLE
use CELERY_CONCURRENCY

### DIFF
--- a/scripts/run_celery.sh
+++ b/scripts/run_celery.sh
@@ -2,6 +2,6 @@
 
 set -e
 
-echo "Start celery"
+echo "Start celery, concurrency: ${CELERY_CONCURRENCY-4}"
 
-celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency=4 -Q database-tasks,-priority-database-tasks.fifo,-normal-database-tasks,-bulk-database-tasks,job-tasks,notify-internal-tasks,periodic-tasks,priority-tasks,normal-tasks,bulk-tasks,reporting-tasks,research-mode-tasks,retry-tasks,send-sms-tasks,send-email-tasks,service-callbacks,delivery-receipts
+celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency=${CELERY_CONCURRENCY-4} -Q database-tasks,-priority-database-tasks.fifo,-normal-database-tasks,-bulk-database-tasks,job-tasks,notify-internal-tasks,periodic-tasks,priority-tasks,normal-tasks,bulk-tasks,reporting-tasks,research-mode-tasks,retry-tasks,send-sms-tasks,send-email-tasks,service-callbacks,delivery-receipts


### PR DESCRIPTION
# Summary | Résumé

Use the new `CELERY_CONCURRENCY` env var.

Note that if the variable is not defined, the concurrency will be the default value of 4.

# Test instructions | Instructions pour tester la modification

1. run `make run-celery` without the env var. Note the concurrency is 4. Kill celery and see 4 workers stopped.
2. set `export CELERY_CONCURRENCY=8` and run `make run-celery` again. This time the concurrency is 8.
