### PR TITLE
Temporarily reverting perf test for a quiet weekend

### DIFF
--- a/tests-perf/locust/locust.conf
+++ b/tests-perf/locust/locust.conf
@@ -3,7 +3,7 @@ locustfile = tests-perf/locust/locust-notifications.py
 host = https://api.staging.notification.cdssandbox.xyz
 users = 3000
 spawn-rate = 20
-run-time = 20m
+run-time = 5m
 
 # headless = true
 # master = true


### PR DESCRIPTION
# Summary | Résumé

Temporarily reverting the nightly load test back to 5 minutes so that we can verify the autoscaling changes from this week.


# Test instructions | Instructions pour tester la modification

Verify nightly load test run.