### PR TITLE
Add organisation_id as a FK to the Email branding table

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -276,7 +276,9 @@ class EmailBranding(BaseModel):
         nullable=False,
         default=BRANDING_ORG_NEW,
     )
-    organisation_id = db.Column(UUID(as_uuid=True), db.ForeignKey("organisation.id"), index=True, nullable=True)
+    organisation_id = db.Column(
+        UUID(as_uuid=True), db.ForeignKey("organisation.id", ondelete="SET NULL"), index=True, nullable=True
+    )
     organisation = db.relationship("Organisation", back_populates="email_branding", foreign_keys=[organisation_id])
 
     def serialize(self) -> dict:
@@ -455,7 +457,7 @@ class Organisation(BaseModel):
     email_branding = db.relationship("EmailBranding", back_populates="organisation", foreign_keys="EmailBranding.organisation_id")
     email_branding_id = db.Column(
         UUID(as_uuid=True),
-        db.ForeignKey("email_branding.id"),
+        db.ForeignKey("email_branding.id", ondelete="SET NULL"),
         nullable=True,
     )
 

--- a/app/models.py
+++ b/app/models.py
@@ -276,6 +276,7 @@ class EmailBranding(BaseModel):
         nullable=False,
         default=BRANDING_ORG_NEW,
     )
+    #organisation_id = db.Column(UUID(as_uuid=True), db.ForeignKey("organisation.id"), index=True, nullable=True)
 
     def serialize(self) -> dict:
         serialized = {
@@ -285,6 +286,7 @@ class EmailBranding(BaseModel):
             "name": self.name,
             "text": self.text,
             "brand_type": self.brand_type,
+            #"organisation_id": str(self.organisation_id) if self.organisation_id else "",
         }
 
         return serialized

--- a/app/models.py
+++ b/app/models.py
@@ -433,7 +433,7 @@ class Organisation(BaseModel):
     agreement_signed_at = db.Column(db.DateTime, nullable=True)
     agreement_signed_by_id = db.Column(
         UUID(as_uuid=True),
-        db.ForeignKey("users.id"),
+        db.ForeignKey("users.id", ondelete="SET NULL"),
         nullable=True,
     )
     agreement_signed_by = db.relationship("User")

--- a/app/models.py
+++ b/app/models.py
@@ -276,7 +276,8 @@ class EmailBranding(BaseModel):
         nullable=False,
         default=BRANDING_ORG_NEW,
     )
-    #organisation_id = db.Column(UUID(as_uuid=True), db.ForeignKey("organisation.id"), index=True, nullable=True)
+    organisation_id = db.Column(UUID(as_uuid=True), db.ForeignKey("organisation.id"), index=True, nullable=True)
+    organisation = db.relationship("Organisation", back_populates="email_branding", foreign_keys=[organisation_id])
 
     def serialize(self) -> dict:
         serialized = {
@@ -286,7 +287,7 @@ class EmailBranding(BaseModel):
             "name": self.name,
             "text": self.text,
             "brand_type": self.brand_type,
-            #"organisation_id": str(self.organisation_id) if self.organisation_id else "",
+            "organisation_id": str(self.organisation_id) if self.organisation_id else "",
         }
 
         return serialized
@@ -451,7 +452,7 @@ class Organisation(BaseModel):
         "Domain",
     )
 
