### PR TITLE
Add filtering with an organisation id

### DIFF
--- a/app/dao/email_branding_dao.py
+++ b/app/dao/email_branding_dao.py
@@ -3,7 +3,9 @@ from app.dao.dao_utils import transactional
 from app.models import EmailBranding
 
 
-def dao_get_email_branding_options():
+def dao_get_email_branding_options(filter_by_organisation_id=None):
+    if filter_by_organisation_id:
+        return EmailBranding.query.filter_by(organisation_id=filter_by_organisation_id).all()
     return EmailBranding.query.all()
 
 

--- a/app/email_branding/rest.py
+++ b/app/email_branding/rest.py
@@ -20,7 +20,10 @@ register_errors(email_branding_blueprint)
 
 @email_branding_blueprint.route("", methods=["GET"])
 def get_email_branding_options():
-    email_branding_options = [o.serialize() for o in dao_get_email_branding_options()]
+    filter_by_organisation_id = request.args.get("organisation_id", None)
+    email_branding_options = [
+        o.serialize() for o in dao_get_email_branding_options(filter_by_organisation_id=filter_by_organisation_id)
+    ]
     return jsonify(email_branding=email_branding_options)
 
 

--- a/tests/app/dao/test_email_branding_dao.py
+++ b/tests/app/dao/test_email_branding_dao.py
@@ -5,11 +5,12 @@ from app.dao.email_branding_dao import (
     dao_update_email_branding,
 )
 from app.models import EmailBranding
-from tests.app.db import create_email_branding
+from tests.app.db import create_email_branding, create_organisation
 
 
 def test_get_email_branding_options_gets_all_email_branding(notify_db, notify_db_session):
-    email_branding_1 = create_email_branding(name="test_email_branding_1")
+    org_1 = create_organisation()
+    email_branding_1 = create_email_branding(name="test_email_branding_1", organisation_id=org_1.id)
     email_branding_2 = create_email_branding(name="test_email_branding_2")
 
     email_branding = dao_get_email_branding_options()
@@ -17,6 +18,13 @@ def test_get_email_branding_options_gets_all_email_branding(notify_db, notify_db
     assert len(email_branding) == 2
     assert email_branding_1 == email_branding[0]
     assert email_branding_2 == email_branding[1]
+
+    org_1_id = email_branding_1.organisation_id
+
+    email_branding = dao_get_email_branding_options(filter_by_organisation_id=org_1_id)
+    assert len(email_branding) == 1
+    assert email_branding_1 == email_branding[0]
+    assert email_branding[0].organisation_id == org_1_id
 
 
 def test_get_email_branding_by_id_gets_correct_email_branding(notify_db, notify_db_session):

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -502,13 +502,15 @@ def create_service_callback_api(
     return service_callback_api
 
 
-def create_email_branding(colour="blue", logo="test_x2.png", name="test_org_1", text="DisplayName"):
+def create_email_branding(colour="blue", logo="test_x2.png", name="test_org_1", text="DisplayName", organisation_id=None):
     data = {
         "colour": colour,
         "logo": logo,
         "name": name,
         "text": text,
     }
+    if organisation_id:
+        data["organisation_id"] = organisation_id
     email_branding = EmailBranding(**data)
     dao_create_email_branding(email_branding)
 

--- a/tests/app/email_branding/test_rest.py
+++ b/tests/app/email_branding/test_rest.py
@@ -33,11 +33,10 @@ def test_get_email_branding_options_filter_org(admin_request, notify_db, notify_
     assert len(email_branding) == 1
     assert email_branding[0]["organisation_id"] == str(sample_organisation.id)
 
-    email_branding2 = admin_request.get("email_branding.get_email_branding_options")[
-        "email_branding"
-    ]
+    email_branding2 = admin_request.get("email_branding.get_email_branding_options")["email_branding"]
 
     assert len(email_branding2) == 2
+
 
 def test_get_email_branding_by_id(admin_request, notify_db, notify_db_session):
     email_branding = EmailBranding(colour="#FFFFFF", logo="/path/image.png", name="Some Org", text="My Org")

--- a/tests/app/email_branding/test_rest.py
+++ b/tests/app/email_branding/test_rest.py
@@ -21,6 +21,19 @@ def test_get_email_branding_options(admin_request, notify_db, notify_db_session,
     assert email_branding[1]["organisation_id"] == ""
 
 
+def test_get_email_branding_options_filter_org(admin_request, notify_db, notify_db_session, sample_organisation):
+    email_branding1 = EmailBranding(colour="#FFFFFF", logo="/path/image.png", name="Org1", organisation_id=sample_organisation.id)
+    email_branding2 = EmailBranding(colour="#000000", logo="/path/other.png", name="Org2")
+    notify_db.session.add_all([email_branding1, email_branding2])
+    notify_db.session.commit()
+    email_branding = admin_request.get("email_branding.get_email_branding_options", organisation_id=sample_organisation.id)[
+        "email_branding"
+    ]
+
+    assert len(email_branding) == 1
+    assert email_branding[0]["organisation_id"] == str(sample_organisation.id)
+
+
 def test_get_email_branding_by_id(admin_request, notify_db, notify_db_session):
     email_branding = EmailBranding(colour="#FFFFFF", logo="/path/image.png", name="Some Org", text="My Org")
     notify_db.session.add(email_branding)

--- a/tests/app/email_branding/test_rest.py
+++ b/tests/app/email_branding/test_rest.py
@@ -33,6 +33,11 @@ def test_get_email_branding_options_filter_org(admin_request, notify_db, notify_
     assert len(email_branding) == 1
     assert email_branding[0]["organisation_id"] == str(sample_organisation.id)
 
+    email_branding2 = admin_request.get("email_branding.get_email_branding_options")[
+        "email_branding"
+    ]
+
+    assert len(email_branding2) == 2
 
 def test_get_email_branding_by_id(admin_request, notify_db, notify_db_session):
     email_branding = EmailBranding(colour="#FFFFFF", logo="/path/image.png", name="Some Org", text="My Org")


### PR DESCRIPTION
# Summary | Résumé

We want to get all the email_brands that belong to a particular organisation. This PR will let us do that.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1157

# Test instructions | Instructions pour tester la modification

This can be tested with the related admin PR

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.