### PR TITLE
Retry callbacks on 429 'too many requests' code

### DIFF
--- a/app/celery/service_callback_tasks.py
+++ b/app/celery/service_callback_tasks.py
@@ -77,6 +77,7 @@ def _send_data_to_service_callback_api(self, data, service_callback_url, token, 
         current_app.logger.warning(
             f"{function_name} request failed for notification_id: {notification_id} and url: {service_callback_url}. exc: {e}"
         )
+        # Retry if the response status code is server-side or 429 (too many requests).
         if not isinstance(e, HTTPError) or e.response.status_code >= 500 or e.response.status_code == 429:
             try:
                 self.retry(queue=QueueNames.CALLBACKS_RETRY)

--- a/app/celery/service_callback_tasks.py
+++ b/app/celery/service_callback_tasks.py
@@ -65,31 +65,22 @@ def _send_data_to_service_callback_api(self, data, service_callback_url, token, 
             data=json.dumps(data),
             headers={
                 "Content-Type": "application/json",
-                "Authorization": "Bearer {}".format(token),
+                "Authorization": f"Bearer {token}",
             },
             timeout=5,
         )
         current_app.logger.info(
-            "{} sending {} to {}, response {}".format(
-                function_name,
-                notification_id,
-                service_callback_url,
-                response.status_code,
-            )
+            f"{function_name} sending {notification_id} to {service_callback_url}, response {response.status_code}"
         )
         response.raise_for_status()
     except RequestException as e:
         current_app.logger.warning(
-            "{} request failed for notification_id: {} and url: {}. exc: {}".format(
-                function_name, notification_id, service_callback_url, e
-            )
+            f"{function_name} request failed for notification_id: {notification_id} and url: {service_callback_url}. exc: {e}"
         )
-        if not isinstance(e, HTTPError) or e.response.status_code >= 500:
+        if not isinstance(e, HTTPError) or e.response.status_code >= 500 or e.response.status_code == 429:
             try:
                 self.retry(queue=QueueNames.CALLBACKS_RETRY)
             except self.MaxRetriesExceededError:
                 current_app.logger.warning(
-                    "Retry: {} has retried the max num of times for callback url {} and notification_id: {}".format(
-                        function_name, service_callback_url, notification_id
-                    )
+                    "Retry: {function_name} has retried the max num of times for callback url {service_callback_url} and notification_id: {notification_id}"
                 )

--- a/tests/app/celery/test_service_callback_tasks.py
+++ b/tests/app/celery/test_service_callback_tasks.py
@@ -90,8 +90,9 @@ def test_send_complaint_to_service_posts_https_request_to_service_with_signed_da
 
 
 @pytest.mark.parametrize("notification_type", ["email", "letter", "sms"])
-def test__send_data_to_service_callback_api_retries_if_request_returns_500_with_signed_data(
-    notify_db_session, mocker, notification_type
+@pytest.mark.parametrize('status_code', [429, 500, 503])
+def test__send_data_to_service_callback_api_retries_if_request_returns_error_code_with_signed_data(
+    notify_db_session, mocker, notification_type, status_code
 ):
     callback_api, template = _set_up_test_data(notification_type, "delivery_status")
     datestr = datetime(2017, 6, 20)
@@ -107,7 +108,7 @@ def test__send_data_to_service_callback_api_retries_if_request_returns_500_with_
     signed_data = _set_up_data_for_status_update(callback_api, notification)
     mocked = mocker.patch("app.celery.service_callback_tasks.send_delivery_status_to_service.retry")
     with requests_mock.Mocker() as request_mock:
-        request_mock.post(callback_api.url, json={}, status_code=500)
+        request_mock.post(callback_api.url, json={}, status_code=status_code)
         send_delivery_status_to_service(notification.id, signed_status_update=signed_data)
 
     assert mocked.call_count == 1

--- a/tests/app/celery/test_service_callback_tasks.py
+++ b/tests/app/celery/test_service_callback_tasks.py
@@ -90,7 +90,7 @@ def test_send_complaint_to_service_posts_https_request_to_service_with_signed_da
 
 
 @pytest.mark.parametrize("notification_type", ["email", "letter", "sms"])
-@pytest.mark.parametrize('status_code', [429, 500, 503])
+@pytest.mark.parametrize("status_code", [429, 500, 503])
 def test__send_data_to_service_callback_api_retries_if_request_returns_error_code_with_signed_data(
     notify_db_session, mocker, notification_type, status_code
 ):


### PR DESCRIPTION
# Summary | Résumé

Applying GDS upstream goodie [from this PR changes](https://github.com/alphagov/notifications-api/pull/3289):

> if we're served a 429, put the item on the retry queue and retry the same as if the service returned a 5xx. 429 is commonly returned for rate limit exceeding, and retrying on a delay is a typical response to that.

## Related Issues | Cartes liées

* [Callback URLs timeout and slows down all Celery workers](https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/326)

# Test instructions | Instructions pour tester la modification

1. Setup a service with a callback URL such as https://httpstat.us/429?sleep=100 (which will return a 429 status code after 100ms).
2. Send a batch of notifications through the newly configured service with the associated 429 callback URL. 
3. Verify the notifications are retried.
4. After verifications, you can either remove the callback URL or use https://httpstat.us/200?sleep=100 (I would favor the first option to skip callback URL) in order to drain the `callbacks_retry` queue.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.