-    email_branding = db.relationship("EmailBranding")
+    email_branding = db.relationship("EmailBranding", back_populates="organisation", foreign_keys="EmailBranding.organisation_id")
     email_branding_id = db.Column(
         UUID(as_uuid=True),
         db.ForeignKey("email_branding.id"),

--- a/migrations/versions/0445_add_org_id_branding.py
+++ b/migrations/versions/0445_add_org_id_branding.py
@@ -1,0 +1,39 @@
+"""
+
+Revision ID: 0445_add_org_id_branding
+Revises: 0444_add_index_n_history2.py
+Create Date: 2024-02-27
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0445_add_org_id_branding"
+down_revision = "0444_add_index_n_history2"
+
+
+def upgrade():
+    op.add_column(
+        "email_branding",
+        sa.Column("organisation_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.create_index(
+        op.f("ix_email_branding_organisation_id"),
+        "email_branding",
+        ["organisation_id"],
+        unique=False,
+    )
+    op.create_foreign_key(
+        "fk_email_branding_organisation",
+        "email_branding",
+        "organisation",
+        ["organisation_id"],
+        ["id"],
+        foreign_keys=['email_branding.organisation_id'],
+    )
+
+def downgrade():
+    op.drop_index(op.f("ix_email_branding_organisation_id"), table_name="email_branding")
+    op.drop_constraint("fk_email_branding_organisation", "email_branding", type_="foreignkey")
+    op.drop_column("email_branding", "organisation_id")

--- a/migrations/versions/0445_add_org_id_branding.py
+++ b/migrations/versions/0445_add_org_id_branding.py
@@ -33,6 +33,17 @@ def upgrade():
         ondelete="SET NULL",
     )
 
+    op.drop_constraint("fk_organisation_agreement_user_id", "organisation", type_="foreignkey")
+
+    op.create_foreign_key(
+        "fk_organisation_agreement_signed_by",
+        "organisation",
+        "users",
+        ["agreement_signed_by_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
 
 def downgrade():
     op.drop_index(op.f("ix_email_branding_organisation_id"), table_name="email_branding")

--- a/migrations/versions/0445_add_org_id_branding.py
+++ b/migrations/versions/0445_add_org_id_branding.py
@@ -29,8 +29,10 @@ def upgrade():
         "email_branding",
         "organisation",
         ["organisation_id"],
-        ["id"]
+        ["id"],
+        ondelete="SET NULL",
     )
+
 
 def downgrade():
     op.drop_index(op.f("ix_email_branding_organisation_id"), table_name="email_branding")

--- a/migrations/versions/0445_add_org_id_branding.py
+++ b/migrations/versions/0445_add_org_id_branding.py
@@ -29,8 +29,7 @@ def upgrade():
         "email_branding",
         "organisation",
         ["organisation_id"],
-        ["id"],
-        foreign_keys=['email_branding.organisation_id'],
+        ["id"]
     )
 
 def downgrade():

--- a/tests/app/email_branding/test_rest.py
+++ b/tests/app/email_branding/test_rest.py
@@ -4,19 +4,20 @@ from app.models import BRANDING_ORG_NEW, EmailBranding
 from tests.app.db import create_email_branding
 
 
-def test_get_email_branding_options(admin_request, notify_db, notify_db_session):
-    email_branding1 = EmailBranding(colour="#FFFFFF", logo="/path/image.png", name="Org1")
+def test_get_email_branding_options(admin_request, notify_db, notify_db_session, sample_organisation):
+    email_branding1 = EmailBranding(colour="#FFFFFF", logo="/path/image.png", name="Org1", organisation_id=sample_organisation.id)
     email_branding2 = EmailBranding(colour="#000000", logo="/path/other.png", name="Org2")
     notify_db.session.add_all([email_branding1, email_branding2])
     notify_db.session.commit()
 
     email_branding = admin_request.get("email_branding.get_email_branding_options")["email_branding"]
-
     assert len(email_branding) == 2
     assert {email_branding["id"] for email_branding in email_branding} == {
         str(email_branding1.id),
         str(email_branding2.id),
     }
+    assert email_branding[0]["organisation_id"] == str(sample_organisation.id)
+    assert email_branding[1]["organisation_id"] == ""
 
 
 def test_get_email_branding_by_id(admin_request, notify_db, notify_db_session):
@@ -30,14 +31,7 @@ def test_get_email_branding_by_id(admin_request, notify_db, notify_db_session):
         email_branding_id=email_branding.id,
     )
 
-    assert set(response["email_branding"].keys()) == {
-        "colour",
-        "logo",
-        "name",
-        "id",
-        "text",
-        "brand_type",
-    }
+    assert set(response["email_branding"].keys()) == {"colour", "logo", "name", "id", "text", "brand_type", "organisation_id"}
     assert response["email_branding"]["colour"] == "#FFFFFF"
     assert response["email_branding"]["logo"] == "/path/image.png"
     assert response["email_branding"]["name"] == "Some Org"


### PR DESCRIPTION
# Summary | Résumé

```
notification_api=# \d email_branding
                       Table "public.email_branding"
     Column      |          Type          | Collation | Nullable | Default 
-----------------+------------------------+-----------+----------+---------
 id              | uuid                   |           | not null | 
 colour          | character varying(7)   |           |          | 
 logo            | character varying(255) |           |          | 
 name            | character varying(255) |           | not null | 
 text            | character varying(255) |           |          | 
 brand_type      | character varying(255) |           | not null | 
 organisation_id | uuid                   |           |          | 
Indexes:
    "email_branding_pkey" PRIMARY KEY, btree (id)
    "ix_email_branding_brand_type" btree (brand_type)
    "ix_email_branding_organisation_id" btree (organisation_id)
    "uq_email_branding_name" UNIQUE CONSTRAINT, btree (name)
Foreign-key constraints:
    "email_branding_brand_type_fkey" FOREIGN KEY (brand_type) REFERENCES branding_type(name)
    "fk_email_branding_organisation" FOREIGN KEY (organisation_id) REFERENCES organisation(id)
```


