### PR TITLE
use config variable for deliver_sms rate limiting

### DIFF
--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -4,7 +4,7 @@ from notifications_utils.statsd_decorators import statsd
 from sqlalchemy.orm.exc import NoResultFound
 
 from app import notify_celery
-from app.config import QueueNames
+from app.config import Config, QueueNames
 from app.dao import notifications_dao
 from app.dao.notifications_dao import update_notification_status_by_id
 from app.delivery import send_to_providers
@@ -47,7 +47,7 @@ def deliver_throttled_sms(self, notification_id):
     name="deliver_sms",
     max_retries=48,
     default_retry_delay=300,
-    rate_limit="1/s",
+    rate_limit=Config.CELERY_DELIVER_SMS_RATE_LIMIT,
 )
 @statsd(namespace="tasks")
 def deliver_sms(self, notification_id):

--- a/app/config.py
+++ b/app/config.py
@@ -507,6 +507,7 @@ class Config(object):
         # },
     }
     CELERY_QUEUES: List[Any] = []
+    CELERY_DELIVER_SMS_RATE_LIMIT = os.getenv("CELERY_DELIVER_SMS_RATE_LIMIT", "1/s")
 
     CONTACT_FORM_EMAIL_ADDRESS = os.getenv("CONTACT_FORM_EMAIL_ADDRESS", "helpdesk@cds-snc.ca")
 


### PR DESCRIPTION
# Summary | Résumé

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/80

make the celery worker rate limit for `deliver_sms` a config variable so we can keep prod as it is while we play with staging.

# Test instructions | Instructions pour tester la modification

- make sure sms still send
- run another `INTERNAL_TEST_NUMBER` perf test in staging and verify that using the default we still get approx 3 sms / sec


