### PR TITLE
tweak celery scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,17 +50,13 @@ smoke-test:
 run: ## Run the web app
 	flask run -p 6011 --host=0.0.0.0
 
-.PHONY: run-celery
-run-celery-local: ## Run the celery workers
+.PHONY: run-celery-local
+run-celery-local: ## Run the celery workers with all the queues
 	./scripts/run_celery_local.sh
 
-.PHONY: run-celery-clean
-run-celery-local-clean: ## Run the celery workers but filter out common scheduled tasks
+.PHONY: run-celery-local-filtered
+run-celery-local-filtered: ## Run the celery workers with all queues but filter out common scheduled tasks
 	./scripts/run_celery_local.sh 2>&1 >/dev/null | grep -Ev 'beat|in-flight-to-inbox|run-scheduled-jobs|check-job-status'
-
-.PHONY: run-celery-sms
-run-celery-sms: ## run the celery workers for sms from dedicated numbers
-	./scripts/run_celery_sms.sh
 
 .PHONY: run-celery-beat
 run-celery-beat: ## Run the celery beat

--- a/Makefile
+++ b/Makefile
@@ -51,12 +51,12 @@ run: ## Run the web app
 	flask run -p 6011 --host=0.0.0.0
 
 .PHONY: run-celery
-run-celery: ## Run the celery workers
-	./scripts/run_celery.sh
+run-celery-local: ## Run the celery workers
+	./scripts/run_celery_local.sh
 
 .PHONY: run-celery-clean
-run-celery-clean: ## Run the celery workers but filter out common scheduled tasks
-	./scripts/run_celery.sh 2>&1 >/dev/null | grep -Ev 'beat|in-flight-to-inbox|run-scheduled-jobs|check-job-status'
+run-celery-local-clean: ## Run the celery workers but filter out common scheduled tasks
+	./scripts/run_celery_local.sh 2>&1 >/dev/null | grep -Ev 'beat|in-flight-to-inbox|run-scheduled-jobs|check-job-status'
 
 .PHONY: run-celery-sms
 run-celery-sms: ## run the celery workers for sms from dedicated numbers

--- a/scripts/run_celery.sh
+++ b/scripts/run_celery.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+# runs all celery queues except the throtted sms queue
+
 set -e
 
 echo "Start celery, concurrency: ${CELERY_CONCURRENCY-4}"

--- a/scripts/run_celery.sh
+++ b/scripts/run_celery.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# runs all celery queues except the throtted sms queue
+# runs celery with all celery queues except the throtted sms queue
 
 set -e
 

--- a/scripts/run_celery_beat.sh
+++ b/scripts/run_celery_beat.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+# runs the celery beat process. This runs the periodic tasks
+
 set -e
 
 celery -A run_celery.notify_celery beat --loglevel=INFO

--- a/scripts/run_celery_local.sh
+++ b/scripts/run_celery_local.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# runs all celery queues.
+# runs celery with all celery queues
 # This is for local use only, NOT for use in AWS
 
 set -e

--- a/scripts/run_celery_local.sh
+++ b/scripts/run_celery_local.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# runs all celery queues.
+# This is for local use only, NOT for use in AWS
+
+set -e
+
+echo "Start celery, concurrency: ${CELERY_CONCURRENCY-4}"
+
+celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency=${CELERY_CONCURRENCY-4} -Q database-tasks,-priority-database-tasks.fifo,-normal-database-tasks,-bulk-database-tasks,job-tasks,notify-internal-tasks,periodic-tasks,priority-tasks,normal-tasks,bulk-tasks,reporting-tasks,research-mode-tasks,retry-tasks,send-sms-tasks,send-sms-high,send-sms-medium,send-sms-low,send-throttled-sms-tasks,send-email-tasks,service-callbacks,delivery-receipts

--- a/scripts/run_celery_no_sms_sending.sh
+++ b/scripts/run_celery_no_sms_sending.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# runs celery with all celery queues except send-throttled-sms-tasks, send-sms-tasks, send-sms-high, send-sms-medium, or send-sms-low
+
+set -e
+
+echo "Start celery, concurrency: ${CELERY_CONCURRENCY-4}"
+
+celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency=${CELERY_CONCURRENCY-4} -Q database-tasks,-priority-database-tasks.fifo,-normal-database-tasks,-bulk-database-tasks,job-tasks,notify-internal-tasks,periodic-tasks,priority-tasks,normal-tasks,bulk-tasks,reporting-tasks,research-mode-tasks,retry-tasks,send-email-tasks,service-callbacks,delivery-receipts

--- a/scripts/run_celery_send_sms.sh
+++ b/scripts/run_celery_send_sms.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# runs celery with only the send-sms queues
+
+set -e
+
+echo "Start celery, concurrency: ${CELERY_CONCURRENCY-4}"
+
+celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency=${CELERY_CONCURRENCY-4} -Q send-sms-high,send-sms-medium,send-sms-low

--- a/scripts/run_celery_send_sms.sh
+++ b/scripts/run_celery_send_sms.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
 
-# runs celery with only the send-sms queues
+# runs celery with only the send-sms-* queues
 
 set -e
 
 echo "Start celery, concurrency: ${CELERY_CONCURRENCY-4}"
 
-celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency=${CELERY_CONCURRENCY-4} -Q send-sms-high,send-sms-medium,send-sms-low
+# TODO: we shouldn't be using the send-sms-tasks queue anymore - once we verify this we can remove it
+celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency=${CELERY_CONCURRENCY-4} -Q send-sms-tasks,send-sms-high,send-sms-medium,send-sms-low

--- a/scripts/run_celery_sms.sh
+++ b/scripts/run_celery_sms.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+# runs celery with only the throttled sms sending queue
+
 set -e
 
 celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=1 -Q send-throttled-sms-tasks


### PR DESCRIPTION
# Summary | Résumé

As part of the process of moving sms sending to its own pod deployment, we need a new script for those pods to run!
Our code is all over the place, so this is the process:

- created new celery queues for sms sending (and associated alarms) **DONE**
- create new scripts for 
  - the new SMS celery pod deployment (**this PR**)
  - the old celery pod deployment (ie not containing the send-sms-* queues) (**this PR**)
- create the new deployment that uses this script in staging ([manifest repo PR](https://github.com/cds-snc/notification-manifests/pull/1980))

I've also added some documentation to the scripts, as well as a new script for running all the queues locally.

