### PR TITLE
Add hybrid_property and expression property for template.process_type

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -78,7 +78,9 @@ def send_sms_to_provider(notification):
             template_id=notification.template_id,
         )
 
-        template_dict = dao_get_template_by_id(notification.template_id, notification.template_version).__dict__
+        template_obj = dao_get_template_by_id(notification.template_id, notification.template_version)
+        template_dict = template_obj.__dict__
+        template_dict["process_type"] = template_obj.process_type
 
         template = SMSMessageTemplate(
             template_dict,
@@ -279,7 +281,9 @@ def send_email_to_provider(notification: Notification):
             else:
                 personalisation_data[key] = personalisation_data[key]["document"]["url"]
 
-        template_dict = dao_get_template_by_id(notification.template_id, notification.template_version).__dict__
+        template_obj = dao_get_template_by_id(notification.template_id, notification.template_version)
+        template_dict = template_obj.__dict__
+        template_dict["process_type"] = template_obj.process_type
 
         # Local Jinja support - Add USE_LOCAL_JINJA_TEMPLATES=True to .env
         # Add a folder to the project root called 'jinja_templates'

--- a/app/models.py
+++ b/app/models.py
@@ -1141,11 +1141,13 @@ class TemplateBase(BaseModel):
 
     @hybrid_property
     def process_type(self):
-        if self.template_type == SMS_TYPE:
-            return self.process_type_column if self.process_type_column else self.template_category.sms_process_type
-        elif self.template_type == EMAIL_TYPE:
-            return self.process_type_column if self.process_type_column else self.template_category.email_process_type
-        return self.process_type_column
+        # The if statement is required as a way to check if FF_TEMPLATE_CATEGORY is enabled
+        if self.template_category_id:
+            if self.template_type == SMS_TYPE:
+                return self.process_type_column if self.process_type_column else self.template_category.sms_process_type
+            elif self.template_type == EMAIL_TYPE:
+                return self.process_type_column if self.process_type_column else self.template_category.email_process_type
+        return self.process_type_column if self.process_type_column else NORMAL
 
     @process_type.setter  # type: ignore
     def process_type(self, value):

--- a/app/models.py
+++ b/app/models.py
@@ -1130,14 +1130,13 @@ class TemplateBase(BaseModel):
         return db.relationship("User")
 
     @declared_attr
-    def process_type_column(self):
+    def process_type_column(cls):
         return db.Column(
             db.String(255),
             db.ForeignKey("template_process_type.name"),
-            name='process_type',
+            name="process_type",
             index=True,
             nullable=True,
-            default=NORMAL,
         )
 
     @hybrid_property
@@ -1148,14 +1147,18 @@ class TemplateBase(BaseModel):
             return self.process_type_column if self.process_type_column else self.template_category.email_process_type
         return self.process_type_column
 
+    @process_type.setter  # type: ignore
+    def process_type(self, value):
+        self.process_type_column = value
+
     @process_type.expression
     def _process_type(self):
         return db.case(
             [
-                (self.template_type == 'sms', db.coalesce(self.process_type_column, self.template_category.sms_process_type)),
-                (self.template_type == 'email', db.coalesce(self.process_type_column, self.template_category.email_process_type)),
+                (self.template_type == "sms", db.coalesce(self.process_type_column, self.template_category.sms_process_type)),
+                (self.template_type == "email", db.coalesce(self.process_type_column, self.template_category.email_process_type)),
             ],
-            else_=self.process_type_column
+            else_=self.process_type_column,
         )
 
     redact_personalisation = association_proxy("template_redacted", "redact_personalisation")
@@ -1263,7 +1266,6 @@ class Template(TemplateBase):
             template_id=self.id,
             _external=True,
         )
-
 
     @classmethod
     def from_json(cls, data, folder=None):

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -395,7 +395,7 @@ class BaseTemplateSchema(BaseSchema):
 class TemplateSchema(BaseTemplateSchema):
     created_by = field_for(models.Template, "created_by", required=True)
     is_precompiled_letter = fields.Method("get_is_precompiled_letter")
-    process_type = field_for(models.Template, "process_type")
+    process_type = field_for(models.Template, "process_type_column")
     template_category = fields.Nested(TemplateCategorySchema, dump_only=True)
     template_category_id = fields.UUID(required=False, allow_none=True)
     redact_personalisation = fields.Method("redact")
@@ -425,7 +425,7 @@ class ReducedTemplateSchema(TemplateSchema):
 class TemplateHistorySchema(BaseSchema):
     reply_to = fields.Method("get_reply_to", allow_none=True)
     reply_to_text = fields.Method("get_reply_to_text", allow_none=True)
