### PR TITLE
feat(magic-link): send magic link email

### DIFF
--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -317,7 +317,11 @@ def send_user_email_code(user_to_send_to, data):
 
     secret_code = create_secret_code()
 
-    personalisation = {"name": user_to_send_to.name, "verify_code": secret_code}
+    personalisation = {
+        "name": user_to_send_to.name,
+        "link_url_en": "{}/magic-login-link/{}".format(current_app.config["ADMIN_BASE_URL"], secret_code),
+        "link_url_fr": "{}/magic-login-link/{}?lang=fr".format(current_app.config["ADMIN_BASE_URL"], secret_code),
+    }
 
     create_2fa_code(
         current_app.config["EMAIL_2FA_TEMPLATE_ID"],


### PR DESCRIPTION
# Summary | Résumé

This PR adds the magic link URL to the email that GC Notify sends for 2FA login into GC Notify itself.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/603

# Test instructions | Instructions pour tester la modification

- Test this in conjunction with https://github.com/cds-snc/notification-admin/pull/1836

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.