### PR TITLE
Use sns for international sending

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -356,7 +356,7 @@ def provider_to_use(
         notification_type (str): SMS or EMAIL.
         notification_id (UUID): id of notification. Just used for logging.
         to (str, optional): recipient. Defaults to None.
-        international (bool, optional):  Flags whether or not the message recipient is outside of Canada and the US. Defaults to False.
+        international (bool, optional):  Flags whether or not the message recipient is outside Zone 1 (US / Canada / Caribbean). Defaults to False.
         sender (str, optional): reply_to_text to use. Defaults to None.
         template_id (str, optional): template_id to use. Defaults to None.
 
@@ -384,6 +384,7 @@ def provider_to_use(
         has_dedicated_number
         or sending_to_us_number
         or cannot_determine_recipient_country
+        or international
         or not current_app.config["AWS_PINPOINT_SC_POOL_ID"]
         or ((not current_app.config["AWS_PINPOINT_DEFAULT_POOL_ID"]) and not using_sc_pool_template)
     )

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -110,6 +110,17 @@ class TestProviderToUse:
             provider = send_to_providers.provider_to_use("sms", "1234", "+17065551234")
         assert provider.name == "sns"
 
+    def test_should_use_sns_for_sms_if_sending_outside_zone_1(self, restore_provider_details, notify_api):
+        with set_config_values(
+            notify_api,
+            {
+                "AWS_PINPOINT_SC_POOL_ID": "sc_pool_id",
+                "AWS_PINPOINT_DEFAULT_POOL_ID": "default_pool_id",
+            },
+        ):
+            provider = send_to_providers.provider_to_use("sms", "1234", "+17065551234", international=True)
+        assert provider.name == "sns"
+
     def test_should_use_sns_for_sms_if_match_fails(self, restore_provider_details, notify_api):
         with set_config_values(
             notify_api,


### PR DESCRIPTION
# Summary | Résumé

We're sorting out how to set a default sender id for pinpoint. While we do that let's at least get Pinpoint out the door for domestic SMS.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/370

# Test instructions | Instructions pour tester la modification

Send to [one of these international test numbers](https://www.proovl.com/test) and [verify that SNS is used](https://ca-central-1.console.aws.amazon.com/cloudwatch/home?region=ca-central-1#logsV2:live-tail$3FlogGroupArns$3D~(~'arn*3aaws*3alogs*3aca-central-1*3a239043911459*3alog-group*3asns*2fca-central-1*2f239043911459*2fDirectPublishToPhoneNumber~'arn*3aaws*3alogs*3aca-central-1*3a239043911459*3alog-group*3asns*2fca-central-1*2f239043911459*2fDirectPublishToPhoneNumber*2fFailure)).

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.