### PR TITLE
Increased the PERSONALISATION_SIZE_LIMIT default to 75kb in code

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -283,8 +283,9 @@ class Config(object):
     SQLALCHEMY_ECHO = env.bool("SQLALCHEMY_ECHO", False)
     PAGE_SIZE = 50
     PERSONALISATION_SIZE_LIMIT = env.int(
-        "PERSONALISATION_SIZE_LIMIT", 1024 * 50
-    )  # 50k bytes limit by default for personalisation data per notification
+        "PERSONALISATION_SIZE_LIMIT", 1024 * 75
+    )  # 75k bytes limit by default for personalisation data per notification
+       # temporary limit for GCForms, we will lower it back to 50k soon.
     API_PAGE_SIZE = 250
     TEST_MESSAGE_FILENAME = "Test message"
     ONE_OFF_MESSAGE_FILENAME = "Report"

--- a/app/config.py
+++ b/app/config.py
@@ -285,7 +285,7 @@ class Config(object):
     PERSONALISATION_SIZE_LIMIT = env.int(
         "PERSONALISATION_SIZE_LIMIT", 1024 * 75
     )  # 75k bytes limit by default for personalisation data per notification
-       # temporary limit for GCForms, we will lower it back to 50k soon.
+    # temporary limit for GCForms, we will lower it back to 50k soon.
     API_PAGE_SIZE = 250
     TEST_MESSAGE_FILENAME = "Test message"
     ONE_OFF_MESSAGE_FILENAME = "Report"


### PR DESCRIPTION
# Summary | Résumé

This will make sure that the newest increase to PERSONALISATION_SIZE_LIMIT will take effect.

We are increasing that value temporarily to accommodate a larger than usual personalization variable sent by the GCForms team.

## Related Issues | Cartes liées

No cards related to this one. 

# Test instructions | Instructions pour tester la modification

None.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.