### PR TITLE
add script to send arbitrary many notifications

### DIFF
--- a/tests_smoke/send_many.py
+++ b/tests_smoke/send_many.py
@@ -1,0 +1,59 @@
+import argparse
+from enum import Enum
+import os
+from typing import Any, Iterator, List, Tuple
+import requests
+from datetime import datetime
+from dotenv import load_dotenv
+import time
+from smoke.common import Config, Notification_type, pretty_print, rows_to_csv, job_line
+ 
+NUM_PER_BULK_JOB = 50000
+
+
+def send_bulk_job(notification_type: Notification_type, job_size: int):
+    """Send a bulk job of notifications
+
+    Args:
+        notification_type (Notification_type): email or sms
+        job_size (int): number of notifications to send
+    """
+
+    template_id = Config.EMAIL_TEMPLATE_ID if notification_type == Notification_type.EMAIL else Config.SMS_TEMPLATE_ID
+    to = Config.EMAIL_TO if notification_type == Notification_type.EMAIL else Config.SMS_TO
+    header = "email address" if notification_type == Notification_type.EMAIL else "phone number"
+
+    response = requests.post(
+        f"{Config.API_HOST_NAME}/v2/notifications/bulk",
+        json={
+            "name": f"Large send {datetime.utcnow().isoformat()}",
+            "template_id": template_id,
+            "csv": rows_to_csv([[header, "var"], *job_line(to, job_size)]),
+        },
+        headers={"Authorization": f"ApiKey-v1 {Config.API_KEY}"},
+    )
+    if response.status_code != 201:
+        pretty_print(response.json())
+        print("FAILED: post failed")
+        exit(1)
+
+
+def main():
+    parser=argparse.ArgumentParser()
+    parser.add_argument("-n", "--notifications", default=1, type=int, help="total number of notifications")
+    parser.add_argument("-j", "--job_size", default=50000, type=int, help="size of bulk send jobs (default 25000)")
+    parser.add_argument("--sms", default=False, action='store_true', help="send sms instead of emails")
+
+    args = parser.parse_args()
+    load_dotenv()
+    
+    notification_type = Notification_type.SMS if args.sms else Notification_type.EMAIL
+    for start_n in range(0, args.notifications, args.job_size):
+        num_sending = min(args.notifications - start_n, args.job_size)
+        print(f"Sending {start_n} - {start_n + num_sending - 1} of {args.notifications}")
+        send_bulk_job(notification_type, num_sending)
+        time.sleep(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests_smoke/send_many.py
+++ b/tests_smoke/send_many.py
@@ -1,14 +1,18 @@
 import argparse
-from enum import Enum
-import os
-from typing import Any, Iterator, List, Tuple
-import requests
-from datetime import datetime
-from dotenv import load_dotenv
 import time
-from smoke.common import Config, Notification_type, pretty_print, rows_to_csv, job_line
- 
-NUM_PER_BULK_JOB = 50000
+from datetime import datetime
+
+import requests
+from dotenv import load_dotenv
+from smoke.common import (  # type: ignore
+    Config,
+    Notification_type,
+    job_line,
+    pretty_print,
+    rows_to_csv,
+)
+
+DEFAULT_JOB_SIZE = 50000
 
 
 def send_bulk_job(notification_type: Notification_type, job_size: int):
@@ -39,14 +43,14 @@ def send_bulk_job(notification_type: Notification_type, job_size: int):
 
 
 def main():
-    parser=argparse.ArgumentParser()
+    parser = argparse.ArgumentParser()
     parser.add_argument("-n", "--notifications", default=1, type=int, help="total number of notifications")
-    parser.add_argument("-j", "--job_size", default=50000, type=int, help="size of bulk send jobs (default 25000)")
+    parser.add_argument("-j", "--job_size", default=DEFAULT_JOB_SIZE, type=int, help=f"size of bulk send jobs (default {DEFAULT_JOB_SIZE})")
     parser.add_argument("--sms", default=False, action='store_true', help="send sms instead of emails")
 
     args = parser.parse_args()
     load_dotenv()
-    
+
     notification_type = Notification_type.SMS if args.sms else Notification_type.EMAIL
     for start_n in range(0, args.notifications, args.job_size):
         num_sending = min(args.notifications - start_n, args.job_size)

--- a/tests_smoke/send_many.py
+++ b/tests_smoke/send_many.py
@@ -24,11 +24,11 @@ def send_admin_csv(notification_type: Notification_type, job_size: int):
         notification_type (Notification_type): email or sms
         job_size (int): number of notifications to send
     """
-    
+
     template_id = Config.EMAIL_TEMPLATE_ID if notification_type == Notification_type.EMAIL else Config.SMS_TEMPLATE_ID
     to = Config.EMAIL_TO if notification_type == Notification_type.EMAIL else Config.SMS_TO
     header = "email address" if notification_type == Notification_type.EMAIL else "phone number"
-    
+
     csv = rows_to_csv([[header, "var"], *job_line(to, job_size)])
     upload_id = s3upload(Config.SERVICE_ID, csv)
     metadata_kwargs = {

--- a/tests_smoke/smoke/common.py
+++ b/tests_smoke/smoke/common.py
@@ -16,6 +16,10 @@ from boto3 import Session
 from dotenv import load_dotenv
 from notifications_python_client.authentication import create_jwt_token
 
+# from app/config.py
+INTERNAL_TEST_NUMBER = "+16135550123"
+INTERNAL_TEST_EMAIL_ADDRESS = "internal.test@cds-snc.ca"
+
 load_dotenv()
 
 
@@ -32,8 +36,8 @@ class Config:
     AWS_SECRET_ACCESS_KEY = os.environ.get("SMOKE_AWS_SECRET_ACCESS_KEY")
     SERVICE_ID = os.environ.get("SMOKE_SERVICE_ID", "")
     USER_ID = os.environ.get("SMOKE_USER_ID")
-    EMAIL_TO = os.environ.get("SMOKE_EMAIL_TO", "")
-    SMS_TO = os.environ.get("SMOKE_SMS_TO", "")
+    EMAIL_TO = os.environ.get("SMOKE_EMAIL_TO", INTERNAL_TEST_EMAIL_ADDRESS)
+    SMS_TO = os.environ.get("SMOKE_SMS_TO", INTERNAL_TEST_NUMBER)
     EMAIL_TEMPLATE_ID = os.environ.get("SMOKE_EMAIL_TEMPLATE_ID")
     SMS_TEMPLATE_ID = os.environ.get("SMOKE_SMS_TEMPLATE_ID")
     API_KEY = os.environ.get("SMOKE_API_KEY", "")


### PR DESCRIPTION
# Summary | Résumé

Add a script to send an arbitrary number of notifications to the api (in batches).
This will make it easier to do a large send, ie 1M or so, without having to manually upload many 50K files.

# Test instructions | Instructions pour tester la modification

`python send_many.py -n 9 -j 3`

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.