### PR TITLE
Add the new sms content

### DIFF
--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -51,7 +51,12 @@ from app.sms_fragment_utils import (
     fetch_todays_requested_sms_count,
     increment_todays_requested_sms_count,
 )
-from app.utils import get_document_url, get_public_notify_type_text, is_blank
+from app.utils import (
+    get_document_url,
+    get_limit_reset_time_et,
+    get_public_notify_type_text,
+    is_blank,
+)
 from app.v2.errors import (
     BadRequestError,
     LiveServiceTooManyEmailRequestsError,
@@ -291,6 +296,7 @@ def warn_about_daily_message_limit(service: Service, messages_sent):
 
 
 def send_near_sms_limit_email(service: Service):
+    limit_reset_time_et = get_limit_reset_time_et()
     send_notification_to_service_users(
         service_id=service.id,
         template_id=current_app.config["NEAR_DAILY_SMS_LIMIT_TEMPLATE_ID"],
@@ -299,6 +305,8 @@ def send_near_sms_limit_email(service: Service):
             "contact_url": f"{current_app.config['ADMIN_BASE_URL']}/contact",
             "message_limit_en": "{:,}".format(service.sms_daily_limit),
             "message_limit_fr": "{:,}".format(service.sms_daily_limit).replace(",", " "),
+            "limit_reset_time_et_12hr": limit_reset_time_et["12hr"],
+            "limit_reset_time_et_24hr": limit_reset_time_et["24hr"],
         },
         include_user_fields=["name"],
     )
@@ -325,6 +333,7 @@ def send_near_email_limit_email(service: Service) -> None:
 
 
 def send_sms_limit_reached_email(service: Service):
+    limit_reset_time_et = get_limit_reset_time_et()
     send_notification_to_service_users(
         service_id=service.id,
         template_id=current_app.config["REACHED_DAILY_SMS_LIMIT_TEMPLATE_ID"],
@@ -333,6 +342,8 @@ def send_sms_limit_reached_email(service: Service):
             "contact_url": f"{current_app.config['ADMIN_BASE_URL']}/contact",
             "message_limit_en": "{:,}".format(service.sms_daily_limit),
             "message_limit_fr": "{:,}".format(service.sms_daily_limit).replace(",", " "),
+            "limit_reset_time_et_12hr": limit_reset_time_et["12hr"],
+            "limit_reset_time_et_24hr": limit_reset_time_et["24hr"],
         },
         include_user_fields=["name"],
     )

--- a/app/utils.py
+++ b/app/utils.py
@@ -195,3 +195,23 @@ def get_document_url(lang: str, path: str):
 def is_blank(content: Any) -> bool:
     content = str(content)
     return not content or content.isspace()
+
+
+def get_limit_reset_time_et() -> dict[str, str]:
+    """
+    This function gets the time when the daily limit resets (UTC midnight)
+    and returns this formatted in eastern time. This will either be 7PM or 8PM,
+    depending on the time of year."""
+
+    now = datetime.now()
+    one_day = timedelta(1.0)
+    next_midnight = datetime(now.year, now.month, now.day) + one_day
+
+    utc = pytz.timezone("UTC")
+    et = pytz.timezone("US/Eastern")
+
+    next_midnight_utc = next_midnight.astimezone(utc)
+    next_midnight_utc_in_et = next_midnight_utc.astimezone(et)
+
+    limit_reset_time_et = {"12hr": next_midnight_utc_in_et.strftime("%-I%p"), "24hr": next_midnight_utc_in_et.strftime("%H")}
+    return limit_reset_time_et

