### PR TITLE
Raise exception when deleting cat that is linked to template(s)

### DIFF
--- a/app/template/template_category_rest.py
+++ b/app/template/template_category_rest.py
@@ -9,7 +9,7 @@ from app.dao.template_categories_dao import (
     dao_update_template_category,
 )
 from app.errors import register_errors
-from app.models import Template, TemplateCategory
+from app.models import TemplateCategory
 from app.schemas import template_category_schema
 
 template_category_blueprint = Blueprint(
@@ -92,13 +92,6 @@ def delete_template_category(template_category_id):
     Returns:
         (flask.Response): The response message and http status code.
     """
-
-    if request.args.get("cascade") == "True":
-        dao_delete_template_category_by_id(template_category_id, cascade=True)
-        return "", 204
-
-    if Template.query.filter_by(template_category_id=template_category_id).count() > 0:
-        return jsonify(message="Cannot delete a template category with templates assigned to it."), 400
-    else:
-        dao_delete_template_category_by_id(template_category_id)
+    cascade = True if request.args.get("cascade") == "True" else False
+    dao_delete_template_category_by_id(template_category_id, cascade=cascade)
     return "", 204

--- a/tests/app/dao/test_template_categories_dao.py
+++ b/tests/app/dao/test_template_categories_dao.py
@@ -10,6 +10,7 @@ from app.dao.template_categories_dao import (
     dao_update_template_category,
 )
 from app.dao.templates_dao import dao_create_template
+from app.errors import InvalidRequest
 from app.models import BULK, NORMAL, Template, TemplateCategory
 from tests.app.conftest import create_sample_template
 
@@ -375,7 +376,8 @@ def test_dao_delete_template_category_by_id_should_not_allow_deletion_when_assoc
 ):
     create_sample_template(notify_db, notify_db_session, template_category=sample_template_category)
 
-    dao_delete_template_category_by_id(sample_template_category.id)
+    with pytest.raises(InvalidRequest):
+        dao_delete_template_category_by_id(sample_template_category.id)
 
     assert TemplateCategory.query.count() == 1
 

--- a/tests/app/template/test_template_category_rest.py
+++ b/tests/app/template/test_template_category_rest.py
@@ -119,7 +119,7 @@ def test_get_template_categories(
     "cascade, expected_status_code, expected_msg",
     [
         ("True", 204, ""),
-        ("False", 400, "Cannot delete a template category with templates assigned to it."),
+        ("False", 400, "Cannot delete categories associated with templates. Dissociate the category from templates first."),
     ],
 )
 def test_delete_template_category_cascade(


### PR DESCRIPTION
# Summary | Résumé

Raise an exception when attempting to delete a template category, without `cascade=True`, that's currently associated with templates.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-admin/pull/1890

# Test instructions | Instructions pour tester la modification
1. Import [this postman collection](https://github.com/user-attachments/files/15975957/Test.Template.Categories.postman_collection.json)
2. Associate a category with one or more templates
3. Attempt to delete the category
4. Note an error message is raised

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.