### PR TITLE
Add alt text en/fr intake

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,7 +67,7 @@ jobs:
       run: |
         cp -f .env.example .env
     - name: Checks for new endpoints against AWS WAF rules
-      uses: cds-snc/notification-utils/.github/actions/waffles@578b4147fe6c7a8f89241649b763f94ef24b2ad4 # 52.2.2
+      uses: cds-snc/notification-utils/.github/actions/waffles@52.2.2
       with:
         app-loc: '/github/workspace'
         app-libs: '/github/workspace/env/site-packages'

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -353,12 +353,16 @@ def get_html_email_options(service: Service):
                 "fip_banner_english": False,
                 "fip_banner_french": True,
                 "logo_with_background_colour": False,
+                "alt_text_en": None,
+                "alt_text_fr": None,
             }
         else:
             return {
                 "fip_banner_english": True,
                 "fip_banner_french": False,
                 "logo_with_background_colour": False,
+                "alt_text_en": None,
+                "alt_text_fr": None,
             }
 
     logo_url = get_logo_url(service.email_branding.logo) if service.email_branding.logo else None
@@ -371,6 +375,8 @@ def get_html_email_options(service: Service):
         "brand_logo": logo_url,
         "brand_text": service.email_branding.text,
         "brand_name": service.email_branding.name,
+        "alt_text_en": service.email_branding.alt_text_en,
+        "alt_text_fr": service.email_branding.alt_text_fr,
     }
 
 

--- a/app/email_branding/email_branding_schema.py
+++ b/app/email_branding/email_branding_schema.py
@@ -10,8 +10,10 @@ post_create_email_branding_schema = {
         "text": {"type": ["string", "null"]},
         "logo": {"type": ["string", "null"]},
         "brand_type": {"enum": BRANDING_TYPES},
+        "alt_text_en": {"type": "string"},
+        "alt_text_fr": {"type": "string"},
     },
-    "required": ["name"],
+    "required": ["name", "alt_text_en", "alt_text_fr"],
 }
 
 post_update_email_branding_schema = {
@@ -24,6 +26,8 @@ post_update_email_branding_schema = {
         "text": {"type": ["string", "null"]},
         "logo": {"type": ["string", "null"]},
         "brand_type": {"enum": BRANDING_TYPES},
+        "alt_text_en": {"type": "string"},
+        "alt_text_fr": {"type": "string"},
     },
     "required": [],
 }

--- a/app/user/contact_request.py
+++ b/app/user/contact_request.py
@@ -31,6 +31,8 @@ class ContactRequest:
     notification_types: str = field(default="")
     expected_volume: str = field(default="")
     branding_url: str = field(default="")
+    alt_text_en: str = field(default="")
+    alt_text_fr: str = field(default="")
 
     def __post_init__(self):
         # email address is mandatory for us

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -500,6 +500,8 @@ def send_branding_request(user_id):
             organisation_id=data["organisation_id"],
             department_org_name=data["organisation_name"],
             branding_url=get_logo_url(data["filename"]),
+            alt_text_en=data["alt_text_en"],
+            alt_text_fr=data["alt_text_fr"],
         )
         contact.tags = ["z_skip_opsgenie", "z_skip_urgent_escalation"]
 

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -596,19 +596,20 @@ def test_get_html_email_renderer_with_branding_details_and_render_fip_banner_eng
     sample_service.email_branding = None
     notify_db.session.add_all([sample_service])
     notify_db.session.commit()
-
     options = send_to_providers.get_html_email_options(sample_service)
 
     assert options == {
         "fip_banner_english": True,
         "fip_banner_french": False,
         "logo_with_background_colour": False,
+        "alt_text_en": None,
+        "alt_text_fr": None,
     }
 
 
 def test_get_html_email_renderer_prepends_logo_path(notify_api):
     Service = namedtuple("Service", ["email_branding"])
