### PR TITLE
Update daily notification stats to use 12am utc 

### DIFF
--- a/app/dao/date_util.py
+++ b/app/dao/date_util.py
@@ -81,3 +81,10 @@ def get_financial_year_for_datetime(start_date):
 
 def get_midnight(datetime: datetime) -> datetime:
     return datetime.replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+def utc_midnight_n_days_ago(number_of_days):
+    """
+    Returns utc midnight a number of days ago.
+    """
+    return get_midnight(datetime.utcnow() - timedelta(days=number_of_days))

--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -1,6 +1,6 @@
-import pytz 
 from datetime import datetime, time, timedelta
 
+import pytz
 from flask import current_app
 from notifications_utils.timezones import convert_local_timezone_to_utc
 from sqlalchemy import Date, case, func

--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -1,6 +1,5 @@
 from datetime import datetime, time, timedelta
 
-import pytz
 from flask import current_app
 from notifications_utils.timezones import convert_local_timezone_to_utc
 from sqlalchemy import Date, case, func
@@ -36,7 +35,6 @@ from app.models import (
 from app.utils import (
     get_local_timezone_midnight_in_utc,
     get_local_timezone_month_from_utc_column,
-    midnight_n_days_ago,
 )
 
 
@@ -241,7 +239,7 @@ def fetch_notification_status_for_service_for_day(bst_day, service_id):
 
 
 def fetch_notification_status_for_service_for_today_and_7_previous_days(service_id, by_template=False, limit_days=7):
-    start_date = utc_midnight_n_days_ago(limit_days-1)
+    start_date = utc_midnight_n_days_ago(limit_days - 1)
 
     stats_for_7_days = db.session.query(
         FactNotificationStatus.notification_type.label("notification_type"),

--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -9,7 +9,7 @@ from sqlalchemy.sql.expression import extract, literal
 from sqlalchemy.types import DateTime, Integer
 
 from app import db
-from app.dao.date_util import get_midnight
+from app.dao.date_util import utc_midnight_n_days_ago
 from app.models import (
     EMAIL_TYPE,
     KEY_TYPE_NORMAL,
@@ -241,10 +241,7 @@ def fetch_notification_status_for_service_for_day(bst_day, service_id):
 
 
 def fetch_notification_status_for_service_for_today_and_7_previous_days(service_id, by_template=False, limit_days=7):
-    if limit_days == 1:
-        start_date = get_midnight(datetime.now(tz=pytz.utc))
-    else:
-        start_date = midnight_n_days_ago(limit_days)
+    start_date = utc_midnight_n_days_ago(limit_days-1)
 
     stats_for_7_days = db.session.query(
         FactNotificationStatus.notification_type.label("notification_type"),

--- a/tests/app/dao/test_fact_notification_status_dao.py
+++ b/tests/app/dao/test_fact_notification_status_dao.py
@@ -1141,3 +1141,35 @@ def test_fetch_monthly_notification_statuses_per_service_for_rows_that_should_be
 
     results = fetch_monthly_notification_statuses_per_service(date(2019, 3, 1), date(2019, 3, 31))
     assert len(results) == 0
+
+
+@freeze_time("2018-10-31T18:00:00")
+def test_fetch_notification_status_for_service_for_today_handles_midnight_utc(
+    notify_db_session,
+):
+    service_1 = create_service(service_name="service_1")
+    email_template = create_template(service=service_1, template_type=EMAIL_TYPE)
+
+    # create notifications that should not be included in count
+    create_ft_notification_status(date(2018, 10, 29), "email", service_1, count=30)
+    save_notification(create_notification(email_template, created_at=datetime(2018, 10, 30, 11, 59, 59), status="delivered"))
+
+    # create notifications that should be included in count
+    save_notification(create_notification(email_template, created_at=datetime(2018, 10, 31, 13, 0, 0), status="delivered"))
+    save_notification(create_notification(email_template, created_at=datetime(2018, 10, 31, 1, 0, 0), status="delivered"))
+
+    # checking the daily stats for this day should give us the 2 created after 12am UTC
+    results = sorted(
+        fetch_notification_status_for_service_for_today_and_7_previous_days(service_1.id, limit_days=1),
+        key=lambda x: (x.notification_type, x.status),
+    )
+
+    assert results[0][2] == 2
+
+    # checking the daily stats for the last 2 days should give us the 2 created after 12am UTC and the 1 from the day before
+    results = sorted(
+        fetch_notification_status_for_service_for_today_and_7_previous_days(service_1.id, limit_days=2),
+        key=lambda x: (x.notification_type, x.status),
+    )
+
+    assert results[0][2] == 3

--- a/tests/app/dao/test_fact_notification_status_dao.py
+++ b/tests/app/dao/test_fact_notification_status_dao.py
@@ -1150,9 +1150,11 @@ def test_fetch_notification_status_for_service_for_today_handles_midnight_utc(
     service_1 = create_service(service_name="service_1")
     email_template = create_template(service=service_1, template_type=EMAIL_TYPE)
 
-    # create notifications that should not be included in count
+    # create notifications that should not be included in today's count
     create_ft_notification_status(date(2018, 10, 29), "email", service_1, count=30)
+    save_notification(create_notification(email_template, created_at=datetime(2018, 10, 30, 23, 59, 59), status="delivered"))
     save_notification(create_notification(email_template, created_at=datetime(2018, 10, 30, 11, 59, 59), status="delivered"))
+    save_notification(create_notification(email_template, created_at=datetime(2018, 10, 29, 11, 59, 59), status="delivered"))
 
     # create notifications that should be included in count
     save_notification(create_notification(email_template, created_at=datetime(2018, 10, 31, 13, 0, 0), status="delivered"))
@@ -1172,4 +1174,4 @@ def test_fetch_notification_status_for_service_for_today_handles_midnight_utc(
         key=lambda x: (x.notification_type, x.status),
     )
 
-    assert results[0][2] == 3
+    assert results[0][2] == 4


### PR DESCRIPTION
# Summary | Résumé

This PR fixes the daily stats query to use midnight UTC which aligns with the way we handle daily limits.