### PR TITLE
Remove server from response

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -2,7 +2,7 @@ import os
 import sys
 import traceback
 
-import gunicorn
+import gunicorn  # type: ignore
 import newrelic.agent  # See https://bit.ly/2xBVKBH
 
 newrelic.agent.initialize()  # noqa: E402

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -2,6 +2,7 @@ import os
 import sys
 import traceback
 
+import gunicorn
 import newrelic.agent  # See https://bit.ly/2xBVKBH
 
 newrelic.agent.initialize()  # noqa: E402
@@ -11,6 +12,8 @@ worker_class = "gevent"
 worker_connections = 256
 bind = "0.0.0.0:{}".format(os.getenv("PORT"))
 accesslog = "-"
+# Guincorn sets the server type on our app. We don't want to show it in the header in the response.
+gunicorn.SERVER = "Undisclosed"
 
 on_aws = os.environ.get("NOTIFY_ENVIRONMENT", "") in ["production", "staging", "scratch", "dev"]
 if on_aws:


### PR DESCRIPTION
# Summary | Résumé

Remove the server response. Tested this locally.

``` gunicorn -c gunicorn_config.py application```

you would need to bind the guincorn port to 6011 when testing locally

after
<img width="603" alt="Screenshot 2023-11-07 at 12 36 06 PM" src="https://github.com/cds-snc/notification-api/assets/8869623/fb297f31-fa9c-478a-834d-51786db4390d">

before
<img width="588" alt="Screenshot 2023-11-07 at 12 34 42 PM" src="https://github.com/cds-snc/notification-api/assets/8869623/cf867c2c-be37-4e89-9e00-f0fd801deccf">
