### PR TITLE
chore: update base catalog info

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,11 +1,18 @@
+# Metadata for the backstage catalog accessible at this link:
+# https://backstage.cdssandbox.xyz/
+---
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: notification-api
-  description: GC Notify API | GC Notification API
+  name: notification-api-service
+  title: GC Notify API | GC Notification API
+  description: REST API service for GC Notification
+  annotations:
+    github.com/project-slug: cds-snc/notification-api
   labels:
     license: MIT
 spec:
-  type: website
-  lifecycle: experimental
-  owner: cds-snc
+  type: service
+  lifecycle: production
+  owner: group:cds-snc/notify-dev
+  system: gc-notification


### PR DESCRIPTION
# Summary | Résumé

Updating base catalog info to set the component as a Service part of the larger GC Notification system, that will provide an API (to be defined hereafter if possible), owned by the notify-dev team and already in production.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.