### PR TITLE
get notification count faster

### DIFF
--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -175,17 +175,17 @@ def create_job(service_id):
     if template.template_type == SMS_TYPE:
         # calculate the number of simulated recipients
         numberOfSimulated = sum(simulated_recipient(i["phone_number"].data, template.template_type) for i in recipient_csv.rows)
-        mixedRecipients = numberOfSimulated > 0 and numberOfSimulated != notification_count
+        mixedRecipients = numberOfSimulated > 0 and numberOfSimulated != len(recipient_csv)
 
         # if they have specified testing and NON-testing recipients, raise an error
         if mixedRecipients:
             raise InvalidRequest(message="Bulk sending to testing and non-testing numbers is not supported", status_code=400)
 
-        is_test_notification = notification_count == numberOfSimulated
+        is_test_notification = len(recipient_csv) == numberOfSimulated
 
         if not is_test_notification:
-            check_sms_daily_limit(service, notification_count)
-            increment_sms_daily_count_send_warnings_if_needed(service, notification_count)
+            check_sms_daily_limit(service, len(recipient_csv))
+            increment_sms_daily_count_send_warnings_if_needed(service, len(recipient_csv))
 
     elif template.template_type == EMAIL_TYPE:
         check_email_daily_limit(service, notification_count)

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -169,31 +169,32 @@ def create_job(service_id):
         placeholders=template._as_utils_template().placeholders,
         template=Template(template.__dict__),
     )
+    notification_count = int(data.get("notification_count", len(recipient_csv)))
     current_app.logger.info(" TEMP LOGGING 5: done RecipientCSV()")
 
     if template.template_type == SMS_TYPE:
         # calculate the number of simulated recipients
         numberOfSimulated = sum(simulated_recipient(i["phone_number"].data, template.template_type) for i in recipient_csv.rows)
-        mixedRecipients = numberOfSimulated > 0 and numberOfSimulated != len(recipient_csv)
+        mixedRecipients = numberOfSimulated > 0 and numberOfSimulated != notification_count
 
         # if they have specified testing and NON-testing recipients, raise an error
         if mixedRecipients:
             raise InvalidRequest(message="Bulk sending to testing and non-testing numbers is not supported", status_code=400)
 
-        is_test_notification = len(recipient_csv) == numberOfSimulated
+        is_test_notification = notification_count == numberOfSimulated
 
         if not is_test_notification:
-            check_sms_daily_limit(service, len(recipient_csv))
-            increment_sms_daily_count_send_warnings_if_needed(service, len(recipient_csv))
+            check_sms_daily_limit(service, notification_count)
+            increment_sms_daily_count_send_warnings_if_needed(service, notification_count)
 
     elif template.template_type == EMAIL_TYPE:
-        check_email_daily_limit(service, len(recipient_csv))
+        check_email_daily_limit(service, notification_count)
         current_app.logger.info(" TEMP LOGGING 6a: done check_email_daily_limit")
 
         scheduled_for = datetime.fromisoformat(data.get("scheduled_for")) if data.get("scheduled_for") else None
 
         if scheduled_for is None or not scheduled_for.date() > datetime.today().date():
-            increment_email_daily_count_send_warnings_if_needed(service, len(recipient_csv))
+            increment_email_daily_count_send_warnings_if_needed(service, notification_count)
     current_app.logger.info(" TEMP LOGGING 6: done checking limits")
 
     data.update({"template_version": template.version})

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -136,7 +136,6 @@ def get_jobs_by_service(service_id):
 @job_blueprint.route("", methods=["POST"])
 def create_job(service_id):
     service = dao_fetch_service_by_id(service_id)
-    current_app.logger.info(" TEMP LOGGING 1: done dao_fetch_service_by_id")
     if not service.active:
         raise InvalidRequest("Create job is not allowed: service is inactive ", 403)
 
@@ -147,7 +146,6 @@ def create_job(service_id):
         data.update(**get_job_metadata_from_s3(service_id, data["id"]))
     except KeyError:
         raise InvalidRequest({"id": ["Missing data for required field."]}, status_code=400)
-    current_app.logger.info(" TEMP LOGGING 2: done data.update")
 
     if data.get("valid") != "True":
         raise InvalidRequest("File is not valid, can't create job", 400)
@@ -155,22 +153,18 @@ def create_job(service_id):
     data["template"] = data.pop("template_id")
 
     template = dao_get_template_by_id(data["template"])
-    current_app.logger.info(" TEMP LOGGING 3: done dao_get_template_by_id")
     template_errors = unarchived_template_schema.validate({"archived": template.archived})
 
     if template_errors:
         raise InvalidRequest(template_errors, status_code=400)
 
     job = get_job_from_s3(service_id, data["id"])
-    current_app.logger.info(" TEMP LOGGING 4: done get_job_from_s3")
     recipient_csv = RecipientCSV(
         job,
         template_type=template.template_type,
         placeholders=template._as_utils_template().placeholders,
         template=Template(template.__dict__),
     )
-    notification_count = int(data.get("notification_count", len(recipient_csv)))
-    current_app.logger.info(" TEMP LOGGING 5: done RecipientCSV()")
 
     if template.template_type == SMS_TYPE:
         # calculate the number of simulated recipients
@@ -188,14 +182,13 @@ def create_job(service_id):
             increment_sms_daily_count_send_warnings_if_needed(service, len(recipient_csv))
 
     elif template.template_type == EMAIL_TYPE:
+        notification_count = int(data.get("notification_count", len(recipient_csv)))
         check_email_daily_limit(service, notification_count)
-        current_app.logger.info(" TEMP LOGGING 6a: done check_email_daily_limit")
 
         scheduled_for = datetime.fromisoformat(data.get("scheduled_for")) if data.get("scheduled_for") else None
 
         if scheduled_for is None or not scheduled_for.date() > datetime.today().date():
             increment_email_daily_count_send_warnings_if_needed(service, notification_count)
-    current_app.logger.info(" TEMP LOGGING 6: done checking limits")
 
     data.update({"template_version": template.version})
 
@@ -205,11 +198,9 @@ def create_job(service_id):
         job.job_status = JOB_STATUS_SCHEDULED
 
     dao_create_job(job)
-    current_app.logger.info(" TEMP LOGGING 7: done dao_create_job")
 
     if job.job_status == JOB_STATUS_PENDING:
         process_job.apply_async([str(job.id)], queue=QueueNames.JOBS)
-    current_app.logger.info(" TEMP LOGGING 8: done process_job.apply_async")
 
     job_json = job_schema.dump(job)
     job_json["statistics"] = []


### PR DESCRIPTION
# Summary | Résumé

A recent incident was caused by `create_job` taking too long. We traced it to the `recipient_csv.get_rows()` function, which was being called repeatedly to use to get the count of notifications. This PR instead uses the `notification_count` included in the s3 metadata. It falls back to a `get_rows()` based approach if the metadata is missing.

## Related Issues | Cartes liées

- https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/308

# Test instructions | Instructions pour tester la modification

Upload test file in staging.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [x] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [x] This PR does not significantly alter performance.
- [x] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.