### PR TITLE
Added a last_used column for the api_key

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -918,6 +918,7 @@ class ApiKey(BaseModel, Versioned):
     created_by = db.relationship("User")
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), index=True, nullable=False)
     compromised_key_info = db.Column(JSONB(none_as_null=True), nullable=True, default={})
+    last_used_timestamp = db.Column(db.DateTime, index=False, unique=False, nullable=True, default=None)
 
     __table_args__ = (
         Index(

--- a/migrations/versions/0443_add_apikey_last_used_column.py
+++ b/migrations/versions/0443_add_apikey_last_used_column.py
@@ -1,0 +1,22 @@
+"""
+Revision ID: 0443_add_apikey_last_used_column
+Revises: 0442_add_heartbeat_templates
+Create Date: 2022-09-21 00:00:00
+"""
+from datetime import datetime
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0443_add_apikey_last_used_column"
+down_revision = "0442_add_heartbeat_templates"
+
+
+def upgrade():
+    op.add_column("api_keys", sa.Column("last_used_timestamp", sa.DateTime(), nullable=True))
+    op.add_column("api_keys_history", sa.Column("last_used_timestamp", sa.DateTime(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("api_keys", "last_used_timestamp")
+    op.drop_column("api_keys_history", "last_used_timestamp")

--- a/tests/app/dao/test_api_key_dao.py
+++ b/tests/app/dao/test_api_key_dao.py
@@ -35,6 +35,7 @@ def test_save_api_key_should_create_new_api_key_and_history(sample_service):
     assert len(all_api_keys) == 1
     assert all_api_keys[0] == api_key
     assert api_key.version == 1
+    assert api_key.last_used_timestamp is None
 
     all_history = api_key.get_history_model().query.all()
     assert len(all_history) == 1


### PR DESCRIPTION
# Summary | Résumé

Added a last_used column for api_key
https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1413

Tested locally by running the upgrade