### PR TITLE
Remove notification fallback

### DIFF
--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -356,14 +356,7 @@ def get_last_send_for_api_key(api_key_id):
     api_key_table = (
         db.session.query(ApiKey.last_used_timestamp.label("last_notification_created")).filter(ApiKey.id == api_key_id).all()
     )
-    if not api_key_table[0][0]:
-        notification_table = (
-            db.session.query(func.max(Notification.created_at).label("last_notification_created"))
-            .filter(Notification.api_key_id == api_key_id)
-            .all()
-        )
-        return [] if notification_table[0][0] is None else notification_table
-    return api_key_table
+    return [] if api_key_table[0][0] is None else api_key_table
 
 
 def get_api_key_ranked_by_notifications_created(n_days_back):

--- a/tests/app/api_key/test_rest.py
+++ b/tests/app/api_key/test_rest.py
@@ -1,9 +1,6 @@
-from datetime import datetime
-
 import pytest
 from flask import url_for
 
-from app import DATETIME_FORMAT
 from app.dao.api_key_dao import get_api_key_by_secret, get_unsigned_secret
 from app.models import KEY_TYPE_NORMAL
 from tests import create_sre_authorization_header
@@ -32,12 +29,6 @@ def test_get_api_key_stats_with_sends(admin_request, notify_db, notify_db_sessio
     assert api_key_stats["email_sends"] == total_sends
     assert api_key_stats["sms_sends"] == 0
     assert api_key_stats["total_sends"] == total_sends
-
-    # the following lines test that a send has occurred within the last second
-    last_send_dt = datetime.strptime(api_key_stats["last_send"], DATETIME_FORMAT)
-    now = datetime.utcnow()
-    time_delta = now - last_send_dt
-    assert abs(time_delta.total_seconds()) < 1
 
 
 def test_get_api_key_stats_no_sends(admin_request, notify_db, notify_db_session):

--- a/tests/app/dao/test_fact_notification_status_dao.py
+++ b/tests/app/dao/test_fact_notification_status_dao.py
@@ -367,20 +367,8 @@ def test_get_last_send_for_api_key_check_last_used(notify_db_session):
 def test_get_last_send_for_api_key(notify_db_session):
     service = create_service(service_name="First Service")
     api_key = create_api_key(service)
-    template_email = create_template(service=service, template_type=EMAIL_TYPE)
-    total_sends = 10
-
     last_send = get_last_send_for_api_key(str(api_key.id))
     assert last_send == []
-
-    for x in range(total_sends):
-        save_notification(create_notification(template=template_email, api_key=api_key))
-
-    # the following lines test that a send has occurred within the last second
-    last_send = get_last_send_for_api_key(str(api_key.id))[0][0]
-    now = datetime.utcnow()
-    time_delta = now - last_send
-    assert abs(time_delta.total_seconds()) < 1
 
 
 def test_get_api_key_ranked_by_notifications_created(notify_db_session):


### PR DESCRIPTION
# Summary | Résumé

Given we have backfilled the last_used_timestamp column in api_keys, we do not want to fallack to the notifications table, if that column is empty