### PR TITLE
send sms using 3 new queues

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -383,5 +383,5 @@ def beat_inbox_sms_priority():
 
     while list_of_sms_notifications:
         save_smss.apply_async((None, list_of_sms_notifications, receipt_id_sms), queue=QueueNames.PRIORITY_DATABASE)
-        current_app.logger.info(f"Batch saving with Bulk Priority: SMS receipt {receipt_id_sms} sent to in-flight.")
+        current_app.logger.info(f"Batch saving with Priority: SMS receipt {receipt_id_sms} sent to in-flight.")
         receipt_id_sms, list_of_sms_notifications = sms_priority.poll()

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -308,7 +308,7 @@ def save_smss(self, service_id: Optional[str], signed_notifications: List[Signed
         try:
             if not current_app.config["FF_EMAIL_DAILY_LIMIT"]:
                 check_service_over_daily_message_limit(notification_obj.key_type, service)
-            queue = notification_id_queue.get(notification_obj.id) or get_delivery_queue_for_template(template)  # type: ignore
+            queue = notification_id_queue.get(notification_obj.id) or get_delivery_queue_for_template(template)
             send_notification_to_queue(
                 notification_obj,
                 service.research_mode,
@@ -436,7 +436,7 @@ def try_to_send_notifications_to_queue(notification_id_queue, service, saved_not
         try:
             if not current_app.config["FF_EMAIL_DAILY_LIMIT"]:
                 check_service_over_daily_message_limit(notification_obj.key_type, service)
-            queue = notification_id_queue.get(notification_obj.id) or get_delivery_queue_for_template(template)  # type: ignore
+            queue = notification_id_queue.get(notification_obj.id) or get_delivery_queue_for_template(template)
             send_notification_to_queue(
                 notification_obj,
                 research_mode,

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -697,19 +697,19 @@ def choose_sending_queue(process_type: str, notif_type: str, notifications_count
     queue: Optional[str] = process_type
 
     if notifications_count >= large_csv_threshold:
-        queue = QueueNames.BULK
+        queue = QueueNames.SEND_SMS_LOW if notif_type == SMS_TYPE else QueueNames.BULK
     # If priority is slow/bulk, but lower than threshold, let's make it
     # faster by switching to normal queue.
     elif process_type == BULK:
-        queue = QueueNames.SEND_NORMAL_QUEUE.format(notif_type)
+        queue = QueueNames.SEND_SMS_MEDIUM if notif_type == SMS_TYPE else QueueNames.SEND_NORMAL_QUEUE.format(notif_type)
     else:
         # If the size isn't a concern, fall back to the template's process type.
         if process_type == PRIORITY:
-            queue = QueueNames.PRIORITY
+            queue = QueueNames.SEND_SMS_HIGH if notif_type == SMS_TYPE else QueueNames.PRIORITY
         elif process_type == BULK:
-            queue = QueueNames.BULK
+            queue = QueueNames.SEND_SMS_LOW if notif_type == SMS_TYPE else QueueNames.BULK
         else:
-            queue = QueueNames.SEND_NORMAL_QUEUE.format(notif_type)
+            queue = QueueNames.SEND_SMS_MEDIUM if notif_type == SMS_TYPE else QueueNames.SEND_NORMAL_QUEUE.format(notif_type)
     return queue
 
 

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -704,12 +704,7 @@ def choose_sending_queue(process_type: str, notif_type: str, notifications_count
         queue = QueueNames.DELIVERY_QUEUES[notif_type][Priorities.MEDIUM]
     else:
         # If the size isn't a concern, fall back to the template's process type.
-        if process_type == PRIORITY:
-            queue = QueueNames.DELIVERY_QUEUES[notif_type][Priorities.HIGH]
-        elif process_type == BULK:
-            queue = QueueNames.DELIVERY_QUEUES[notif_type][Priorities.LOW]
-        else:
-            queue = QueueNames.DELIVERY_QUEUES[notif_type][Priorities.MEDIUM]
+        queue = QueueNames.DELIVERY_QUEUES[notif_type][Priorities.to_lmh(process_type)]
     return queue
 
 

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -80,7 +80,7 @@ from app.notifications.process_notifications import (
 )
 from app.notifications.validators import check_service_over_daily_message_limit
 from app.types import VerifiedNotification
-from app.utils import get_csv_max_rows
+from app.utils import get_csv_max_rows, get_delivery_queue_for_template
 from app.v2.errors import (
     LiveServiceTooManyRequestsError,
     LiveServiceTooManySMSRequestsError,
@@ -308,7 +308,7 @@ def save_smss(self, service_id: Optional[str], signed_notifications: List[Signed
         try:
             if not current_app.config["FF_EMAIL_DAILY_LIMIT"]:
                 check_service_over_daily_message_limit(notification_obj.key_type, service)
-            queue = notification_id_queue.get(notification_obj.id) or template.queue_to_use()  # type: ignore
+            queue = notification_id_queue.get(notification_obj.id) or get_delivery_queue_for_template(template)  # type: ignore
             send_notification_to_queue(
                 notification_obj,
                 service.research_mode,
@@ -436,7 +436,7 @@ def try_to_send_notifications_to_queue(notification_id_queue, service, saved_not
         try:
             if not current_app.config["FF_EMAIL_DAILY_LIMIT"]:
                 check_service_over_daily_message_limit(notification_obj.key_type, service)
-            queue = notification_id_queue.get(notification_obj.id) or template.queue_to_use()  # type: ignore
+            queue = notification_id_queue.get(notification_obj.id) or get_delivery_queue_for_template(template)  # type: ignore
             send_notification_to_queue(
                 notification_obj,
                 research_mode,

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -35,7 +35,7 @@ from app.aws.metrics import (
     put_batch_saving_bulk_created,
     put_batch_saving_bulk_processed,
 )
-from app.config import Config, QueueNames
+from app.config import Config, Priorities, QueueNames
 from app.dao.inbound_sms_dao import dao_get_inbound_sms_by_id
 from app.dao.jobs_dao import dao_get_in_progress_jobs, dao_get_job_by_id, dao_update_job
 from app.dao.notifications_dao import (
@@ -697,19 +697,19 @@ def choose_sending_queue(process_type: str, notif_type: str, notifications_count
     queue: Optional[str] = process_type
 
     if notifications_count >= large_csv_threshold:
-        queue = QueueNames.SEND_SMS_LOW if notif_type == SMS_TYPE else QueueNames.BULK
+        queue = QueueNames.DELIVERY_QUEUES[notif_type][Priorities.LOW]
     # If priority is slow/bulk, but lower than threshold, let's make it
     # faster by switching to normal queue.
     elif process_type == BULK:
-        queue = QueueNames.SEND_SMS_MEDIUM if notif_type == SMS_TYPE else QueueNames.SEND_NORMAL_QUEUE.format(notif_type)
+        queue = QueueNames.DELIVERY_QUEUES[notif_type][Priorities.MEDIUM]
     else:
         # If the size isn't a concern, fall back to the template's process type.
         if process_type == PRIORITY:
-            queue = QueueNames.SEND_SMS_HIGH if notif_type == SMS_TYPE else QueueNames.PRIORITY
+            queue = QueueNames.DELIVERY_QUEUES[notif_type][Priorities.HIGH]
         elif process_type == BULK:
-            queue = QueueNames.SEND_SMS_LOW if notif_type == SMS_TYPE else QueueNames.BULK
+            queue = QueueNames.DELIVERY_QUEUES[notif_type][Priorities.LOW]
         else:
-            queue = QueueNames.SEND_SMS_MEDIUM if notif_type == SMS_TYPE else QueueNames.SEND_NORMAL_QUEUE.format(notif_type)
+            queue = QueueNames.DELIVERY_QUEUES[notif_type][Priorities.MEDIUM]
     return queue
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -11,12 +11,18 @@ from kombu import Exchange, Queue
 from notifications_utils import logging
 
 from celery.schedules import crontab
+from models import SMS_TYPE, EMAIL_TYPE, BULK as PROCESS_TYPE_BULK, NORMAL as PROCESS_TYPE_NORMAL, PRIORITY as PROCESS_TYPE_PRIORITY
 
 env = Env()
 env.read_env()
 load_dotenv()
 
+class Priorities(object):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
 
+    
 class QueueNames(object):
     # Periodic tasks executed by Notify.
     PERIODIC = "periodic-tasks"
@@ -93,6 +99,25 @@ class QueueNames(object):
     # Queue for delivery receipts such as emails sent through AWS SES.
     DELIVERY_RECEIPTS = "delivery-receipts"
 
+    DELIVERY_QUEUES = {
+        SMS_TYPE: {
+            Priorities.LOW: SEND_SMS_LOW,
+            PROCESS_TYPE_BULK: SEND_SMS_LOW,
+            Priorities.MEDIUM: SEND_SMS_MEDIUM,
+            PROCESS_TYPE_NORMAL: SEND_SMS_MEDIUM,
+            Priorities.HIGH: SEND_SMS_HIGH,
+            PROCESS_TYPE_PRIORITY: SEND_SMS_HIGH,
+        },
+        EMAIL_TYPE: {
+            Priorities.LOW: BULK,
+            PROCESS_TYPE_BULK: BULK,
+            Priorities.MEDIUM: SEND_EMAIL,
+            PROCESS_TYPE_NORMAL: SEND_EMAIL,
+            Priorities.HIGH: PRIORITY,
+            PROCESS_TYPE_PRIORITY: PRIORITY,
+        },
+    }
+    
     @staticmethod
     def all_queues():
         return [

--- a/app/config.py
+++ b/app/config.py
@@ -52,8 +52,12 @@ class QueueNames(object):
     # pretty quickly.
     SEND_NORMAL_QUEUE = "send-{}-tasks"  # notification type to be filled in the queue name
 
-    # Queue for sending all SMS, except long dedicated numbers.
-    # TODO: Deprecate to favor priority queues instead, i.e. bulk, normal, priority.
+    # Queues for sending all SMS, except long dedicated numbers.
+    SEND_SMS_HIGH = "send-sms-high"
+    SEND_SMS_MEDIUM = "send-sms-medium"
+    SEND_SMS_LOW= "send-sms-low"
+
+    # TODO: Delete this queue once we verify that it is not used anymore.
     SEND_SMS = "send-sms-tasks"
 
     # Primarily used for long dedicated numbers sent from us-west-2 upon which
@@ -99,6 +103,9 @@ class QueueNames(object):
             QueueNames.PRIORITY_DATABASE,
             QueueNames.NORMAL_DATABASE,
             QueueNames.BULK_DATABASE,
+            QueueNames.SEND_SMS_HIGH,
+            QueueNames.SEND_SMS_MEDIUM,
+            QueueNames.SEND_SMS_LOW,
             QueueNames.SEND_SMS,
             QueueNames.SEND_THROTTLED_SMS,
             QueueNames.SEND_EMAIL,

--- a/app/config.py
+++ b/app/config.py
@@ -28,6 +28,16 @@ class Priorities(object):
 
     @staticmethod
     def to_lmh(priority: str) -> str:
+        """
+        Convert bulk / normal / priority to low / medium / high. Anything else left alone.
+
+        Args:
+            priority (str): priority to convert.
+
+        Returns:
+            str: low, medium, or high
+        """
+
         if priority == Priorities.BULK:
             return Priorities.LOW
         elif priority == Priorities.NORMAL:

--- a/app/config.py
+++ b/app/config.py
@@ -55,7 +55,7 @@ class QueueNames(object):
     # Queues for sending all SMS, except long dedicated numbers.
     SEND_SMS_HIGH = "send-sms-high"
     SEND_SMS_MEDIUM = "send-sms-medium"
-    SEND_SMS_LOW= "send-sms-low"
+    SEND_SMS_LOW = "send-sms-low"
 
     # TODO: Delete this queue once we verify that it is not used anymore.
     SEND_SMS = "send-sms-tasks"

--- a/app/models.py
+++ b/app/models.py
@@ -55,7 +55,6 @@ template_types = db.Enum(*TEMPLATE_TYPES, name="template_type")
 NORMAL = "normal"
 PRIORITY = "priority"
 BULK = "bulk"
-
 TEMPLATE_PROCESS_TYPE = [NORMAL, PRIORITY, BULK]
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -38,9 +38,9 @@ from app import (
     signer_inbound_sms,
     signer_personalisation,
 )
-from app.config import QueueNames
 from app.encryption import check_hash, hashpw
 from app.history_meta import Versioned
+from app.utils import get_delivery_queue_for_template
 
 TemplateType = Literal["sms", "email", "letter"]
 
@@ -55,6 +55,7 @@ template_types = db.Enum(*TEMPLATE_TYPES, name="template_type")
 NORMAL = "normal"
 PRIORITY = "priority"
 BULK = "bulk"
+
 TEMPLATE_PROCESS_TYPE = [NORMAL, PRIORITY, BULK]
 
 
@@ -1084,7 +1085,7 @@ class TemplateBase(BaseModel):
         )
 
     def queue_to_use(self):
-        return QueueNames.DELIVERY_QUEUES[self.template_type][self.process_type]
+        return get_delivery_queue_for_template(self)
 
     redact_personalisation = association_proxy("template_redacted", "redact_personalisation")
 

--- a/app/models.py
+++ b/app/models.py
@@ -1089,7 +1089,7 @@ class TemplateBase(BaseModel):
                 NORMAL: QueueNames.SEND_SMS_MEDIUM,
                 PRIORITY: QueueNames.SEND_SMS_HIGH,
                 BULK: QueueNames.SEND_SMS_LOW,
-                }[self.process_type]
+            }[self.process_type]
         else:
             return {
                 NORMAL: QueueNames.NORMAL,

--- a/app/models.py
+++ b/app/models.py
@@ -40,7 +40,6 @@ from app import (
 )
 from app.encryption import check_hash, hashpw
 from app.history_meta import Versioned
-from app.utils import get_delivery_queue_for_template
 
 TemplateType = Literal["sms", "email", "letter"]
 
@@ -1082,9 +1081,6 @@ class TemplateBase(BaseModel):
             nullable=False,
             default=NORMAL,
         )
-
-    def queue_to_use(self):
-        return get_delivery_queue_for_template(self)
 
     redact_personalisation = association_proxy("template_redacted", "redact_personalisation")
 

--- a/app/models.py
+++ b/app/models.py
@@ -1084,18 +1084,7 @@ class TemplateBase(BaseModel):
         )
 
     def queue_to_use(self):
-        if self.template_type == SMS_TYPE:
-            return {
-                NORMAL: QueueNames.SEND_SMS_MEDIUM,
-                PRIORITY: QueueNames.SEND_SMS_HIGH,
-                BULK: QueueNames.SEND_SMS_LOW,
-            }[self.process_type]
-        else:
-            return {
-                NORMAL: QueueNames.NORMAL,
-                PRIORITY: QueueNames.PRIORITY,
-                BULK: QueueNames.BULK,
-            }[self.process_type]
+        return QueueNames.DELIVERY_QUEUES[self.template_type][self.process_type]
 
     redact_personalisation = association_proxy("template_redacted", "redact_personalisation")
 

--- a/app/models.py
+++ b/app/models.py
@@ -1084,11 +1084,18 @@ class TemplateBase(BaseModel):
         )
 
     def queue_to_use(self):
-        return {
-            NORMAL: QueueNames.NORMAL,
-            PRIORITY: QueueNames.PRIORITY,
-            BULK: QueueNames.BULK,
-        }[self.process_type]
+        if self.template_type == SMS_TYPE:
+            return {
+                NORMAL: QueueNames.SEND_SMS_MEDIUM,
+                PRIORITY: QueueNames.SEND_SMS_HIGH,
+                BULK: QueueNames.SEND_SMS_LOW,
+                }[self.process_type]
+        else:
+            return {
+                NORMAL: QueueNames.NORMAL,
+                PRIORITY: QueueNames.PRIORITY,
+                BULK: QueueNames.BULK,
+            }[self.process_type]
 
     redact_personalisation = association_proxy("template_redacted", "redact_personalisation")
 

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -36,7 +36,7 @@ from app.models import (
     Service,
 )
 from app.types import VerifiedNotification
-from app.utils import get_template_instance
+from app.utils import get_delivery_queue_for_template, get_template_instance
 from app.v2.errors import BadRequestError
 
 
@@ -116,7 +116,7 @@ def persist_notification(
     if isinstance(template, tuple):
         template = template[0]
     notification.queue_name = choose_queue(
-        notification=notification, research_mode=service.research_mode, queue=template.queue_to_use()
+        notification=notification, research_mode=service.research_mode, queue=get_delivery_queue_for_template(template)
     )
 
     if notification_type == SMS_TYPE:
@@ -336,7 +336,7 @@ def persist_notifications(notifications: List[VerifiedNotification]) -> List[Not
             template = template[0]
         service = dao_fetch_service_by_id(service_id, use_cache=True)
         notification_obj.queue_name = choose_queue(
-            notification=notification_obj, research_mode=service.research_mode, queue=template.queue_to_use()
+            notification=notification_obj, research_mode=service.research_mode, queue=get_delivery_queue_for_template(template)
         )
 
         if notification.get("notification_type") == SMS_TYPE:

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -283,7 +283,7 @@ def send_notification_to_queue(notification, research_mode, queue=None):
         raise
 
     current_app.logger.info(
-        "{} {} sent to the {} queue for delivery".format(notification.notification_type, notification.id, queue)
+        "------ ---- {} {} sent to the {} queue for delivery".format(notification.notification_type, notification.id, queue)
     )
     # TODO: once we've cleaned up all the unused code paths and ensured that this warning never occurs we can delete
     # the warning as well as the above calculation of queue.

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -232,7 +232,7 @@ def choose_queue(notification, research_mode, queue=None) -> QueueNames:
         if notification.sends_with_custom_number():
             queue = QueueNames.SEND_THROTTLED_SMS
         if not queue:
-            queue = QueueNames.SEND_SMS
+            queue = QueueNames.SEND_SMS_MEDIUM
     if notification.notification_type == EMAIL_TYPE:
         if not queue:
             queue = QueueNames.SEND_EMAIL

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -283,7 +283,7 @@ def send_notification_to_queue(notification, research_mode, queue=None):
         raise
 
     current_app.logger.info(
-        "------ ---- {} {} sent to the {} queue for delivery".format(notification.notification_type, notification.id, queue)
+        "{} {} sent to the {} queue for delivery".format(notification.notification_type, notification.id, queue)
     )
     # TODO: once we've cleaned up all the unused code paths and ensured that this warning never occurs we can delete
     # the warning as well as the above calculation of queue.

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -266,7 +266,7 @@ def send_notification_to_queue(notification, research_mode, queue=None):
             deliver_task = provider_tasks.deliver_throttled_sms
             queue = QueueNames.SEND_THROTTLED_SMS
         if not queue or queue == QueueNames.NORMAL:
-            queue = QueueNames.SEND_SMS
+            queue = QueueNames.SEND_SMS_MEDIUM
     if notification.notification_type == EMAIL_TYPE:
         if not queue or queue == QueueNames.NORMAL:
             queue = QueueNames.SEND_EMAIL

--- a/app/notifications/rest.py
+++ b/app/notifications/rest.py
@@ -34,6 +34,7 @@ from app.schemas import (
 )
 from app.service.utils import service_allowed_to_send_to
 from app.utils import (
+    get_delivery_queue_for_template,
     get_document_url,
     get_public_notify_type_text,
     get_template_instance,
@@ -141,7 +142,7 @@ def send_notification(notification_type: NotificationType):
         send_notification_to_queue(
             notification=notification_model,
             research_mode=authenticated_service.research_mode,
-            queue=template.queue_to_use(),
+            queue=get_delivery_queue_for_template(template),
         )
     else:
         current_app.logger.debug("POST simulated notification for id: {}".format(notification_model.id))

--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -111,11 +111,17 @@ def send_one_off_notification(service_id, post_data):
             NOTIFICATION_DELIVERED,
         )
     else:
+        # allow one-off sends from admin to go quicker by using normal queue instead of bulk queue
+        queue = template.queue_to_use()
+        if template.template_type == SMS_TYPE and queue == QueueNames.SEND_SMS_LOW:
+            queue = QueueNames.SEND_SMS_MEDIUM
+        elif template.template_type == EMAIL_TYPE and queue == QueueNames.BULK:
+            queue = QueueNames.NORMAL
+            
         send_notification_to_queue(
             notification=notification,
             research_mode=service.research_mode,
-            # allow one-off sends from admin to go quicker by using normal queue instead of bulk queue
-            queue=QueueNames.NORMAL if template.queue_to_use() == QueueNames.BULK else template.queue_to_use(),
+            queue=queue,
         )
 
     return {"id": str(notification.id)}

--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -4,7 +4,7 @@ from notifications_utils.s3 import s3download as utils_s3download
 from sqlalchemy.orm.exc import NoResultFound
 
 from app import create_random_identifier
-from app.config import QueueNames
+from app.config import QueueNames, Priorities
 from app.dao.notifications_dao import _update_notification_status
 from app.dao.service_email_reply_to_dao import dao_get_reply_to_by_id
 from app.dao.service_sms_sender_dao import dao_get_service_sms_senders_by_id
@@ -113,10 +113,8 @@ def send_one_off_notification(service_id, post_data):
     else:
         # allow one-off sends from admin to go quicker by using normal queue instead of bulk queue
         queue = template.queue_to_use()
-        if template.template_type == SMS_TYPE and queue == QueueNames.SEND_SMS_LOW:
-            queue = QueueNames.SEND_SMS_MEDIUM
-        elif template.template_type == EMAIL_TYPE and queue == QueueNames.BULK:
-            queue = QueueNames.NORMAL
+        if queue == QueueNames.DELIVERY_QUEUES[template.template_type][Priorities.LOW]:
+            queue = QueueNames.DELIVERY_QUEUES[template.template_type][Priorities.MEDIUM]
 
         send_notification_to_queue(
             notification=notification,

--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -4,7 +4,7 @@ from notifications_utils.s3 import s3download as utils_s3download
 from sqlalchemy.orm.exc import NoResultFound
 
 from app import create_random_identifier
-from app.config import QueueNames, Priorities
+from app.config import Priorities, QueueNames
 from app.dao.notifications_dao import _update_notification_status
 from app.dao.service_email_reply_to_dao import dao_get_reply_to_by_id
 from app.dao.service_sms_sender_dao import dao_get_service_sms_senders_by_id

--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -40,6 +40,7 @@ from app.notifications.validators import (
     validate_and_format_recipient,
     validate_template,
 )
+from app.utils import get_delivery_queue_for_template
 from app.v2.errors import BadRequestError
 
 
@@ -112,7 +113,7 @@ def send_one_off_notification(service_id, post_data):
         )
     else:
         # allow one-off sends from admin to go quicker by using normal queue instead of bulk queue
-        queue = template.queue_to_use()
+        queue = get_delivery_queue_for_template(template)
         if queue == QueueNames.DELIVERY_QUEUES[template.template_type][Priorities.LOW]:
             queue = QueueNames.DELIVERY_QUEUES[template.template_type][Priorities.MEDIUM]
 

--- a/app/service/send_notification.py
+++ b/app/service/send_notification.py
@@ -117,7 +117,7 @@ def send_one_off_notification(service_id, post_data):
             queue = QueueNames.SEND_SMS_MEDIUM
         elif template.template_type == EMAIL_TYPE and queue == QueueNames.BULK:
             queue = QueueNames.NORMAL
-            
+
         send_notification_to_queue(
             notification=notification,
             research_mode=service.research_mode,

--- a/app/utils.py
+++ b/app/utils.py
@@ -11,6 +11,8 @@ from notifications_utils.template import (
 )
 from sqlalchemy import func
 
+from app.config import Priorities, QueueNames
+
 local_timezone = pytz.timezone(os.getenv("TIMEZONE", "America/Toronto"))
 
 
@@ -40,6 +42,10 @@ def get_template_instance(template, values):
     return {SMS_TYPE: SMSMessageTemplate, EMAIL_TYPE: WithSubjectTemplate, LETTER_TYPE: WithSubjectTemplate}[
         template["template_type"]
     ](template, values)
+
+
+def get_delivery_queue_for_template(template):
+    return QueueNames.DELIVERY_QUEUES[template.template_type][Priorities.to_lmh(template.process_type)]
 
 
 def get_html_email_body_from_template(template_instance):

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -87,6 +87,7 @@ from app.schema_validation import validate
 from app.schemas import job_schema
 from app.service.utils import safelisted_members
 from app.sms_fragment_utils import fetch_todays_requested_sms_count
+from app.utils import get_delivery_queue_for_template
 from app.v2.errors import BadRequestError
 from app.v2.notifications import v2_notification_blueprint
 from app.v2.notifications.create_response import (
@@ -433,7 +434,7 @@ def process_sms_or_email_notification(
             notification.queue_name = choose_queue(
                 notification=notification,
                 research_mode=service.research_mode,
-                queue=template.queue_to_use(),
+                queue=get_delivery_queue_for_template(template),
             )
             db_save_and_send_notification(notification)
 

--- a/migrations/versions/0433_update_email_templates.py
+++ b/migrations/versions/0433_update_email_templates.py
@@ -1,0 +1,164 @@
+"""
+
+Revision ID: 0433_update_email_templates
+Revises: 0432_daily_email_limit_templates
+Create Date: 2023-08-08 00:00:00
+
+"""
+from datetime import datetime
+
+from alembic import op
+from flask import current_app
+
+revision = "0433_update_email_templates"
+down_revision = "0432_daily_email_limit_templates"
+
+near_content = "\n".join(
+    [
+        "(la version française suit)",
+        "",
+        "Hello ((name)),",
+        "",
+        "((service_name)) can send ((message_limit_en)) emails per day. You’ll be blocked from sending if you exceed that limit before 7pm Eastern Time. Check [your current local time](https://nrc.canada.ca/en/web-clock/).",
+        "",
+        "To request a limit increase, [contact us](https://notification.canada.ca/contact). We’ll respond within 1 business day.",
+        "",
+        "The GC Notify team",
+        "",
+        "---",
+        "",
+        "Bonjour ((name)),",
+        "",
+        "La limite quotidienne d’envoi est de ((message_limit_fr)) courriels par jour pour ((service_name)). Si vous dépassez cette limite avant 19 heures, heure de l’Est, vos envois seront bloqués.",
+        "",
+        "Comparez [les heures officielles au Canada](https://nrc.canada.ca/fr/horloge-web/).",
+        "",
+        "Veuillez [nous contacter](https://notification.canada.ca/contact) si vous souhaitez augmenter votre limite d’envoi. Nous vous répondrons en un jour ouvrable.",
+        "",
+        "L’équipe Notification GC",
+    ]
+)
+
+
+reached_content = "\n".join(
+    [
+        "(la version française suit)",
+        "",
+        "Hello ((name)),",
+        "",
+        "((service_name)) has sent ((message_limit_en)) emails today.",
+        "",
+        "You can send more messages after 7pm Eastern Time. Compare [official times across Canada](https://nrc.canada.ca/en/web-clock/).",
+        "",
+        "To request a limit increase, [contact us](https://notification.canada.ca/contact). We’ll respond within 1 business day.",
+        "",
+        "The GC Notify team",
+        "",
+        "---",
+        "",
+        "Bonjour ((name)),",
+        "",
+        "Aujourd’hui, ((message_limit_fr)) courriels ont été envoyés pour ((service_name)).",
+        "",
+        "Vous pourrez envoyer davantage de courriels après 19 heures, heure de l’Est. Comparez [les heures officielles au Canada](https://nrc.canada.ca/fr/horloge-web/).",
+        "",
+        "Veuillez [nous contacter](https://notification.canada.ca/contact) si vous désirez augmenter votre limite d’envoi. Nous vous répondrons en un jour ouvrable.",
+        "",
+        "L’équipe Notification GC",
+    ]
+)
+
+updated_content = "\n".join(
+    [
+        "(la version française suit)",
+        "",
+        "Hello ((name)),",
+        "",
+        "You can now send ((message_limit_en)) email messages per day.",
+        "",
+        "The GC Notify Team",
+        "",
+        "---",
+        "",
+        "Bonjour ((name)),",
+        "",
+        "Vous pouvez désormais envoyer ((message_limit_fr)) courriels par jour.",
+        "",
+        "L’équipe Notification GC",
+    ]
+)
+
+templates = [
+    {
+        "id": current_app.config["NEAR_DAILY_EMAIL_LIMIT_TEMPLATE_ID"],
+        "name": "Near daily EMAIL limit",
+        "template_type": "email",
+        "content": near_content,
+        "subject": "((service_name)) is near its daily limit for emails. | La limite quotidienne d’envoi de courriels est presque atteinte pour ((service_name)).",
+        "process_type": "priority",
+    },
+    {
+        "id": current_app.config["REACHED_DAILY_EMAIL_LIMIT_TEMPLATE_ID"],
+        "name": "Daily EMAIL limit reached",
+        "template_type": "email",
+        "content": reached_content,
+        "subject": "((service_name)) has reached its daily limit for email messages | La limite quotidienne d’envoi de courriels atteinte pour ((service_name)).",
+        "process_type": "priority",
+    },
+    {
+        "id": current_app.config["DAILY_EMAIL_LIMIT_UPDATED_TEMPLATE_ID"],
+        "name": "Daily EMAIL limit updated",
+        "template_type": "email",
+        "content": updated_content,
+        "subject": "We’ve updated the daily email limit for ((service_name)) | Nous avons mis à jour la limite quotidienne de courriels pour ((service_name))",
+        "process_type": "priority",
+    },
+]
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    for template in templates:
+        current_version = conn.execute("select version from templates where id='{}'".format(template["id"])).fetchone()
+        template["version"] = current_version[0] + 1
+
+    template_update = """
+        UPDATE templates SET content = '{}', subject = '{}', version = '{}', updated_at = '{}'
+        WHERE id = '{}'
+    """
+    template_history_insert = """
+        INSERT INTO templates_history (id, name, template_type, created_at, content, archived, service_id, subject,
+        created_by_id, version, process_type, hidden)
+        VALUES ('{}', '{}', '{}', '{}', '{}', False, '{}', '{}', '{}', {}, '{}', false)
+    """
+
+    for template in templates:
+        op.execute(
+            template_update.format(
+                template["content"],
+                template["subject"],
+                template["version"],
+                datetime.utcnow(),
+                template["id"],
+            )
+        )
+
+        op.execute(
+            template_history_insert.format(
+                template["id"],
+                template["name"],
+                template["template_type"],
+                datetime.utcnow(),
+                template["content"],
+                current_app.config["NOTIFY_SERVICE_ID"],
+                template["subject"],
+                current_app.config["NOTIFY_USER_ID"],
+                template["version"],
+                template["process_type"],
+            )
+        )
+
+
+def downgrade():
+    pass

--- a/scripts/run_celery.ps1
+++ b/scripts/run_celery.ps1
@@ -1,3 +1,3 @@
 $ENV:FORKED_BY_MULTIPROCESSING=1
 
-celery --app run_celery worker --pidfile="$env:TEMP\celery.pid" --pool=solo --loglevel=DEBUG --concurrency=1 -Q "database-tasks,-priority-database-tasks.fifo,-normal-database-tasks,-bulk-database-tasks,job-tasks,notify-internal-tasks,periodic-tasks,priority-tasks,normal-tasks,bulk-tasks,reporting-tasks,research-mode-tasks,retry-tasks,send-sms-tasks,send-email-tasks,service-callbacks,delivery-receipts"
+celery --app run_celery worker --pidfile="$env:TEMP\celery.pid" --pool=solo --loglevel=DEBUG --concurrency=1 -Q "database-tasks,-priority-database-tasks.fifo,-normal-database-tasks,-bulk-database-tasks,job-tasks,notify-internal-tasks,periodic-tasks,priority-tasks,normal-tasks,bulk-tasks,reporting-tasks,research-mode-tasks,retry-tasks,send-sms-tasks,send-sms-high,send-sms-medium,send-sms-low,send-email-tasks,service-callbacks,delivery-receipts"

--- a/scripts/run_celery.sh
+++ b/scripts/run_celery.sh
@@ -4,4 +4,4 @@ set -e
 
 echo "Start celery, concurrency: ${CELERY_CONCURRENCY-4}"
 
-celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency=${CELERY_CONCURRENCY-4} -Q database-tasks,-priority-database-tasks.fifo,-normal-database-tasks,-bulk-database-tasks,job-tasks,notify-internal-tasks,periodic-tasks,priority-tasks,normal-tasks,bulk-tasks,reporting-tasks,research-mode-tasks,retry-tasks,send-sms-tasks,send-email-tasks,service-callbacks,delivery-receipts
+celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency=${CELERY_CONCURRENCY-4} -Q database-tasks,-priority-database-tasks.fifo,-normal-database-tasks,-bulk-database-tasks,job-tasks,notify-internal-tasks,periodic-tasks,priority-tasks,normal-tasks,bulk-tasks,reporting-tasks,research-mode-tasks,retry-tasks,send-sms-tasks,send-sms-high,send-sms-medium,send-sms-low,send-email-tasks,service-callbacks,delivery-receipts

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -184,7 +184,7 @@ def test_should_send_all_scheduled_notifications_to_deliver_queue(sample_templat
 
     send_scheduled_notifications()
 
-    mocked.apply_async.assert_called_once_with([str(message_to_deliver.id)], queue="send-sms-tasks")
+    mocked.apply_async.assert_called_once_with([str(message_to_deliver.id)], queue="send-sms-medium")
     scheduled_notifications = dao_get_scheduled_notifications()
     assert not scheduled_notifications
 
@@ -364,7 +364,7 @@ def test_replay_created_notifications(notify_db_session, sample_service, mocker)
 
     replay_created_notifications()
     email_delivery_queue.assert_called_once_with([str(old_email.id)], queue="send-email-tasks")
-    sms_delivery_queue.assert_called_once_with([str(old_sms.id)], queue="send-sms-tasks")
+    sms_delivery_queue.assert_called_once_with([str(old_sms.id)], queue="send-sms-medium")
 
 
 def test_check_job_status_task_does_not_raise_error(sample_template):

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -184,7 +184,7 @@ def test_should_send_all_scheduled_notifications_to_deliver_queue(sample_templat
 
     send_scheduled_notifications()
 
-    mocked.apply_async.assert_called_once_with([str(message_to_deliver.id)], queue="send-sms-medium")
+    mocked.apply_async.assert_called_once_with([str(message_to_deliver.id)], queue=QueueNames.SEND_SMS_MEDIUM)
     scheduled_notifications = dao_get_scheduled_notifications()
     assert not scheduled_notifications
 
@@ -364,7 +364,7 @@ def test_replay_created_notifications(notify_db_session, sample_service, mocker)
 
     replay_created_notifications()
     email_delivery_queue.assert_called_once_with([str(old_email.id)], queue="send-email-tasks")
-    sms_delivery_queue.assert_called_once_with([str(old_sms.id)], queue="send-sms-medium")
+    sms_delivery_queue.assert_called_once_with([str(old_sms.id)], queue=QueueNames.SEND_SMS_MEDIUM)
 
 
 def test_check_job_status_task_does_not_raise_error(sample_template):

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -1196,9 +1196,7 @@ class TestSaveSmss:
                 [str(persisted_notification.id)], queue="send-sms-high"
             )
         else:
-            provider_tasks.deliver_sms.apply_async.assert_called_once_with(
-                [str(persisted_notification.id)], queue="send-sms-low"
-            )
+            provider_tasks.deliver_sms.apply_async.assert_called_once_with([str(persisted_notification.id)], queue="send-sms-low")
         assert mocked_deliver_sms.called
 
     def test_should_route_save_sms_task_to_bulk_on_large_csv_file(self, notify_db, notify_db_session, mocker):

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -1014,7 +1014,7 @@ class TestProcessRows:
         signed_notification = [i for i in args[0]][1][0]
         notification = signer_notification.verify(signed_notification)
         assert expected_queue == notification.get("queue")
-        
+
     def test_should_not_save_sms_if_restricted_service_and_invalid_number(self, notify_db_session, mocker):
         user = create_user(mobile_number="6502532222")
         service = create_service(user=user, restricted=True)

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -891,7 +891,7 @@ class TestProcessRows:
         mocker.patch("app.celery.tasks.create_uuid", return_value="noti_uuid")
         task_mock = mocker.patch("app.celery.tasks.{}".format(expected_function))
         signer_mock = mocker.patch("app.celery.tasks.signer_notification.sign")
-        template = Mock(id="template_id", template_type=template_type)
+        template = Mock(id="template_id", template_type=template_type, process_type=NORMAL)
         job = Mock(id="job_id", template_version="temp_vers", notification_count=1, api_key_id=api_key_id, sender_id=sender_id)
         service = Mock(id="service_id", research_mode=research_mode)
 

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -1193,11 +1193,11 @@ class TestSaveSmss:
         persisted_notification = Notification.query.one()
         if process_type == "priority":
             provider_tasks.deliver_sms.apply_async.assert_called_once_with(
-                [str(persisted_notification.id)], queue=f"send-sms-high"
+                [str(persisted_notification.id)], queue="send-sms-high"
             )
         else:
             provider_tasks.deliver_sms.apply_async.assert_called_once_with(
-                [str(persisted_notification.id)], queue=f"send-sms-low"
+                [str(persisted_notification.id)], queue="send-sms-low"
             )
         assert mocked_deliver_sms.called
 

--- a/tests/app/notifications/rest/test_send_notification.py
+++ b/tests/app/notifications/rest/test_send_notification.py
@@ -1024,7 +1024,11 @@ def test_send_notification_uses_appropriate_queue_when_template_has_process_type
     notification_id = response_data["notification"]["id"]
 
     assert response.status_code == 201
-    mocked.assert_called_once_with([notification_id], queue=f"{process_type}-tasks")
+    if notification_type == SMS_TYPE:
+        expected_queue = "send-sms-high" if process_type == "priority" else "send-sms-low"
+    else:
+        expected_queue = f"{process_type}-tasks"
+    mocked.assert_called_once_with([notification_id], queue=expected_queue)
 
 
 @pytest.mark.parametrize("notification_type, send_to", [("sms", "6502532222"), ("email", "sample@email.com")])

--- a/tests/app/notifications/rest/test_send_notification.py
+++ b/tests/app/notifications/rest/test_send_notification.py
@@ -321,7 +321,7 @@ def test_should_allow_valid_sms_notification(notify_api, sample_template, mocker
             response_data = json.loads(response.data)["data"]
             notification_id = response_data["notification"]["id"]
 
-            mocked.assert_called_once_with([notification_id], queue="send-sms-tasks")
+            mocked.assert_called_once_with([notification_id], queue="send-sms-medium")
             assert response.status_code == 201
             assert notification_id
             assert "subject" not in response_data
@@ -653,13 +653,13 @@ def test_should_send_sms_if_team_api_key_and_a_service_user(client, sample_templ
         ],
     )
 
-    app.celery.provider_tasks.deliver_sms.apply_async.assert_called_once_with([fake_uuid], queue="send-sms-tasks")
+    app.celery.provider_tasks.deliver_sms.apply_async.assert_called_once_with([fake_uuid], queue="send-sms-medium")
     assert response.status_code == 201
 
 
 @pytest.mark.parametrize(
     "template_type,queue_name",
-    [(SMS_TYPE, "send-sms-tasks"), (EMAIL_TYPE, "send-email-tasks")],
+    [(SMS_TYPE, "send-sms-medium"), (EMAIL_TYPE, "send-email-tasks")],
 )
 def test_should_persist_notification(
     client,
@@ -709,7 +709,7 @@ def test_should_persist_notification(
 
 @pytest.mark.parametrize(
     "template_type,queue_name",
-    [(SMS_TYPE, "send-sms-tasks"), (EMAIL_TYPE, "send-email-tasks")],
+    [(SMS_TYPE, "send-sms-medium"), (EMAIL_TYPE, "send-email-tasks")],
 )
 def test_should_delete_notification_and_return_error_if_sqs_fails(
     client,
@@ -1076,7 +1076,7 @@ def test_should_allow_store_original_number_on_sms_notification(client, sample_t
     response_data = json.loads(response.data)["data"]
     notification_id = response_data["notification"]["id"]
 
-    mocked.assert_called_once_with([notification_id], queue="send-sms-tasks")
+    mocked.assert_called_once_with([notification_id], queue="send-sms-medium")
     assert response.status_code == 201
     assert notification_id
     notifications = Notification.query.all()

--- a/tests/app/notifications/rest/test_send_notification.py
+++ b/tests/app/notifications/rest/test_send_notification.py
@@ -9,6 +9,7 @@ from notifications_python_client.authentication import create_jwt_token
 from notifications_utils import SMS_CHAR_COUNT_LIMIT
 
 import app
+from app.config import QueueNames
 from app.dao import notifications_dao
 from app.dao.api_key_dao import save_model_api_key
 from app.dao.services_dao import dao_update_service
@@ -321,7 +322,7 @@ def test_should_allow_valid_sms_notification(notify_api, sample_template, mocker
             response_data = json.loads(response.data)["data"]
             notification_id = response_data["notification"]["id"]
 
-            mocked.assert_called_once_with([notification_id], queue="send-sms-medium")
+            mocked.assert_called_once_with([notification_id], queue=QueueNames.SEND_SMS_MEDIUM)
             assert response.status_code == 201
             assert notification_id
             assert "subject" not in response_data
@@ -653,13 +654,13 @@ def test_should_send_sms_if_team_api_key_and_a_service_user(client, sample_templ
         ],
     )
 
-    app.celery.provider_tasks.deliver_sms.apply_async.assert_called_once_with([fake_uuid], queue="send-sms-medium")
+    app.celery.provider_tasks.deliver_sms.apply_async.assert_called_once_with([fake_uuid], queue=QueueNames.SEND_SMS_MEDIUM)
     assert response.status_code == 201
 
 
 @pytest.mark.parametrize(
     "template_type,queue_name",
-    [(SMS_TYPE, "send-sms-medium"), (EMAIL_TYPE, "send-email-tasks")],
+    [(SMS_TYPE, QueueNames.SEND_SMS_MEDIUM), (EMAIL_TYPE, "send-email-tasks")],
 )
 def test_should_persist_notification(
     client,
@@ -709,7 +710,7 @@ def test_should_persist_notification(
 
 @pytest.mark.parametrize(
     "template_type,queue_name",
-    [(SMS_TYPE, "send-sms-medium"), (EMAIL_TYPE, "send-email-tasks")],
+    [(SMS_TYPE, QueueNames.SEND_SMS_MEDIUM), (EMAIL_TYPE, "send-email-tasks")],
 )
 def test_should_delete_notification_and_return_error_if_sqs_fails(
     client,
@@ -1025,7 +1026,7 @@ def test_send_notification_uses_appropriate_queue_when_template_has_process_type
 
     assert response.status_code == 201
     if notification_type == SMS_TYPE:
-        expected_queue = "send-sms-high" if process_type == "priority" else "send-sms-low"
+        expected_queue = QueueNames.SEND_SMS_HIGH if process_type == "priority" else QueueNames.SEND_SMS_LOW
     else:
         expected_queue = f"{process_type}-tasks"
     mocked.assert_called_once_with([notification_id], queue=expected_queue)
@@ -1080,7 +1081,7 @@ def test_should_allow_store_original_number_on_sms_notification(client, sample_t
     response_data = json.loads(response.data)["data"]
     notification_id = response_data["notification"]["id"]
 
-    mocked.assert_called_once_with([notification_id], queue="send-sms-medium")
+    mocked.assert_called_once_with([notification_id], queue=QueueNames.SEND_SMS_MEDIUM)
     assert response.status_code == 201
     assert notification_id
     notifications = Notification.query.all()

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -495,9 +495,9 @@ class TestSendNotificationQueue:
                 "send-throttled-sms-tasks",
                 "deliver_throttled_sms",
             ),
-            (False, None, "sms", "normal", None, "send-sms-tasks", "deliver_sms"),
+            (False, None, "sms", "normal", None, "send-sms-medium", "deliver_sms"),
             (False, None, "email", "normal", None, "send-email-tasks", "deliver_email"),
-            (False, None, "sms", "team", None, "send-sms-tasks", "deliver_sms"),
+            (False, None, "sms", "team", None, "send-sms-medium", "deliver_sms"),
             (
                 False,
                 None,

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -11,6 +11,7 @@ from notifications_utils.recipients import (
 )
 from sqlalchemy.exc import SQLAlchemyError
 
+from app.config import QueueNames
 from app.dao.service_sms_sender_dao import dao_update_service_sms_sender
 from app.models import (
     LETTER_TYPE,
@@ -495,9 +496,9 @@ class TestSendNotificationQueue:
                 "send-throttled-sms-tasks",
                 "deliver_throttled_sms",
             ),
-            (False, None, "sms", "normal", None, "send-sms-medium", "deliver_sms"),
+            (False, None, "sms", "normal", None, QueueNames.SEND_SMS_MEDIUM, "deliver_sms"),
             (False, None, "email", "normal", None, "send-email-tasks", "deliver_email"),
-            (False, None, "sms", "team", None, "send-sms-medium", "deliver_sms"),
+            (False, None, "sms", "team", None, QueueNames.SEND_SMS_MEDIUM, "deliver_sms"),
             (
                 False,
                 None,
@@ -599,7 +600,7 @@ class TestSendNotificationQueue:
         )
         with pytest.raises(Boto3Error):
             send_notification_to_queue(sample_notification, False)
-        mocked.assert_called_once_with([(str(sample_notification.id))], queue="send-sms-medium")
+        mocked.assert_called_once_with([(str(sample_notification.id))], queue=QueueNames.SEND_SMS_MEDIUM)
 
         assert Notification.query.count() == 0
         assert NotificationHistory.query.count() == 0
@@ -675,9 +676,9 @@ class TestChooseQueue:
                 "+14383898585",
                 "send-throttled-sms-tasks",
             ),
-            (False, None, "sms", "normal", None, "send-sms-medium"),
+            (False, None, "sms", "normal", None, QueueNames.SEND_SMS_MEDIUM),
             (False, None, "email", "normal", None, "send-email-tasks"),
-            (False, None, "sms", "team", None, "send-sms-medium"),
+            (False, None, "sms", "team", None, QueueNames.SEND_SMS_MEDIUM),
             (
                 False,
                 None,
@@ -973,9 +974,9 @@ class TestDBSaveAndSendNotification:
                 "send-throttled-sms-tasks",
                 "deliver_throttled_sms",
             ),
-            ("sms", "normal", None, "send-sms-medium", "deliver_sms"),
+            ("sms", "normal", None, QueueNames.SEND_SMS_MEDIUM, "deliver_sms"),
             ("email", "normal", None, "send-email-tasks", "deliver_email"),
-            ("sms", "team", None, "send-sms-medium", "deliver_sms"),
+            ("sms", "team", None, QueueNames.SEND_SMS_MEDIUM, "deliver_sms"),
             ("sms", "test", None, "research-mode-tasks", "deliver_sms"),
             (
                 "sms",
@@ -1074,12 +1075,12 @@ class TestDBSaveAndSendNotification:
             reply_to_text=sample_template.service.get_default_sms_sender(),
             to="+16502532222",
             created_at=datetime.datetime(2016, 11, 11, 16, 8, 18),
-            queue_name="send-sms-medium",
+            queue_name=QueueNames.SEND_SMS_MEDIUM,
         )
 
         with pytest.raises(Boto3Error):
             db_save_and_send_notification(notification)
-        mocked.assert_called_once_with([(str(notification.id))], queue="send-sms-medium")
+        mocked.assert_called_once_with([(str(notification.id))], queue=QueueNames.SEND_SMS_MEDIUM)
 
         assert Notification.query.count() == 0
         assert NotificationHistory.query.count() == 0

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -599,7 +599,7 @@ class TestSendNotificationQueue:
         )
         with pytest.raises(Boto3Error):
             send_notification_to_queue(sample_notification, False)
-        mocked.assert_called_once_with([(str(sample_notification.id))], queue="send-sms-tasks")
+        mocked.assert_called_once_with([(str(sample_notification.id))], queue="send-sms-medium")
 
         assert Notification.query.count() == 0
         assert NotificationHistory.query.count() == 0
@@ -675,9 +675,9 @@ class TestChooseQueue:
                 "+14383898585",
                 "send-throttled-sms-tasks",
             ),
-            (False, None, "sms", "normal", None, "send-sms-tasks"),
+            (False, None, "sms", "normal", None, "send-sms-medium"),
             (False, None, "email", "normal", None, "send-email-tasks"),
-            (False, None, "sms", "team", None, "send-sms-tasks"),
+            (False, None, "sms", "team", None, "send-sms-medium"),
             (
                 False,
                 None,
@@ -973,9 +973,9 @@ class TestDBSaveAndSendNotification:
                 "send-throttled-sms-tasks",
                 "deliver_throttled_sms",
             ),
-            ("sms", "normal", None, "send-sms-tasks", "deliver_sms"),
+            ("sms", "normal", None, "send-sms-medium", "deliver_sms"),
             ("email", "normal", None, "send-email-tasks", "deliver_email"),
-            ("sms", "team", None, "send-sms-tasks", "deliver_sms"),
+            ("sms", "team", None, "send-sms-medium", "deliver_sms"),
             ("sms", "test", None, "research-mode-tasks", "deliver_sms"),
             (
                 "sms",
@@ -1074,12 +1074,12 @@ class TestDBSaveAndSendNotification:
             reply_to_text=sample_template.service.get_default_sms_sender(),
             to="+16502532222",
             created_at=datetime.datetime(2016, 11, 11, 16, 8, 18),
-            queue_name="send-sms-tasks",
+            queue_name="send-sms-medium",
         )
 
         with pytest.raises(Boto3Error):
             db_save_and_send_notification(notification)
-        mocked.assert_called_once_with([(str(notification.id))], queue="send-sms-tasks")
+        mocked.assert_called_once_with([(str(notification.id))], queue="send-sms-medium")
 
         assert Notification.query.count() == 0
         assert NotificationHistory.query.count() == 0

--- a/tests/app/service/test_send_one_off_notification.py
+++ b/tests/app/service/test_send_one_off_notification.py
@@ -60,7 +60,7 @@ def test_send_one_off_notification_calls_celery_correctly(persist_mock, celery_m
 
     assert resp == {"id": str(persist_mock.return_value.id)}
 
-    celery_mock.assert_called_once_with(notification=persist_mock.return_value, research_mode=False, queue="normal-tasks")
+    celery_mock.assert_called_once_with(notification=persist_mock.return_value, research_mode=False, queue="send-sms-medium")
 
 
 def test_send_one_off_notification_calls_persist_correctly_for_sms(persist_mock, celery_mock, notify_db_session):
@@ -189,7 +189,7 @@ def test_send_one_off_notification_honors_research_mode(notify_db_session, persi
     assert celery_mock.call_args[1]["research_mode"] is True
 
 
-@pytest.mark.parametrize("process_type, expected_queue", [("priority", "priority"), ("bulk", "normal"), ("normal", "normal")])
+@pytest.mark.parametrize("process_type, expected_queue", [("priority", "priority-tasks"), ("bulk", "normal-tasks"), ("normal", "normal-tasks")])
 def test_send_one_off_email_notification_honors_process_type(
     notify_db_session, persist_mock, celery_mock, process_type, expected_queue
 ):
@@ -199,23 +199,23 @@ def test_send_one_off_email_notification_honors_process_type(
 
     post_data = {
         "template_id": str(template.id),
-        "to": "6502532222",
+        "to": "test@test.com",
         "created_by": str(service.created_by_id),
     }
 
     send_one_off_notification(service.id, post_data)
 
-    assert celery_mock.call_args[1]["queue"] == f"{expected_queue}-tasks"
+    assert celery_mock.call_args[1]["queue"] == expected_queue
 
 
 @pytest.mark.parametrize(
-    "process_type, expected_queue", [("priority", "semd-sms-high"), ("bulk", "send-sms-medium"), ("normal", "send-sms-medium")]
+    "process_type, expected_queue", [("priority", "send-sms-high"), ("bulk", "send-sms-medium"), ("normal", "send-sms-medium")]
 )
 def test_send_one_off_sms_notification_honors_process_type(
     notify_db_session, persist_mock, celery_mock, process_type, expected_queue
 ):
     service = create_service()
-    template = create_template(service=service, template_type=EMAIL_TYPE)
+    template = create_template(service=service, template_type=SMS_TYPE)
     template.process_type = process_type
 
     post_data = {
@@ -426,7 +426,7 @@ def test_send_one_off_sms_notification_should_use_sms_sender_reply_to_text(sampl
 
     notification_id = send_one_off_notification(service_id=sample_service.id, post_data=data)
     notification = Notification.query.get(notification_id["id"])
-    celery_mock.assert_called_once_with(notification=notification, research_mode=False, queue="normal-tasks")
+    celery_mock.assert_called_once_with(notification=notification, research_mode=False, queue="send-sms-medium")
 
     assert notification.reply_to_text == "+16502532222"
 
@@ -444,7 +444,7 @@ def test_send_one_off_sms_notification_should_use_default_service_reply_to_text(
 
     notification_id = send_one_off_notification(service_id=sample_service.id, post_data=data)
     notification = Notification.query.get(notification_id["id"])
-    celery_mock.assert_called_once_with(notification=notification, research_mode=False, queue="normal-tasks")
+    celery_mock.assert_called_once_with(notification=notification, research_mode=False, queue="send-sms-medium")
 
     assert notification.reply_to_text == "+16502532222"
 

--- a/tests/app/service/test_send_one_off_notification.py
+++ b/tests/app/service/test_send_one_off_notification.py
@@ -189,7 +189,9 @@ def test_send_one_off_notification_honors_research_mode(notify_db_session, persi
     assert celery_mock.call_args[1]["research_mode"] is True
 
 
-@pytest.mark.parametrize("process_type, expected_queue", [("priority", "priority-tasks"), ("bulk", "normal-tasks"), ("normal", "normal-tasks")])
+@pytest.mark.parametrize(
+    "process_type, expected_queue", [("priority", "priority-tasks"), ("bulk", "normal-tasks"), ("normal", "normal-tasks")]
+)
 def test_send_one_off_email_notification_honors_process_type(
     notify_db_session, persist_mock, celery_mock, process_type, expected_queue
 ):

--- a/tests/app/service/test_send_one_off_notification.py
+++ b/tests/app/service/test_send_one_off_notification.py
@@ -193,7 +193,8 @@ def test_send_one_off_notification_honors_research_mode(notify_db_session, persi
 
 
 @pytest.mark.parametrize(
-    "process_type, expected_queue", [("priority", "priority-tasks"), ("bulk", "normal-tasks"), ("normal", "normal-tasks")]
+    "process_type, expected_queue",
+    [("priority", QueueNames.PRIORITY), ("bulk", QueueNames.SEND_EMAIL), ("normal", QueueNames.SEND_EMAIL)],
 )
 def test_send_one_off_email_notification_honors_process_type(
     notify_db_session, persist_mock, celery_mock, process_type, expected_queue
@@ -381,7 +382,7 @@ def test_send_one_off_notification_should_add_email_reply_to_text_for_notificati
 
     notification_id = send_one_off_notification(service_id=sample_email_template.service.id, post_data=data)
     notification = Notification.query.get(notification_id["id"])
-    celery_mock.assert_called_once_with(notification=notification, research_mode=False, queue="normal-tasks")
+    celery_mock.assert_called_once_with(notification=notification, research_mode=False, queue=QueueNames.SEND_EMAIL)
     assert notification.reply_to_text == reply_to_email.email_address
 
 
@@ -397,7 +398,7 @@ def test_send_one_off_letter_notification_should_use_template_reply_to_text(samp
 
     notification_id = send_one_off_notification(service_id=sample_letter_template.service.id, post_data=data)
     notification = Notification.query.get(notification_id["id"])
-    celery_mock.assert_called_once_with(notification=notification, research_mode=False, queue="normal-tasks")
+    celery_mock.assert_called_once_with(notification=notification, research_mode=False, queue=QueueNames.NORMAL)
 
     assert notification.reply_to_text == "Edinburgh, ED1 1AA"
 

--- a/tests/app/test_config.py
+++ b/tests/app/test_config.py
@@ -27,7 +27,7 @@ def reload_config():
 def test_queue_names_all_queues_correct():
     # Need to ensure that all_queues() only returns queue names used in API
     queues = QueueNames.all_queues()
-    assert len(queues) == 17
+    assert len(queues) == 20
     assert set(
         [
             QueueNames.PRIORITY,
@@ -38,6 +38,9 @@ def test_queue_names_all_queues_correct():
             QueueNames.NORMAL_DATABASE,
             QueueNames.BULK_DATABASE,
             QueueNames.SEND_SMS,
+            QueueNames.SEND_SMS_HIGH,
+            QueueNames.SEND_SMS_MEDIUM,
+            QueueNames.SEND_SMS_LOW,
             QueueNames.SEND_THROTTLED_SMS,
             QueueNames.SEND_EMAIL,
             QueueNames.RESEARCH_MODE,

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -4,7 +4,6 @@ from freezegun import freeze_time
 from sqlalchemy.exc import IntegrityError
 
 from app import signer_personalisation
-from app.config import QueueNames
 from app.models import (
     EMAIL_TYPE,
     MOBILE_TYPE,
@@ -368,22 +367,6 @@ def test_is_precompiled_letter_hidden_true_not_name(sample_letter_template):
 def test_is_precompiled_letter_name_correct_not_hidden(sample_letter_template):
     sample_letter_template.name = PRECOMPILED_TEMPLATE_NAME
     assert not sample_letter_template.is_precompiled_letter
-
-
-@pytest.mark.parametrize(
-    "template_type, process_type, expected_queue",
-    [
-        (SMS_TYPE, "normal", QueueNames.SEND_SMS_MEDIUM),
-        (SMS_TYPE, "priority", QueueNames.SEND_SMS_HIGH),
-        (SMS_TYPE, "bulk", QueueNames.SEND_SMS_LOW),
-        (EMAIL_TYPE, "normal", QueueNames.SEND_EMAIL),
-        (EMAIL_TYPE, "priority", QueueNames.PRIORITY),
-        (EMAIL_TYPE, "bulk", QueueNames.BULK),
-    ],
-)
-def test_template_queue_to_use(sample_service, template_type, process_type, expected_queue):
-    template = create_template(sample_service, process_type=process_type, template_type=template_type)
-    assert template.queue_to_use() == expected_queue
 
 
 def test_template_folder_is_parent(sample_service):

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -376,9 +376,9 @@ def test_is_precompiled_letter_name_correct_not_hidden(sample_letter_template):
         (SMS_TYPE, "normal", QueueNames.SEND_SMS_MEDIUM),
         (SMS_TYPE, "priority", QueueNames.SEND_SMS_HIGH),
         (SMS_TYPE, "bulk", QueueNames.SEND_SMS_LOW),
-        (EMAIL_TYPE, "normal", "normal-tasks"),
-        (EMAIL_TYPE, "priority", "priority-tasks"),
-        (EMAIL_TYPE, "bulk", "bulk-tasks"),
+        (EMAIL_TYPE, "normal", QueueNames.SEND_EMAIL),
+        (EMAIL_TYPE, "priority", QueueNames.PRIORITY),
+        (EMAIL_TYPE, "bulk", QueueNames.BULK),
     ],
 )
 def test_template_queue_to_use(sample_service, template_type, process_type, expected_queue):

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -370,15 +370,18 @@ def test_is_precompiled_letter_name_correct_not_hidden(sample_letter_template):
 
 
 @pytest.mark.parametrize(
-    "process_type, expected_queue",
+    "template_type, process_type, expected_queue",
     [
-        ("normal", "normal-tasks"),
-        ("priority", "priority-tasks"),
-        ("bulk", "bulk-tasks"),
+        (SMS_TYPE, "normal", "send-sms-medium"),
+        (SMS_TYPE, "priority", "send-sms-high"),
+        (SMS_TYPE, "bulk", "send-sms-low"),
+        (EMAIL_TYPE, "normal", "send-email-task"),
+        (EMAIL_TYPE, "priority", "priority-tasks"),
+        (EMAIL_TYPE, "bulk", "bulk-tasks"),
     ],
 )
-def test_template_queue_to_use(sample_service, process_type, expected_queue):
-    template = create_template(sample_service, process_type=process_type)
+def test_template_queue_to_use(sample_service, template_type, process_type, expected_queue):
+    template = create_template(sample_service, process_type=process_type, template_type=template_type)
     assert template.queue_to_use() == expected_queue
 
 

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -375,7 +375,7 @@ def test_is_precompiled_letter_name_correct_not_hidden(sample_letter_template):
         (SMS_TYPE, "normal", "send-sms-medium"),
         (SMS_TYPE, "priority", "send-sms-high"),
         (SMS_TYPE, "bulk", "send-sms-low"),
-        (EMAIL_TYPE, "normal", "send-email-task"),
+        (EMAIL_TYPE, "normal", "normal-tasks"),
         (EMAIL_TYPE, "priority", "priority-tasks"),
         (EMAIL_TYPE, "bulk", "bulk-tasks"),
     ],

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -4,6 +4,7 @@ from freezegun import freeze_time
 from sqlalchemy.exc import IntegrityError
 
 from app import signer_personalisation
+from app.config import QueueNames
 from app.models import (
     EMAIL_TYPE,
     MOBILE_TYPE,
@@ -372,9 +373,9 @@ def test_is_precompiled_letter_name_correct_not_hidden(sample_letter_template):
 @pytest.mark.parametrize(
     "template_type, process_type, expected_queue",
     [
-        (SMS_TYPE, "normal", "send-sms-medium"),
-        (SMS_TYPE, "priority", "send-sms-high"),
-        (SMS_TYPE, "bulk", "send-sms-low"),
+        (SMS_TYPE, "normal", QueueNames.SEND_SMS_MEDIUM),
+        (SMS_TYPE, "priority", QueueNames.SEND_SMS_HIGH),
+        (SMS_TYPE, "bulk", QueueNames.SEND_SMS_LOW),
         (EMAIL_TYPE, "normal", "normal-tasks"),
         (EMAIL_TYPE, "priority", "priority-tasks"),
         (EMAIL_TYPE, "bulk", "bulk-tasks"),

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -4,7 +4,10 @@ import pytest
 from flask import Flask
 from freezegun import freeze_time
 
+from app.config import QueueNames
+from app.models import EMAIL_TYPE, SMS_TYPE
 from app.utils import (
+    get_delivery_queue_for_template,
     get_document_url,
     get_limit_reset_time_et,
     get_local_timezone_midnight,
@@ -14,6 +17,7 @@ from app.utils import (
     midnight_n_days_ago,
     update_dct_to_str,
 )
+from tests.app.db import create_template
 
 
 # Naive date times are ambiguous and are treated different on Mac OS vs flavours of *nix
@@ -136,3 +140,19 @@ def test_get_limit_reset_time_et():
         assert get_limit_reset_time_et() == {"12hr": "8PM", "24hr": "20"}
     with freeze_time("2023-01-10 00:00"):
         assert get_limit_reset_time_et() == {"12hr": "7PM", "24hr": "19"}
+
+
+@pytest.mark.parametrize(
+    "template_type, process_type, expected_queue",
+    [
+        (SMS_TYPE, "normal", QueueNames.SEND_SMS_MEDIUM),
+        (SMS_TYPE, "priority", QueueNames.SEND_SMS_HIGH),
+        (SMS_TYPE, "bulk", QueueNames.SEND_SMS_LOW),
+        (EMAIL_TYPE, "normal", QueueNames.SEND_EMAIL),
+        (EMAIL_TYPE, "priority", QueueNames.PRIORITY),
+        (EMAIL_TYPE, "bulk", QueueNames.BULK),
+    ],
+)
+def test_get_delivery_queue_for_template(sample_service, template_type, process_type, expected_queue):
+    template = create_template(sample_service, process_type=process_type, template_type=template_type)
+    assert get_delivery_queue_for_template(template) == expected_queue


### PR DESCRIPTION
# Summary | Résumé

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/186

Move sms sending (ie `deliver_sms()`) to their own queues (send-sms-high, send-sms-medium, send-sms-low)

note that these queues are still all services with the same celery works as the other queues.

# Test instructions | Instructions pour tester la modification

- Send some sms
  - one-off, bulk
  - priority, normal, and bulk templates
- see what delivery queues are being used by looking for lines in the celery logs like "... sent to the .... queue for delivery"
- ensure the correct queue was used in each case

# Release Instructions | Instructions pour le déploiement

- We will need alarms added to terraform for these queues
- also need to add "age of oldest message" charts to the SMS dashboard