-    EmailBranding = namedtuple("EmailBranding", ["brand_type", "colour", "name", "logo", "text"])
+    EmailBranding = namedtuple("EmailBranding", ["brand_type", "colour", "name", "logo", "text", "alt_text_en", "alt_text_fr"])
 
     email_branding = EmailBranding(
         brand_type=BRANDING_ORG_NEW,
@@ -616,6 +617,8 @@ def test_get_html_email_renderer_prepends_logo_path(notify_api):
         logo="justice-league.png",
         name="Justice League",
         text="League of Justice",
+        alt_text_en="alt_text_en",
+        alt_text_fr="alt_text_fr",
     )
     service = Service(
         email_branding=email_branding,
@@ -628,7 +631,7 @@ def test_get_html_email_renderer_prepends_logo_path(notify_api):
 
 def test_get_html_email_renderer_handles_email_branding_without_logo(notify_api):
     Service = namedtuple("Service", ["email_branding"])
-    EmailBranding = namedtuple("EmailBranding", ["brand_type", "colour", "name", "logo", "text"])
+    EmailBranding = namedtuple("EmailBranding", ["brand_type", "colour", "name", "logo", "text", "alt_text_en", "alt_text_fr"])
 
     email_branding = EmailBranding(
         brand_type=BRANDING_ORG_BANNER_NEW,
@@ -636,6 +639,8 @@ def test_get_html_email_renderer_handles_email_branding_without_logo(notify_api)
         logo=None,
         name="Justice League",
         text="League of Justice",
+        alt_text_en="alt_text_en",
+        alt_text_fr="alt_text_fr",
     )
     service = Service(
         email_branding=email_branding,
@@ -649,6 +654,8 @@ def test_get_html_email_renderer_handles_email_branding_without_logo(notify_api)
     assert renderer["brand_text"] == "League of Justice"
     assert renderer["brand_colour"] == "#000000"
     assert renderer["brand_name"] == "Justice League"
+    assert renderer["alt_text_en"] == "alt_text_en"
+    assert renderer["alt_text_fr"] == "alt_text_fr"
 
 
 def test_should_not_update_notification_if_research_mode_on_exception(sample_service, sample_notification, mocker):

--- a/tests/app/email_branding/test_rest.py
+++ b/tests/app/email_branding/test_rest.py
@@ -78,6 +78,8 @@ def test_post_create_email_branding(admin_request, notify_db_session):
         "colour": "#0000ff",
         "logo": "/images/test_x2.png",
         "brand_type": BRANDING_ORG_NEW,
+        "alt_text_en": "hello world",
+        "alt_text_fr": "bonjour le monde",
     }
     response = admin_request.post("email_branding.create_email_branding", _data=data, _expected_status=201)
     assert data["name"] == response["data"]["name"]
@@ -85,6 +87,8 @@ def test_post_create_email_branding(admin_request, notify_db_session):
     assert data["logo"] == response["data"]["logo"]
     assert data["name"] == response["data"]["text"]
     assert data["brand_type"] == response["data"]["brand_type"]
+    assert data["alt_text_en"] == response["data"]["alt_text_en"]
+    assert data["alt_text_fr"] == response["data"]["alt_text_fr"]
 
 
 def test_post_create_email_branding_without_brand_type_defaults(admin_request, notify_db_session):
@@ -92,16 +96,15 @@ def test_post_create_email_branding_without_brand_type_defaults(admin_request, n
         "name": "test email_branding",
         "colour": "#0000ff",
         "logo": "/images/test_x2.png",
+        "alt_text_en": "hello world",
+        "alt_text_fr": "bonjour le monde",
     }
     response = admin_request.post("email_branding.create_email_branding", _data=data, _expected_status=201)
     assert BRANDING_ORG_NEW == response["data"]["brand_type"]
 
 
 def test_post_create_email_branding_without_logo_is_ok(admin_request, notify_db_session):
-    data = {
-        "name": "test email_branding",
-        "colour": "#0000ff",
-    }
+    data = {"name": "test email_branding", "colour": "#0000ff", "alt_text_en": "hello", "alt_text_fr": "bonjour"}
     response = admin_request.post(
         "email_branding.create_email_branding",
         _data=data,
@@ -111,13 +114,15 @@ def test_post_create_email_branding_without_logo_is_ok(admin_request, notify_db_
 
 
 def test_post_create_email_branding_colour_is_valid(admin_request, notify_db_session):
-    data = {"logo": "images/text_x2.png", "name": "test branding"}
+    data = {"logo": "images/text_x2.png", "name": "test branding", "alt_text_en": "hello", "alt_text_fr": "bonjour"}
     response = admin_request.post("email_branding.create_email_branding", _data=data, _expected_status=201)
 
     assert response["data"]["logo"] == data["logo"]
     assert response["data"]["name"] == "test branding"
     assert response["data"]["colour"] is None
     assert response["data"]["text"] == "test branding"
+    assert response["data"]["alt_text_en"] == "hello"
+    assert response["data"]["alt_text_fr"] == "bonjour"
 
 
 def test_post_create_email_branding_with_text(admin_request, notify_db_session):
@@ -125,6 +130,8 @@ def test_post_create_email_branding_with_text(admin_request, notify_db_session):
         "text": "text for brand",
         "logo": "images/text_x2.png",
         "name": "test branding",
+        "alt_text_en": "hello",
+        "alt_text_fr": "bonjour",
     }
     response = admin_request.post("email_branding.create_email_branding", _data=data, _expected_status=201)
 
@@ -132,6 +139,8 @@ def test_post_create_email_branding_with_text(admin_request, notify_db_session):
     assert response["data"]["name"] == "test branding"
     assert response["data"]["colour"] is None
     assert response["data"]["text"] == "text for brand"
+    assert response["data"]["alt_text_en"] == "hello"
+    assert response["data"]["alt_text_fr"] == "bonjour"
 
 
 def test_post_create_email_branding_with_text_and_name(admin_request, notify_db_session):
@@ -139,6 +148,8 @@ def test_post_create_email_branding_with_text_and_name(admin_request, notify_db_
         "name": "name for brand",
         "text": "text for brand",
         "logo": "images/text_x2.png",
+        "alt_text_en": "hello",
+        "alt_text_fr": "bonjour",
     }
     response = admin_request.post("email_branding.create_email_branding", _data=data, _expected_status=201)
 
@@ -146,20 +157,35 @@ def test_post_create_email_branding_with_text_and_name(admin_request, notify_db_
     assert response["data"]["name"] == "name for brand"
     assert response["data"]["colour"] is None
     assert response["data"]["text"] == "text for brand"
+    assert response["data"]["alt_text_en"] == "hello"
+    assert response["data"]["alt_text_fr"] == "bonjour"
 
 
 def test_post_create_email_branding_with_text_as_none_and_name(admin_request, notify_db_session):
-    data = {"name": "name for brand", "text": None, "logo": "images/text_x2.png"}
+    data = {
+        "name": "name for brand",
+        "text": None,
+        "logo": "images/text_x2.png",
+        "alt_text_en": "hello",
+        "alt_text_fr": "bonjour",
+    }
     response = admin_request.post("email_branding.create_email_branding", _data=data, _expected_status=201)
 
     assert response["data"]["logo"] == data["logo"]
     assert response["data"]["name"] == "name for brand"
     assert response["data"]["colour"] is None
     assert response["data"]["text"] is None
+    assert response["data"]["alt_text_en"] == "hello"
+    assert response["data"]["alt_text_fr"] == "bonjour"
 
 
 def test_post_create_email_branding_returns_400_when_name_is_missing(admin_request, notify_db_session):
-    data = {"text": "some text", "logo": "images/text_x2.png"}
+    data = {
+        "text": "some text",
+        "logo": "images/text_x2.png",
+        "alt_text_en": "hello",
+        "alt_text_fr": "bonjour",
+    }
     response = admin_request.post("email_branding.create_email_branding", _data=data, _expected_status=400)
 
     assert response["errors"][0]["message"] == "name is a required property"
@@ -176,7 +202,7 @@ def test_post_create_email_branding_returns_400_when_name_is_missing(admin_reque
     ],
 )
 def test_post_update_email_branding_updates_field(admin_request, notify_db_session, data_update):
-    data = {"name": "test email_branding", "logo": "images/text_x2.png"}
+    data = {"name": "test email_branding", "logo": "images/text_x2.png", "alt_text_en": "hello", "alt_text_fr": "bonjour"}
     response = admin_request.post("email_branding.create_email_branding", _data=data, _expected_status=201)
 
     email_branding_id = response["data"]["id"]
@@ -205,7 +231,7 @@ def test_post_update_email_branding_updates_field(admin_request, notify_db_sessi
     ],
 )
 def test_post_update_email_branding_updates_field_with_text(admin_request, notify_db_session, data_update):
-    data = {"name": "test email_branding", "logo": "images/text_x2.png"}
+    data = {"name": "test email_branding", "logo": "images/text_x2.png", "alt_text_en": "hello", "alt_text_fr": "bonjour"}
     response = admin_request.post("email_branding.create_email_branding", _data=data, _expected_status=201)
 
     email_branding_id = response["data"]["id"]

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -964,6 +964,8 @@ def test_send_branding_request(client, sample_service, sample_organisation, mock
         "organisation_id": str(sample_service.organisation.id),
         "organisation_name": sample_service.organisation.name,
         "filename": "branding_url",
+        "alt_text_en": "hello world",
+        "alt_text_fr": "bonjour",
     }
     mocked_freshdesk = mocker.patch("app.user.rest.Freshdesk.send_ticket", return_value=201)
     mocked_salesforce_client = mocker.patch("app.user.rest.salesforce_client")


### PR DESCRIPTION
# Summary | Résumé

Add fields to add alt text en/fr to the Branding update/modidfy as well as Intake form. 

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1542

# Test instructions | Instructions pour tester la modification

Will need to test along with the [admin PR here](https://github.com/cds-snc/notification-admin/pull/1820)

# Release Instructions | Instructions pour le déploiement

Cannot merge without this: https://github.com/cds-snc/notification-admin/pull/1820

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.