### PR TITLE
Add logging and tweak recipient_csv use

### DIFF
--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -174,26 +174,28 @@ def create_job(service_id):
     if template.template_type == SMS_TYPE:
         # calculate the number of simulated recipients
         numberOfSimulated = sum(
-            simulated_recipient(i["phone_number"].data, template.template_type) for i in list(recipient_csv.get_rows())
+            simulated_recipient(i["phone_number"].data, template.template_type) for i in recipient_csv.rows
         )
-        mixedRecipients = numberOfSimulated > 0 and numberOfSimulated != len(list(recipient_csv.get_rows()))
+        mixedRecipients = numberOfSimulated > 0 and numberOfSimulated != len(recipient_csv)
 
         # if they have specified testing and NON-testing recipients, raise an error
         if mixedRecipients:
             raise InvalidRequest(message="Bulk sending to testing and non-testing numbers is not supported", status_code=400)
 
-        is_test_notification = len(list(recipient_csv.get_rows())) == numberOfSimulated
+        is_test_notification = len(recipient_csv) == numberOfSimulated
 
         if not is_test_notification:
             check_sms_daily_limit(service, len(recipient_csv))
             increment_sms_daily_count_send_warnings_if_needed(service, len(recipient_csv))
 
     elif template.template_type == EMAIL_TYPE:
-        check_email_daily_limit(service, len(list(recipient_csv.get_rows())))
+        check_email_daily_limit(service, len(recipient_csv))
+        current_app.logger.info(" TEMP LOGGING 6a: done check_email_daily_limit")
+
         scheduled_for = datetime.fromisoformat(data.get("scheduled_for")) if data.get("scheduled_for") else None
 
         if scheduled_for is None or not scheduled_for.date() > datetime.today().date():
-            increment_email_daily_count_send_warnings_if_needed(service, len(list(recipient_csv.get_rows())))
+            increment_email_daily_count_send_warnings_if_needed(service, len(recipient_csv))
     current_app.logger.info(" TEMP LOGGING 6: done checking limits")
 
     data.update({"template_version": template.version})

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -173,9 +173,7 @@ def create_job(service_id):
 
     if template.template_type == SMS_TYPE:
         # calculate the number of simulated recipients
-        numberOfSimulated = sum(
-            simulated_recipient(i["phone_number"].data, template.template_type) for i in recipient_csv.rows
-        )
+        numberOfSimulated = sum(simulated_recipient(i["phone_number"].data, template.template_type) for i in recipient_csv.rows)
         mixedRecipients = numberOfSimulated > 0 and numberOfSimulated != len(recipient_csv)
 
         # if they have specified testing and NON-testing recipients, raise an error


### PR DESCRIPTION
# Summary | Résumé

- Add another log line to help diagnose where the slowdown in `create_job` is
- changed usage of `recipient_csv` to use cached values rather than recalculating. Note that
  - [`recipient_csv.rows == list(recipient_csv.get_rows()`](https://github.com/cds-snc/notification-utils/blob/9d9e8c7c32e3608f4dd8f320eaba4bb67edfcbf5/notifications_utils/recipients.py#L176-L180)
  - [ `len(recipient_csv) == len(list(recipient_csv.get_rows()` ](https://github.com/cds-snc/notification-utils/blob/9d9e8c7c32e3608f4dd8f320eaba4bb67edfcbf5/notifications_utils/recipients.py#L108-L111)

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/308

# Test instructions | Instructions pour tester la modification

upload the big test CSV (on staging) to the IRCC test template and see what happens!

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.