### PR TITLE
Task/add freshdesk other

### DIFF
--- a/app/clients/freshdesk.py
+++ b/app/clients/freshdesk.py
@@ -77,7 +77,20 @@ class Freshdesk(object):
                     f"- Texte alternatif français : {self.contact.alt_text_fr}",
                 ]
             )
-
+        elif self.contact.is_new_template_category_request():
+            message = "<br>".join(
+                [
+                    f"New template category request from {self.contact.name} ({self.contact.email_address}):",
+                    f"- Service id: {self.contact.service_id}",
+                    f"- New Template Category Request name: {self.contact.template_category_name_en}",
+                    f"- Template id request: {self.contact.template_id_link}",
+                    "<hr>",
+                    f"Demande de nouvelle catégorie de modèle de {self.contact.name} ({self.contact.email_address}):",
+                    f"- Identifiant du service: {self.contact.service_id}",
+                    f"- Nom de la nouvelle catégorie de modèle demandée: {self.contact.template_category_name_fr}",
+                    f"- Demande d'identifiant de modèle: {self.contact.template_id_link}",
+                ]
+            )
         if len(self.contact.user_profile):
             message += f"<br><br>---<br><br> {self.contact.user_profile}"
 

--- a/app/user/contact_request.py
+++ b/app/user/contact_request.py
@@ -34,6 +34,9 @@ class ContactRequest:
     branding_logo_name: str = field(default="")
     alt_text_en: str = field(default="")
     alt_text_fr: str = field(default="")
+    template_category_name_en: str = field(default="")
+    template_category_name_fr: str = field(default="")
+    template_id_link: str = field(default="")
 
     def __post_init__(self):
         # email address is mandatory for us
@@ -56,3 +59,6 @@ class ContactRequest:
 
     def is_branding_request(self):
         return "branding_request" in self.support_type.lower()
+
+    def is_new_template_category_request(self):
+        return "new_template_category_request" in self.support_type.lower()

--- a/tests/app/clients/test_freshdesk.py
+++ b/tests/app/clients/test_freshdesk.py
@@ -184,15 +184,21 @@ class TestSendTicket:
     def test_send_ticket_other_category(self, email_freshdesk_ticket_mock, notify_api: Flask):
         def match_json(request):
             expected = {
-                "New template category request from name (test@email.com):<br>",
-                "- Service id: 8624bd36-b70b-4d4b-a459-13e1f4770b92<br>",
-                "- New Template Category Request name: test category name <br>",
-                "- Template id request: http://localhost:6012/services/8624bd36-b70b-4d4b-a459-13e1f4770b92/templates/3ed1f07a-1b20-4f83-9a3e-158ab9b00103<br>",
-                "<hr><br>",
-                "Demande de nouvelle catégorie de modèle de name (test@email.com):<br>",
-                "- Identifiant du service: 8624bd36-b70b-4d4b-a459-13e1f4770b92<br>",
-                "- Nom de la nouvelle catégorie de modèle demandée: test category name <br>",
+                "product_id": 42,
+                "subject": "Support Request",
+                "description": "New template category request from name (test@email.com):<br>"
+                "- Service id: 8624bd36-b70b-4d4b-a459-13e1f4770b92<br>"
+                "- New Template Category Request name: test category name <br>"
+                "- Template id request: http://localhost:6012/services/8624bd36-b70b-4d4b-a459-13e1f4770b92/templates/3ed1f07a-1b20-4f83-9a3e-158ab9b00103<br>"
+                "<hr><br>"
+                "Demande de nouvelle catégorie de modèle de name (test@email.com):<br>"
+                "- Identifiant du service: 8624bd36-b70b-4d4b-a459-13e1f4770b92<br>"
+                "- Nom de la nouvelle catégorie de modèle demandée: test category name <br>"
                 "- Demande d'identifiant de modèle:  http://localhost:6012/services/8624bd36-b70b-4d4b-a459-13e1f4770b92/templates/3ed1f07a-1b20-4f83-9a3e-158ab9b00103<br>",
+                "email": "test@email.com",
+                "priority": 1,
+                "status": 2,
+                "tags": [],
             }
 
             encoded_auth = base64.b64encode(b"freshdesk-api-key:x").decode("ascii")

