### PR TITLE
Add the limit reset time variable to the email limit templates

### DIFF
--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -318,6 +318,7 @@ def send_near_email_limit_email(service: Service) -> None:
     Send an email to service users when nearing the daily email limit.
 
     """
+    limit_reset_time_et = get_limit_reset_time_et()
     send_notification_to_service_users(
         service_id=service.id,
         template_id=current_app.config["NEAR_DAILY_EMAIL_LIMIT_TEMPLATE_ID"],
@@ -326,6 +327,8 @@ def send_near_email_limit_email(service: Service) -> None:
             "contact_url": f"{current_app.config['ADMIN_BASE_URL']}/contact",
             "message_limit_en": "{:,}".format(service.message_limit),
             "message_limit_fr": "{:,}".format(service.message_limit).replace(",", " "),
+            "limit_reset_time_et_12hr": limit_reset_time_et["12hr"],
+            "limit_reset_time_et_24hr": limit_reset_time_et["24hr"],
         },
         include_user_fields=["name"],
     )
@@ -350,6 +353,7 @@ def send_sms_limit_reached_email(service: Service):
 
 
 def send_email_limit_reached_email(service: Service):
+    limit_reset_time_et = get_limit_reset_time_et()
     send_notification_to_service_users(
         service_id=service.id,
         template_id=current_app.config["REACHED_DAILY_EMAIL_LIMIT_TEMPLATE_ID"],
@@ -358,6 +362,8 @@ def send_email_limit_reached_email(service: Service):
             "contact_url": f"{current_app.config['ADMIN_BASE_URL']}/contact",
             "message_limit_en": "{:,}".format(service.message_limit),
             "message_limit_fr": "{:,}".format(service.message_limit).replace(",", " "),
+            "limit_reset_time_et_12hr": limit_reset_time_et["12hr"],
+            "limit_reset_time_et_24hr": limit_reset_time_et["24hr"],
         },
         include_user_fields=["name"],
     )

--- a/migrations/versions/0435_update_email_templates_2.py
+++ b/migrations/versions/0435_update_email_templates_2.py
@@ -1,0 +1,136 @@
+"""
+
+Revision ID: 0435_update_email_templates_2
+Revises: 0434_update_email_templates_sms
+Create Date: 2023-08-08 00:00:00
+
+"""
+from datetime import datetime
+
+from alembic import op
+from flask import current_app
+
+revision = "0435_update_email_templates_2"
+down_revision = "0434_update_email_templates_sms"
+
+near_content = "\n".join(
+    [
+        "(la version française suit)",
+        "",
+        "Hello ((name)),",
+        "",
+        "((service_name)) can send ((message_limit_en)) emails per day. You’ll be blocked from sending if you exceed that limit before ((limit_reset_time_et_12hr)) Eastern Time. Check [your current local time](https://nrc.canada.ca/en/web-clock/).",
+        "",
+        "To request a limit increase, [contact us](https://notification.canada.ca/contact). We’ll respond within 1 business day.",
+        "",
+        "The GC Notify team",
+        "",
+        "---",
+        "",
+        "Bonjour ((name)),",
+        "",
+        "La limite quotidienne d’envoi est de ((message_limit_fr)) courriels par jour pour ((service_name)). Si vous dépassez cette limite avant ((limit_reset_time_et_24hr)) heures, heure de l’Est, vos envois seront bloqués.",
+        "",
+        "Comparez [les heures officielles au Canada](https://nrc.canada.ca/fr/horloge-web/).",
+        "",
+        "Veuillez [nous contacter](https://notification.canada.ca/contact) si vous souhaitez augmenter votre limite d’envoi. Nous vous répondrons en un jour ouvrable.",
+        "",
+        "L’équipe Notification GC",
+    ]
+)
+
+
+reached_content = "\n".join(
+    [
+        "(la version française suit)",
+        "",
+        "Hello ((name)),",
+        "",
+        "((service_name)) has sent ((message_limit_en)) emails today.",
+        "",
+        "You can send more messages after ((limit_reset_time_et_12hr)) Eastern Time. Compare [official times across Canada](https://nrc.canada.ca/en/web-clock/).",
+        "",
+        "To request a limit increase, [contact us](https://notification.canada.ca/contact). We’ll respond within 1 business day.",
+        "",
+        "The GC Notify team",
+        "",
+        "---",
+        "",
+        "Bonjour ((name)),",
+        "",
+        "Aujourd’hui, ((message_limit_fr)) courriels ont été envoyés pour ((service_name)).",
+        "",
+        "Vous pourrez envoyer davantage de courriels après ((limit_reset_time_et_24hr)) heures, heure de l’Est. Comparez [les heures officielles au Canada](https://nrc.canada.ca/fr/horloge-web/).",
+        "",
+        "Veuillez [nous contacter](https://notification.canada.ca/contact) si vous désirez augmenter votre limite d’envoi. Nous vous répondrons en un jour ouvrable.",
+        "",
+        "L’équipe Notification GC",
+    ]
+)
+
+templates = [
+    {
+        "id": current_app.config["NEAR_DAILY_EMAIL_LIMIT_TEMPLATE_ID"],
+        "name": "Near daily EMAIL limit",
+        "template_type": "email",
+        "content": near_content,
+        "subject": "((service_name)) is near its daily limit for emails. | La limite quotidienne d’envoi de courriels est presque atteinte pour ((service_name)).",
+        "process_type": "priority",
+    },
+    {
+        "id": current_app.config["REACHED_DAILY_EMAIL_LIMIT_TEMPLATE_ID"],
+        "name": "Daily EMAIL limit reached",
+        "template_type": "email",
+        "content": reached_content,
+        "subject": "((service_name)) has reached its daily limit for email messages | La limite quotidienne d’envoi de courriels atteinte pour ((service_name)).",
+        "process_type": "priority",
+    },
+]
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    for template in templates:
+        current_version = conn.execute("select version from templates where id='{}'".format(template["id"])).fetchone()
+        template["version"] = current_version[0] + 1
+
+    template_update = """
+        UPDATE templates SET content = '{}', subject = '{}', version = '{}', updated_at = '{}'
+        WHERE id = '{}'
+    """
+    template_history_insert = """
+        INSERT INTO templates_history (id, name, template_type, created_at, content, archived, service_id, subject,
+        created_by_id, version, process_type, hidden)
+        VALUES ('{}', '{}', '{}', '{}', '{}', False, '{}', '{}', '{}', {}, '{}', false)
+    """
+
+    for template in templates:
+        op.execute(
+            template_update.format(
+                template["content"],
+                template["subject"],
+                template["version"],
+                datetime.utcnow(),
+                template["id"],
+            )
+        )
+
+        op.execute(
+            template_history_insert.format(
+                template["id"],
+                template["name"],
+                template["template_type"],
+                datetime.utcnow(),
+                template["content"],
+                current_app.config["NOTIFY_SERVICE_ID"],
+                template["subject"],
+                current_app.config["NOTIFY_USER_ID"],
+                template["version"],
+                template["process_type"],
+            )
+        )
+
+
+def downgrade():
+    pass

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -226,7 +226,7 @@ class TestCheckDailySMSEmailLimits:
                 call(count_key(limit_type, service.id)),
                 call(near_key(limit_type, service.id)),
             ]
-            kwargs = {"limit_reset_time_et_12hr": "7PM", "limit_reset_time_et_24hr": "19"} if limit_type == "sms" else {}
+            kwargs = {"limit_reset_time_et_12hr": "7PM", "limit_reset_time_et_24hr": "19"}
             send_notification.assert_called_once_with(
                 service_id=service.id,
                 template_id=current_app.config[template_name],


### PR DESCRIPTION
# Summary | Résumé

I left the content of these emails the same, and added personalisation variables for the limit reset time.

# Test instructions | Instructions pour tester la modification

1. check out locally
2. run the migration `poetry run flask db upgrade`
3. make sure you have `FF_EMAIL_DAILY_LIMIT=True` in your .env file for both api and admin
4. start both api and admin locally
5. set your service's daily email limit to 5
6. send 4 emails
7. verify that you get the "near limit" warning email and that it contains 8PM / 20 heures
8. send 1 more email
9. verify that you get the "limit reached" email and that it contains  8PM / 20 heures