### PR TITLE
Migration Creation of DB Users/roles

### DIFF
--- a/migrations/versions/0451_create_db_users.py
+++ b/migrations/versions/0451_create_db_users.py
@@ -22,7 +22,7 @@ def upgrade():
 
 def create_role_if_not_exist(role):
     """
-    Makes sure the expected user exists in the database before performing the ALTER USER operation.
+    Makes sure the expected user exists in the database before performing the GRANT USER operation.
     If the user already exists, nothing happens.  This is needed so that the migrations can be
     run on localhost where the users do not exist.
     """

--- a/migrations/versions/0451_create_db_users.py
+++ b/migrations/versions/0451_create_db_users.py
@@ -12,8 +12,6 @@ down_revision = "0450_enable_pinpoint_provider"
 
 super_role = "rds_superuser"
 roles = ["app_db_user", "quicksight_db_user"]
-database_name = op.get_bind().engine.url.database  # database name that the migration is being run on
-
 
 def upgrade():
     create_role_if_not_exist(super_role)

--- a/migrations/versions/0451_create_db_users.py
+++ b/migrations/versions/0451_create_db_users.py
@@ -16,12 +16,7 @@ database_name = op.get_bind().engine.url.database  # database name that the migr
 
 
 def upgrade():
-    # Skip this migration in the test database as there are multiple test databases that are created.
-    # This leads to a race condition attempting to alter the same users\ multiple times and causes
-    # sporadic unit test failures.
-    if "test_notification_api" in database_name:
-        return
-
+    create_role_if_not_exist(super_role)
     for role in roles:
         create_role_if_not_exist(role)
         op.execute(f"GRANT {role} TO {super_role} WITH ADMIN OPTION;")

--- a/migrations/versions/0451_create_db_users.py
+++ b/migrations/versions/0451_create_db_users.py
@@ -13,6 +13,7 @@ down_revision = "0450_enable_pinpoint_provider"
 super_role = "rds_superuser"
 roles = ["app_db_user", "quicksight_db_user"]
 
+
 def upgrade():
     create_role_if_not_exist(super_role)
     for role in roles:

--- a/migrations/versions/0451_create_db_users.py
+++ b/migrations/versions/0451_create_db_users.py
@@ -24,7 +24,6 @@ def upgrade():
 
     for role in roles:
         create_role_if_not_exist(role)
-        op.execute(f"CREATE ROLE {role};")
         op.execute(f"GRANT {role} TO {super_role} WITH ADMIN OPTION;")
 
 

--- a/migrations/versions/0451_create_db_users.py
+++ b/migrations/versions/0451_create_db_users.py
@@ -1,0 +1,46 @@
+"""
+
+Revision ID: 0451_create_db_users
+Revises: 0450_enable_pinpoint_provider
+Create Date: 2024-05-23 12:00:00
+
+"""
+from alembic import op
+
+revision = "0451_create_db_users"
+down_revision = "0450_enable_pinpoint_provider"
+
+super_role = "rds_superuser"
+roles = ["app_db_user", "quicksight_db_user"]
+database_name = op.get_bind().engine.url.database  # database name that the migration is being run on
+
+
+def upgrade():
+    # Skip this migration in the test database as there are multiple test databases that are created.
+    # This leads to a race condition attempting to alter the same users\ multiple times and causes
+    # sporadic unit test failures.
+    if "test_notification_api" in database_name:
+        return
+
+    for role in roles:
+        create_role_if_not_exist(role)
+        op.execute(f"CREATE ROLE {role};")
+        op.execute(f"GRANT {role} TO {super_role} WITH ADMIN OPTION;")
+
+
+def create_role_if_not_exist(role):
+    """
+    Makes sure the expected user exists in the database before performing the ALTER USER operation.
+    If the user already exists, nothing happens.  This is needed so that the migrations can be
+    run on localhost where the users do not exist.
+    """
+    op.execute(
+        f"""
+        DO $$
+        BEGIN
+        CREATE ROLE {role};
+        EXCEPTION WHEN duplicate_object THEN RAISE NOTICE '%, skipping', SQLERRM USING ERRCODE = SQLSTATE;
+        END
+        $$;
+    """
+    )


### PR DESCRIPTION
# Summary | Résumé

Adding a migration that handles the creation of db roles/users and the granting them superuser role powers -- includes quicksight_db_user and app_db_user.  

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/359

# Test instructions | Instructions pour tester la modification

Follow this migration across dev and staging -- if the users are created, or ignored if they exist and granted rds_superuser rights, then it's working.  if the migration fails, or that doesn't happen then this is broken.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.