### PR TITLE
increase concurrency on staging sms celery pods

### DIFF
--- a/scripts/run_celery_send_sms.sh
+++ b/scripts/run_celery_send_sms.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-echo "Start celery, concurrency: ${CELERY_CONCURRENCY-4}"
+echo "Start celery, concurrency: 6"
 
 # TODO: we shouldn't be using the send-sms-tasks queue anymore - once we verify this we can remove it
-celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency=${CELERY_CONCURRENCY-4} -Q send-sms-tasks,send-sms-high,send-sms-medium,send-sms-low
+celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency=6 -Q send-sms-tasks,send-sms-high,send-sms-medium,send-sms-low


### PR DESCRIPTION
# Summary | Résumé

Bump up the concurrency on the sms-send celery pods from 4 to 6 to try to get them to do more work.

Note that these pods / script are currently only in staging.
