### PR TITLE
Allow sns and pinpoint to send internationally

### DIFF
--- a/migrations/versions/0453_set_supports_international.py
+++ b/migrations/versions/0453_set_supports_international.py
@@ -1,0 +1,25 @@
+"""
+
+Revision ID: 0453_set_supports_international
+Revises: 0452_set_pgaudit_config
+Create Date: 2024-06-20 14:36:03.038934
+
+"""
+from alembic import op
+
+revision = "0453_set_supports_international"
+down_revision = "0452_set_pgaudit_config"
+
+
+def upgrade():
+    op.execute("UPDATE provider_details SET supports_international=True WHERE identifier='sns'")
+    op.execute("UPDATE provider_details SET supports_international=True WHERE identifier='pinpoint'")
+    op.execute("UPDATE provider_details_history SET supports_international=True WHERE identifier='sns'")
+    op.execute("UPDATE provider_details_history SET supports_international=True WHERE identifier='pinpoint'")
+
+
+def downgrade():
+    op.execute("UPDATE provider_details SET supports_international=False WHERE identifier='sns'")
+    op.execute("UPDATE provider_details SET supports_international=False WHERE identifier='pinpoint'")
+    op.execute("UPDATE provider_details_history SET supports_international=False WHERE identifier='sns'")
+    op.execute("UPDATE provider_details_history SET supports_international=False WHERE identifier='pinpoint'")

--- a/tests/app/dao/test_provider_details_dao.py
+++ b/tests/app/dao/test_provider_details_dao.py
@@ -29,7 +29,7 @@ def test_can_get_sms_non_international_providers(restore_provider_details):
 
 def test_can_get_sms_international_providers(restore_provider_details):
     sms_providers = get_provider_details_by_notification_type("sms", True)
-    assert len(sms_providers) == 1
+    assert len(sms_providers) == 3
     assert all("sms" == prov.notification_type for prov in sms_providers)
     assert all(prov.supports_international for prov in sms_providers)
 

--- a/tests/app/dao/test_provider_details_dao.py
+++ b/tests/app/dao/test_provider_details_dao.py
@@ -291,7 +291,7 @@ def test_dao_get_provider_stats(notify_db_session):
 
     assert result[1].identifier == "sns"
     assert result[1].display_name == "AWS SNS"
-    assert result[1].supports_international is False
+    assert result[1].supports_international is True
     assert result[1].active is True
     assert result[1].current_month_billable_sms == 4
 
@@ -312,6 +312,6 @@ def test_dao_get_provider_stats(notify_db_session):
 
     assert result[5].identifier == "pinpoint"
     assert result[5].notification_type == "sms"
-    assert result[5].supports_international is False
+    assert result[5].supports_international is True
     assert result[5].active is True
     assert result[5].current_month_billable_sms == 0


### PR DESCRIPTION
# Summary | Résumé

In the code SNS and Pinpoint are not allowed to send internationally. At some point in the past we changed the production database to allow SNS to send internationally.

This PR sets `supports_international` for both SNS and Pinpoint through a migration. This will allow us to test international sending in unit tests as well as in staging.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/370

# Test instructions | Instructions pour tester la modification

- Check the admin providers page and verify that SNS and Pinpoint are both listed at the bottom as international providers.
- Send to the [fake French number](https://en.wikipedia.org/wiki/Fictitious_telephone_number) +33 1 99 00 11 11 (it should fail but there will be an SNS boto call / delivery receipt and no celery errors)

# Release Instructions | Instructions pour le déploiement

None. In particular:
- this is already set in production for SNS
- Pinpoint is not currently being used in production (or staging) for international SMS. This will change in a subsequent PR.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.