### PR TITLE
Fix/restrict job query size

### DIFF
--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -49,14 +49,15 @@ def remove_letter_csv_files():
 
 
 def _remove_csv_files(job_types):
-    jobs = dao_get_jobs_older_than_data_retention(notification_types=job_types)
-    current_app.logger.info("TEMP LOGGING: trying to remove {} jobs.".format(len(jobs)))
-    for job in jobs:
-        current_app.logger.info("TEMP LOGGING: trying to remove Job ID {} from s3.".format(job.id))
-        s3.remove_job_from_s3(job.service_id, job.id)
-        current_app.logger.info("TEMP LOGGING: trying to archive Job ID {}".format(job.id))
-        dao_archive_job(job)
-        current_app.logger.info("Job ID {} has been removed from s3.".format(job.id))
+    while True:
+        jobs = dao_get_jobs_older_than_data_retention(notification_types=job_types, limit=20000)
+        if len(jobs) == 0:
+            break
+        current_app.logger.info("Archiving {} jobs.".format(len(jobs)))
+        for job in jobs:
+            s3.remove_job_from_s3(job.service_id, job.id)
+            dao_archive_job(job)
+            current_app.logger.info("Job ID {} has been removed from s3.".format(job.id))
 
 
 @notify_celery.task(name="delete-sms-notifications")

--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -165,7 +165,7 @@ def dao_get_jobs_older_than_data_retention(notification_types, limit=None):
             .order_by(desc(Job.created_at))
         )
         if limit:
-            query = query.limit(limit)
+            query = query.limit(limit - len(jobs))
         jobs.extend(query.all())
 
     return jobs

--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -137,12 +137,16 @@ def dao_get_jobs_older_than_data_retention(notification_types, limit=None):
     today = datetime.utcnow().date()
     for f in flexible_data_retention:
         end_date = today - timedelta(days=f.days_of_retention)
-        query = Job.query.join(Template).filter(
-                    func.coalesce(Job.scheduled_for, Job.created_at) < end_date,
-                    Job.archived == False,  # noqa
-                    Template.template_type == f.notification_type,
-                    Job.service_id == f.service_id,
-                ).order_by(desc(Job.created_at))
+        query = (
+            Job.query.join(Template)
+            .filter(
+                func.coalesce(Job.scheduled_for, Job.created_at) < end_date,
+                Job.archived == False,  # noqa
+                Template.template_type == f.notification_type,
+                Job.service_id == f.service_id,
+            )
+            .order_by(desc(Job.created_at))
+        )
         if limit:
             query = query.limit(limit)
         jobs.extend(query.all())
@@ -150,14 +154,18 @@ def dao_get_jobs_older_than_data_retention(notification_types, limit=None):
     end_date = today - timedelta(days=7)
     for notification_type in notification_types:
         services_with_data_retention = [x.service_id for x in flexible_data_retention if x.notification_type == notification_type]
-        query = Job.query.join(Template).filter(
+        query = (
+            Job.query.join(Template)
+            .filter(
                 func.coalesce(Job.scheduled_for, Job.created_at) < end_date,
                 Job.archived == False,  # noqa
                 Template.template_type == notification_type,
                 Job.service_id.notin_(services_with_data_retention),
-            ).order_by(desc(Job.created_at))
+            )
+            .order_by(desc(Job.created_at))
+        )
         if limit:
-            query = query.limit(limit)        
+            query = query.limit(limit)
         jobs.extend(query.all())
 
     return jobs

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -17,6 +17,7 @@ from app.dao.jobs_dao import (
     dao_set_scheduled_jobs_to_pending,
     dao_update_job,
 )
