### PR TITLE
fix/opted out phone numbers in pinpoint

### DIFF
--- a/app/clients/sms/aws_pinpoint.py
+++ b/app/clients/sms/aws_pinpoint.py
@@ -25,6 +25,7 @@ class AwsPinpointClient(SmsClient):
         messageType = "TRANSACTIONAL"
         matched = False
         opted_out = False
+        response = {}
 
         if template_id is not None and str(template_id) in self.current_app.config["AWS_PINPOINT_SC_TEMPLATE_IDS"]:
             pool_id = self.current_app.config["AWS_PINPOINT_SC_POOL_ID"]
@@ -60,7 +61,7 @@ class AwsPinpointClient(SmsClient):
                 self.current_app.logger.info("AWS Pinpoint request finished in {}".format(elapsed_time))
                 self.statsd_client.timing("clients.pinpoint.request-time", elapsed_time)
                 self.statsd_client.incr("clients.pinpoint.success")
-            return "opted_out" if opted_out else response["MessageId"]
+            return "opted_out" if opted_out else response.get("MessageId")
 
         if not matched:
             self.statsd_client.incr("clients.pinpoint.error")

--- a/app/clients/sms/aws_pinpoint.py
+++ b/app/clients/sms/aws_pinpoint.py
@@ -55,7 +55,7 @@ class AwsPinpointClient(SmsClient):
 
             except Exception as e:
                 self.statsd_client.incr("clients.pinpoint.error")
-                raise Exception(e)
+                raise e
             finally:
                 elapsed_time = monotonic() - start_time
                 self.current_app.logger.info("AWS Pinpoint request finished in {}".format(elapsed_time))

--- a/app/clients/sms/aws_pinpoint.py
+++ b/app/clients/sms/aws_pinpoint.py
@@ -24,6 +24,7 @@ class AwsPinpointClient(SmsClient):
     def send_sms(self, to, content, reference, multi=True, sender=None, template_id=None):
         messageType = "TRANSACTIONAL"
         matched = False
+        opted_out = False
 
         if template_id is not None and str(template_id) in self.current_app.config["AWS_PINPOINT_SC_TEMPLATE_IDS"]:
             pool_id = self.current_app.config["AWS_PINPOINT_SC_POOL_ID"]

--- a/tests/app/clients/test_aws_pinpoint.py
+++ b/tests/app/clients/test_aws_pinpoint.py
@@ -74,9 +74,6 @@ def test_send_sms_returns_raises_error_if_there_is_no_valid_number_is_found(noti
 
 
 def test_handles_opted_out_numbers(notify_api, mocker, sample_template):
-    # mock_client = mocker.patch.object(aws_pinpoint_client, "_client", create=True)
-    # mocker.patch.object(aws_pinpoint_client, "statsd_client", create=True)
-
     conflict_error = aws_pinpoint_client._client.exceptions.ConflictException(
         error_response={"Reason": "DESTINATION_PHONE_NUMBER_OPTED_OUT"}, operation_name="send_text_message"
     )

--- a/tests/app/clients/test_aws_pinpoint.py
+++ b/tests/app/clients/test_aws_pinpoint.py
@@ -71,3 +71,18 @@ def test_send_sms_returns_raises_error_if_there_is_no_valid_number_is_found(noti
         aws_pinpoint_client.send_sms(to, content, reference)
 
     assert "No valid numbers found for SMS delivery" in str(excinfo.value)
+
+
+def test_handles_opted_out_numbers(notify_api, mocker, sample_template):
+    # mock_client = mocker.patch.object(aws_pinpoint_client, "_client", create=True)
+    # mocker.patch.object(aws_pinpoint_client, "statsd_client", create=True)
+
+    conflict_error = aws_pinpoint_client._client.exceptions.ConflictException(
+        error_response={"Reason": "DESTINATION_PHONE_NUMBER_OPTED_OUT"}, operation_name="send_text_message"
+    )
+    mocker.patch("app.aws_pinpoint_client._client.send_text_message", side_effect=conflict_error)
+
+    to = "6135555555"
+    content = "foo"
+    reference = "ref"
+    assert aws_pinpoint_client.send_sms(to, content, reference=reference, template_id=sample_template.id) == "opted_out"

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -190,7 +190,6 @@ def test_should_return_highest_priority_active_provider(restore_provider_details
 
 
 def test_should_handle_opted_out_phone_numbers_if_using_pinpoint(notify_api, sample_template, mocker):
-    # statsd_mock = mocker.patch("app.delivery.send_to_providers.statsd_client")
     mocker.patch("app.aws_pinpoint_client.send_sms", return_value="opted_out")
     db_notification = save_notification(
         create_notification(

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -189,6 +189,32 @@ def test_should_return_highest_priority_active_provider(restore_provider_details
     assert send_to_providers.provider_to_use("sms", "1234").name == first.identifier
 
 
+def test_should_handle_opted_out_phone_numbers_if_using_pinpoint(notify_api, sample_template, mocker):
+    # statsd_mock = mocker.patch("app.delivery.send_to_providers.statsd_client")
+    mocker.patch("app.aws_pinpoint_client.send_sms", return_value="opted_out")
+    db_notification = save_notification(
+        create_notification(
+            template=sample_template,
+            to_field="+16135551234",
+            status="created",
+            reply_to_text=sample_template.service.get_default_sms_sender(),
+        )
+    )
+
+    with set_config_values(
+        notify_api,
+        {
+            "AWS_PINPOINT_SC_POOL_ID": "sc_pool_id",
+            "AWS_PINPOINT_DEFAULT_POOL_ID": "default_pool_id",
+        },
+    ):
+        send_to_providers.send_sms_to_provider(db_notification)
+
+        notification = Notification.query.filter_by(id=db_notification.id).one()
+        assert notification.status == "permanent-failure"
+        assert notification.provider_response == "Phone number is opted out"
+
+
 def test_should_send_personalised_template_to_correct_sms_provider_and_persist(sample_sms_template_with_html, mocker):
     db_notification = save_notification(
         create_notification(


### PR DESCRIPTION
# Summary | Résumé

The Pinpoint boto call throws an exception if we try to send to a phone number that has opted out. (SNS will accept the boto call and later log that the number has opted out).

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/370

# Test instructions | Instructions pour tester la modification

0) Make sure Pinpoint is configured.
1) Send yourself a text. 
2) Reply "STOP" to opt out.
3) After ten or so seconds send yourself another text.
4) Within a few seconds the status of the notification should be "Phone number is opted out".
5) In staging or locally reply "START" to opt back in.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.