### PR TITLE
Upgrade utils to 52.1.5

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -331,13 +331,13 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "bleach"
-version = "6.0.0"
+version = "6.1.0"
 description = "An easy safelist-based HTML-sanitizing tool."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "bleach-6.0.0-py3-none-any.whl", hash = "sha256:33c16e3353dbd13028ab4799a0f89a83f113405c766e9c122df8a06f5b85b3f4"},
-    {file = "bleach-6.0.0.tar.gz", hash = "sha256:1a1a85c1595e07d8db14c5f09f09e6433502c51c595970edc090551f0db99414"},
+    {file = "bleach-6.1.0-py3-none-any.whl", hash = "sha256:3225f354cfc436b9789c66c4ee030194bee0568fbf9cbdad3bc8b5c26c5f12b6"},
+    {file = "bleach-6.1.0.tar.gz", hash = "sha256:0a31f1837963c41d46bbf1331b8778e1308ea0791db03cc4e7357b97cf42a8fe"},
 ]
 
 [package.dependencies]
@@ -345,7 +345,7 @@ six = ">=1.9.0"
 webencodings = "*"
 
 [package.extras]
-css = ["tinycss2 (>=1.1.0,<1.2)"]
+css = ["tinycss2 (>=1.1.0,<1.3)"]
 
 [[package]]
 name = "blinker"
@@ -2444,16 +2444,16 @@ requests = ">=2.0.0"
 
 [[package]]
 name = "notifications-utils"
-version = "52.1.3"
+version = "52.1.5"
 description = "Shared python code for Notification - Provides logging utils etc."
 optional = false
-python-versions = "~3.10"
+python-versions = "~3.10.9"
 files = []
 develop = false
 
 [package.dependencies]
 awscli = "1.32.25"
-bleach = "6.0.0"
+bleach = "6.1.0"
 boto3 = "1.34.25"
 cachetools = "4.2.4"
 certifi = "^2023.7.22"
@@ -2479,8 +2479,8 @@ werkzeug = "2.3.7"
 [package.source]
 type = "git"
 url = "https://github.com/cds-snc/notifier-utils.git"
-reference = "52.1.3"
-resolved_reference = "06a40db6286f525fe3551e029418458d33342592"
+reference = "52.1.5"
+resolved_reference = "9d9e8c7c32e3608f4dd8f320eaba4bb67edfcbf5"
 
 [[package]]
 name = "ordered-set"
@@ -4255,4 +4255,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10.9"
-content-hash = "f2bf5c58fe6d2689072e7b9d4cf91976e07e76ade98dc3153977c4377b98c86e"
+content-hash = "f00992b7f47d8434a76d0be08135eace31315c696e20a222a10e2bf926e8a561"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ Werkzeug = "2.3.7"
 MarkupSafe = "2.1.4"
 # REVIEW: v2 is using sha512 instead of sha1 by default (in v1)
 itsdangerous = "2.1.2"
-notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", tag = "52.1.3" }
+notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", tag = "52.1.5" }
 # rsa = "4.9  # awscli 1.22.38 depends on rsa<4.8
 typing-extensions = "4.7.1"
 greenlet = "2.0.2"


### PR DESCRIPTION
# Summary | Résumé

Upgrade notification-utils to latest

## Related Issues | Cartes liées

* the utils change fixed: https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/305

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.