### PR TITLE
fix/use a service's fixed phone number if set

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -246,10 +246,19 @@ def save_smss(self, service_id: Optional[str], signed_notifications: List[Signed
         reply_to_text = ""  # type: ignore
         if sender_id:
             reply_to_text = dao_get_service_sms_senders_by_id(service_id, sender_id).sms_sender
+            current_app.logger.info(
+                f"notification {notification_id} setting reply_to_text to {reply_to_text} using sender_id {sender_id}"
+            )
         elif template.service:
             reply_to_text = template.get_reply_to_text()
+            current_app.logger.info(
+                f"notification {notification_id} setting reply_to_text to {reply_to_text} using template {template.id}"
+            )
         else:
             reply_to_text = service.get_default_sms_sender()  # type: ignore
+            current_app.logger.info(
+                f"notification {notification_id} setting reply_to_text to {reply_to_text} using service {service.id}"
+            )
 
         notification: VerifiedNotification = {
             **_notification,  # type: ignore

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -246,15 +246,18 @@ def save_smss(self, service_id: Optional[str], signed_notifications: List[Signed
         sender_id = _notification.get("sender_id")  # type: ignore
         notification_id = _notification.get("id", create_uuid())
 
-        reply_to_text = ""  # type: ignore
-        if sender_id:
-            reply_to_text = try_validate_and_format_phone_number(
-                dao_get_service_sms_senders_by_id(service_id, sender_id).sms_sender
-            )
-        elif template.service:
-            reply_to_text = template.get_reply_to_text()
+        if "reply_to_text" in _notification and _notification["reply_to_text"]:
+            reply_to_text = _notification["reply_to_text"]
         else:
-            reply_to_text = service.get_default_sms_sender()  # type: ignore
+            reply_to_text = ""  # type: ignore
+            if sender_id:
+                reply_to_text = try_validate_and_format_phone_number(
+                    dao_get_service_sms_senders_by_id(service_id, sender_id).sms_sender
+                )
+            elif template.service:
+                reply_to_text = template.get_reply_to_text()
+            else:
+                reply_to_text = service.get_default_sms_sender()  # type: ignore
 
         notification: VerifiedNotification = {
             **_notification,  # type: ignore

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -169,8 +169,8 @@ def create_job(service_id):
     if template.template_type == SMS_TYPE:
         # set sender_id if missing
         default_senders = [x for x in service.service_sms_senders if x.is_default]
-        default_sender = default_senders[0] if default_senders else None
-        data["sender_id"] = data.get("sender_id", default_sender.id)
+        default_sender_id = default_senders[0].id if default_senders else None
+        data["sender_id"] = data.get("sender_id", default_sender_id)
 
         # calculate the number of simulated recipients
         numberOfSimulated = sum(simulated_recipient(i["phone_number"].data, template.template_type) for i in recipient_csv.rows)

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -167,6 +167,9 @@ def create_job(service_id):
     )
 
     if template.template_type == SMS_TYPE:
+        default_sms_sender = [x for x in service.service_sms_senders if x.is_default]
+        data["sender_id"] = default_sms_sender[0].id if default_sms_sender else None
+
         # calculate the number of simulated recipients
         numberOfSimulated = sum(simulated_recipient(i["phone_number"].data, template.template_type) for i in recipient_csv.rows)
         mixedRecipients = numberOfSimulated > 0 and numberOfSimulated != len(recipient_csv)

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -170,7 +170,7 @@ def create_job(service_id):
         # set sender_id if missing
         default_senders = [x for x in service.service_sms_senders if x.is_default]
         default_sender = default_senders[0] if default_senders else None
-        data["sender_id"] = data.get("sender_id", default_sender)
+        data["sender_id"] = data.get("sender_id", default_sender.id)
 
         # calculate the number of simulated recipients
         numberOfSimulated = sum(simulated_recipient(i["phone_number"].data, template.template_type) for i in recipient_csv.rows)

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -167,8 +167,10 @@ def create_job(service_id):
     )
 
     if template.template_type == SMS_TYPE:
-        default_sms_sender = [x for x in service.service_sms_senders if x.is_default]
-        data["sender_id"] = default_sms_sender[0].id if default_sms_sender else None
+        # set sender_id if missing
+        default_senders = [x for x in service.service_sms_senders if x.is_default]
+        default_sender = default_senders[0] if default_senders else None
+        data["sender_id"] = data.get("sender_id", default_sender)
 
         # calculate the number of simulated recipients
         numberOfSimulated = sum(simulated_recipient(i["phone_number"].data, template.template_type) for i in recipient_csv.rows)

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -234,7 +234,7 @@ def post_bulk():
             default_senders = [x for x in authenticated_service.service_sms_senders if x.is_default]
             default_sender = default_senders[0] if default_senders else None
             form["validated_sender_id"] = default_sender.id
-        
+
         # calculate the number of simulated recipients
         numberOfSimulated = sum(
             simulated_recipient(i["phone_number"].data, template.template_type) for i in list(recipient_csv.get_rows())

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -229,6 +229,12 @@ def post_bulk():
             increment_email_daily_count_send_warnings_if_needed(authenticated_service, len(list(recipient_csv.get_rows())))
 
     if template.template_type == SMS_TYPE:
+        # set sender_id if missing
+        if form["validated_sender_id"] is None:
+            default_senders = [x for x in authenticated_service.service_sms_senders if x.is_default]
+            default_sender = default_senders[0] if default_senders else None
+            form["validated_sender_id"] = default_sender.id
+        
         # calculate the number of simulated recipients
         numberOfSimulated = sum(
             simulated_recipient(i["phone_number"].data, template.template_type) for i in list(recipient_csv.get_rows())

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -232,8 +232,8 @@ def post_bulk():
         # set sender_id if missing
         if form["validated_sender_id"] is None:
             default_senders = [x for x in authenticated_service.service_sms_senders if x.is_default]
-            default_sender = default_senders[0] if default_senders else None
-            form["validated_sender_id"] = default_sender.id
+            default_sender_id = default_senders[0].id if default_senders else None
+            form["validated_sender_id"] = default_sender_id
 
         # calculate the number of simulated recipients
         numberOfSimulated = sum(

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -1154,7 +1154,7 @@ class TestSaveSmss:
             notification["sender_id"] = sender_id
 
         sms_sender = ServiceSmsSender()
-        sms_sender.sms_sender = "+16502532222"
+        sms_sender.sms_sender = "6135550123"
         mocked_get_sender_id = mocker.patch("app.celery.tasks.dao_get_service_sms_senders_by_id", return_value=sms_sender)
         celery_task = "deliver_throttled_sms" if sender_id else "deliver_sms"
         mocked_deliver_sms = mocker.patch(f"app.celery.provider_tasks.{celery_task}.apply_async")
@@ -1191,6 +1191,8 @@ class TestSaveSmss:
         assert persisted_notification.personalisation == {"name": "Jo"}
         assert persisted_notification._personalisation == signer_personalisation.sign({"name": "Jo"})
         assert persisted_notification.notification_type == "sms"
+        assert persisted_notification.reply_to_text == (f"+1{sms_sender.sms_sender}" if sender_id else None)
+
         mocked_deliver_sms.assert_called_once_with(
             [str(persisted_notification.id)], queue="send-throttled-sms-tasks" if sender_id else QueueNames.SEND_SMS_MEDIUM
         )

--- a/tests/app/job/test_rest.py
+++ b/tests/app/job/test_rest.py
@@ -8,12 +8,14 @@ from freezegun import freeze_time
 
 import app.celery.tasks
 from app.dao.templates_dao import dao_update_template
-from app.models import JOB_STATUS_PENDING, JOB_STATUS_TYPES
+from app.models import JOB_STATUS_PENDING, JOB_STATUS_TYPES, ServiceSmsSender
 from tests import create_authorization_header
 from tests.app.db import (
     create_ft_notification_status,
     create_job,
     create_notification,
+    create_service_with_inbound_number,
+    create_template,
     save_notification,
 )
 from tests.conftest import set_config
@@ -261,6 +263,39 @@ def test_create_unscheduled_job_with_sender_id_in_metadata(client, sample_templa
     assert resp_json["data"]["sender_id"] == fake_uuid
 
     app.celery.tasks.process_job.apply_async.assert_called_once_with(([str(fake_uuid)]), queue="job-tasks")
+
+
+def test_create_job_sets_sender_id_from_database(client, mocker, fake_uuid, sample_user):
+    service = create_service_with_inbound_number(inbound_number="12345")
+    template = create_template(service=service)
+    sms_sender = ServiceSmsSender.query.filter_by(service_id=service.id).first()
+
+    mocker.patch("app.celery.tasks.process_job.apply_async")
+    mocker.patch(
+        "app.job.rest.get_job_metadata_from_s3",
+        return_value={
+            "template_id": str(template.id),
+            "original_file_name": "thisisatest.csv",
+            "notification_count": "1",
+            "valid": "True",
+        },
+    )
+    mocker.patch(
+        "app.job.rest.get_job_from_s3",
+        return_value="phone number\r\n6502532222",
+    )
+    data = {
+        "id": fake_uuid,
+        "created_by": str(template.created_by.id),
+    }
+    path = "/service/{}/job".format(service.id)
+    auth_header = create_authorization_header()
+    headers = [("Content-Type", "application/json"), auth_header]
+
+    response = client.post(path, data=json.dumps(data), headers=headers)
+    resp_json = json.loads(response.get_data(as_text=True))
+
+    assert resp_json["data"]["sender_id"] == str(sms_sender.id)
 
 
 @freeze_time("2016-01-01 12:00:00.000000")

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -26,6 +26,7 @@ from app.models import (
     ApiKey,
     Notification,
     ScheduledNotification,
+    ServiceSmsSender,
 )
 from app.schema_validation import validate
 from app.utils import get_document_url
@@ -2489,6 +2490,33 @@ class TestBulkSend:
                 "sender_id": str(reply_to_email.id) if use_sender_id else None,
             }
         }
+
+    def test_post_bulk_sms_sets_sender_id_from_database(
+        self,
+        client,
+        mocker,
+        notify_user,
+        notify_api,
+    ):
+        service = create_service_with_inbound_number(inbound_number="12345")
+        template = create_template(service=service)
+        sms_sender = ServiceSmsSender.query.filter_by(service_id=service.id).first()
+        data = {"name": "job_name", "template_id": template.id, "rows": [["phone number"], ["6135550111"]]}
+        job_id = str(uuid.uuid4())
+        mocker.patch("app.v2.notifications.post_notifications.upload_job_to_s3", return_value=job_id)
+        mocker.patch("app.v2.notifications.post_notifications.process_job.apply_async")
+
+        client.post(
+            "/v2/notifications/bulk",
+            data=json.dumps(data),
+            headers=[
+                ("Content-Type", "application/json"),
+                create_authorization_header(service_id=service.id),
+            ],
+        )
+
+        job = dao_get_job_by_id(job_id)
+        assert job.sender_id == sms_sender.id
 
     def test_post_bulk_with_too_large_sms_fails(self, client, notify_db, notify_db_session, mocker):
         mocker.patch("app.sms_normal_publish.publish")


### PR DESCRIPTION
# Summary | Résumé

Have a case where a [service with a dedicated number is not using the number for bulk sends](https://cds-snc.freshdesk.com/a/tickets/17255) though it is for individual sends.

Found that the `reply_to_text` is not being set for these notifications. Admin one-offs still are working fine, but the other 3 ways to send are affected.

I think there's an issue where foreign keys set in other tables but referencing the `services` table do not appear in the services table when we cache it. In this case, though, we can just set the reply_to_text / sender_id when the job or notification is created.


# Test instructions | Instructions pour tester la modification

- Set a dedicated phone number for a service (locally you can just choose one from staging and add it to your local setup as an inbound number, then assign it to your service)
- send yourself some sms. All should come from the dedicated number.
- go to another service that doesn't have a set number
- send yourself sms
- all should come from a number different from the dedicated number (ie one of our numbers in ca-central-1)

# Release Instructions | Instructions pour le déploiement

Ask [user](https://cds-snc.freshdesk.com/a/tickets/17255) to test.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.