### PR TITLE
Celery init fix

### DIFF
--- a/scripts/run_celery.sh
+++ b/scripts/run_celery.sh
@@ -5,7 +5,7 @@
 set -e
 
 # Check and see if this is running in K8s and if so, wait for cloudwatch agent
-if [[ -z "${STATSD_HOST}" ]]; then
+if [[ ! -z "${STATSD_HOST}" ]]; then
     echo "Initializing... Waiting for CWAgent to become ready."
     while :
     do

--- a/scripts/run_celery.sh
+++ b/scripts/run_celery.sh
@@ -10,10 +10,10 @@ if [[ -z "${STATSD_HOST}" ]]; then
     while :
     do
         if  nc -vz $STATSD_HOST 25888; then
-            echo "CWAgent is Ready." > /dev/stderr
+            echo "CWAgent is Ready."
             break;
         else
-            echo "Waiting for CWAgent to become ready." > /dev/stderr
+            echo "Waiting for CWAgent to become ready."
             sleep 1
         fi
     done

--- a/scripts/run_celery.sh
+++ b/scripts/run_celery.sh
@@ -2,27 +2,21 @@
 
 # runs celery with all celery queues except the throtted sms queue
 
-init()
-{
-    # Wait for cwagent to become available.
-
-    while :
-    do
-        if  nc -vz $STATSD_HOST 25888; then
-            echo "CWAgent is Ready."
-            break;
-        else
-            echo "Waiting for CWAgent to become ready."
-            sleep 1
-        fi
-    done
-}
-
 set -e
 
 # Check and see if this is running in K8s and if so, wait for cloudwatch agent
 if [[ -z "${STATSD_HOST}" ]]; then
-    init
+    echo "Initializing... Waiting for CWAgent to become ready."
+    while :
+    do
+        if  nc -vz $STATSD_HOST 25888; then
+            echo "CWAgent is Ready." > /dev/stderr
+            break;
+        else
+            echo "Waiting for CWAgent to become ready." > /dev/stderr
+            sleep 1
+        fi
+    done
 fi
 
 echo "Start celery, concurrency: ${CELERY_CONCURRENCY-4}"

--- a/scripts/run_celery_no_sms_sending.sh
+++ b/scripts/run_celery_no_sms_sending.sh
@@ -2,28 +2,23 @@
 
 # runs celery with only the throttled sms sending queue
 
-init()
-{
-     # Wait for cwagent to become available.   
-    while :
-    do
-        if  nc -vz $STATSD_HOST 25888; then
-            echo "CWAgent is Ready."
-            break;
-        else
-            echo "Waiting for CWAgent to become ready."
-            sleep 1
-        fi
-    done
-}
-
 # runs celery with all celery queues except send-throttled-sms-tasks, send-sms-tasks, send-sms-high, send-sms-medium, or send-sms-low
 
 set -e
 
 # Check and see if this is running in K8s and if so, wait for cloudwatch agent
 if [[ -z "${STATSD_HOST}" ]]; then
-    init
+    echo "Initializing... Waiting for CWAgent to become ready."
+    while :
+    do
+        if  nc -vz $STATSD_HOST 25888; then
+            echo "CWAgent is Ready." > /dev/stderr
+            break;
+        else
+            echo "Waiting for CWAgent to become ready." > /dev/stderr
+            sleep 1
+        fi
+    done
 fi
 
 echo "Start celery, concurrency: ${CELERY_CONCURRENCY-4}"

--- a/scripts/run_celery_no_sms_sending.sh
+++ b/scripts/run_celery_no_sms_sending.sh
@@ -7,7 +7,7 @@
 set -e
 
 # Check and see if this is running in K8s and if so, wait for cloudwatch agent
-if [[ -z "${STATSD_HOST}" ]]; then
+if [[ ! -z "${STATSD_HOST}" ]]; then
     echo "Initializing... Waiting for CWAgent to become ready."
     while :
     do
@@ -18,8 +18,7 @@ if [[ -z "${STATSD_HOST}" ]]; then
             echo "Waiting for CWAgent to become ready."
             sleep 1
         fi
-    done
-fi
+    done fi
 
 echo "Start celery, concurrency: ${CELERY_CONCURRENCY-4}"
 

--- a/scripts/run_celery_no_sms_sending.sh
+++ b/scripts/run_celery_no_sms_sending.sh
@@ -12,10 +12,10 @@ if [[ -z "${STATSD_HOST}" ]]; then
     while :
     do
         if  nc -vz $STATSD_HOST 25888; then
