### PR TITLE
add command to make user a platform admin

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -1045,3 +1045,17 @@ def fix_billable_units():
         Notification.query.filter(Notification.id == notification.id).update({"billable_units": template.fragment_count})
     db.session.commit()
     print("End fix_billable_units")
+
+
+@notify_command(name="admin")
+@click.option("-u", "--user_email", required=True, help="user email address")
+@click.option("--on/--off", required=False, default=True, show_default="on", help="toggle admin on or off")
+def toggle_admin(user_email, on):
+    try:
+        user = User.query.filter(User.email_address == user_email).one()
+    except NoResultFound:
+        print(f"User {user_email} not found")
+        return
+    user.platform_admin = on
+    db.session.commit()
+    print(f"User {user.email_address} is now {'an admin' if user.platform_admin else 'not an admin'}")


### PR DESCRIPTION
# Summary | Résumé

Command to toggle the user `platform_admin` setting.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/389

# Test instructions | Instructions pour tester la modification

- log into an api or celery pod
- run the command `flask command admin -u <your email address> --off`
- clear the users cache and verify that you are no longer an admin!
- run the command `flask command admin -u <your email address>`
- log into Notify again and verify that you are once more an admin.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.