### PR TITLE
register process-pinpoint-result task explicitly

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -361,6 +361,7 @@ class Config(object):
         "app.celery.scheduled_tasks",
         "app.celery.reporting_tasks",
         "app.celery.nightly_tasks",
+        "app.celery.process_pinpoint_receipts_tasks",
     )
     CELERYBEAT_SCHEDULE = {
         # app/celery/scheduled_tasks.py


### PR DESCRIPTION
# Summary | Résumé

The `process-pinpoint-result` task does not appear in staging in the list of registered celery tasks and so when the lambda calls it, celery doesn't run it. I have no idea why it is not registered but, for example, `process-sns-result` is. Possibly there's some dynamic code where it's registering `process-*` over a list, but searches for this and similar strings came up empty. However, If I explicitly add the `process_pinpoint_receipts_tasks` to the list of celery imports than the task does get registered locally. Hopefully in k8s as well.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/286

# Test instructions | Instructions pour tester la modification

Send pinpoint in staging and see if the task runs

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.