### PR TITLE
Encoding unicode in "friendly-from" field

### DIFF
--- a/app/clients/email/aws_ses.py
+++ b/app/clients/email/aws_ses.py
@@ -2,14 +2,12 @@ from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from time import monotonic
-import base64
 
 import boto3
 import botocore
 from flask import current_app
 from notifications_utils.recipients import InvalidEmailError
 from notifications_utils.statsd_decorators import statsd
-# from unidecode import unidecode
 
 from app.clients.email import EmailClient, EmailClientException
 
@@ -64,8 +62,6 @@ class AwsSesClient(EmailClient):
         attachments = attachments or []
         if isinstance(to_addresses, str):
             to_addresses = [to_addresses]
-        # TODO: fix this to allow accents
-        # source = base64.b64encode(bytes(source, "utf-8"))
 
         reply_to_addresses = [reply_to_address] if reply_to_address else []
 
@@ -104,10 +100,8 @@ class AwsSesClient(EmailClient):
                 msg.attach(attachment_part)
 
             start_time = monotonic()
-            response = self._client.send_raw_email(RawMessage={"Data": msg.as_string()})
+            response = self._client.send_raw_email(Source=source, RawMessage={"Data": msg.as_string()})
         except botocore.exceptions.ClientError as e:
-            # got an error here using a service with accents in the name
-            
             self.statsd_client.incr("clients.ses.error")
 
             # http://docs.aws.amazon.com/ses/latest/DeveloperGuide/api-error-codes.html

--- a/app/clients/email/aws_ses.py
+++ b/app/clients/email/aws_ses.py
@@ -2,13 +2,14 @@ from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from time import monotonic
+import base64
 
 import boto3
 import botocore
 from flask import current_app
 from notifications_utils.recipients import InvalidEmailError
 from notifications_utils.statsd_decorators import statsd
-from unidecode import unidecode
+# from unidecode import unidecode
 
 from app.clients.email import EmailClient, EmailClientException
 
@@ -63,7 +64,9 @@ class AwsSesClient(EmailClient):
         attachments = attachments or []
         if isinstance(to_addresses, str):
             to_addresses = [to_addresses]
-        source = unidecode(source)
+        # TODO: fix this to allow accents
+        # source = base64.b64encode(bytes(source, "utf-8"))
+
         reply_to_addresses = [reply_to_address] if reply_to_address else []
 
         # - If sending a TXT email without attachments:
@@ -101,8 +104,10 @@ class AwsSesClient(EmailClient):
                 msg.attach(attachment_part)
 
             start_time = monotonic()
-            response = self._client.send_raw_email(Source=source, RawMessage={"Data": msg.as_string()})
+            response = self._client.send_raw_email(RawMessage={"Data": msg.as_string()})
         except botocore.exceptions.ClientError as e:
+            # got an error here using a service with accents in the name
+            
             self.statsd_client.incr("clients.ses.error")
 
             # http://docs.aws.amazon.com/ses/latest/DeveloperGuide/api-error-codes.html

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -187,7 +187,7 @@ def check_service_over_bounce_rate(service_id: str):
         )
 
 
-def mime_encoded_word_syntax(charset="utf-8", encoding="B", encoded_text="") -> str:
+def mime_encoded_word_syntax(encoded_text="", charset="utf-8", encoding="B") -> str:
     """MIME encoded-word syntax is a way to encode non-ASCII characters in email headers.
     It is described here:
     https://docs.aws.amazon.com/ses/latest/dg/send-email-raw.html#send-email-mime-encoding-headers
@@ -205,7 +205,7 @@ def get_from_address(friendly_from: str, email_from: str, sending_domain: str) -
     name using MIME encoded-word syntax, as described in Sending raw email using the Amazon SES API."
     """
     friendly_from_b64 = base64.b64encode(friendly_from.encode()).decode("utf-8")
