### PR TITLE
Explicitly restarting deployments in staging and adding email celery

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -77,6 +77,16 @@ jobs:
         kubectl set image deployment.apps/celery-beat celery-beat=$DOCKER_SLUG:${GITHUB_SHA::7} -n=notification-canada-ca --kubeconfig=$HOME/.kube/config
         kubectl set image deployment.apps/celery-sms celery-sms=$DOCKER_SLUG:${GITHUB_SHA::7} -n=notification-canada-ca --kubeconfig=$HOME/.kube/config
         kubectl set image deployment.apps/celery-sms-send celery-sms-send=$DOCKER_SLUG:${GITHUB_SHA::7} -n=notification-canada-ca --kubeconfig=$HOME/.kube/config
+        kubectl set image deployment.apps/celery-email-send celery-sms-email=$DOCKER_SLUG:${GITHUB_SHA::7} -n=notification-canada-ca --kubeconfig=$HOME/.kube/config
+
+    - name: Restart deployments in staging
+      run: |
+        kubectl rollout restart deployment/api -n notification-canada-ca
+        kubectl rollout restart deployment/celery -n notification-canada-ca
+        kubectl rollout restart deployment/celery-beat -n notification-canada-ca
+        kubectl rollout restart deployment/celery-email-send -n notification-canada-ca
+        kubectl rollout restart deployment/celery-sms -n notification-canada-ca
+        kubectl rollout restart deployment/celery-sms-send -n notification-canada-ca
 
     - name: my-app-install token
       id: notify-pr-bot


### PR DESCRIPTION
# Summary | Résumé

I don't think that setting the image in deployment is a reliable way to get the deployment to restart. I've added a new build step that will explicitly restart the deployments

I've also added in celery-email-send as one of the deployment images to set and restart as it was missing.

