### PR TITLE
Update to the new content for emails regarding the email daily limits

### DIFF
--- a/migrations/versions/0433_update_daily_email_limit_templates.py
+++ b/migrations/versions/0433_update_daily_email_limit_templates.py
@@ -1,0 +1,154 @@
+"""
+
+Revision ID: 0433_update_daily_email_limit_templates
+Revises: 0432_daily_email_limit_templates
+Create Date: 2023-08-08 00:00:00
+
+"""
+from datetime import datetime
+
+from alembic import op
+from flask import current_app
+
+revision = "0433_update_daily_email_limit_templates"
+down_revision = "0432_daily_email_limit_templates"
+
+near_content = """
+(la version française suit)
+
+Hello ((name)),
+
+((service_name)) can send ((message_limit_en)) emails per day. You’ll be blocked from sending if you exceed that limit before 7pm Eastern Time. Check [your current local time](https://nrc.canada.ca/en/web-clock/).
+
+To request a limit increase, [contact us](https://notification.canada.ca/contact). We’ll respond within 1 business day.
+
+The GC Notify team
+
+---
+Bonjour ((name)),
+
+La limite quotidienne d’envoi est de ((message_limit_fr)) courriels par jour pour ((service_name)). Si vous dépassez cette limite avant 19 heures, heure de l’Est, vos envois seront bloqués.
+
+Comparez [les heures officielles au Canada](https://nrc.canada.ca/fr/horloge-web/).
+
+Veuillez [nous contacter](https://notification.canada.ca/contact) si vous souhaitez augmenter votre limite d’envoi. Nous vous répondrons en un jour ouvrable.
+
+L’équipe Notification GC
+"""
+
+reached_content = """
+(la version française suit)
+
+Hello ((name)),
+
+((service_name)) has sent ((message_limit_en)) emails today.
+
+You can send more messages after 7pm Eastern Time. Compare [official times across Canada](https://nrc.canada.ca/en/web-clock/).
+
+To request a limit increase, [contact us](https://notification.canada.ca/contact). We’ll respond within 1 business day.
+
+The GC Notify team
+
+---
+Bonjour ((name)),
+
+Aujourd’hui, ((message_limit_fr)) courriels ont été envoyés pour ((service_name)).
+
+Vous pourrez envoyer davantage de courriels après 19 heures, heure de l’Est. Comparez [les heures officielles au Canada](https://nrc.canada.ca/fr/horloge-web/). 
+
+Veuillez [nous contacter](https://notification.canada.ca/contact) si vous désirez augmenter votre limite d’envoi. Nous vous répondrons en un jour ouvrable.
+
+L’équipe Notification GC
+"""
+
+updated_content = """
+(la version française suit)
+
+Hello ((name)),
+
+You can now send ((message_limit_en)) email messages per day.
+
+The GC Notify Team
+
+---
+Bonjour ((name)),
+
+Vous pouvez désormais envoyer ((message_limit_fr)) courriels par jour.
+
+L’équipe Notification GC
+"""
+
+templates = [
+    {
+        "id": current_app.config["NEAR_DAILY_EMAIL_LIMIT_TEMPLATE_ID"],
+        "name": "Near daily EMAIL limit",
+        "template_type": "email",
+        "content": near_content,
+        "subject": "((service_name)) is near its daily limit for emails. | La limite quotidienne d’envoi de courriels est presque atteinte pour ((service_name)).",
+        "process_type": "priority",
+    },
+    {
+        "id": current_app.config["REACHED_DAILY_EMAIL_LIMIT_TEMPLATE_ID"],
+        "name": "Daily EMAIL limit reached",
+        "template_type": "email",
+        "content": reached_content,
+        "subject": "((service_name)) has reached its daily limit for email messages | La limite quotidienne d’envoi de courriels atteinte pour ((service_name)).",
+        "process_type": "priority",
+    },
+    {
+        "id": current_app.config["DAILY_EMAIL_LIMIT_UPDATED_TEMPLATE_ID"],
+        "name": "Daily EMAIL limit updated",
+        "template_type": "email",
+        "content": updated_content,
+        "subject": "We’ve updated the daily email limit for ((service_name)) | Nous avons mis à jour la limite quotidienne de courriels pour ((service_name))",
+        "process_type": "priority",
+    },
+]
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    for template in templates:
+        current_version = conn.execute("select version from templates where id='{}'".format(template["id"])).fetchone()
+        template["version"] = current_version[0] + 1
+
+    template_update = """
+        UPDATE templates SET content = '{}', subject = '{}', version = '{}', updated_at = '{}'
+        WHERE id = '{}'
+    """
+    template_history_insert = """
+        INSERT INTO templates_history (id, name, template_type, created_at, content, archived, service_id, subject,
+        created_by_id, version, process_type, hidden)
+        VALUES ('{}', '{}', '{}', '{}', '{}', False, '{}', '{}', '{}', {}, '{}', false)
+    """
+
+    for template in templates:
+        op.execute(
+            template_update.format(
+                template["content"],
+                template["subject"],
+                template["version"],
+                datetime.utcnow(),
+                template["id"],
+            )
+        )
+
+        op.execute(
+            template_history_insert.format(
+                template["id"],
+                template["name"],
+                template["template_type"],
+                datetime.utcnow(),
+                template["content"],
+                current_app.config["NOTIFY_SERVICE_ID"],
+                template["subject"],
+                current_app.config["NOTIFY_USER_ID"],
+                template["version"],
+                template["process_type"],
+            )
+        )
+
+
+def downgrade():
+    pass

