### PR TITLE
Add a template schema that excludes the content prop

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -419,12 +419,7 @@ class TemplateSchema(BaseTemplateSchema):
 class ReducedTemplateSchema(TemplateSchema):
     class Meta(BaseSchema.Meta):
         model = models.Template
-        exclude = [
-            "content",
-            "jobs",
-            "service_id",
-            "service_letter_contact_id"
-        ]
+        exclude = ["content", "jobs", "service_id", "service_letter_contact_id"]
 
 
 class TemplateHistorySchema(BaseSchema):

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -419,7 +419,13 @@ class TemplateSchema(BaseTemplateSchema):
 class ReducedTemplateSchema(TemplateSchema):
     class Meta(BaseSchema.Meta):
         model = models.Template
-        exclude = ["content"]
+        exclude = [
+            "content",
+            "jobs",
+            "users",
+            "service_id"
+            "service_letter_contact_id"
+        ]
 
 
 class TemplateHistorySchema(BaseSchema):

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -416,6 +416,12 @@ class TemplateSchema(BaseTemplateSchema):
                 raise ValidationError("Invalid template subject", "subject")
 
 
+class ReducedTemplateSchema(TemplateSchema):
+    class Meta(BaseSchema.Meta):
+        model = models.Template
+        exclude = ["content"]
+
+
 class TemplateHistorySchema(BaseSchema):
     reply_to = fields.Method("get_reply_to", allow_none=True)
     reply_to_text = fields.Method("get_reply_to_text", allow_none=True)
@@ -834,6 +840,7 @@ service_history_schema = ServiceHistorySchema()
 api_key_history_schema = ApiKeyHistorySchema()
 template_history_schema = TemplateHistorySchema()
 template_category_schema = TemplateCategorySchema()
+reduced_template_schema = ReducedTemplateSchema()
 event_schema = EventSchema()
 provider_details_schema = ProviderDetailsSchema()
 provider_details_history_schema = ProviderDetailsHistorySchema()

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -422,8 +422,7 @@ class ReducedTemplateSchema(TemplateSchema):
         exclude = [
             "content",
             "jobs",
-            "users",
-            "service_id"
+            "service_id",
             "service_letter_contact_id"
         ]
 

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -42,7 +42,11 @@ from app.models import (
 )
 from app.notifications.validators import check_reply_to, service_has_permission
 from app.schema_validation import validate
-from app.schemas import template_history_schema, template_schema
+from app.schemas import (
+    reduced_template_schema,
+    template_history_schema,
+    template_schema,
+)
 from app.template.template_schemas import post_create_template_schema
 from app.utils import get_public_notify_type_text, get_template_instance
 
@@ -225,7 +229,7 @@ def get_precompiled_template_for_service(service_id):
 @template_blueprint.route("", methods=["GET"])
 def get_all_templates_for_service(service_id):
     templates = dao_get_all_templates_for_service(service_id=service_id)
-    data = template_schema.dump(templates, many=True)
+    data = reduced_template_schema.dump(templates, many=True)
     return jsonify(data=data)
 
 


### PR DESCRIPTION
# Summary | Résumé

This PR introduces the `ReducedTemplateSchema`, which excludes the `content` property. The front end fetches all templates when creating the global `current_service` object, however we do not need this data until we are editing a template.

## Related Issues | Cartes liées
- [Incident](https://gcdigital.slack.com/archives/C07BV518NH1/p1720635761141479)

# Test instructions | Instructions pour tester la modification

1. Log in and access your service
2. Check Redis and note that the `service-<id>-templates` key does not contain template content

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.