+from app.dao.service_data_retention_dao import insert_service_data_retention
 from app.models import EMAIL_TYPE, LETTER_TYPE, SMS_TYPE, Job
 from tests.app.db import (
     create_job,
@@ -350,15 +351,21 @@ def test_should_get_jobs_seven_days_old_by_scheduled_for_date(sample_service):
 
 @freeze_time("2016-10-31 10:00:00")
 def test_should_get_limited_number_of_jobs(sample_template):
+    flexable_retention_service = create_service(service_name="Another service")
+    insert_service_data_retention(flexable_retention_service.id, sample_template.template_type, 3)
+    flexable_template = create_template(flexable_retention_service, template_type=sample_template.template_type)
+
     eight_days_ago = datetime.utcnow() - timedelta(days=8)
+    four_days_ago = datetime.utcnow() - timedelta(days=4)
 
+    create_job(flexable_template, created_at=four_days_ago)
+    create_job(flexable_template, created_at=four_days_ago)
     create_job(sample_template, created_at=eight_days_ago)
     create_job(sample_template, created_at=eight_days_ago)
-    create_job(sample_template, created_at=eight_days_ago)
 
-    jobs = dao_get_jobs_older_than_data_retention(notification_types=[sample_template.template_type], limit=2)
+    jobs = dao_get_jobs_older_than_data_retention(notification_types=[sample_template.template_type], limit=3)
 
-    assert len(jobs) == 2
+    assert len(jobs) == 3
 
 
 @freeze_time("2016-10-31 10:00:00")

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -348,6 +348,32 @@ def test_should_get_jobs_seven_days_old_by_scheduled_for_date(sample_service):
     assert job_to_remain.id not in [job.id for job in jobs]
 
 
+@freeze_time("2016-10-31 10:00:00")
+def test_should_get_limited_number_of_jobs(sample_template):
+    eight_days_ago = datetime.utcnow() - timedelta(days=8)
+
+    create_job(sample_template, created_at=eight_days_ago)
+    create_job(sample_template, created_at=eight_days_ago)
+    create_job(sample_template, created_at=eight_days_ago)
+    
+    jobs = dao_get_jobs_older_than_data_retention(notification_types=[sample_template.template_type], limit=2)
+
+    assert len(jobs) == 2
+
+@freeze_time("2016-10-31 10:00:00")
+def test_should_get_not_get_limited_number_of_jobs_by_default(sample_template):
+    eight_days_ago = datetime.utcnow() - timedelta(days=8)
+
+    create_job(sample_template, created_at=eight_days_ago)
+    create_job(sample_template, created_at=eight_days_ago)
+    create_job(sample_template, created_at=eight_days_ago)
+    
+    jobs = dao_get_jobs_older_than_data_retention(notification_types=[sample_template.template_type])
+
+    assert len(jobs) == 3
+
+
+
 def assert_job_stat(job, result, sent, delivered, failed):
     assert result.job_id == job.id
     assert result.original_file_name == job.original_file_name

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -355,10 +355,11 @@ def test_should_get_limited_number_of_jobs(sample_template):
     create_job(sample_template, created_at=eight_days_ago)
     create_job(sample_template, created_at=eight_days_ago)
     create_job(sample_template, created_at=eight_days_ago)
-    
+
     jobs = dao_get_jobs_older_than_data_retention(notification_types=[sample_template.template_type], limit=2)
 
     assert len(jobs) == 2
+
 
 @freeze_time("2016-10-31 10:00:00")
 def test_should_get_not_get_limited_number_of_jobs_by_default(sample_template):
@@ -367,11 +368,10 @@ def test_should_get_not_get_limited_number_of_jobs_by_default(sample_template):
     create_job(sample_template, created_at=eight_days_ago)
     create_job(sample_template, created_at=eight_days_ago)
     create_job(sample_template, created_at=eight_days_ago)
-    
+
     jobs = dao_get_jobs_older_than_data_retention(notification_types=[sample_template.template_type])
 
     assert len(jobs) == 3
-
 
 
 def assert_job_stat(job, result, sent, delivered, failed):


### PR DESCRIPTION
# Summary | Résumé

Stop `dao_get_jobs_older_than_data_retention` from crashing.

We now have almost 500K unarchived jobs that are more than a week old. This is crashing the query so that none are getting archived and the list grows. This PR sets the limit to the query to 20K, which is how many jobs / day we had in the past without any OOM issues.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/307

# Test instructions | Instructions pour tester la modification

- change [this line](https://github.com/cds-snc/notification-api/blob/260722e4ffdcf9b2f865583161dd6642e9f36fad/app/config.py#L486) to `"schedule": 60,` (to run the task every minute)
- change [this line](https://github.com/cds-snc/notification-api/blob/260722e4ffdcf9b2f865583161dd6642e9f36fad/app/dao/jobs_dao.py#L153) to `end_date = today + timedelta(days=7)` (to remove all jobs, not just old ones)
- change the [query limit](https://github.com/cds-snc/notification-api/pull/2127/files#diff-dd4f118014701d2a8a706498e3c2d318a7aa191065f0a2e3d61aa5633c24c3a8R53) from `20000` to `2`
- purge your queues with `make run-celery-purge`
- run celery and api with `make run-celery-local` and `make run`
- POST several (5 or so) jobs job to your local /bulk endpoint. 
- After a minute you should see something like (intermingled with other lines):
```
[2024-03-04 18:44:48,955: INFO/MainProcess] Task remove_sms_email_jobs[a813a22c-94df-4dbd-9bef-7129278672a3] received
...
[2024-03-04 18:44:48,974: INFO/ForkPoolWorker-2] Archiving 2 jobs.
...
[2024-03-04 18:44:50,110: INFO/ForkPoolWorker-2] Archiving 2 jobs.
...
[2024-03-04 18:44:51,072: INFO/ForkPoolWorker-2] Archiving 1 jobs.
```

# Release Instructions | Instructions pour le déploiement

- Should see lines in the logs similar to `Archiving 20000 jobs.`
- Should see the number of unarchived jobs in the database drop significantly after the first time this code runs

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.