### PR TITLE
Reinstate bulk sms limit

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,7 +67,7 @@ jobs:
       run: |
         cp -f .env.example .env
     - name: Checks for new endpoints against AWS WAF rules
-      uses: cds-snc/notification-utils/.github/actions/waffles@06a40db6286f525fe3551e029418458d33342592 # 52.1.0
+      uses: cds-snc/notification-utils/.github/actions/waffles@4e204b1ec688961ae32c3a6646246c58a1c1bc4f # 52.1.10
       with:
         app-loc: '/github/workspace'
         app-libs: '/github/workspace/env/site-packages'

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -706,7 +706,7 @@ def check_for_csv_errors(recipient_csv, max_rows, remaining_messages):
                 message=f"You cannot send to these recipients {explanation}",
                 status_code=400,
             )
-        if any(recipient_csv.rows_with_combined_variable_content_too_long):
+        if recipient_csv.template_type == SMS_TYPE and any(recipient_csv.rows_with_combined_variable_content_too_long):
             raise BadRequestError(
                 message=f"Row {next(recipient_csv.rows_with_combined_variable_content_too_long).index + 1} - has a character count greater than {SMS_CHAR_COUNT_LIMIT} characters. Some messages may be too long due to custom content.",
                 status_code=400,

--- a/poetry.lock
+++ b/poetry.lock
@@ -2444,7 +2444,7 @@ requests = ">=2.0.0"
 
 [[package]]
 name = "notifications-utils"
-version = "52.2.2"
+version = "52.2.3"
 description = "Shared python code for Notification - Provides logging utils etc."
 optional = false
 python-versions = "~3.10.9"
@@ -2479,8 +2479,8 @@ werkzeug = "2.3.7"
 [package.source]
 type = "git"
 url = "https://github.com/cds-snc/notifier-utils.git"
-reference = "52.2.2"
-resolved_reference = "578b4147fe6c7a8f89241649b763f94ef24b2ad4"
+reference = "reinstate-bulk-sms-limit"
+resolved_reference = "b89daceb96065599f7f6b689b91cfd88dad93aa9"
 
 [[package]]
 name = "ordered-set"
@@ -4255,4 +4255,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10.9"
-content-hash = "94cd1ef6449c0b8e8dc6d90152b64b6295aa6123b5d78ceb414eb1e139110462"
+content-hash = "8ce59848a30301161a85fcaefd46c576ef5d6a51f4658b2db1e4a817c6d38f7b"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2444,7 +2444,7 @@ requests = ">=2.0.0"
 
 [[package]]
 name = "notifications-utils"
-version = "52.2.0"
+version = "52.1.10"
 description = "Shared python code for Notification - Provides logging utils etc."
 optional = false
 python-versions = "~3.10.9"
@@ -2479,8 +2479,8 @@ werkzeug = "2.3.7"
 [package.source]
 type = "git"
 url = "https://github.com/cds-snc/notifier-utils.git"
-reference = "52.2.0"
-resolved_reference = "0146718a423b0144566392ab3082d15779f4a73f"
+reference = "52.1.10"
+resolved_reference = "4e204b1ec688961ae32c3a6646246c58a1c1bc4f"
 
 [[package]]
 name = "ordered-set"
@@ -4255,4 +4255,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10.9"
-content-hash = "18ed30bed79c84db2cc559fecdba223a88c8d8546f4fb951f85ef1d76142a714"
+content-hash = "c4c46eaf3c731be2eb3e27d29405e0c79ab17d53eaf3e7728f80145abc39c88e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ Werkzeug = "2.3.7"
 MarkupSafe = "2.1.5"
 # REVIEW: v2 is using sha512 instead of sha1 by default (in v1)
 itsdangerous = "2.1.2"
-notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", tag = "52.2.3" }
+notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", branch = "reinstate-bulk-sms-limit" }
 # rsa = "4.9  # awscli 1.22.38 depends on rsa<4.8
 typing-extensions = "4.7.1"
 greenlet = "2.0.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ Werkzeug = "2.3.7"
 MarkupSafe = "2.1.4"
 # REVIEW: v2 is using sha512 instead of sha1 by default (in v1)
 itsdangerous = "2.1.2"
-notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", tag = "52.2.0" }
+notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", tag = "52.1.10" }
 # rsa = "4.9  # awscli 1.22.38 depends on rsa<4.8
 typing-extensions = "4.7.1"
 greenlet = "2.0.2"

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -2,7 +2,7 @@ import json
 import uuid
 from datetime import datetime, timedelta
 from unittest import mock
-from unittest.mock import Mock, call
+from unittest.mock import MagicMock, Mock, call
 
 import pytest
 import requests_mock
@@ -891,9 +891,10 @@ class TestProcessRows:
         mocker.patch("app.celery.tasks.create_uuid", return_value="noti_uuid")
         task_mock = mocker.patch("app.celery.tasks.{}".format(expected_function))
         signer_mock = mocker.patch("app.celery.tasks.signer_notification.sign")
-        template = Mock(id="template_id", template_type=template_type, process_type=NORMAL)
+        template = MagicMock(id="template_id", template_type=template_type, process_type=NORMAL)
         job = Mock(id="job_id", template_version="temp_vers", notification_count=1, api_key_id=api_key_id, sender_id=sender_id)
         service = Mock(id="service_id", research_mode=research_mode)
+        template.__len__.return_value = 1
 
         process_rows(
             [
@@ -950,10 +951,11 @@ class TestProcessRows:
     ):
         mock_save_email = mocker.patch("app.celery.tasks.save_emails")
 
-        template = Mock(id=1, template_type=EMAIL_TYPE, process_type=template_process_type)
+        template = MagicMock(id=1, template_type=EMAIL_TYPE, process_type=template_process_type)
         api_key = Mock(id=1, key_type=KEY_TYPE_NORMAL)
         job = Mock(id=1, template_version="temp_vers", notification_count=1, api_key=api_key)
         service = Mock(id=1, research_mode=False)
+        template.__len__.return_value = 1
 
         row = next(
             RecipientCSV(
@@ -994,10 +996,11 @@ class TestProcessRows:
     ):
         mock_save_sms = mocker.patch("app.celery.tasks.save_smss")
 
-        template = Mock(id=1, template_type=SMS_TYPE, process_type=template_process_type)
+        template = MagicMock(id=1, template_type=SMS_TYPE, process_type=template_process_type)
         api_key = Mock(id=1, key_type=KEY_TYPE_NORMAL)
         job = Mock(id=1, template_version="temp_vers", notification_count=1, api_key=api_key)
         service = Mock(id=1, research_mode=False)
+        template.__len__.return_value = 1
 
         row = next(
             RecipientCSV(
@@ -1066,7 +1069,8 @@ class TestProcessRows:
         mocker.patch("app.celery.tasks.create_uuid", return_value="noti_uuid")
         task_mock = mocker.patch("app.celery.tasks.{}".format(expected_function))
         signer_mock = mocker.patch("app.celery.tasks.signer_notification.sign")
-        template = Mock(id="template_id", template_type=template_type, process_type=NORMAL)
+        template = MagicMock(id="template_id", template_type=template_type, process_type=NORMAL)
+        template.__len__.return_value = 1
         api_key = {}
         job = Mock(
             id="job_id",

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -2495,7 +2495,7 @@ class TestBulkSend:
         mocker.patch("app.v2.notifications.post_notifications.create_bulk_job", return_value=str(uuid.uuid4()))
 
         service = create_service(sms_daily_limit=10, message_limit=100)
-        template = create_sample_template(notify_db, notify_db_session, service=service, template_type="sms", content="a" * 612)
+        template = create_sample_template(notify_db, notify_db_session, service=service, template_type="sms", content="a" * 613)
         data = {
             "name": "job_name",
             "template_id": template.id,
@@ -2546,7 +2546,7 @@ class TestBulkSend:
         )
         assert response.status_code == 400
         assert "has a character count greater than" in str(response.data)
-        assert "row #{}".format(failure_row) in str(response.data)
+        assert "Row {}".format(failure_row) in str(response.data)
 
 
 class TestBatchPriorityLanes:


### PR DESCRIPTION
# Summary | Résumé

This PR reinstates bulk sms validation code that was reverted in [this PR](https://github.com/cds-snc/notification-api/pull/2164) due to issues with the added validation firing on bulk emails as well.

## Related Issues | Cartes liées

https://github.com/cds-snc/notification-utils/pull/294

# Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.