### PR TITLE
Clean up celery config for beat schedule

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -438,87 +438,54 @@ class Config(object):
         # app/celery/nightly_tasks.py
         "timeout-sending-notifications": {
             "task": "timeout-sending-notifications",
-            "schedule": crontab(hour=0, minute=5),
+            "schedule": crontab(hour=5, minute=5),  # 00:05 EST in UTC
             "options": {"queue": QueueNames.PERIODIC},
         },
         "create-nightly-billing": {
             "task": "create-nightly-billing",
-            "schedule": crontab(hour=0, minute=15),
+            "schedule": crontab(hour=5, minute=15),  # 00:15 EST in UTC
             "options": {"queue": QueueNames.REPORTING},
         },
         "create-nightly-notification-status": {
             "task": "create-nightly-notification-status",
-            "schedule": crontab(hour=0, minute=30),  # after 'timeout-sending-notifications'
+            "schedule": crontab(hour=5, minute=30),  # 00:30 EST in UTC, after 'timeout-sending-notifications'
             "options": {"queue": QueueNames.REPORTING},
         },
         "delete-sms-notifications": {
             "task": "delete-sms-notifications",
-            "schedule": crontab(hour=4, minute=15),  # after 'create-nightly-notification-status'
+            "schedule": crontab(hour=9, minute=15),  # 4:15 EST in UTC,  after 'create-nightly-notification-status'
             "options": {"queue": QueueNames.PERIODIC},
         },
         "delete-email-notifications": {
             "task": "delete-email-notifications",
-            "schedule": crontab(hour=4, minute=30),  # after 'create-nightly-notification-status'
+            "schedule": crontab(hour=9, minute=30),  # 4:30 EST in UTC, after 'create-nightly-notification-status'
             "options": {"queue": QueueNames.PERIODIC},
         },
         "delete-letter-notifications": {
             "task": "delete-letter-notifications",
-            "schedule": crontab(hour=4, minute=45),  # after 'create-nightly-notification-status'
+            "schedule": crontab(hour=9, minute=45),  # 4:45 EST in UTC, after 'create-nightly-notification-status'
             "options": {"queue": QueueNames.PERIODIC},
         },
         "delete-inbound-sms": {
             "task": "delete-inbound-sms",
-            "schedule": crontab(hour=1, minute=40),
+            "schedule": crontab(hour=6, minute=40),  # 1:40 EST in UTC
             "options": {"queue": QueueNames.PERIODIC},
         },
         "send-daily-performance-platform-stats": {
             "task": "send-daily-performance-platform-stats",
-            "schedule": crontab(hour=2, minute=0),
+            "schedule": crontab(hour=7, minute=0),  # 2:00 EST in UTC
             "options": {"queue": QueueNames.PERIODIC},
         },
         "remove_transformed_dvla_files": {
             "task": "remove_transformed_dvla_files",
-            "schedule": crontab(hour=3, minute=40),
+            "schedule": crontab(hour=8, minute=40),  # 3:40 EST in UTC
             "options": {"queue": QueueNames.PERIODIC},
         },
         "remove_sms_email_jobs": {
             "task": "remove_sms_email_jobs",
-            "schedule": crontab(hour=4, minute=0),
+            "schedule": crontab(hour=9, minute=0),  # 4:00 EST in UTC
             "options": {"queue": QueueNames.PERIODIC},
         },
-        # 'remove_letter_jobs': {
-        # 'task': 'remove_letter_jobs',
-        # 'schedule': crontab(hour=4, minute=20),
-        #  since we mark jobs as archived
-        # 'options': {'queue': QueueNames.PERIODIC},
-        # },
-        # 'check-templated-letter-state': {
-        # 'task': 'check-templated-letter-state',
-        # 'schedule': crontab(day_of_week='mon-fri', hour=9, minute=0),
-        # 'options': {'queue': QueueNames.PERIODIC}
-        # },
-        # 'check-precompiled-letter-state': {
-        # 'task': 'check-precompiled-letter-state',
-        # 'schedule': crontab(day_of_week='mon-fri', hour='9,15', minute=0),
-        # 'options': {'queue': QueueNames.PERIODIC}
-        # },
-        # 'raise-alert-if-letter-notifications-still-sending': {
-        # 'task': 'raise-alert-if-letter-notifications-still-sending',
-        # 'schedule': crontab(hour=16, minute=30),
-        # 'options': {'queue': QueueNames.PERIODIC}
-        # },
-        # The collate-letter-pdf does assume it is called in an hour that BST does not make a
-        # difference to the truncate date which translates to the filename to process
-        # 'collate-letter-pdfs-for-day': {
-        # 'task': 'collate-letter-pdfs-for-day',
-        # 'schedule': crontab(hour=17, minute=50),
-        # 'options': {'queue': QueueNames.PERIODIC}
-        # },
-        # 'raise-alert-if-no-letter-ack-file': {
-        # 'task': 'raise-alert-if-no-letter-ack-file',
-        # 'schedule': crontab(hour=23, minute=00),
-        # 'options': {'queue': QueueNames.PERIODIC}
-        # },
     }
     CELERY_QUEUES: List[Any] = []
     CELERY_DELIVER_SMS_RATE_LIMIT = os.getenv("CELERY_DELIVER_SMS_RATE_LIMIT", "1/s")


### PR DESCRIPTION
# Summary | Résumé

The celery beat schedule needed to be fixed for UTC instead of EST. This PR does that.