--- a/migrations/versions/0434_update_email_templates_sms.py
+++ b/migrations/versions/0434_update_email_templates_sms.py
@@ -1,0 +1,143 @@
+"""
+
+Revision ID: 0434_update_email_templates_sms
+Revises: 0433_update_email_templates
+Create Date: 2023-08-09 00:00:00
+
+"""
+from datetime import datetime
+
+from alembic import op
+from flask import current_app
+
+revision = "0434_update_email_templates_sms"
+down_revision = "0433_update_email_templates"
+
+near_content = "\n".join(
+    [
+        "(la version française suit)",
+        "",
+        "Hello ((name)),",
+        "",
+        "If a text message is long, it travels in fragments. The fragments assemble into 1 message for the recipient. Each fragment counts towards your daily limit.",
+        "",
+        "The number of fragments may be higher than the number of recipients. Complex factors determine how messages split into fragments. These factors include character count and type of characters used.",
+        "",
+        "((service_name)) can send ((message_limit_en)) text fragments per day. You’ll be blocked from sending if you exceed that limit before 7 pm Eastern Time. Check [your current local time](https://nrc.canada.ca/en/web-clock/).",
+        "",
+        "To request a limit increase, [contact us](((contact_url))). We’ll respond within 1 business day.",
+        "",
+        "The GC Notify team",
+        "",
+        "---",
+        "",
+        "Bonjour ((name)),",
+        "",
+        "Lorsqu’un message texte est long, il se fragmente lors de la transmission. Tous les fragments sont rassemblés pour former un message unique pour le destinataire. Chaque fragment compte dans votre limite quotidienne.",
+        "",
+        "Le nombre de fragments peut être supérieur au nombre de destinataires. La division des messages en fragments dépend de facteurs complexes, dont le nombre de caractères et le type de caractères utilisés.",
+        "",
+        "La limite quotidienne d’envoi est de ((message_limit_fr)) fragments de message texte par jour pour ((service_name)). Si vous dépassez cette limite avant 19 heures, heure de l’Est, vos envois seront bloqués.",
+        "",
+        "Comparez [les heures officielles au Canada](https://nrc.canada.ca/fr/horloge-web/)." "",
+        "Veuillez [nous contacter](((contact_url))) si vous désirez augmenter votre limite d’envoi. Nous vous répondrons en un jour ouvrable.",
+        "",
+        "L’équipe Notification GC",
+    ]
+)
+
+
+reached_content = "\n".join(
+    [
+        "(la version française suit)",
+        "",
+        "Hello ((name)),",
+        "",
+        "((service_name)) has sent ((message_limit_en)) emails today.",
+        "",
+        "You can send more messages after 7pm Eastern Time. Compare [official times across Canada](https://nrc.canada.ca/en/web-clock/).",
+        "",
+        "To request a limit increase, [contact us](https://notification.canada.ca/contact). We’ll respond within 1 business day.",
+        "",
+        "The GC Notify team",
+        "",
+        "---",
+        "",
+        "Bonjour ((name)),",
+        "",
+        "Aujourd’hui, ((message_limit_fr)) courriels ont été envoyés pour ((service_name)).",
+        "",
+        "Vous pourrez envoyer davantage de courriels après 19 heures, heure de l’Est. Comparez [les heures officielles au Canada](https://nrc.canada.ca/fr/horloge-web/).",
+        "",
+        "Veuillez [nous contacter](https://notification.canada.ca/contact) si vous désirez augmenter votre limite d’envoi. Nous vous répondrons en un jour ouvrable.",
+        "",
+        "L’équipe Notification GC",
+    ]
+)
+
+
+templates = [
+    {
+        "id": current_app.config["NEAR_DAILY_SMS_LIMIT_TEMPLATE_ID"],
+        "template_type": "email",
+        "content": near_content,
+        "process_type": "priority",
+    },
+    {
+        "id": current_app.config["REACHED_DAILY_SMS_LIMIT_TEMPLATE_ID"],
+        "template_type": "email",
+        "content": reached_content,
+        "process_type": "priority",
+    },
+]
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    for template in templates:
+        current_version = conn.execute("select version from templates where id='{}'".format(template["id"])).fetchone()
+        subject = conn.execute("select subject from templates where id='{}'".format(template["id"])).fetchone()
+        name = conn.execute("select name from templates where id='{}'".format(template["id"])).fetchone()
+        template["version"] = current_version[0] + 1
+        template["subject"] = subject[0]
+        template["name"] = name[0]
+
+    template_update = """
+        UPDATE templates SET content = '{}', version = '{}', updated_at = '{}'
+        WHERE id = '{}'
+    """
+    template_history_insert = """
+        INSERT INTO templates_history (id, name, template_type, created_at, content, archived, service_id, subject,
+        created_by_id, version, process_type, hidden)
+        VALUES ('{}', '{}', '{}', '{}', '{}', False, '{}', '{}', '{}', {}, '{}', false)
+    """
+
+    for template in templates:
+        op.execute(
+            template_update.format(
+                template["content"],
+                template["version"],
+                datetime.utcnow(),
+                template["id"],
+            )
+        )
+
+        op.execute(
+            template_history_insert.format(
+                template["id"],
+                template["name"],
+                template["template_type"],
+                datetime.utcnow(),
+                template["content"],
+                current_app.config["NOTIFY_SERVICE_ID"],
+                template["subject"],
+                current_app.config["NOTIFY_USER_ID"],
+                template["version"],
+                template["process_type"],
+            )
+        )
+
+
+def downgrade():
+    pass

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -226,6 +226,7 @@ class TestCheckDailySMSEmailLimits:
                 call(count_key(limit_type, service.id)),
                 call(near_key(limit_type, service.id)),
             ]
