### PR TITLE
Feat/notify user on apikey revoke

### DIFF
--- a/app/api_key/rest.py
+++ b/app/api_key/rest.py
@@ -74,7 +74,7 @@ def get_api_keys_ranked(n_days_back):
     return jsonify(data=data)
 
 
-def send_api_key_revokation_email(service_id, api_key_name, api_key_information):
+def send_api_key_revocation_email(service_id, api_key_name, api_key_information):
     service = dao_fetch_service_by_id(service_id)
     send_notification_to_service_users(
         service_id=service_id,
@@ -150,6 +150,6 @@ def revoke_api_keys():
     )
 
     # Step 4
-    send_api_key_revokation_email(api_key.service_id, api_key.name, api_key_data)
+    send_api_key_revocation_email(api_key.service_id, api_key.name, api_key_data)
 
     return jsonify(result="ok"), 201

--- a/app/config.py
+++ b/app/config.py
@@ -338,6 +338,7 @@ class Config(object):
     NEAR_DAILY_EMAIL_LIMIT_TEMPLATE_ID = "9aa60ad7-2d7f-46f0-8cbe-2bac3d4d77d8"
     REACHED_DAILY_EMAIL_LIMIT_TEMPLATE_ID = "ee036547-e51b-49f1-862b-10ea982cfceb"
     DAILY_EMAIL_LIMIT_UPDATED_TEMPLATE_ID = "97dade64-ea8d-460f-8a34-900b74ee5eb0"
+    APIKEY_REVOKE_TEMPLATE_ID = "a0a4e7b8-8a6a-4eaa-9f4e-9c3a5b2dbcf3"
 
     # Allowed service IDs able to send HTML through their templates.
     ALLOW_HTML_SERVICE_IDS: List[str] = [id.strip() for id in os.getenv("ALLOW_HTML_SERVICE_IDS", "").split(",")]

--- a/migrations/versions/0440_add_apikey_revoke_email.py
+++ b/migrations/versions/0440_add_apikey_revoke_email.py
@@ -13,6 +13,7 @@ down_revision = "0439_add_index_n_history"
 
 apikey_revoke_template_id = current_app.config["APIKEY_REVOKE_TEMPLATE_ID"]
 
+
 def upgrade():
     template_insert = """
         INSERT INTO templates (id, name, template_type, created_at, content, archived, service_id, subject,
@@ -24,7 +25,6 @@ def upgrade():
         created_by_id, version, process_type, hidden)
         VALUES ('{}', '{}', '{}', '{}', '{}', False, '{}', '{}', '{}', 1, '{}', false)
     """
-
 
     apikey_revoke_limit_content = "\n".join(
         [
@@ -55,7 +55,6 @@ def upgrade():
             "[[/fr]]",
         ]
     )
