### PR TITLE
Use sns for non-CA zone 1

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -369,6 +369,7 @@ def provider_to_use(
 
     has_dedicated_number = sender is not None and sender.startswith("+1")
     cannot_determine_recipient_country = False
+    recipient_outside_canada = False
     sending_to_us_number = False
     if to is not None:
         match = next(iter(phonenumbers.PhoneNumberMatcher(to, "US")), None)
@@ -378,6 +379,8 @@ def provider_to_use(
             phonenumbers.region_code_for_number(match.number) == "US"
         ):  # The US is a special case that needs to send from a US toll free number
             sending_to_us_number = True
+        elif phonenumbers.region_code_for_number(match.number) != "CA":
+            recipient_outside_canada = True
     using_sc_pool_template = template_id is not None and str(template_id) in current_app.config["AWS_PINPOINT_SC_TEMPLATE_IDS"]
 
     do_not_use_pinpoint = (
@@ -385,6 +388,7 @@ def provider_to_use(
         or sending_to_us_number
         or cannot_determine_recipient_country
         or international
+        or recipient_outside_canada
         or not current_app.config["AWS_PINPOINT_SC_POOL_ID"]
         or ((not current_app.config["AWS_PINPOINT_DEFAULT_POOL_ID"]) and not using_sc_pool_template)
     )

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -121,6 +121,17 @@ class TestProviderToUse:
             provider = send_to_providers.provider_to_use("sms", "1234", "+17065551234", international=True)
         assert provider.name == "sns"
 
+    def test_should_use_sns_for_sms_if_sending_to_non_CA_zone_1(self, restore_provider_details, notify_api):
+        with set_config_values(
+            notify_api,
+            {
+                "AWS_PINPOINT_SC_POOL_ID": "sc_pool_id",
+                "AWS_PINPOINT_DEFAULT_POOL_ID": "default_pool_id",
+            },
+        ):
+            provider = send_to_providers.provider_to_use("sms", "1234", "+16715550123")
+        assert provider.name == "sns"
+
     def test_should_use_sns_for_sms_if_match_fails(self, restore_provider_details, notify_api):
         with set_config_values(
             notify_api,


### PR DESCRIPTION
# Summary | Résumé

Getting a `NO_ORIGINATION_IDENTITIES_FOUND` when trying to use a Pinpoint pool to send to the fake Guam number 16715550123. Works with SNS, so changing to use that for now.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/370

# Test instructions | Instructions pour tester la modification

Send to 16715550123. Should send via SNS (and fail because that's not a real number)

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.