### PR TITLE
Handle the `UnsupportedMediaType` error

### DIFF
--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -251,6 +251,11 @@ def post_notification(notification_type: NotificationType):
             message="Error decoding arguments: {}".format(e.description),
             status_code=400,
         )
+    except werkzeug.exceptions.UnsupportedMediaType as e:
+        raise BadRequestError(
+            message="UnsupportedMediaType error: {}".format(e.description),
+            status_code=415,
+        )
 
     if notification_type == EMAIL_TYPE:
         form = validate(request_json, post_email_request)

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -161,6 +161,11 @@ def post_bulk():
         request_json = request.get_json()
     except werkzeug.exceptions.BadRequest as e:
         raise BadRequestError(message=f"Error decoding arguments: {e.description}", status_code=400)
+    except werkzeug.exceptions.UnsupportedMediaType as e:
+        raise BadRequestError(
+            message="UnsupportedMediaType error: {}".format(e.description),
+            status_code=415,
+        )
 
     max_rows = current_app.config["CSV_MAX_ROWS"]
     epoch_seeding_bounce = current_app.config["FF_BOUNCE_RATE_SEED_EPOCH_MS"]


### PR DESCRIPTION
# Summary | Résumé

This PR adds error handling so that we don't cause a 500 error when and API caller doesn't set the `Content-Type` header to `application/json`. You can reproduce the error on staging with the following command:
```
curl -i -X POST \
   -H "Authorization:ApiKey-v1  gcntfy-talend_key-3********" \
   -H "Content-Type:" \
   -d \
'{
  "email_address": "stephen.astels@cds-snc.ca",
  "template_id": "eb3a6c36-2e4d-4e55-9e25-ed4b314ff3e9",
  "personalisation": {
        "var": "test /email"
    }
}' \
 'https://api.staging.notification.cdssandbox.xyz/v2/notifications/email'
```

# Test instructions | Instructions pour tester la modification

Check out this branch locally and try the above curl command. You should get a 415 error back now instead of a 500 error.