-
 
     templates = [
         {

--- a/migrations/versions/0440_add_apikey_revoke_email.py
+++ b/migrations/versions/0440_add_apikey_revoke_email.py
@@ -1,0 +1,104 @@
+"""
+Revision ID: 0440_add_apikey_revoke_email
+Revises: 0439_add_index_n_history
+Create Date: 2022-09-21 00:00:00
+"""
+from datetime import datetime
+
+from alembic import op
+from flask import current_app
+
+revision = "0440_add_apikey_revoke_email"
+down_revision = "0439_add_index_n_history"
+
+apikey_revoke_template_id = current_app.config["APIKEY_REVOKE_TEMPLATE_ID"]
+
+def upgrade():
+    template_insert = """
+        INSERT INTO templates (id, name, template_type, created_at, content, archived, service_id, subject,
+        created_by_id, version, process_type, hidden)
+        VALUES ('{}', '{}', '{}', '{}', '{}', False, '{}', '{}', '{}', 1, '{}', false)
+    """
+    template_history_insert = """
+        INSERT INTO templates_history (id, name, template_type, created_at, content, archived, service_id, subject,
+        created_by_id, version, process_type, hidden)
+        VALUES ('{}', '{}', '{}', '{}', '{}', False, '{}', '{}', '{}', 1, '{}', false)
+    """
+
+
+    apikey_revoke_limit_content = "\n".join(
+        [
+            "[[fr]]",
+            "(La version française suit)",
+            "[[/fr]]",
+            "",
+            "[[en]]",
+            "Hello,",
+            "",
+            "We discovered that an API key for service **''((service_name))''** is publicly available. GC Notify detected the key at ((public_location)). To protect GC Notify’s security, we revoked **''((key_name))''**.",
+            "",
+            "If you have questions or concerns, contact us.",
+            "",
+            "The GC Notify team",
+            "[[/en]]",
+            "",
+            "---",
+            "",
+            "[[fr]]",
+            "Bonjour,",
+            "",
+            "Nous avons découvert qu’une clé API du service **''((service_name))''** était à la disposition du public. Notification GC a détecté la clé à l’adresse suivante : ((public_location)). Pour la sécurité de Notification GC, nous avons révoqué **''((key_name))''**.",
+            "",
+            "Pour toutes questions, contactez-nous.",
+            "",
+            "L’équipe Notification GC",
+            "[[/fr]]",
+        ]
+    )
+
+
+    templates = [
+        {
+            "id": apikey_revoke_template_id,
+            "name": "API Key revoke EMAIL",
+            "subject": "We revoked your API key | Nous avons révoqué votre clé API",
+            "content": apikey_revoke_limit_content,
+        },
+    ]
+
+    for template in templates:
+        op.execute(
+            template_insert.format(
+                template["id"],
+                template["name"],
+                "email",
+                datetime.utcnow(),
+                template["content"],
+                current_app.config["NOTIFY_SERVICE_ID"],
+                template["subject"],
+                current_app.config["NOTIFY_USER_ID"],
+                "normal",
+            )
+        )
+
+        op.execute(
+            template_history_insert.format(
+                template["id"],
+                template["name"],
+                "email",
+                datetime.utcnow(),
+                template["content"],
+                current_app.config["NOTIFY_SERVICE_ID"],
+                template["subject"],
+                current_app.config["NOTIFY_USER_ID"],
+                "normal",
+            )
+        )
+
+
+def downgrade():
+    op.execute("DELETE FROM notifications WHERE template_id = '{}'".format(apikey_revoke_template_id))
+    op.execute("DELETE FROM notification_history WHERE template_id = '{}'".format(apikey_revoke_template_id))
+    op.execute("DELETE FROM template_redacted WHERE template_id = '{}'".format(apikey_revoke_template_id))
+    op.execute("DELETE FROM templates_history WHERE id = '{}'".format(apikey_revoke_template_id))
+    op.execute("DELETE FROM templates WHERE id = '{}'".format(apikey_revoke_template_id))

--- a/migrations/versions/0440_add_index_n_history_comp.py
+++ b/migrations/versions/0440_add_index_n_history_comp.py
@@ -9,7 +9,7 @@ from datetime import datetime
 
 from alembic import op
 
-revision = "0440_add_index_n_history_2"
+revision = "0440_add_index_n_history_comp"
 down_revision = "0439_add_index_n_history"
 
 

--- a/migrations/versions/0441_add_apikey_revoke_email.py
+++ b/migrations/versions/0441_add_apikey_revoke_email.py
@@ -1,6 +1,6 @@
 """
-Revision ID: 0440_add_apikey_revoke_email
-Revises: 0439_add_index_n_history
+Revision ID: 0441_add_apikey_revoke_email
+Revises: 0440_add_index_n_history_comp
 Create Date: 2022-09-21 00:00:00
 """
 from datetime import datetime
@@ -8,8 +8,8 @@ from datetime import datetime
 from alembic import op
 from flask import current_app
 
-revision = "0440_add_apikey_revoke_email"
-down_revision = "0439_add_index_n_history"
+revision = "0441_add_apikey_revoke_email"
+down_revision = "0440_add_index_n_history_comp"
 
 apikey_revoke_template_id = current_app.config["APIKEY_REVOKE_TEMPLATE_ID"]
 

--- a/tests/app/api_key/test_rest.py
+++ b/tests/app/api_key/test_rest.py
@@ -83,7 +83,9 @@ def test_get_api_keys_ranked(admin_request, notify_db, notify_db_session):
 
 
 class TestApiKeyRevocation:
-    def test_revoke_api_keys_with_valid_auth(self, client, notify_db, notify_db_session, mocker):
+    def test_revoke_api_keys_with_valid_auth_revokes_and_notifies_user(self, client, notify_db, notify_db_session, mocker):
+        notify_users = mocker.patch("app.api_key.rest.send_api_key_revocation_email")
+
         service = create_service(service_name="Service 1")
         api_key_1 = create_api_key(service, key_type=KEY_TYPE_NORMAL, key_name="Key 1")
         unsigned_secret = get_unsigned_secret(api_key_1.id)
@@ -103,6 +105,8 @@ class TestApiKeyRevocation:
         assert api_key_1.compromised_key_info["url"] == "https://example.com"
         assert api_key_1.compromised_key_info["source"] == "cds-tester"
         assert api_key_1.compromised_key_info["time_of_revocation"]
+
+        notify_users.assert_called_once()
 
     def test_revoke_api_keys_fails_with_no_auth(self, client, notify_db, notify_db_session, mocker):
         service = create_service(service_name="Service 1")


### PR DESCRIPTION
# Summary | Résumé

This PR finishes off the api key revoke method to notify service users when a key is automatically revoked.