### PR TITLE
add index for notification history

### DIFF
--- a/migrations/versions/0439_add_index_n_history.py
+++ b/migrations/versions/0439_add_index_n_history.py
@@ -1,0 +1,23 @@
+"""
+
+Revision ID: 0439_add_index_n_history
+Revises: 0438_sms_templates_msgs_left
+Create Date: 2023-10-05 00:00:00
+
+"""
+from datetime import datetime
+
+from alembic import op
+from flask import current_app
+
+revision = "0439_add_index_n_history"
+down_revision = "0438_sms_templates_msgs_left"
+
+# option 1
+def upgrade():
+    op.execute("COMMIT")
+    op.create_index(op.f("ix_notification_history_created_by_id"), "notification_history", ["created_by_id"], postgresql_concurrently=True)
+
+
+def downgrade():
+    op.drop_index(op.f("ix_notification_history_created_by_id"), table_name="notification_history")

--- a/migrations/versions/0439_add_index_n_history.py
+++ b/migrations/versions/0439_add_index_n_history.py
@@ -8,7 +8,6 @@ Create Date: 2023-10-05 00:00:00
 from datetime import datetime
 
 from alembic import op
-from flask import current_app
 
 revision = "0439_add_index_n_history"
 down_revision = "0438_sms_templates_msgs_left"

--- a/migrations/versions/0439_add_index_n_history.py
+++ b/migrations/versions/0439_add_index_n_history.py
@@ -12,10 +12,13 @@ from alembic import op
 revision = "0439_add_index_n_history"
 down_revision = "0438_sms_templates_msgs_left"
 
+
 # option 1
 def upgrade():
     op.execute("COMMIT")
-    op.create_index(op.f("ix_notification_history_created_by_id"), "notification_history", ["created_by_id"], postgresql_concurrently=True)
+    op.create_index(
+        op.f("ix_notification_history_created_by_id"), "notification_history", ["created_by_id"], postgresql_concurrently=True
+    )
 
 
 def downgrade():


### PR DESCRIPTION
# Summary | Résumé

Need to use the notification history table in the data portage. As I am getting the created_by_id - it is v v slow.
Added an index so filtering should be faster. Tested locally

```
   "ix_nh_created_by_id" btree (created_by_id)
    "ix_notification_history_api_key_id" btree (api_key_id)
    "ix_notification_history_created_at" btree (created_at)
```