### PR TITLE
handle extra spaces in api key auth line

### DIFF
--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -63,7 +63,7 @@ def get_auth_token(req):
     for el in AUTH_TYPES:
         scheme, auth_type, _ = el
         if auth_header.lower().startswith(scheme.lower()):
-            token = auth_header[len(scheme) + 1 :]
+            token = auth_header[len(scheme) + 1 :].strip()
             return auth_type, token
 
     raise AuthError(

--- a/tests/app/authentication/test_authentication.py
+++ b/tests/app/authentication/test_authentication.py
@@ -141,6 +141,14 @@ def test_should_allow_auth_with_api_key_scheme(client, sample_api_key, scheme):
     assert response.status_code == 200
 
 
+def test_should_allow_auth_with_api_key_scheme_and_extra_spaces(client, sample_api_key):
+    api_key_secret = get_unsigned_secret(sample_api_key.id)
+    unsigned_secret = f"gcntfy-keyname-{sample_api_key.service_id}-{api_key_secret}"
+    response = client.get("/notifications", headers={"Authorization": f"ApiKey-v1    {unsigned_secret}"})
+
+    assert response.status_code == 200
+
+
 def test_should_NOT_allow_auth_with_api_key_scheme_with_incorrect_format(client, sample_api_key):
     api_key_secret = "fhsdkjhfdsfhsd" + get_unsigned_secret(sample_api_key.id)
 


### PR DESCRIPTION
# Summary | Résumé

We noticed that when doing an api call to send an email, if there is an extra space in the auth line we now get an error.
For example, using
```
Authorization:ApiKey-v1   gcntfy-new...
```
gets a 403 "Invalid token: Enter your full API key"
But
```
Authorization:ApiKey-v1 gcntfy-new...
```
works fine. This PR allows extra spaces between `ApiKey-v1` and the key.

# Test instructions | Instructions pour tester la modification

Add extra spaces and see if there's an auth error.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.