### PR TITLE
Remove redundant group by and add a composite index

### DIFF
--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -339,12 +339,13 @@ def get_last_send_for_api_key(api_key_id):
         .filter(Notification.api_key_id == api_key_id)
         .all()
     )
-    if not notification_table:
-        return (
+    if not notification_table[0][0]:
+        notification_table = (
             db.session.query(func.max(NotificationHistory.created_at).label("last_notification_created"))
             .filter(NotificationHistory.api_key_id == api_key_id)
             .all()
         )
+        notification_table = [] if notification_table[0][0] is None else notification_table
     return notification_table
 
 

--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -337,14 +337,12 @@ def get_last_send_for_api_key(api_key_id):
     notification_table = (
         db.session.query(func.max(Notification.created_at).label("last_notification_created"))
         .filter(Notification.api_key_id == api_key_id)
-        .group_by(Notification.api_key_id)
         .all()
     )
     if not notification_table:
         return (
             db.session.query(func.max(NotificationHistory.created_at).label("last_notification_created"))
             .filter(NotificationHistory.api_key_id == api_key_id)
-            .group_by(NotificationHistory.api_key_id)
             .all()
         )
     return notification_table

--- a/migrations/versions/0440_add_index_n_history_comp.py
+++ b/migrations/versions/0440_add_index_n_history_comp.py
@@ -1,0 +1,37 @@
+"""
+
+Revision ID: 0439_add_index_n_history
+Revises: 0438_sms_templates_msgs_left
+Create Date: 2023-10-05 00:00:00
+
+"""
+from datetime import datetime
+
+from alembic import op
+
+revision = "0440_add_index_n_history_2"
+down_revision = "0439_add_index_n_history"
+
+
+def index_exists(name):
+    connection = op.get_bind()
+    result = connection.execute(
+        "SELECT exists(SELECT 1 from pg_indexes where indexname = '{}') as ix_exists;".format(name)
+    ).first()
+    return result.ix_exists
+
+
+# option 1
+def upgrade():
+    op.execute("COMMIT")
+    if not index_exists("ix_notification_history_created_api_key_id"):
+        op.create_index(
+            op.f("ix_notification_history_created_api_key_id"),
+            "notification_history",
+            ["created_at", "api_key_id"],
+            postgresql_concurrently=True,
+        )
+
+
+def downgrade():
+    op.drop_index(op.f("ix_notification_history_created_api_key_id"), table_name="notification_history")


### PR DESCRIPTION
# Summary | Résumé

We are timing out when we go to the api key page for certain services.
We are running:
    -- SELECT max(created_at) as last_notification_created
    -- FROM notification_history
    -- WHERE api_key_id = xxx
   -- GROUP BY api_key_id;
and that takes a couple of seconds to return.
Just doing a count to see how many notifications get returned in for that api - key we are looking at : 6,728,109
Essentially we get 6mil rows back and then reorder them which is the problem. I will optimize this query by 1. removing the group by api_key_id (that doesnt do anything here) (this PR)
 and by adding a composite index on (created_at, api_key_id)
again as I am adding an index on a very large table - I expect our usual process to time out. I will add it manually with the OL this week

Added the composite index locally:
```
 feedback_type       | notification_feedback_types    |           |          | 
 feedback_subtype    | notification_feedback_subtypes |           |          | 
 ses_feedback_id     | character varying              |           |          | 
 ses_feedback_date   | timestamp without time zone    |           |          | 
Indexes:
    "notification_history_pkey" PRIMARY KEY, btree (id)
    "ix_n_history_created_by_id" btree (created_by_id)
    "ix_nh_created_by_id" btree (created_by_id)
    "ix_notification_history_api_key_id" btree (api_key_id)
    "ix_notification_history_created_api_key_id" btree (created_at, api_key_id)
    
    ```