--- a/tests/app/clients/test_freshdesk.py
+++ b/tests/app/clients/test_freshdesk.py
@@ -185,16 +185,16 @@ class TestSendTicket:
         def match_json(request):
             expected = {
                 "product_id": 42,
-                "subject": "Support Request",
+                "subject": "New template category request",
                 "description": "New template category request from name (test@email.com):<br>"
                 "- Service id: 8624bd36-b70b-4d4b-a459-13e1f4770b92<br>"
-                "- New Template Category Request name: test category name <br>"
+                "- New Template Category Request name: test category name<br>"
                 "- Template id request: http://localhost:6012/services/8624bd36-b70b-4d4b-a459-13e1f4770b92/templates/3ed1f07a-1b20-4f83-9a3e-158ab9b00103<br>"
                 "<hr><br>"
                 "Demande de nouvelle catégorie de modèle de name (test@email.com):<br>"
                 "- Identifiant du service: 8624bd36-b70b-4d4b-a459-13e1f4770b92<br>"
-                "- Nom de la nouvelle catégorie de modèle demandée: test category name <br>"
-                "- Demande d'identifiant de modèle:  http://localhost:6012/services/8624bd36-b70b-4d4b-a459-13e1f4770b92/templates/3ed1f07a-1b20-4f83-9a3e-158ab9b00103<br>",
+                "- Nom de la nouvelle catégorie de modèle demandée: test category name<br>"
+                "- Demande d'identifiant de modèle: http://localhost:6012/services/8624bd36-b70b-4d4b-a459-13e1f4770b92/templates/3ed1f07a-1b20-4f83-9a3e-158ab9b00103",
                 "email": "test@email.com",
                 "priority": 1,
                 "status": 2,
@@ -221,7 +221,7 @@ class TestSendTicket:
                 "support_type": "new_template_category_request",
                 "service_id": "8624bd36-b70b-4d4b-a459-13e1f4770b92",
                 "template_category_name_en": "test category name",
-                "template_category_name_fr": "test_category_name",
+                "template_category_name_fr": "test category name",
                 "template_id_link": "http://localhost:6012/services/8624bd36-b70b-4d4b-a459-13e1f4770b92/templates/3ed1f07a-1b20-4f83-9a3e-158ab9b00103",
             }
             with notify_api.app_context():

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -980,6 +980,31 @@ def test_send_branding_request(client, sample_service, sample_organisation, mock
     mocked_salesforce_client.engagement_update.assert_not_called()
 
 
+class TestFreshDeskRequestTickets:
+    def test_send_request_for_new_category(self, client, sample_service, sample_organisation, mocker):
+        sample_user = sample_service.users[0]
+        sample_service.organisation = sample_organisation
+        post_data = {
+            "service_name": sample_service.name,
+            "email_address": sample_user.email_address,
+            "service_id": str(sample_service.id),
+            "template_category_name_en": "test",
+            "template_category_name_fr": "test",
+            "template_id": "1234",
+        }
+        mocked_freshdesk = mocker.patch("app.user.rest.Freshdesk.send_ticket", return_value=201)
+        mocked_salesforce_client = mocker.patch("app.user.rest.salesforce_client")
+
+        resp = client.post(
+            url_for("user.send_new_template_category_request", user_id=str(sample_user.id)),
+            data=json.dumps(post_data),
+            headers=[("Content-Type", "application/json"), create_authorization_header()],
+        )
+        assert resp.status_code == 204
+        mocked_freshdesk.assert_called_once_with()
+        mocked_salesforce_client.engagement_update.assert_not_called()
+
+
 def test_send_user_confirm_new_email_returns_204(client, sample_user, change_email_confirmation_template, mocker):
     mocked = mocker.patch("app.celery.provider_tasks.deliver_email.apply_async")
     new_email = "new_address@dig.gov.uk"


### PR DESCRIPTION
# Summary | Résumé

Add api for sending other template category to freshdesk

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1610

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.