### PR TITLE
Add a further exception to process ses results

### DIFF
--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -29,7 +29,7 @@ from celery.exceptions import Retry
     default_retry_delay=300,
 )
 @statsd(namespace="tasks")
-def process_ses_results(self, response):
+def process_ses_results(self, response):  # noqa: C901
     # initialize these to None so error handling is simpler
     notification = None
     reference = None
@@ -55,6 +55,18 @@ def process_ses_results(self, response):
                 self.retry(queue=QueueNames.RETRY)
             except self.MaxRetriesExceededError:
                 current_app.logger.warning(f"notification not found for SES reference: {reference}. Giving up.")
+            return
+        except Exception as e:
+            try:
+                current_app.logger.warning(
+                    f"RETRY {self.request.retries}: notification not found for SES reference {reference}. "
+                    f"There was an Error: {e}. Adding task to retry queue"
+                )
+                self.retry(queue=QueueNames.RETRY)
+            except self.MaxRetriesExceededError:
+                current_app.logger.warning(
+                    f"notification not found for SES reference: {reference}. Error has persisted > number of retries. Giving up."
+                )
             return
 
         aws_response_dict = get_aws_responses(ses_message)


### PR DESCRIPTION
# Summary | Résumé

Add a further exception if the process_ses_results times out for different reasons.

Tested:
- added unit tests

https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1478