### PR TITLE
Change delete_template_category http code to 204

### DIFF
--- a/app/template/template_category_rest.py
+++ b/app/template/template_category_rest.py
@@ -101,4 +101,4 @@ def delete_template_category(template_category_id):
         return jsonify(message="Cannot delete a template category with templates assigned to it."), 400
     else:
         dao_delete_template_category_by_id(template_category_id)
-    return "", 200
+    return "", 204

--- a/app/template/template_category_rest.py
+++ b/app/template/template_category_rest.py
@@ -95,7 +95,7 @@ def delete_template_category(template_category_id):
 
     if request.args.get("cascade") == "True":
         dao_delete_template_category_by_id(template_category_id, cascade=True)
-        return "", 200
+        return "", 204
 
     if Template.query.filter_by(template_category_id=template_category_id).count() > 0:
         return jsonify(message="Cannot delete a template category with templates assigned to it."), 400

--- a/tests/app/template/test_template_category_rest.py
+++ b/tests/app/template/test_template_category_rest.py
@@ -111,7 +111,7 @@ def test_get_template_categories(
     )
 
     assert response.status_code == expected_status_code
-    if not expected_status_code == 200:
+    if not expected_status_code == 204:
         assert response.json["message"] == expected_msg
 
 

--- a/tests/app/template/test_template_category_rest.py
+++ b/tests/app/template/test_template_category_rest.py
@@ -118,7 +118,7 @@ def test_get_template_categories(
 @pytest.mark.parametrize(
     "cascade, expected_status_code, expected_msg",
     [
-        ("True", 200, ""),
+        ("True", 204, ""),
         ("False", 400, "Cannot delete a template category with templates assigned to it."),
     ],
 )

--- a/tests/app/template/test_template_category_rest.py
+++ b/tests/app/template/test_template_category_rest.py
@@ -111,7 +111,7 @@ def test_get_template_categories(
     )
 
     assert response.status_code == expected_status_code
-    if not expected_status_code == 204:
+    if not expected_status_code == 200:
         assert response.json["message"] == expected_msg
 
 


### PR DESCRIPTION
# Summary | Résumé

This PR updates changes the `delete_template_category` API endpoint to return a 204 if a TC was successfully deleted, fixing an issue with the API client in Admin.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-admin/pull/1890

# Test instructions | Instructions pour tester la modification

Tests pass

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.