### PR TITLE
Reverting Notification History read for api last used key

### DIFF
--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -362,14 +362,7 @@ def get_last_send_for_api_key(api_key_id):
             .filter(Notification.api_key_id == api_key_id)
             .all()
         )
-        if not notification_table[0][0]:
-            notification_table = (
-                db.session.query(func.max(NotificationHistory.created_at).label("last_notification_created"))
-                .filter(NotificationHistory.api_key_id == api_key_id)
-                .all()
-            )
-            notification_table = [] if notification_table[0][0] is None else notification_table
-        return notification_table
+        return [] if notification_table[0][0] is None else notification_table
     return api_key_table
 
 

--- a/tests/app/dao/test_fact_notification_status_dao.py
+++ b/tests/app/dao/test_fact_notification_status_dao.py
@@ -423,24 +423,24 @@ def test_get_api_key_ranked_by_notifications_created(notify_db_session):
     assert int(second_place[8]) == sms_sends
 
 
-def test_last_used_for_api_key(notify_db_session):
-    service = create_service(service_name="Service 1")
-    api_key_1 = create_api_key(service, key_type=KEY_TYPE_NORMAL, key_name="Key 1")
-    api_key_2 = create_api_key(service, key_type=KEY_TYPE_NORMAL, key_name="Key 2")
-    api_key_3 = create_api_key(service, key_type=KEY_TYPE_NORMAL, key_name="Key 3")
-    template_email = create_template(service=service, template_type="email")
-    create_notification_history(template=template_email, api_key=api_key_1, created_at="2022-03-04")
-    save_notification(create_notification(template=template_email, api_key=api_key_1, created_at="2022-03-05"))
+# def test_last_used_for_api_key(notify_db_session):
+#     service = create_service(service_name="Service 1")
+#     api_key_1 = create_api_key(service, key_type=KEY_TYPE_NORMAL, key_name="Key 1")
+#     api_key_2 = create_api_key(service, key_type=KEY_TYPE_NORMAL, key_name="Key 2")
+#     api_key_3 = create_api_key(service, key_type=KEY_TYPE_NORMAL, key_name="Key 3")
+#     template_email = create_template(service=service, template_type="email")
+#     create_notification_history(template=template_email, api_key=api_key_1, created_at="2022-03-04")
+#     save_notification(create_notification(template=template_email, api_key=api_key_1, created_at="2022-03-05"))
 
-    assert (get_last_send_for_api_key(str(api_key_1.id))[0][0]).strftime("%Y-%m-%d") == "2022-03-05"
+#     assert (get_last_send_for_api_key(str(api_key_1.id))[0][0]).strftime("%Y-%m-%d") == "2022-03-05"
 
-    save_notification(create_notification(template=template_email, api_key=api_key_2, created_at="2022-03-06"))
+#     save_notification(create_notification(template=template_email, api_key=api_key_2, created_at="2022-03-06"))
 
-    assert (get_last_send_for_api_key(str(api_key_2.id))[0][0]).strftime("%Y-%m-%d") == "2022-03-06"
+#     assert (get_last_send_for_api_key(str(api_key_2.id))[0][0]).strftime("%Y-%m-%d") == "2022-03-06"
 
-    create_notification_history(template=template_email, api_key=api_key_3, created_at="2022-03-07")
+#     create_notification_history(template=template_email, api_key=api_key_3, created_at="2022-03-07")
 
-    assert (get_last_send_for_api_key(str(api_key_3.id))[0][0]).strftime("%Y-%m-%d") == "2022-03-07"
+#     assert (get_last_send_for_api_key(str(api_key_3.id))[0][0]).strftime("%Y-%m-%d") == "2022-03-07"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Summary | Résumé

Reverting last used so as to not read from the notification history table. This is so that we don't timeout on the api keys page.