### PR TITLE
Fix slow create_job for real this time

### DIFF
--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -182,9 +182,9 @@ def create_job(service_id):
             increment_sms_daily_count_send_warnings_if_needed(service, len(recipient_csv))
 
     elif template.template_type == EMAIL_TYPE:
-        if "notification_count" in data:
+        try:
             notification_count = int(data["notification_count"])
-        else:
+        except KeyError:
             current_app.logger.warning(f"notification_count not in metadata for job {data['id']}, using len(recipient_csv) instead.")
             notification_count = len(recipient_csv)
 

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -182,9 +182,9 @@ def create_job(service_id):
             increment_sms_daily_count_send_warnings_if_needed(service, len(recipient_csv))
 
     elif template.template_type == EMAIL_TYPE:
-        try:
+        if "notification_count" in data:
             notification_count = int(data["notification_count"])
-        except KeyError:
+        else:
             current_app.logger.warning(
                 f"notification_count not in metadata for job {data['id']}, using len(recipient_csv) instead."
             )

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -182,7 +182,12 @@ def create_job(service_id):
             increment_sms_daily_count_send_warnings_if_needed(service, len(recipient_csv))
 
     elif template.template_type == EMAIL_TYPE:
-        notification_count = int(data.get("notification_count", len(recipient_csv)))
+        if "notification_count" in data:
+            notification_count = int(data["notification_count"])
+        else:
+            current_app.logger.warning(f"notification_count not in metadata for job {data['id']}, using len(recipient_csv) instead.")
+            notification_count = len(recipient_csv)
+
         check_email_daily_limit(service, notification_count)
 
         scheduled_for = datetime.fromisoformat(data.get("scheduled_for")) if data.get("scheduled_for") else None

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -185,7 +185,9 @@ def create_job(service_id):
         try:
             notification_count = int(data["notification_count"])
         except KeyError:
-            current_app.logger.warning(f"notification_count not in metadata for job {data['id']}, using len(recipient_csv) instead.")
+            current_app.logger.warning(
+                f"notification_count not in metadata for job {data['id']}, using len(recipient_csv) instead."
+            )
             notification_count = len(recipient_csv)
 
         check_email_daily_limit(service, notification_count)


### PR DESCRIPTION
# Summary | Résumé

In #2133 we tried to avoid calling `len(recipient_csv)` by using
```
notification_count = int(data.get("notification_count", len(recipient_csv)))
```
However, the default value in the `get` is being evaluated regardless of whether `notification_count` in a key of `data`.
For example:
```
>>> data = {"notification_count": 12}
>>> data.get("notification_count", print("not needed"))
not needed
12
```

This PR switches to an if/else.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/308

# Test instructions | Instructions pour tester la modification

Run on staging...

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.