### PR TITLE
Refactor dao_get_template_by_id to no longer return a tuple

### DIFF
--- a/app/clients/freshdesk.py
+++ b/app/clients/freshdesk.py
@@ -119,8 +119,6 @@ class Freshdesk(object):
     def email_freshdesk_ticket(self, content: dict) -> None:
         try:
             template = dao_get_template_by_id(current_app.config["CONTACT_FORM_DIRECT_EMAIL_TEMPLATE_ID"])
-            if isinstance(template, tuple):
-                template = template[0]
             notify_service = dao_fetch_service_by_id(current_app.config["NOTIFY_SERVICE_ID"])
 
             if current_app.config["CONTACT_FORM_EMAIL_ADDRESS"] is None:

--- a/app/dao/templates_dao.py
+++ b/app/dao/templates_dao.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 from datetime import datetime
-from typing import Tuple, Union
+from typing import Union
 
 from flask import current_app
 from notifications_utils.clients.redis import template_version_cache_key
@@ -92,9 +92,7 @@ def dao_get_template_by_id_and_service_id(template_id, service_id, version=None)
     return db.on_reader().query(Template).filter_by(id=template_id, hidden=False, service_id=service_id).one()
 
 
-def dao_get_template_by_id(
-    template_id, version=None, use_cache=False
-) -> Union[Union[Template, TemplateHistory], Tuple[Union[Template, TemplateHistory], dict]]:
+def dao_get_template_by_id(template_id, version=None, use_cache=False) -> Union[Template, TemplateHistory]:
     if use_cache:
         # When loading a SQLAlchemy object from cache it is in the transient state.
         # We do not add it to the session. This would defeat the purpose of using the cache.
@@ -106,9 +104,9 @@ def dao_get_template_by_id(
         if template_cache:
             template_cache_decoded = json.loads(template_cache.decode("utf-8"))["data"]
             if version:
-                return TemplateHistory.from_json(template_cache_decoded), template_cache_decoded
+                return TemplateHistory.from_json(template_cache_decoded)
             else:
-                return Template.from_json(template_cache_decoded), template_cache_decoded
+                return Template.from_json(template_cache_decoded)
     if version is not None:
         return TemplateHistory.query.filter_by(id=template_id, version=version).one()
     return Template.query.filter_by(id=template_id).one()

--- a/app/models.py
+++ b/app/models.py
@@ -607,7 +607,7 @@ class Service(BaseModel, Versioned):
 
     def get_default_sms_sender(self):
         default_sms_sender = [x for x in self.service_sms_senders if x.is_default]
-        return default_sms_sender[0].sms_sender
+        return default_sms_sender[0].sms_sender if default_sms_sender else None
 
     def get_default_reply_to_email_address(self):
         default_reply_to = [x for x in self.reply_to_email_addresses if x.is_default]

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -110,11 +110,6 @@ def persist_notification(
         billable_units=billable_units,
     )
     template = dao_get_template_by_id(template_id, template_version, use_cache=True)
-    # if the template is obtained from cache a tuple will be returned where
-    # the first element is the Template object and the second the template cache data
-    # in the form of a dict
-    if isinstance(template, tuple):
-        template = template[0]
     notification.queue_name = choose_queue(
         notification=notification, research_mode=service.research_mode, queue=template.queue_to_use()
     )
@@ -329,11 +324,6 @@ def persist_notifications(notifications: List[VerifiedNotification]) -> List[Not
             billable_units=notification.get("billable_units"),  # type: ignore
         )
         template = dao_get_template_by_id(notification_obj.template_id, notification_obj.template_version, use_cache=True)
-        # if the template is obtained from cache a tuple will be returned where
-        # the first element is the Template object and the second the template cache data
-        # in the form of a dict
-        if isinstance(template, tuple):
-            template = template[0]
         service = dao_fetch_service_by_id(service_id, use_cache=True)
         notification_obj.queue_name = choose_queue(
             notification=notification_obj, research_mode=service.research_mode, queue=template.queue_to_use()

--- a/tests/app/dao/test_templates_dao.py
+++ b/tests/app/dao/test_templates_dao.py
@@ -304,8 +304,7 @@ def test_get_template_id_from_redis_when_cached(sample_service, mocker):
     template = dao_get_template_by_id(sample_template.id, use_cache=True)
 
     assert mocked_redis_get.called
-    assert str(sample_template.id) == template[0].id
-    assert json.dumps(json_data["data"], default=lambda o: o.hex if isinstance(o, UUID) else None) == json.dumps(template[1])
+    assert str(sample_template.id) == template.id
 
 
 def test_get_template_id_with_specific_version_from_redis(sample_service, mocker, notify_db_session):
@@ -320,9 +319,8 @@ def test_get_template_id_with_specific_version_from_redis(sample_service, mocker
     template = dao_get_template_by_id(sample_template.id, version=1, use_cache=True)
 
     assert mocked_redis_get.called
-    assert str(sample_template.id) == template[0].id
-    assert isinstance(template[0], TemplateHistory)
-    assert json.dumps(json_data["data"], default=lambda o: o.hex if isinstance(o, UUID) else None) == json.dumps(template[1])
+    assert str(sample_template.id) == template.id
+    assert isinstance(template, TemplateHistory)
 
 
 def test_get_template_by_id_and_service(sample_service):


### PR DESCRIPTION
# Summary | Résumé
This PR refactors `dao_get_template_by_id` so that it returns either a `Template` or `TemplateHistory` object rather than a tuple.

- Added additional fallbacks for fetching the `reply_to_text` to `save_smss` and `save_emails` when either then template or service is fetched from the cache and relationship data is not populated.