### PR TITLE
Use SNS for international phone numbers

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -356,7 +356,7 @@ def provider_to_use(
         notification_type (str): SMS or EMAIL.
         notification_id (UUID): id of notification. Just used for logging.
         to (str, optional): recipient. Defaults to None.
-        international (bool, optional): It is not clear what this flag indicates. Defaults to False.
+        international (bool, optional):  Flags whether or not the message is outside of Canada and the US. Defaults to False.
         sender (str, optional): reply_to_text to use. Defaults to None.
         template_id (str, optional): template_id to use. Defaults to None.
 

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -356,7 +356,7 @@ def provider_to_use(
         notification_type (str): SMS or EMAIL.
         notification_id (UUID): id of notification. Just used for logging.
         to (str, optional): recipient. Defaults to None.
-        international (bool, optional): Wish to use an international provider. Defaults to False.
+        international (bool, optional): It is not clear what this flag indicates. Defaults to False.
         sender (str, optional): reply_to_text to use. Defaults to None.
         template_id (str, optional): template_id to use. Defaults to None.
 
@@ -381,6 +381,7 @@ def provider_to_use(
 
     do_not_use_pinpoint = (
         has_dedicated_number
+        or international  # Defaulting back to SNS: it's not entirely clear what this flag is for. Not always set for international recipients.
         or sending_to_us_number
         or sending_internationally
         or not current_app.config["AWS_PINPOINT_SC_POOL_ID"]

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -372,9 +372,13 @@ def provider_to_use(
     sending_internationally = False
     if to is not None:
         match = next(iter(phonenumbers.PhoneNumberMatcher(to, "US")), None)
-        if match and phonenumbers.region_code_for_number(match.number) == "US":  # The US is a special case that needs to send from a US toll free number
+        if (
+            match and phonenumbers.region_code_for_number(match.number) == "US"
+        ):  # The US is a special case that needs to send from a US toll free number
             sending_to_us_number = True
-        elif match and phonenumbers.region_code_for_number(match.number) != "CA":  # Currently Pinpoint is having issues sending to non-Canadian numbers.
+        elif (
+            match and phonenumbers.region_code_for_number(match.number) != "CA"
+        ):  # Currently Pinpoint is having issues sending to non-Canadian numbers.
             sending_internationally = True
 
     using_sc_pool_template = template_id is not None and str(template_id) in current_app.config["AWS_PINPOINT_SC_TEMPLATE_IDS"]

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -350,13 +350,13 @@ def provider_to_use(
 ) -> Any:
     """
     Get the provider to use for sending the notification.
-    SMS that are being sent with a dedicated number or to a US number should not use Pinpoint.
+    SMS that are being sent with a dedicated number or internationally should not use Pinpoint.
 
     Args:
         notification_type (str): SMS or EMAIL.
         notification_id (UUID): id of notification. Just used for logging.
         to (str, optional): recipient. Defaults to None.
-        international (bool, optional): Recipient is international. Defaults to False.
+        international (bool, optional): Wish to use an international provider. Defaults to False.
         sender (str, optional): reply_to_text to use. Defaults to None.
         template_id (str, optional): template_id to use. Defaults to None.
 
@@ -369,16 +369,20 @@ def provider_to_use(
 
     has_dedicated_number = sender is not None and sender.startswith("+1")
     sending_to_us_number = False
+    sending_internationally = False
     if to is not None:
         match = next(iter(phonenumbers.PhoneNumberMatcher(to, "US")), None)
-        if match and phonenumbers.region_code_for_number(match.number) == "US":
+        if match and phonenumbers.region_code_for_number(match.number) == "US":  # The US is a special case that needs to send from a US toll free number
             sending_to_us_number = True
+        elif match and phonenumbers.region_code_for_number(match.number) != "CA":  # Currently Pinpoint is having issues sending to non-Canadian numbers.
+            sending_internationally = True
 
     using_sc_pool_template = template_id is not None and str(template_id) in current_app.config["AWS_PINPOINT_SC_TEMPLATE_IDS"]
 
     do_not_use_pinpoint = (
         has_dedicated_number
         or sending_to_us_number
+        or sending_internationally
         or not current_app.config["AWS_PINPOINT_SC_POOL_ID"]
         or ((not current_app.config["AWS_PINPOINT_DEFAULT_POOL_ID"]) and not using_sc_pool_template)
     )

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -118,9 +118,8 @@ class TestProviderToUse:
                 "AWS_PINPOINT_DEFAULT_POOL_ID": "default_pool_id",
             },
         ):
-            provider = send_to_providers.provider_to_use("sms", "1234", "+4408456021111") # British Telecom test line
+            provider = send_to_providers.provider_to_use("sms", "1234", "+4408456021111")  # British Telecom test line
         assert provider.name == "sns"
-
 
     @pytest.mark.parametrize("sc_pool_id, default_pool_id", [("", "default_pool_id"), ("sc_pool_id", "")])
     def test_should_use_sns_if_pinpoint_not_configured(self, restore_provider_details, notify_api, sc_pool_id, default_pool_id):

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -110,6 +110,18 @@ class TestProviderToUse:
             provider = send_to_providers.provider_to_use("sms", "1234", "+17065551234")
         assert provider.name == "sns"
 
+    def test_should_use_sns_for_sms_if_sending_internationally(self, restore_provider_details, notify_api):
+        with set_config_values(
+            notify_api,
+            {
+                "AWS_PINPOINT_SC_POOL_ID": "sc_pool_id",
+                "AWS_PINPOINT_DEFAULT_POOL_ID": "default_pool_id",
+            },
+        ):
+            provider = send_to_providers.provider_to_use("sms", "1234", "+18692291111")
+        assert provider.name == "sns"
+
+
     @pytest.mark.parametrize("sc_pool_id, default_pool_id", [("", "default_pool_id"), ("sc_pool_id", "")])
     def test_should_use_sns_if_pinpoint_not_configured(self, restore_provider_details, notify_api, sc_pool_id, default_pool_id):
         with set_config_values(

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -118,7 +118,7 @@ class TestProviderToUse:
                 "AWS_PINPOINT_DEFAULT_POOL_ID": "default_pool_id",
             },
         ):
-            provider = send_to_providers.provider_to_use("sms", "1234", "+18692291111")
+            provider = send_to_providers.provider_to_use("sms", "1234", "+4408456021111") # British Telecom test line
         assert provider.name == "sns"
 
 


### PR DESCRIPTION
# Summary | Résumé

Pinpoint is having a problem sending to international phone numbers. This PR sends them with SNS instead.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/370

# Test instructions | Instructions pour tester la modification

Send a SMS to the UK BT Text number +4408456021111
SNS should be used to send (in the logs "AWS SNS request finished in...")

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.