### PR TITLE
Fix ses-process-results error handling

### DIFF
--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -30,6 +30,11 @@ from celery.exceptions import Retry
 )
 @statsd(namespace="tasks")
 def process_ses_results(self, response):
+    # initialize these to None so error handling is simpler
+    notification = None
+    reference = None
+    notification_status = None
+
     try:
         ses_message = json.loads(response["Message"])
         notification_type = ses_message["notificationType"]


### PR DESCRIPTION
# Summary | Résumé

Initialize variables at the start so that error handling is simplified and existence of variables doesn't need to be checked before logging.