-            echo "CWAgent is Ready." > /dev/stderr
+            echo "CWAgent is Ready."
             break;
         else
-            echo "Waiting for CWAgent to become ready." > /dev/stderr
+            echo "Waiting for CWAgent to become ready."
             sleep 1
         fi
     done

--- a/scripts/run_celery_send_sms.sh
+++ b/scripts/run_celery_send_sms.sh
@@ -8,10 +8,10 @@ if [[ -z "${STATSD_HOST}" ]]; then
     while :
     do
         if  nc -vz $STATSD_HOST 25888; then
-            echo "CWAgent is Ready." > /dev/stderr
+            echo "CWAgent is Ready."
             break;
         else
-            echo "Waiting for CWAgent to become ready." > /dev/stderr
+            echo "Waiting for CWAgent to become ready."
             sleep 1
         fi
     done

--- a/scripts/run_celery_send_sms.sh
+++ b/scripts/run_celery_send_sms.sh
@@ -3,7 +3,7 @@
 # runs celery with only the send-sms-* queues
 set -e
 
-if [[ -z "${STATSD_HOST}" ]]; then
+if [[ ! -z "${STATSD_HOST}" ]]; then
     echo "Initializing... Waiting for CWAgent to become ready."
     while :
     do

--- a/scripts/run_celery_send_sms.sh
+++ b/scripts/run_celery_send_sms.sh
@@ -1,26 +1,20 @@
 #!/bin/sh
 
 # runs celery with only the send-sms-* queues
-
-init()
-{
-     # Wait for cwagent to become available.   
-    while :
-    do
-        if  nc -vz $STATSD_HOST 25888; then
-            echo "CWAgent is Ready."
-            break;
-        else
-            echo "Waiting for CWAgent to become ready."
-            sleep 1
-        fi
-    done
-}
-
 set -e
 
 if [[ -z "${STATSD_HOST}" ]]; then
-    init
+    echo "Initializing... Waiting for CWAgent to become ready."
+    while :
+    do
+        if  nc -vz $STATSD_HOST 25888; then
+            echo "CWAgent is Ready." > /dev/stderr
+            break;
+        else
+            echo "Waiting for CWAgent to become ready." > /dev/stderr
+            sleep 1
+        fi
+    done
 fi
 
 echo "Start celery, concurrency: ${CELERY_CONCURRENCY-4}"

--- a/scripts/run_celery_sms.sh
+++ b/scripts/run_celery_sms.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-if [[ -z "${STATSD_HOST}" ]]; then
+if [[ ! -z "${STATSD_HOST}" ]]; then
     echo "Initializing... Waiting for CWAgent to become ready."
     while :
     do

--- a/scripts/run_celery_sms.sh
+++ b/scripts/run_celery_sms.sh
@@ -9,10 +9,10 @@ if [[ -z "${STATSD_HOST}" ]]; then
     while :
     do
         if  nc -vz $STATSD_HOST 25888; then
-            echo "CWAgent is Ready." > /dev/stderr
+            echo "CWAgent is Ready."
             break;
         else
-            echo "Waiting for CWAgent to become ready." > /dev/stderr
+            echo "Waiting for CWAgent to become ready."
             sleep 1
         fi
     done

--- a/scripts/run_celery_sms.sh
+++ b/scripts/run_celery_sms.sh
@@ -2,26 +2,20 @@
 
 # runs celery with only the throttled sms sending queue
 
-init()
-{
-     # Wait for cwagent to become available.   
+set -e
+
+if [[ -z "${STATSD_HOST}" ]]; then
+    echo "Initializing... Waiting for CWAgent to become ready."
     while :
     do
         if  nc -vz $STATSD_HOST 25888; then
-            echo "CWAgent is Ready."
+            echo "CWAgent is Ready." > /dev/stderr
             break;
         else
-            echo "Waiting for CWAgent to become ready."
+            echo "Waiting for CWAgent to become ready." > /dev/stderr
             sleep 1
         fi
     done
-}
-
-set -e
-
-# Check and see if this is running in K8s and if so, wait for cloudwatch agent
-if [[ -z "${STATSD_HOST}" ]]; then
-    init
 fi
 
 celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=1 -Q send-throttled-sms-tasks


### PR DESCRIPTION
# Summary | Résumé

I had the run init condition backwards in the if statement. Need to run if the value is not empty, not if it is empty.