--- a/migrations/versions/0433_update_email_templates.py
+++ b/migrations/versions/0433_update_email_templates.py
@@ -68,7 +68,7 @@ reached_content = "\n".join(
     ]
 )
 
-updated_content =  "\n".join(
+updated_content = "\n".join(
     [
         "(la version française suit)",
         "",

--- a/migrations/versions/0433_update_email_templates.py
+++ b/migrations/versions/0433_update_email_templates.py
@@ -1,6 +1,6 @@
 """
 
-Revision ID: 0433_update_daily_email_limit_templates
+Revision ID: 0433_update_email_templates
 Revises: 0432_daily_email_limit_templates
 Create Date: 2023-08-08 00:00:00
 
@@ -10,73 +10,83 @@ from datetime import datetime
 from alembic import op
 from flask import current_app
 
-revision = "0433_update_daily_email_limit_templates"
+revision = "0433_update_email_templates"
 down_revision = "0432_daily_email_limit_templates"
 
-near_content = """
-(la version française suit)
+near_content = "\n".join(
+    [
+        "(la version française suit)",
+        "",
+        "Hello ((name)),",
+        "",
+        "((service_name)) can send ((message_limit_en)) emails per day. You’ll be blocked from sending if you exceed that limit before 7pm Eastern Time. Check [your current local time](https://nrc.canada.ca/en/web-clock/).",
+        "",
+        "To request a limit increase, [contact us](https://notification.canada.ca/contact). We’ll respond within 1 business day.",
+        "",
+        "The GC Notify team",
+        "",
+        "---",
+        "",
+        "Bonjour ((name)),",
+        "",
+        "La limite quotidienne d’envoi est de ((message_limit_fr)) courriels par jour pour ((service_name)). Si vous dépassez cette limite avant 19 heures, heure de l’Est, vos envois seront bloqués.",
+        "",
+        "Comparez [les heures officielles au Canada](https://nrc.canada.ca/fr/horloge-web/).",
+        "",
+        "Veuillez [nous contacter](https://notification.canada.ca/contact) si vous souhaitez augmenter votre limite d’envoi. Nous vous répondrons en un jour ouvrable.",
+        "",
+        "L’équipe Notification GC",
+    ]
+)
 
-Hello ((name)),
 
-((service_name)) can send ((message_limit_en)) emails per day. You’ll be blocked from sending if you exceed that limit before 7pm Eastern Time. Check [your current local time](https://nrc.canada.ca/en/web-clock/).
+reached_content = "\n".join(
+    [
+        "(la version française suit)",
+        "",
+        "Hello ((name)),",
+        "",
+        "((service_name)) has sent ((message_limit_en)) emails today.",
+        "",
+        "You can send more messages after 7pm Eastern Time. Compare [official times across Canada](https://nrc.canada.ca/en/web-clock/).",
+        "",
+        "To request a limit increase, [contact us](https://notification.canada.ca/contact). We’ll respond within 1 business day.",
+        "",
+        "The GC Notify team",
+        "",
+        "---",
+        "",
+        "Bonjour ((name)),",
+        "",
+        "Aujourd’hui, ((message_limit_fr)) courriels ont été envoyés pour ((service_name)).",
+        "",
+        "Vous pourrez envoyer davantage de courriels après 19 heures, heure de l’Est. Comparez [les heures officielles au Canada](https://nrc.canada.ca/fr/horloge-web/).",
+        "",
+        "Veuillez [nous contacter](https://notification.canada.ca/contact) si vous désirez augmenter votre limite d’envoi. Nous vous répondrons en un jour ouvrable.",
+        "",
+        "L’équipe Notification GC",
+    ]
+)
 
-To request a limit increase, [contact us](https://notification.canada.ca/contact). We’ll respond within 1 business day.
-
-The GC Notify team
-
----
-Bonjour ((name)),
-
-La limite quotidienne d’envoi est de ((message_limit_fr)) courriels par jour pour ((service_name)). Si vous dépassez cette limite avant 19 heures, heure de l’Est, vos envois seront bloqués.
-
-Comparez [les heures officielles au Canada](https://nrc.canada.ca/fr/horloge-web/).
-
-Veuillez [nous contacter](https://notification.canada.ca/contact) si vous souhaitez augmenter votre limite d’envoi. Nous vous répondrons en un jour ouvrable.
-
-L’équipe Notification GC
-"""
-
-reached_content = """
-(la version française suit)
-
-Hello ((name)),
-
-((service_name)) has sent ((message_limit_en)) emails today.
-
-You can send more messages after 7pm Eastern Time. Compare [official times across Canada](https://nrc.canada.ca/en/web-clock/).
-
-To request a limit increase, [contact us](https://notification.canada.ca/contact). We’ll respond within 1 business day.
-
-The GC Notify team
-
----
-Bonjour ((name)),
-
-Aujourd’hui, ((message_limit_fr)) courriels ont été envoyés pour ((service_name)).
-
-Vous pourrez envoyer davantage de courriels après 19 heures, heure de l’Est. Comparez [les heures officielles au Canada](https://nrc.canada.ca/fr/horloge-web/). 
-
-Veuillez [nous contacter](https://notification.canada.ca/contact) si vous désirez augmenter votre limite d’envoi. Nous vous répondrons en un jour ouvrable.
-
-L’équipe Notification GC
-"""
-
-updated_content = """
-(la version française suit)
-
-Hello ((name)),
-
-You can now send ((message_limit_en)) email messages per day.
-
-The GC Notify Team
-
----
-Bonjour ((name)),
-
-Vous pouvez désormais envoyer ((message_limit_fr)) courriels par jour.
-
-L’équipe Notification GC
-"""
+updated_content =  "\n".join(
+    [
+        "(la version française suit)",
+        "",
+        "Hello ((name)),",
+        "",
+        "You can now send ((message_limit_en)) email messages per day.",
+        "",
+        "The GC Notify Team",
+        "",
+        "---",
+        "",
+        "Bonjour ((name)),",
+        "",
+        "Vous pouvez désormais envoyer ((message_limit_fr)) courriels par jour.",
+        "",
+        "L’équipe Notification GC",
+    ]
+)
 
 templates = [
     {


### PR DESCRIPTION
# Summary | Résumé

Updated to the new content from here: https://www.figma.com/file/j7NLJsOY8UQkGNH50Js00t/Sending-capacity---capacit%C3%A9-d'envoi?type=design&node-id=1538-12097&mode=design&t=8vuUvcO0SyrJXTgQ-0

I created test templates using the new markdown to make sure they looked correct.

Near limit:
<img width="1009" alt="Screenshot 2023-08-08 at 4 57 01 PM" src="https://github.com/cds-snc/notification-api/assets/5498428/2dfdbb2c-8153-415a-9372-52f4f918a38f">

At limit:
<img width="1002" alt="Screenshot 2023-08-08 at 4 57 27 PM" src="https://github.com/cds-snc/notification-api/assets/5498428/ff990354-f9b1-41a2-b499-3ad3a05ea73d">

Limit updated:
<img width="1007" alt="Screenshot 2023-08-08 at 4 58 10 PM" src="https://github.com/cds-snc/notification-api/assets/5498428/99d09e3b-4f40-40b2-b71f-f4b4c5cb44eb">


# Test instructions | Instructions pour tester la modification

1. check out locally
2. run the migration
3. view the new email templates
4. make sure they match the designs in figma