-    friendly_from_mime = mime_encoded_word_syntax(charset="utf-8", encoding="B", encoded_text=friendly_from_b64)
+    friendly_from_mime = mime_encoded_word_syntax(encoded_text=friendly_from_b64, charset="utf-8", encoding="B")
     return f'"{friendly_from_mime}" <{unidecode(email_from)}@{unidecode(sending_domain)}>'
 
 

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -1221,3 +1221,17 @@ class TestBounceRate:
             mock_logger = mocker.patch("app.notifications.validators.current_app.logger.warning")
             assert send_to_providers.check_service_over_bounce_rate(fake_uuid) is None
             mock_logger.assert_not_called()
+
+
+@pytest.mark.parametrize("encoded_text, charset, encoding, expected", 
+    [
+        ("hello_world", "utf-8", "B", "=?utf-8?B?hello_world?="),
+        ("hello_world", "utf-8", "Q", "=?utf-8?Q?hello_world?="),
+        ("hello_world2", "utf-8", "B", "=?utf-8?B?hello_world2?="),
+    ],
+)
+def test_mime_encoded_word_syntax_encoding(encoded_text, charset, encoding, expected):
+        result = send_to_providers.mime_encoded_word_syntax(
+            encoded_text=encoded_text, charset=charset, encoding=encoding
+        )
+        assert result ==  expected

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -153,7 +153,7 @@ def test_should_send_personalised_template_to_correct_email_provider_and_persist
     send_to_providers.send_email_to_provider(db_notification)
 
     app.aws_ses_client.send_email.assert_called_once_with(
-        '"Sample service" <sample.service@notification.canada.ca>',
+        '"=?utf-8?B?U2FtcGxlIHNlcnZpY2U=?=" <sample.service@notification.canada.ca>',
         "jo.smith@example.com",
         "Jo <em>some HTML</em>",
         body="Hello Jo\nThis is an email from GOV.\u200bUK with <em>some HTML</em>\n",
@@ -244,7 +244,7 @@ def test_should_respect_custom_sending_domains(sample_service, mocker, sample_em
     send_to_providers.send_email_to_provider(db_notification)
 
     app.aws_ses_client.send_email.assert_called_once_with(
-        '"Sample service" <sample.service@foo.bar>',
+        '"=?utf-8?B?U2FtcGxlIHNlcnZpY2U=?=" <sample.service@foo.bar>',
         "jo.smith@example.com",
         "Jo <em>some HTML</em>",
         body="Hello Jo\nThis is an email from GOV.\u200bUK with <em>some HTML</em>\n",


### PR DESCRIPTION
# Summary | Résumé

This PR changes the way we are encoding the "friendly from" field in the email headers, so that we can include non-ascii characters that show up in service names. The AWS documentation provided examples of how to do this. There are 2 steps:
1. encode the utf-8 characters as base64
2. replace the ascii-encoded "friendly from" field with "MIME encoded-word syntax" that includes the base64 encoded string

Here is a link to [the AWS docs](https://docs.aws.amazon.com/ses/latest/dg/send-email-raw.html#send-email-mime-encoding-headers) that I used.

# Test instructions | Instructions pour tester la modification

Reproduce the bug:
1. log into staging
4. visit your service settings page
5. change the name of your service to `Accent service èé ÀÂËÎÏÔŒÙÛâçêëîïôœû`
6. send an email to yourself 
7. observe that the accents are missing from the "friendly from" part of the the email: 
<img width="1075" alt="Screenshot 2023-09-26 at 10 27 55 AM" src="https://github.com/cds-snc/notification-api/assets/5498428/34867b71-aad2-49ca-9a17-3f57f534b6de">


Test the fix:
1. Check out this branch and run the api locally
2. connect the locally running admin
3. log in and visit your service page
4. change the name of your service to `Accent service èé ÀÂËÎÏÔŒÙÛâçêëîïôœû`
4. send an email to yourself 
5. observe that the accents are displayed correctly from the "friendly from" part of the the email: 
<img width="1178" alt="Screenshot 2023-09-26 at 10 33 02 AM" src="https://github.com/cds-snc/notification-api/assets/5498428/d5356477-9a7d-4052-9c0e-cde109100803">
