### PR TITLE
Added alt text for email_branding table

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -280,6 +280,8 @@ class EmailBranding(BaseModel):
         UUID(as_uuid=True), db.ForeignKey("organisation.id", ondelete="SET NULL"), index=True, nullable=True
     )
     organisation = db.relationship("Organisation", back_populates="email_branding", foreign_keys=[organisation_id])
+    alt_text_en = db.Column(db.String(), nullable=True)
+    alt_text_fr = db.Column(db.String(), nullable=True)
 
     def serialize(self) -> dict:
         serialized = {
@@ -290,6 +292,8 @@ class EmailBranding(BaseModel):
             "text": self.text,
             "brand_type": self.brand_type,
             "organisation_id": str(self.organisation_id) if self.organisation_id else "",
+            "alt_text_en": self.alt_text_en,
+            "alt_text_fr": self.alt_text_fr,
         }
 
         return serialized

--- a/migrations/versions/0446_add_alt_text.py
+++ b/migrations/versions/0446_add_alt_text.py
@@ -6,7 +6,6 @@ Create Date: 2024-04-23
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy import text
-from sqlalchemy.dialects import postgresql
 
 revision = "0446_add_alt_text"
 down_revision = "0445_add_org_id_branding"

--- a/migrations/versions/0446_add_alt_text.py
+++ b/migrations/versions/0446_add_alt_text.py
@@ -1,0 +1,35 @@
+"""
+Revision ID: 0446_add_alt_text.py
+Revises: 0445_add_org_id_branding.py
+Create Date: 2024-04-23
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import text
+from sqlalchemy.dialects import postgresql
+
+revision = "0446_add_alt_text"
+down_revision = "0445_add_org_id_branding"
+
+
+def upgrade():
+    table_description = op.get_bind().execute(
+        text("SELECT * FROM information_schema.columns WHERE table_name = 'email_branding'")
+    )
+
+    # Check if the column exists
+    if "alt_text_en" not in [column["column_name"] for column in table_description]:
+        op.add_column(
+            "email_branding",
+            sa.Column("alt_text_en", sa.String(), nullable=True),
+        )
+    if "alt_text_fr" not in [column["column_name"] for column in table_description]:
+        op.add_column(
+            "email_branding",
+            sa.Column("alt_text_fr", sa.String(), nullable=True),
+        )
+
+
+def downgrade():
+    op.drop_column("email_branding", "alt_text_fr")
+    op.drop_column("email_branding", "alt_text_en")

--- a/tests/app/email_branding/test_rest.py
+++ b/tests/app/email_branding/test_rest.py
@@ -39,7 +39,9 @@ def test_get_email_branding_options_filter_org(admin_request, notify_db, notify_
 
 
 def test_get_email_branding_by_id(admin_request, notify_db, notify_db_session):
-    email_branding = EmailBranding(colour="#FFFFFF", logo="/path/image.png", name="Some Org", text="My Org", alt_text_en="hello world")
+    email_branding = EmailBranding(
+        colour="#FFFFFF", logo="/path/image.png", name="Some Org", text="My Org", alt_text_en="hello world"
+    )
     notify_db.session.add(email_branding)
     notify_db.session.commit()
 

--- a/tests/app/email_branding/test_rest.py
+++ b/tests/app/email_branding/test_rest.py
@@ -39,7 +39,7 @@ def test_get_email_branding_options_filter_org(admin_request, notify_db, notify_
 
 
 def test_get_email_branding_by_id(admin_request, notify_db, notify_db_session):
-    email_branding = EmailBranding(colour="#FFFFFF", logo="/path/image.png", name="Some Org", text="My Org")
+    email_branding = EmailBranding(colour="#FFFFFF", logo="/path/image.png", name="Some Org", text="My Org", alt_text_en="hello world")
     notify_db.session.add(email_branding)
     notify_db.session.commit()
 
@@ -57,6 +57,8 @@ def test_get_email_branding_by_id(admin_request, notify_db, notify_db_session):
         "text",
         "brand_type",
         "organisation_id",
+        "alt_text_en",
+        "alt_text_fr",
     }
     assert response["email_branding"]["colour"] == "#FFFFFF"
     assert response["email_branding"]["logo"] == "/path/image.png"
@@ -64,6 +66,8 @@ def test_get_email_branding_by_id(admin_request, notify_db, notify_db_session):
     assert response["email_branding"]["text"] == "My Org"
     assert response["email_branding"]["id"] == str(email_branding.id)
     assert response["email_branding"]["brand_type"] == str(email_branding.brand_type)
+    assert response["email_branding"]["alt_text_en"] == "hello world"
+    assert response["email_branding"]["alt_text_fr"] is None
 
 
 def test_post_create_email_branding(admin_request, notify_db_session):


### PR DESCRIPTION
# Summary | Résumé
Add alt text columns in the branding table

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1541

# Test instructions | Instructions pour tester la modification
<img width="734" alt="Screenshot 2024-04-23 at 3 51 55 PM" src="https://github.com/cds-snc/notification-api/assets/8869623/1844152b-df0b-433e-abb5-4a95ca289324">

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [x] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [x] This PR does not significantly alter performance.
- [x] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.