### PR TITLE
Fix TC deletion bug

### DIFF
--- a/tests/app/dao/test_template_categories_dao.py
+++ b/tests/app/dao/test_template_categories_dao.py
@@ -391,3 +391,13 @@ def test_dao_delete_template_category_by_id_should_allow_deletion_with_cascade_w
     # 3 here because we have 3 generic defaut categories that will remain post-delete
     assert TemplateCategory.query.count() == 3
     assert str(template.template_category_id) == current_app.config["DEFAULT_TEMPLATE_CATEGORY_MEDIUM"]
+
+
+def test_dao_delete_template_category_by_id_should_allow_deletion_if_only_assciated_with_archived_templates(
+    notify_db, notify_db_session, sample_template_category, populate_generic_categories
+):
+    template = create_sample_template(notify_db, notify_db_session, archived=True, template_category=sample_template_category)
+
+    dao_delete_template_category_by_id(sample_template_category.id)
+    assert TemplateCategory.query.count() == 3
+    assert template.template_category_id is None


### PR DESCRIPTION
# Summary | Résumé
This PR fixes an issue where a Template Category could not be deleted following deletion of the templates it was associated with. 

When a user "deletes" a template the template is marked as `archived` rather than deleted and removed from the templates table, preventing deletion.

`dao_delete_template_category_by_id` now checks if the category is ONLY associated with archived templates. If that is the case, we set the archived template's `template_category_id` to `null` and proceed with deleting the template category. 

A side effect of this is that the `templates_history` table will contain rows with references to categories that no longer exist and cannot ever be cross referenced as we do not have a `template_category_history` table.

## Related Issues | Cartes liées
This issue was uncovered during the template categories bug bash and is documented below
https://docs.google.com/document/d/1swqV2sKYBZB9UHKjXsspPSp6SEJSBWVxmbAcUKFu5Ts/edit#task=OuE8AO3ICha-9aYF

# Test instructions | Instructions pour tester la modification

1. Create a new template category
2. Associate the category with 1 template
3. Delete the template
4. Delete the template category
5. The delete should succeed
6. Verify in the DB that the archived template's `template_category_id` is set to `null`

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.