### PR TITLE
Change process type values to be consistent

### DIFF
--- a/migrations/versions/0454_add_template_category.py
+++ b/migrations/versions/0454_add_template_category.py
@@ -35,17 +35,17 @@ def upgrade():
 
     # Insert the generic low, medium, and high categories
     op.execute(
-        "INSERT INTO template_categories (id, name_en, name_fr, sms_process_type, email_process_type, hidden, created_at) VALUES ('{}', 'Low Category (Bulk)', 'Catégorie Basse (En Vrac)', 'low', 'low', true, now())".format(
+        "INSERT INTO template_categories (id, name_en, name_fr, sms_process_type, email_process_type, hidden, created_at) VALUES ('{}', 'Low Category (Bulk)', 'Catégorie Basse (En Vrac)', 'bulk', 'bulk', true, now())".format(
             current_app.config["DEFAULT_TEMPLATE_CATEGORY_LOW"],
         )
     )
     op.execute(
-        "INSERT INTO template_categories (id, name_en, name_fr, sms_process_type, email_process_type, hidden, created_at) VALUES ('{}', 'Medium Category (Normal)', 'Catégorie Moyenne (Normale)', 'low', 'low', true, now())".format(
+        "INSERT INTO template_categories (id, name_en, name_fr, sms_process_type, email_process_type, hidden, created_at) VALUES ('{}', 'Medium Category (Normal)', 'Catégorie Moyenne (Normale)', 'normal', 'normal', true, now())".format(
             current_app.config["DEFAULT_TEMPLATE_CATEGORY_MEDIUM"]
         )
     )
     op.execute(
-        "INSERT INTO template_categories (id, name_en, name_fr, sms_process_type, email_process_type, hidden, created_at) VALUES ('{}', 'High Category (Priority)', 'Catégorie Haute (Priorité)', 'low', 'low', true, now())".format(
+        "INSERT INTO template_categories (id, name_en, name_fr, sms_process_type, email_process_type, hidden, created_at) VALUES ('{}', 'High Category (Priority)', 'Catégorie Haute (Priorité)', 'priority', 'priority', true, now())".format(
             current_app.config["DEFAULT_TEMPLATE_CATEGORY_HIGH"]
         )
     )

--- a/migrations/versions/0454_add_template_category.py
+++ b/migrations/versions/0454_add_template_category.py
@@ -35,17 +35,17 @@ def upgrade():
 
     # Insert the generic low, medium, and high categories
     op.execute(
-        "INSERT INTO template_categories (id, name_en, name_fr, sms_process_type, email_process_type, hidden, created_at) VALUES ('{}', 'Low Category (Bulk)', 'Catégorie Basse (En Vrac)', 'bulk', 'bulk', true, now())".format(
+        "INSERT INTO template_categories (id, name_en, name_fr, sms_process_type, email_process_type, hidden, created_at) VALUES ('{}', 'Low Category', 'Catégorie Basse', 'bulk', 'bulk', true, now())".format(
             current_app.config["DEFAULT_TEMPLATE_CATEGORY_LOW"],
         )
     )
     op.execute(
-        "INSERT INTO template_categories (id, name_en, name_fr, sms_process_type, email_process_type, hidden, created_at) VALUES ('{}', 'Medium Category (Normal)', 'Catégorie Moyenne (Normale)', 'normal', 'normal', true, now())".format(
+        "INSERT INTO template_categories (id, name_en, name_fr, sms_process_type, email_process_type, hidden, created_at) VALUES ('{}', 'Medium Category', 'Catégorie Moyenne', 'normal', 'normal', true, now())".format(
             current_app.config["DEFAULT_TEMPLATE_CATEGORY_MEDIUM"]
         )
     )
     op.execute(
-        "INSERT INTO template_categories (id, name_en, name_fr, sms_process_type, email_process_type, hidden, created_at) VALUES ('{}', 'High Category (Priority)', 'Catégorie Haute (Priorité)', 'priority', 'priority', true, now())".format(
+        "INSERT INTO template_categories (id, name_en, name_fr, sms_process_type, email_process_type, hidden, created_at) VALUES ('{}', 'High Category', 'Catégorie Haute', 'priority', 'priority', true, now())".format(
             current_app.config["DEFAULT_TEMPLATE_CATEGORY_HIGH"]
         )
     )

--- a/migrations/versions/0455_add_starter_category.py
+++ b/migrations/versions/0455_add_starter_category.py
@@ -34,7 +34,7 @@ category_ids = [
 
 # Corresponding English and French names and descriptions and process_type
 category_data = [
-    ("Alert", "Alerte", "System checks and monitoring", "Contrôles et suivi du système", "normal", "normal"),
+    ("Alert", "Alerte", "System checks and monitoring", "Contrôles et suivi du système", "medium", "medium"),
     (
         "Authentication",
         "Authentification",
@@ -51,7 +51,7 @@ category_data = [
         "priority",
         "priority",
     ),
-    ("Decision", "Décision", "Permits, documents and results", "Permis, documents et résultats", "bulk", "bulk"),
+    ("Decision", "Décision", "Permits, documents and results", "Permis, documents et résultats", "low", "low"),
     (
         "Information blast",
         "Information de masse",
@@ -68,6 +68,10 @@ category_data = [
 
 
 def upgrade():
+    # Insert new process_type
+    op.execute("INSERT INTO template_process_type (name) VALUES ('low')")
+    op.execute("INSERT INTO template_process_type (name) VALUES ('medium')")
+    op.execute("INSERT INTO template_process_type (name) VALUES ('high')")
 
     def insert_statement(id, name_en, name_fr, description_en, description_fr, sms_process_type, email_process_type):
         # Escape single quotes in string values
@@ -75,9 +79,9 @@ def upgrade():
         description_fr = description_fr.replace("'", "''")
 
         return f"""
-        INSERT INTO template_categories
+        INSERT INTO template_categories 
         (id, name_en, name_fr, description_en, description_fr, sms_process_type, email_process_type, hidden, created_at)
-        VALUES
+        VALUES 
         ('{id}', '{name_en}', '{name_fr}', '{description_en}', '{description_fr}', '{sms_process_type}', '{email_process_type}', false, now())
         """
 
@@ -89,3 +93,8 @@ def upgrade():
 def downgrade():
     for id in category_ids:
         op.execute(f"DELETE FROM template_categories WHERE id = '{id}'")
+
+    # Delete process_type
+    op.execute("DELETE FROM template_process_type WHERE name = 'low'")
+    op.execute("DELETE FROM template_process_type WHERE name = 'medium'")
+    op.execute("DELETE FROM template_process_type WHERE name = 'high'")

--- a/migrations/versions/0455_add_starter_category.py
+++ b/migrations/versions/0455_add_starter_category.py
@@ -34,7 +34,7 @@ category_ids = [
 
 # Corresponding English and French names and descriptions and process_type
 category_data = [
-    ("Alert", "Alerte", "System checks and monitoring", "Contrôles et suivi du système", "medium", "medium"),
+    ("Alert", "Alerte", "System checks and monitoring", "Contrôles et suivi du système", "normal", "normal"),
     (
         "Authentication",
         "Authentification",
@@ -51,7 +51,7 @@ category_data = [
         "priority",
         "priority",
     ),
-    ("Decision", "Décision", "Permits, documents and results", "Permis, documents et résultats", "low", "low"),
+    ("Decision", "Décision", "Permits, documents and results", "Permis, documents et résultats", "bulk", "bulk"),
     (
         "Information blast",
         "Information de masse",
@@ -68,10 +68,6 @@ category_data = [
 
 
 def upgrade():
-    # Insert new process_type
-    op.execute("INSERT INTO template_process_type (name) VALUES ('low')")
-    op.execute("INSERT INTO template_process_type (name) VALUES ('medium')")
-    op.execute("INSERT INTO template_process_type (name) VALUES ('high')")
 
     def insert_statement(id, name_en, name_fr, description_en, description_fr, sms_process_type, email_process_type):
         # Escape single quotes in string values
@@ -79,9 +75,9 @@ def upgrade():
         description_fr = description_fr.replace("'", "''")
 
         return f"""
-        INSERT INTO template_categories 
+        INSERT INTO template_categories
         (id, name_en, name_fr, description_en, description_fr, sms_process_type, email_process_type, hidden, created_at)
-        VALUES 
+        VALUES
         ('{id}', '{name_en}', '{name_fr}', '{description_en}', '{description_fr}', '{sms_process_type}', '{email_process_type}', false, now())
         """
 
@@ -93,8 +89,3 @@ def upgrade():
 def downgrade():
     for id in category_ids:
         op.execute(f"DELETE FROM template_categories WHERE id = '{id}'")
-
-    # Delete process_type
-    op.execute("DELETE FROM template_process_type WHERE name = 'low'")
-    op.execute("DELETE FROM template_process_type WHERE name = 'medium'")
-    op.execute("DELETE FROM template_process_type WHERE name = 'high'")


### PR DESCRIPTION
# Summary | Résumé
Quick PR to fix the sms/email process type values for the default categories. Rather than high, normal, low,  we'll use priority, normal, bulk for consistency sake.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-admin/pull/1884

# Test instructions | Instructions pour tester la modification

1. Run the migration
2. Check your local DB
3. Note that the values for `sms/email_process_type` in the default categories are priority, normal, bulk.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.