### PR TITLE
Adding cwagent wait script to all celery launchers

### DIFF
--- a/scripts/run_celery_beat.sh
+++ b/scripts/run_celery_beat.sh
@@ -4,4 +4,20 @@
 
 set -e
 
+# Check and see if this is running in K8s and if so, wait for cloudwatch agent
+if [[ ! -z "${STATSD_HOST}" ]]; then
+
+    echo "Initializing... Waiting for CWAgent to become ready."
+    while :
+    do
+        if  nc -vz $STATSD_HOST 25888; then
+            echo "CWAgent is Ready."
+            break;
+        else
+            echo "Waiting for CWAgent to become ready."
+            sleep 1
+        fi
+    done
+fi
+
 celery -A run_celery.notify_celery beat --loglevel=INFO

--- a/scripts/run_celery_core_tasks.sh
+++ b/scripts/run_celery_core_tasks.sh
@@ -4,6 +4,22 @@
 
 set -e
 
+# Check and see if this is running in K8s and if so, wait for cloudwatch agent
+if [[ ! -z "${STATSD_HOST}" ]]; then
+
+    echo "Initializing... Waiting for CWAgent to become ready."
+    while :
+    do
+        if  nc -vz $STATSD_HOST 25888; then
+            echo "CWAgent is Ready."
+            break;
+        else
+            echo "Waiting for CWAgent to become ready."
+            sleep 1
+        fi
+    done
+fi
+
 echo "Start celery, concurrency: ${CELERY_CONCURRENCY-4}"
 
 celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency=${CELERY_CONCURRENCY-4} -Q database-tasks,-priority-database-tasks.fifo,-normal-database-tasks,-bulk-database-tasks,job-tasks,notify-internal-tasks,periodic-tasks,priority-tasks,normal-tasks,bulk-tasks,reporting-tasks,research-mode-tasks,retry-tasks,service-callbacks,delivery-receipts

--- a/scripts/run_celery_send_email.sh
+++ b/scripts/run_celery_send_email.sh
@@ -4,6 +4,22 @@
 
 set -e
 
+# Check and see if this is running in K8s and if so, wait for cloudwatch agent
+if [[ ! -z "${STATSD_HOST}" ]]; then
+
+    echo "Initializing... Waiting for CWAgent to become ready."
+    while :
+    do
+        if  nc -vz $STATSD_HOST 25888; then
+            echo "CWAgent is Ready."
+            break;
+        else
+            echo "Waiting for CWAgent to become ready."
+            sleep 1
+        fi
+    done
+fi
+
 echo "Start celery, concurrency: ${CELERY_CONCURRENCY-4}"
 
 # TODO: we shouldn't be using the send-email-tasks queue anymore - once we verify this we can remove it


### PR DESCRIPTION
# Summary | Résumé

There were a few celery run scripts that weren't checking that cwagent was ready before launching.

# Test instructions | Instructions pour tester la modification

Deploy to staging
Ensure the waiting for cwagent line is in celery logs
Smoke test staging

