### PR TITLE
use Pinpoint for international numbers

### DIFF
--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -110,17 +110,6 @@ class TestProviderToUse:
             provider = send_to_providers.provider_to_use("sms", "1234", "+17065551234")
         assert provider.name == "sns"
 
-    def test_should_use_sns_for_sms_if_sending_internationally(self, restore_provider_details, notify_api):
-        with set_config_values(
-            notify_api,
-            {
-                "AWS_PINPOINT_SC_POOL_ID": "sc_pool_id",
-                "AWS_PINPOINT_DEFAULT_POOL_ID": "default_pool_id",
-            },
-        ):
-            provider = send_to_providers.provider_to_use("sms", "1234", "+4408456021111")  # British Telecom test line
-        assert provider.name == "sns"
-
     def test_should_use_sns_for_sms_if_match_fails(self, restore_provider_details, notify_api):
         with set_config_values(
             notify_api,


### PR DESCRIPTION
# Summary | Résumé

Allow Pinpoint to send to international numbers again.

Merge after https://github.com/cds-snc/notification-api/pull/2197 and https://github.com/cds-snc/notification-terraform/pull/1396

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/370

# Test instructions | Instructions pour tester la modification

Send to the [fake French number](https://en.wikipedia.org/wiki/Fictitious_telephone_number) +33 1 99 00 11 11 (it should fail but there will be a Pinpoint boto call / delivery receipt and no celery errors)

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.