### PR TITLE
Move some verbose celery INFO-level logs to reduce log size

### DIFF
--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -63,7 +63,7 @@ SCAN_MAX_BACKOFF_RETRIES = 5
 @statsd(namespace="tasks")
 def deliver_email(self, notification_id):
     try:
-        current_app.logger.info("Start sending email for notification id: {}".format(notification_id))
+        current_app.logger.debug("Start sending email for notification id: {}".format(notification_id))
         notification = notifications_dao.get_notification_by_id(notification_id)
         if not notification:
             raise NoResultFound()

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -277,12 +277,12 @@ def save_smss(self, service_id: Optional[str], signed_notifications: List[Signed
     try:
         # If the data is not present in the encrypted data then fallback on whats needed for process_job.
         saved_notifications = persist_notifications(verified_notifications)
-        current_app.logger.info(
+        current_app.logger.debug(
             f"Saved following notifications into db: {notification_id_queue.keys()} associated with receipt {receipt}"
         )
         if receipt:
             acknowledge_receipt(SMS_TYPE, process_type, receipt)
-            current_app.logger.info(
+            current_app.logger.debug(
                 f"Batch saving: receipt_id {receipt} removed from buffer queue for notification_id {notification_id} for process_type {process_type}"
             )
         else:
@@ -297,7 +297,7 @@ def save_smss(self, service_id: Optional[str], signed_notifications: List[Signed
         signed_and_verified = list(zip(signed_notifications, verified_notifications))
         handle_batch_error_and_forward(self, signed_and_verified, SMS_TYPE, e, receipt, template)
 
-    current_app.logger.info(f"Sending following sms notifications to AWS: {notification_id_queue.keys()}")
+    current_app.logger.debug(f"Sending following sms notifications to AWS: {notification_id_queue.keys()}")
     for notification_obj in saved_notifications:
         try:
             if not current_app.config["FF_EMAIL_DAILY_LIMIT"]:
@@ -383,7 +383,7 @@ def save_emails(self, _service_id: Optional[str], signed_notifications: List[Sig
     try:
         # If the data is not present in the encrypted data then fallback on whats needed for process_job
         saved_notifications = persist_notifications(verified_notifications)
-        current_app.logger.info(
+        current_app.logger.debug(
             f"Saved following notifications into db: {notification_id_queue.keys()} associated with receipt {receipt}"
         )
         if receipt:
@@ -392,7 +392,7 @@ def save_emails(self, _service_id: Optional[str], signed_notifications: List[Sig
             # at this point in the code we have a list of notifications (saved_notifications)
             # which could use multiple templates
             acknowledge_receipt(EMAIL_TYPE, process_type, receipt)
-            current_app.logger.info(
+            current_app.logger.debug(
                 f"Batch saving: receipt_id {receipt} removed from buffer queue for notification_id {notification_id} for process_type {process_type}"
             )
         else:
@@ -415,7 +415,7 @@ def try_to_send_notifications_to_queue(notification_id_queue, service, saved_not
     Loop through saved_notifications, check if the service has hit their daily rate limit,
     and if not, call send_notification_to_queue on notification
     """
-    current_app.logger.info(f"Sending following email notifications to AWS: {notification_id_queue.keys()}")
+    current_app.logger.debug(f"Sending following email notifications to AWS: {notification_id_queue.keys()}")
     # todo: fix this potential bug
     # service is whatever it was set to last in the for loop above.
     # at this point in the code we have a list of notifications (saved_notifications)

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -174,7 +174,7 @@ def check_service_over_bounce_rate(service_id: str):
     bounce_rate = bounce_rate_client.get_bounce_rate(service_id)
     bounce_rate_status = bounce_rate_client.check_bounce_rate_status(service_id)
     debug_data = bounce_rate_client.get_debug_data(service_id)
-    current_app.logger.info(
+    current_app.logger.debug(
         f"Service id: {service_id} Bounce Rate: {bounce_rate} Bounce Status: {bounce_rate_status}, Debug Data: {debug_data}"
     )
     if bounce_rate_status == BounceRateStatus.CRITICAL.value:


### PR DESCRIPTION
# Summary | Résumé

Because we want to lower AWS CF costs and increase CW agent bandwidth on the K8s pods, this PR contains changes to demote redundant or unnecessary log messages currently set at INFO level into DEBUG level. 

* The list of notifications IDs that are processed and about to be sent to providers.
* The notification IDs that are saved into the database.
* The Celery task execution time: this one can be sensitive if we have a dashboard that builds a metric on top of this. I verified and didn't see any but that would require double verifications from a team members. 
* Bounce rate debug data.

This is a repeat of reverted PR #2019 but without the new statsd metrics, as this proved to be a breaking change once deployed in the staging environment. Hence this PR contains the safe changes that can have a positive impact on cost and will keep the statsd metrics changes in a different future PR.

# Test instructions | Instructions pour tester la modification

* Verify that the log output are invisible in staging environment.

# Release Instructions | Instructions pour le déploiement

None.

> Necessary steps to perform before and after the deployment of these changes.
> For example, emptying the cache on a feature that changes the cache data
> structure in Redis could be mentioned.

---

> Étapes nécessaires à exécuter avant et après le déploiement des changements
> introduits par cette proposition. Par exemple, vider la cache suite à des
> changements modifiant une structure de données de la cache pourrait être
> mentionné.

# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their
review | Voici une suggestion de liste de vérification comprenant des questions
que les réviseurs pourraient poser pendant leur examen :


- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne
      une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une
      fonctionnalité existante?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une
      modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des
      préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de
      façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de
      risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README
      setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce
      changement (fichier README, etc.)?
