### PR TITLE
Fix/update template schema

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -397,6 +397,7 @@ class TemplateSchema(BaseTemplateSchema):
     is_precompiled_letter = fields.Method("get_is_precompiled_letter")
     process_type = field_for(models.Template, "process_type")
     template_category = fields.Nested(TemplateCategorySchema, dump_only=True)
+    template_category_id = fields.UUID(required=False, allow_none=True)
     redact_personalisation = fields.Method("redact")
     created_at = FlexibleDateTime()
     updated_at = FlexibleDateTime()

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -273,7 +273,7 @@ def get_template_versions(service_id, template_id):
 def _template_has_not_changed(current_data, updated_template):
     return all(
         current_data[key] == updated_template[key]
-        for key in ("name", "content", "subject", "archived", "process_type", "postage")
+        for key in ("name", "content", "subject", "archived", "process_type", "postage", "template_category_id")
     )
 
 


### PR DESCRIPTION
# Summary | Résumé

This PR adds `template_category_id` to the templates schema to allow template categories to be updated by admin.

## Related Issues | Cartes liées
- https://github.com/cds-snc/notification-planning/issues/1588

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.