### PR TITLE
Task/read from last used

### DIFF
--- a/app/dao/api_key_dao.py
+++ b/app/dao/api_key_dao.py
@@ -69,6 +69,13 @@ def expire_api_key(service_id, api_key_id):
 
 
 @transactional
+def update_last_used_api_key(api_key_id, last_used=None) -> None:
+    api_key = ApiKey.query.filter_by(id=api_key_id).one()
+    api_key.last_used_timestamp = last_used if last_used else datetime.utcnow()
+    db.session.add(api_key)
+
+
+@transactional
 @version_class(ApiKey)
 def update_compromised_api_key_info(service_id, api_key_id, compromised_info):
     api_key = ApiKey.query.filter_by(id=api_key_id, service_id=service_id).one()

--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -336,24 +336,37 @@ def get_total_notifications_sent_for_api_key(api_key_id):
 
 def get_last_send_for_api_key(api_key_id):
     """
+    SELECT last_used_timestamp as last_notification_created
+    FROM api_keys
+    WHERE id = 'api_key_id';
+
+    If last_used_timestamp is null, then check notifications table/ or notification_history.
     SELECT max(created_at) as last_notification_created
     FROM notifications
     WHERE api_key_id = 'api_key_id'
     GROUP BY api_key_id;
     """
-    notification_table = (
-        db.session.query(func.max(Notification.created_at).label("last_notification_created"))
-        .filter(Notification.api_key_id == api_key_id)
+    # Fetch last_used_timestamp from api_keys table
+    api_key_table = (
+        db.session.query(ApiKey.last_used_timestamp.label("last_notification_created"))
+        .filter(ApiKey.id == api_key_id)
         .all()
     )
-    if not notification_table[0][0]:
+    if not api_key_table[0][0]:
         notification_table = (
-            db.session.query(func.max(NotificationHistory.created_at).label("last_notification_created"))
-            .filter(NotificationHistory.api_key_id == api_key_id)
+            db.session.query(func.max(Notification.created_at).label("last_notification_created"))
+            .filter(Notification.api_key_id == api_key_id)
             .all()
         )
-        notification_table = [] if notification_table[0][0] is None else notification_table
-    return notification_table
+        if not notification_table[0][0]:
+            notification_table = (
+                db.session.query(func.max(NotificationHistory.created_at).label("last_notification_created"))
+                .filter(NotificationHistory.api_key_id == api_key_id)
+                .all()
+            )
+            notification_table = [] if notification_table[0][0] is None else notification_table
+        return notification_table
+    return api_key_table
 
 
 def get_api_key_ranked_by_notifications_created(n_days_back):

--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -348,9 +348,7 @@ def get_last_send_for_api_key(api_key_id):
     """
     # Fetch last_used_timestamp from api_keys table
     api_key_table = (
-        db.session.query(ApiKey.last_used_timestamp.label("last_notification_created"))
-        .filter(ApiKey.id == api_key_id)
-        .all()
+        db.session.query(ApiKey.last_used_timestamp.label("last_notification_created")).filter(ApiKey.id == api_key_id).all()
     )
     if not api_key_table[0][0]:
         notification_table = (

--- a/tests/app/dao/test_api_key_dao.py
+++ b/tests/app/dao/test_api_key_dao.py
@@ -14,6 +14,7 @@ from app.dao.api_key_dao import (
     resign_api_keys,
     save_model_api_key,
     update_compromised_api_key_info,
+    update_last_used_api_key,
 )
 from app.models import KEY_TYPE_NORMAL, ApiKey
 from tests.app.db import create_api_key
@@ -59,6 +60,17 @@ def test_expire_api_key_should_update_the_api_key_and_create_history_record(noti
     sorted_all_history = sorted(all_history, key=lambda hist: hist.version)
     sorted_all_history[0].version = 1
     sorted_all_history[1].version = 2
+
+
+def test_last_used_should_update_the_api_key_and_not_create_history_record(notify_api, sample_api_key):
+    last_used = datetime.utcnow()
+    update_last_used_api_key(api_key_id=sample_api_key.id, last_used=last_used)
+    all_api_keys = get_model_api_keys(service_id=sample_api_key.service_id)
+    assert len(all_api_keys) == 1
+    assert all_api_keys[0].last_used_timestamp == last_used
+
+    all_history = sample_api_key.get_history_model().query.all()
+    assert len(all_history) == 1
 
 
 def test_update_compromised_api_key_info_and_create_history_record(notify_api, sample_api_key):

--- a/tests/app/dao/test_fact_notification_status_dao.py
+++ b/tests/app/dao/test_fact_notification_status_dao.py
@@ -355,6 +355,15 @@ def test_get_total_notifications_sent_for_api_key(notify_db_session):
     api_key_stats_3 = get_total_notifications_sent_for_api_key(str(api_key.id))
     assert dict(api_key_stats_3) == dict([(EMAIL_TYPE, total_sends), (SMS_TYPE, total_sends)])
 
+def test_get_last_send_for_api_key_check_last_used(notify_db_session):
+    service = create_service(service_name="First Service")
+    api_key = create_api_key(service, last_used=datetime.utcnow())
+    template_email = create_template(service=service, template_type=EMAIL_TYPE)
+    total_sends = 10
+
+    last_send = get_last_send_for_api_key(str(api_key.id))[0][0]
+    assert last_send == api_key.last_used_timestamp
+
 
 def test_get_last_send_for_api_key(notify_db_session):
     service = create_service(service_name="First Service")

--- a/tests/app/dao/test_fact_notification_status_dao.py
+++ b/tests/app/dao/test_fact_notification_status_dao.py
@@ -355,11 +355,10 @@ def test_get_total_notifications_sent_for_api_key(notify_db_session):
     api_key_stats_3 = get_total_notifications_sent_for_api_key(str(api_key.id))
     assert dict(api_key_stats_3) == dict([(EMAIL_TYPE, total_sends), (SMS_TYPE, total_sends)])
 
+
 def test_get_last_send_for_api_key_check_last_used(notify_db_session):
     service = create_service(service_name="First Service")
     api_key = create_api_key(service, last_used=datetime.utcnow())
-    template_email = create_template(service=service, template_type=EMAIL_TYPE)
-    total_sends = 10
 
     last_send = get_last_send_for_api_key(str(api_key.id))[0][0]
     assert last_send == api_key.last_used_timestamp

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -551,7 +551,7 @@ def create_letter_rate(
     return rate
 
 
-def create_api_key(service, key_type=KEY_TYPE_NORMAL, key_name=None):
+def create_api_key(service, key_type=KEY_TYPE_NORMAL, key_name=None, last_used=None):
     id_ = uuid.uuid4()
 
     name = key_name if key_name else "{} api key {}".format(key_type, id_)
@@ -563,6 +563,7 @@ def create_api_key(service, key_type=KEY_TYPE_NORMAL, key_name=None):
         key_type=key_type,
         id=id_,
         secret=uuid.uuid4(),
+        last_used_timestamp=last_used,
     )
     db.session.add(api_key)
     db.session.commit()

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -19,6 +19,7 @@ from app.models import (
     LETTER_TYPE,
     NORMAL,
     PRIORITY,
+    ApiKey,
     Notification,
     NotificationHistory,
     ScheduledNotification,
@@ -432,6 +433,10 @@ class TestPersistNotification:
         assert persisted_notification[0].to == "foo@bar.com"
         assert persisted_notification[1].to == "foo2@bar.com"
         assert persisted_notification[0].service == sample_job.service
+
+        # Test that the api key last_used_timestamp got updated
+        api_key = ApiKey.query.get(sample_api_key.id)
+        assert api_key.last_used_timestamp is not None
 
     def test_persist_notifications_reply_to_text_is_original_value_if_sender_is_changed_later(
         self, sample_template, sample_api_key, mocker
@@ -913,6 +918,8 @@ class TestTransformNotification:
 
         assert persisted_notification.to == recipient
         assert persisted_notification.normalised_to == expected_recipient_normalised
+        api_key = ApiKey.query.get(sample_api_key.id)
+        assert api_key.last_used_timestamp is not None
 
 
 class TestDBSaveAndSendNotification:


### PR DESCRIPTION
# Summary | Résumé

We want to store the last time an api_key is used in the api_key table.
Changes made:
1. Add a function to update the api key last used timestamp
1. Update persist_notification and persist_notifications to store the last_used_timestamp
1. Change the get_last_used api_key to use the last_used_timestamp from the api_key table

Testing locally
1. Run the migration to add the last_used column (its on main already)
1. Check the api_key table for one of your services 
1. Send a message using an api_key, in your database you should see the `last_used_timestamp` for the api_key to be populated
<img width="852" alt="Screenshot 2024-01-23 at 2 53 21 PM" src="https://github.com/cds-snc/notification-api/assets/8869623/b3b691a7-4c90-4000-9366-eae0ecef10a6">


https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1413