### PR TITLE
Adding a check to wait for cwagent before starting

### DIFF
--- a/scripts/run_celery.sh
+++ b/scripts/run_celery.sh
@@ -2,7 +2,28 @@
 
 # runs celery with all celery queues except the throtted sms queue
 
+init()
+{
+    # Wait for cwagent to become available.
+
+    while :
+    do
+        if  nc -vz $STATSD_HOST 25888; then
+            echo "CWAgent is Ready."
+            break;
+        else
+            echo "Waiting for CWAgent to become ready."
+            sleep 1
+        fi
+    done
+}
+
 set -e
+
+# Check and see if this is running in K8s and if so, wait for cloudwatch agent
+if [[ -z "${STATSD_HOST}" ]]; then
+    init
+fi
 
 echo "Start celery, concurrency: ${CELERY_CONCURRENCY-4}"
 

--- a/scripts/run_celery_no_sms_sending.sh
+++ b/scripts/run_celery_no_sms_sending.sh
@@ -1,8 +1,30 @@
 #!/bin/sh
 
+# runs celery with only the throttled sms sending queue
+
+init()
+{
+     # Wait for cwagent to become available.   
+    while :
+    do
+        if  nc -vz $STATSD_HOST 25888; then
+            echo "CWAgent is Ready."
+            break;
+        else
+            echo "Waiting for CWAgent to become ready."
+            sleep 1
+        fi
+    done
+}
+
 # runs celery with all celery queues except send-throttled-sms-tasks, send-sms-tasks, send-sms-high, send-sms-medium, or send-sms-low
 
 set -e
+
+# Check and see if this is running in K8s and if so, wait for cloudwatch agent
+if [[ -z "${STATSD_HOST}" ]]; then
+    init
+fi
 
 echo "Start celery, concurrency: ${CELERY_CONCURRENCY-4}"
 

--- a/scripts/run_celery_send_sms.sh
+++ b/scripts/run_celery_send_sms.sh
@@ -2,7 +2,26 @@
 
 # runs celery with only the send-sms-* queues
 
+init()
+{
+     # Wait for cwagent to become available.   
+    while :
+    do
+        if  nc -vz $STATSD_HOST 25888; then
+            echo "CWAgent is Ready."
+            break;
+        else
+            echo "Waiting for CWAgent to become ready."
+            sleep 1
+        fi
+    done
+}
+
 set -e
+
+if [[ -z "${STATSD_HOST}" ]]; then
+    init
+fi
 
 echo "Start celery, concurrency: ${CELERY_CONCURRENCY-4}"
 

--- a/scripts/run_celery_sms.sh
+++ b/scripts/run_celery_sms.sh
@@ -2,6 +2,26 @@
 
 # runs celery with only the throttled sms sending queue
 
+init()
+{
+     # Wait for cwagent to become available.   
+    while :
+    do
+        if  nc -vz $STATSD_HOST 25888; then
+            echo "CWAgent is Ready."
+            break;
+        else
+            echo "Waiting for CWAgent to become ready."
+            sleep 1
+        fi
+    done
+}
+
 set -e
+
+# Check and see if this is running in K8s and if so, wait for cloudwatch agent
+if [[ -z "${STATSD_HOST}" ]]; then
+    init
+fi
 
 celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=1 -Q send-throttled-sms-tasks


### PR DESCRIPTION
# Summary | Résumé

This PR will implement a status check on the CWAgent in Kubernetes before starting celery. This is required to alleviate a race condition between CWAgent and Celery when starting up on an autoscaled node.

# Test instructions | Instructions pour tester la modification

- Deploy on staging
- Run several load tests in staging to see if we get any alerts re: race condition

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their
review | Voici une suggestion de liste de vérification comprenant des questions
que les réviseurs pourraient poser pendant leur examen :


- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne
      une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une
      fonctionnalité existante?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une
      modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des
      préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de
      façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de
      risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README
      setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce
      changement (fichier README, etc.)?
