### PR TITLE
TemplateCategory : updated the template category model

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -65,6 +65,11 @@ DELIVERY_STATUS_CALLBACK_TYPE = "delivery_status"
 COMPLAINT_CALLBACK_TYPE = "complaint"
 SERVICE_CALLBACK_TYPES = [DELIVERY_STATUS_CALLBACK_TYPE, COMPLAINT_CALLBACK_TYPE]
 
+SHORT_CODE = "short_code"
+LONG_CODE = "long_code"
+
+sms_sending_vehicles = db.Enum(*[SHORT_CODE, LONG_CODE], name="sms_sending_vehicles")
+
 
 def filter_null_value_fields(obj):
     return dict(filter(lambda x: x[1] is not None, obj.items()))
@@ -1046,6 +1051,7 @@ class TemplateCategory(BaseModel):
     hidden = db.Column(db.Boolean, nullable=False, default=False)
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
     updated_at = db.Column(db.DateTime, onupdate=datetime.datetime.utcnow)
+    sms_sending_vehicle = db.Column(sms_sending_vehicles, nullable=False, default="long_code")
 
     def serialize(self):
         return {
@@ -1059,6 +1065,7 @@ class TemplateCategory(BaseModel):
             "hidden": self.hidden,
             "created_at": self.created_at,
             "updated_at": self.updated_at,
+            "sms_sending_vehicle": self.sms_sending_vehicle,
         }
 
     @classmethod

--- a/tests/app/dao/test_template_categories_dao.py
+++ b/tests/app/dao/test_template_categories_dao.py
@@ -14,22 +14,45 @@ from app.models import BULK, NORMAL, Template, TemplateCategory
 from tests.app.conftest import create_sample_template
 
 
-def test_create_template_category(notify_db_session):
-    data = {
-        "name_en": "english",
-        "name_fr": "french",
-        "description_en": "english description",
-        "description_fr": "french description",
-        "sms_process_type": NORMAL,
-        "email_process_type": NORMAL,
-        "hidden": False,
-    }
+class TestCreateTemplateCategory:
+    def test_create_template_category(self, notify_db_session):
+        data = {
+            "name_en": "english",
+            "name_fr": "french",
+            "description_en": "english description",
+            "description_fr": "french description",
+            "sms_process_type": NORMAL,
+            "email_process_type": NORMAL,
+            "hidden": False,
+            "sms_sending_vehicle": "short_code",
+        }
 
-    template_category = TemplateCategory(**data)
-    dao_create_template_category(template_category)
+        template_category = TemplateCategory(**data)
+        dao_create_template_category(template_category)
 
-    assert TemplateCategory.query.count() == 1
-    assert len(dao_get_all_template_categories()) == 1
+        temp_cat = dao_get_all_template_categories()
+        assert TemplateCategory.query.count() == 1
+        assert len(temp_cat) == 1
+        assert temp_cat[0].sms_sending_vehicle == "short_code"
+
+    def test_create_template_category_with_no_sms_sending_vehicle(self, notify_db_session):
+        data = {
+            "name_en": "english",
+            "name_fr": "french",
+            "description_en": "english description",
+            "description_fr": "french description",
+            "sms_process_type": NORMAL,
+            "email_process_type": NORMAL,
+            "hidden": False,
+        }
+
+        template_category = TemplateCategory(**data)
+        dao_create_template_category(template_category)
+
+        temp_cat = dao_get_all_template_categories()
+        assert TemplateCategory.query.count() == 1
+        assert len(temp_cat) == 1
+        assert temp_cat[0].sms_sending_vehicle == "long_code"  # default value
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Summary | Résumé

1. Updated the model to add a sms_sending_vehicle column
2. Added tests

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1609
# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.