### PR TITLE
make perf test longer

### DIFF
--- a/tests-perf/locust/locust.conf
+++ b/tests-perf/locust/locust.conf
@@ -3,7 +3,7 @@ locustfile = tests-perf/locust/locust-notifications.py
 host = https://api.staging.notification.cdssandbox.xyz
 users = 3000
 spawn-rate = 20
-run-time = 5m
+run-time = 10m
 
 # headless = true
 # master = true


### PR DESCRIPTION
# Summary | Résumé

Looking at [this script](https://github.com/cds-snc/notification-api/blob/9cf34043b1a99136132926c2588f5fc908af55f0/bin/execute_and_publish_performance_test.sh#L9), I think the changes here will make the perf test run longer. This should allow the email deployment time to spin up to a sustained level.


# Test instructions | Instructions pour tester la modification

See what happens to the nightly perf tests?


