### PR TITLE
Batch up job archiving code a bit

### DIFF
--- a/app/aws/s3.py
+++ b/app/aws/s3.py
@@ -60,8 +60,9 @@ def get_job_metadata_from_s3(service_id, job_id):
     return obj.get()["Metadata"]
 
 
-def remove_job_from_s3(service_id, job_id):
-    return remove_s3_object(*get_job_location(service_id, job_id))
+def remove_job_batch_from_s3(jobs):
+    for job in jobs:
+        remove_s3_object(*get_job_location(job.service_id, job.id))
 
 
 def get_s3_bucket_objects(bucket_name, subfolder="", older_than=7, limit_days=2):

--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -12,7 +12,10 @@ from app.celery.service_callback_tasks import send_delivery_status_to_service
 from app.config import QueueNames
 from app.cronitor import cronitor
 from app.dao.inbound_sms_dao import delete_inbound_sms_older_than_retention
-from app.dao.jobs_dao import dao_archive_job, dao_get_jobs_older_than_data_retention
+from app.dao.jobs_dao import (
+    dao_archive_job_batch,
+    dao_get_jobs_older_than_data_retention,
+)
 from app.dao.notifications_dao import (
     dao_timeout_notifications,
     delete_notifications_older_than_retention_by_type,
@@ -50,13 +53,13 @@ def remove_letter_csv_files():
 
 def _remove_csv_files(job_types):
     while True:
-        jobs = dao_get_jobs_older_than_data_retention(notification_types=job_types, limit=20000)
+        jobs = dao_get_jobs_older_than_data_retention(notification_types=job_types, limit=100)
         if len(jobs) == 0:
             break
         current_app.logger.info("Archiving {} jobs.".format(len(jobs)))
+        s3.remove_job_batch_from_s3(jobs)
+        dao_archive_job_batch(jobs)
         for job in jobs:
-            s3.remove_job_from_s3(job.service_id, job.id)
-            dao_archive_job(job)
             current_app.logger.info("Job ID {} has been removed from s3.".format(job.id))
 
 

--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -71,9 +71,10 @@ def dao_get_job_by_id(job_id) -> Job:
     return Job.query.filter_by(id=job_id).one()
 
 
-def dao_archive_job(job):
-    job.archived = True
-    db.session.add(job)
+def dao_archive_job_batch(jobs):
+    for job in jobs:
+        job.archived = True
+        db.session.add(job)
     db.session.commit()
 
 

--- a/tests/app/celery/test_nightly_tasks.py
+++ b/tests/app/celery/test_nightly_tasks.py
@@ -76,7 +76,7 @@ def test_will_remove_csv_files_for_jobs_older_than_seven_days(notify_db, notify_
     """
     Jobs older than seven days are deleted, but only two day's worth (two-day window)
     """
-    mocker.patch("app.celery.nightly_tasks.s3.remove_job_from_s3")
+    mocker.patch("app.celery.nightly_tasks.s3.remove_job_batch_from_s3")
 
     seven_days_ago = datetime.utcnow() - timedelta(days=7)
     just_under_seven_days = seven_days_ago + timedelta(seconds=1)
@@ -93,9 +93,10 @@ def test_will_remove_csv_files_for_jobs_older_than_seven_days(notify_db, notify_
 
     remove_sms_email_csv_files()
 
-    assert s3.remove_job_from_s3.call_args_list == [
-        call(job1_to_delete.service_id, job1_to_delete.id),
-        call(job2_to_delete.service_id, job2_to_delete.id),
+    assert s3.remove_job_batch_from_s3.call_args_list == [
+        call([job1_to_delete, job2_to_delete])
+        # call(job1_to_delete.service_id, job1_to_delete.id),
+        # call(job2_to_delete.service_id, job2_to_delete.id),
     ]
     assert job1_to_delete.archived is True
     assert dont_delete_me_1.archived is False
@@ -106,7 +107,7 @@ def test_will_remove_csv_files_for_jobs_older_than_retention_period(notify_db, n
     """
     Jobs older than retention period are deleted, but only two day's worth (two-day window)
     """
-    mocker.patch("app.celery.nightly_tasks.s3.remove_job_from_s3")
+    mocker.patch("app.celery.nightly_tasks.s3.remove_job_batch_from_s3")
     service_1 = create_service(service_name="service 1")
     service_2 = create_service(service_name="service 2")
     create_service_data_retention(service=service_1, notification_type=SMS_TYPE, days_of_retention=3)
@@ -131,20 +132,15 @@ def test_will_remove_csv_files_for_jobs_older_than_retention_period(notify_db, n
 
     remove_sms_email_csv_files()
 
-    s3.remove_job_from_s3.assert_has_calls(
-        [
-            call(job1_to_delete.service_id, job1_to_delete.id),
-            call(job2_to_delete.service_id, job2_to_delete.id),
-            call(job3_to_delete.service_id, job3_to_delete.id),
-            call(job4_to_delete.service_id, job4_to_delete.id),
-        ],
-        any_order=True,
+    args = s3.remove_job_batch_from_s3.call_args.args[0]
+    assert sorted(args, key=lambda x: x.id) == sorted(
+        [job1_to_delete, job2_to_delete, job3_to_delete, job4_to_delete], key=lambda x: x.id
     )
 
 
 @freeze_time("2017-01-01 10:00:00")
 def test_remove_csv_files_filters_by_type(mocker, sample_service):
-    mocker.patch("app.celery.nightly_tasks.s3.remove_job_from_s3")
+    mocker.patch("app.celery.nightly_tasks.s3.remove_job_batch_from_s3")
     """
     Jobs older than seven days are deleted, but only two day's worth (two-day window)
     """
@@ -158,8 +154,8 @@ def test_remove_csv_files_filters_by_type(mocker, sample_service):
 
     remove_letter_csv_files()
 
-    assert s3.remove_job_from_s3.call_args_list == [
-        call(job_to_delete.service_id, job_to_delete.id),
+    assert s3.remove_job_batch_from_s3.call_args_list == [
+        call([job_to_delete]),
     ]
 
 


### PR DESCRIPTION
# Summary | Résumé


Task that archives jobs is archiving about 230 jobs / minute, which is pretty slow given that we expect it to do about 40K per day. This PR batches up both the database operation to mark the jobs as archived as well as deleting the files from s3.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/307

# Test instructions | Instructions pour tester la modification

Staging should have old jobs being archived without issues.

# Release Instructions | Instructions pour le déploiement

Check the speed that jobs are being archived. Should be much faster than 230 / minute.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.