### PR TITLE
Ignore SUCCESSFUL pinpoint receipts

### DIFF
--- a/app/aws/mocks.py
+++ b/app/aws/mocks.py
@@ -193,7 +193,33 @@ def sns_failed_callback(provider_response, reference=None, timestamp="2016-06-28
 
 
 # Note that 1467074434 = 2016-06-28 00:40:34.558 UTC
-def pinpoint_success_callback(reference=None, timestamp=1467074434, destination="+1XXX5550100"):
+def pinpoint_successful_callback(reference=None, timestamp=1467074434, destination="+1XXX5550100"):
+    body = {
+        "eventType": "TEXT_SUCCESSFUL",
+        "eventVersion": "1.0",
+        "eventTimestamp": timestamp,
+        "isFinal": False,
+        "originationPhoneNumber": "+18078061258",
+        "destinationPhoneNumber": destination,
+        "isoCountryCode": "CA",
+        "mcc": "302",
+        "mnc": "610",
+        "carrierName": "Bell Cellular Inc. / Aliant Telecom",
+        "messageId": reference,
+        "messageRequestTimestamp": timestamp,
+        "messageEncoding": "GSM",
+        "messageType": "TRANSACTIONAL",
+        "messageStatus": "SUCCESSFUL",
+        "messageStatusDescription": "Message has been accepted by phone carrier",
+        "totalMessageParts": 1,
+        "totalMessagePrice": 0.00581,
+        "totalCarrierFee": 0.00767,
+    }
+
+    return _pinpoint_callback(body)
+
+
+def pinpoint_delivered_callback(reference=None, timestamp=1467074434, destination="+1XXX5550100"):
     body = {
         "eventType": "TEXT_DELIVERED",
         "eventVersion": "1.0",

--- a/app/celery/process_pinpoint_receipts_tasks.py
+++ b/app/celery/process_pinpoint_receipts_tasks.py
@@ -53,10 +53,10 @@ def process_pinpoint_results(self, response):
         provider_response = receipt["messageStatusDescription"]
 
         notification_status = determine_pinpoint_status(status, provider_response)
-        
+
         if notification_status == NOTIFICATION_SENT:
             return  # we don't want to update the status to sent if it's already sent
-        
+
         if not notification_status:
             current_app.logger.warning(f"unhandled provider response for reference {reference}, received '{provider_response}'")
             notification_status = NOTIFICATION_TECHNICAL_FAILURE  # revert to tech failure by default

--- a/app/celery/process_pinpoint_receipts_tasks.py
+++ b/app/celery/process_pinpoint_receipts_tasks.py
@@ -53,6 +53,10 @@ def process_pinpoint_results(self, response):
         provider_response = receipt["messageStatusDescription"]
 
         notification_status = determine_pinpoint_status(status, provider_response)
+        
+        if notification_status == NOTIFICATION_SENT:
+            return  # we don't want to update the status to sent if it's already sent
+        
         if not notification_status:
             current_app.logger.warning(f"unhandled provider response for reference {reference}, received '{provider_response}'")
             notification_status = NOTIFICATION_TECHNICAL_FAILURE  # revert to tech failure by default
@@ -125,6 +129,8 @@ def determine_pinpoint_status(status: str, provider_response: str) -> Union[str,
 
     if status == "DELIVERED":
         return NOTIFICATION_DELIVERED
+    elif status == "SUCCESSFUL":  # carrier has accepted the message but it hasn't gone to the phone yet
+        return NOTIFICATION_SENT
 
     response_lower = provider_response.lower()
 


### PR DESCRIPTION
# Summary | Résumé

Pinpoint returns a `SUCCESSFUL` receipt when it sends the text to the carrier. Right now we'll just ignore these (the notification is already set to "sent") and wait for a `DELIVERED` or some sort of failure.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/286

# Test instructions | Instructions pour tester la modification

send in staging and make sure the `process-pinpoint-result` task doesn't complain

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.