+            kwargs = {"limit_reset_time_et_12hr": "7PM", "limit_reset_time_et_24hr": "19"} if limit_type == "sms" else {}
             send_notification.assert_called_once_with(
                 service_id=service.id,
                 template_id=current_app.config[template_name],
@@ -234,6 +235,7 @@ class TestCheckDailySMSEmailLimits:
                     "contact_url": f"{current_app.config['ADMIN_BASE_URL']}/contact",
                     "message_limit_en": "5",
                     "message_limit_fr": "5",
+                    **kwargs,
                 },
                 include_user_fields=["name"],
             )

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -6,6 +6,7 @@ from freezegun import freeze_time
 
 from app.utils import (
     get_document_url,
+    get_limit_reset_time_et,
     get_local_timezone_midnight,
     get_local_timezone_midnight_in_utc,
     get_logo_url,
@@ -127,3 +128,11 @@ def test_get_document_url(notify_api: Flask):
     with notify_api.app_context():
         assert get_document_url("en", "test.html") == "https://documentation.notification.canada.ca/en/test.html"
         assert get_document_url("None", "None") == "https://documentation.notification.canada.ca/None/None"
+
+
+def test_get_limit_reset_time_et():
+    # the daily limit resets at 8PM or 7PM depending on whether it's daylight savings time or not
+    with freeze_time("2023-08-10 00:00"):
+        assert get_limit_reset_time_et() == {"12hr": "8PM", "24hr": "20"}
+    with freeze_time("2023-01-10 00:00"):
+        assert get_limit_reset_time_et() == {"12hr": "7PM", "24hr": "19"}


### PR DESCRIPTION
# Summary | Résumé

Add the new SMS limit email content from here: https://www.figma.com/file/j7NLJsOY8UQkGNH50Js00t/Sending-capacity---capacit%C3%A9-d'envoi?type=design&node-id=1623-2924&mode=design&t=87MnIuJOGMSnVZ8C-0

Made the limit reset time dynamic with a new function.

I tested locally and the emails looked correct:
Limit reached:
<img width="683" alt="Screenshot 2023-08-10 at 2 33 33 PM" src="https://github.com/cds-snc/notification-api/assets/5498428/51fa6f4f-6a2d-4736-abde-c85c812460f5">

Near limit:
<img width="715" alt="Screenshot 2023-08-10 at 2 37 28 PM" src="https://github.com/cds-snc/notification-api/assets/5498428/d3ad48b8-26e0-4f85-a0d2-8eba1da8c531">

# Test instructions | Instructions pour tester la modification

1. Check out locally, run api and admin
2. run `poetry run flask db upgrade`
3. view the templates and make sure they look correct
4. try sending sms to trigger the various emails, and make sure the email you receive is correct (should contain 8PM / 20 heures at this time of year)