-    process_type = field_for(models.Template, "process_type")
+    process_type = field_for(models.Template, "process_type_column")
     template_category = fields.Nested(TemplateCategorySchema, dump_only=True)
     created_by = fields.Nested(UserSchema, only=["id", "name", "email_address"], dump_only=True)
     created_at = field_for(models.Template, "created_at", format="%Y-%m-%d %H:%M:%S.%f")

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -1580,17 +1580,19 @@ class TestTemplateCategory:
 
     # ensure that the process_type is overridden when a user changes categories
     @pytest.mark.parametrize(
-        "template_category_id, expected_process_type",
+        "template_category_id, expected_process_type_column, expected_process_type",
         [
             # category doesnt change, process_type should remain as priority
             (
                 "unchanged",
+                "priority",
                 "priority",
             ),
             # category changes, process_type should be removed
             (
                 DEFAULT_TEMPLATE_CATEGORY_MEDIUM,
                 None,
+                "normal",
             ),
         ],
     )
@@ -1602,6 +1604,7 @@ class TestTemplateCategory:
         admin_request,
         populate_generic_categories,
         template_category_id,
+        expected_process_type_column,
         expected_process_type,
         notify_api,
     ):
@@ -1624,4 +1627,5 @@ class TestTemplateCategory:
             template = dao_get_template_by_id(sample_template_with_priority_override.id)
 
             assert str(template.template_category_id) == calculated_tc
+            assert template.process_type_column == expected_process_type_column
             assert template.process_type == expected_process_type

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -358,32 +358,34 @@ def test_template_folder_is_parent(sample_service):
     assert not folders[1].is_parent_of(folders[0])
 
 
-@pytest.mark.parametrize(
-    "template_type, process_type, sms_process_type, email_process_type, expected_template_process_type",
-    [
-        (SMS_TYPE, None, NORMAL, BULK, NORMAL),
-        (EMAIL_TYPE, None, BULK, NORMAL, NORMAL),
-        (SMS_TYPE, BULK, PRIORITY, PRIORITY, BULK),
-        (EMAIL_TYPE, BULK, PRIORITY, PRIORITY, BULK),
-    ],
-)
-def test_template_process_type(
-    notify_db,
-    notify_db_session,
-    template_type,
-    process_type,
-    sms_process_type,
-    email_process_type,
-    expected_template_process_type,
-):
-    template_category = create_template_category(
-        notify_db, notify_db_session, sms_process_type=sms_process_type, email_process_type=email_process_type
+class TestTemplateProcessType:
+    @pytest.mark.parametrize(
+        "template_type, process_type, sms_process_type, email_process_type, expected_template_process_type",
+        [
+            (SMS_TYPE, None, NORMAL, BULK, NORMAL),
+            (EMAIL_TYPE, None, BULK, NORMAL, NORMAL),
+            (SMS_TYPE, BULK, PRIORITY, PRIORITY, BULK),
+            (EMAIL_TYPE, BULK, PRIORITY, PRIORITY, BULK),
+        ],
     )
-    template = create_template(
-        service=create_service(), template_type=template_type, process_type=process_type, template_category=template_category
-    )
-
-    assert template.template_process_type == expected_template_process_type
+    def test_template_process_type(
+        self,
+        notify_db,
+        notify_db_session,
+        template_type,
+        process_type,
+        sms_process_type,
+        email_process_type,
+        expected_template_process_type,
+    ):
+        template_category = create_template_category(
+            notify_db, notify_db_session, sms_process_type=sms_process_type, email_process_type=email_process_type
+        )
+        template = create_template(
+            service=create_service(), template_type=template_type, process_type=process_type, template_category=template_category
+        )
+        assert template.process_type_column == process_type
+        assert template.process_type == expected_template_process_type
 
 
 def test_fido2_key_serialization(sample_fido2_key):


### PR DESCRIPTION
# Summary | Résumé

We want template.process_type to return template.process_type if that had data, else it should return the process_type from the TemplateCategory associated with that template.

# Test instructions | Instructions pour tester la modification

## Test 1:
Create a new template and set the TemplateCategory.
- [x] Send the email
- [x] sms

## Test 2: 
Use an existing template where the TemplateCategory is NOT set.
- [x] Send the email
- [x] SMS 

##  Test 3:
Edit and existing template and set the TemplateCategory
- [x] Email
- [x] SMS

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.