### PR TITLE
10m -> 20m perf test

### DIFF
--- a/tests-perf/locust/locust.conf
+++ b/tests-perf/locust/locust.conf
@@ -3,7 +3,7 @@ locustfile = tests-perf/locust/locust-notifications.py
 host = https://api.staging.notification.cdssandbox.xyz
 users = 3000
 spawn-rate = 20
-run-time = 10m
+run-time = 20m
 
 # headless = true
 # master = true


### PR DESCRIPTION
# Summary | Résumé

perf test running longer, but still hasn't gotten to levelling off.
![image](https://github.com/cds-snc/notification-api/assets/8228248/e534a785-5294-4d54-b053-ad60167f4570)

# Test instructions | Instructions pour tester la modification
check perf test after it runs