### PR TITLE
Fix/expose process type column

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -384,7 +384,7 @@ class BaseTemplateSchema(BaseSchema):
 
     def get_hybrid_process_type(self, template):
         return template.process_type_column
-    
+
     def get_reply_to(self, template):
         return template.reply_to
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -380,7 +380,11 @@ class NotificationModelSchema(BaseSchema):
 class BaseTemplateSchema(BaseSchema):
     reply_to = fields.Method("get_reply_to", allow_none=True)
     reply_to_text = fields.Method("get_reply_to_text", allow_none=True)
+    process_type_column = fields.Method("get_hybrid_process_type")
 
+    def get_hybrid_process_type(self, template):
+        return template.process_type_column
+    
     def get_reply_to(self, template):
         return template.reply_to
 

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -210,11 +210,6 @@ def update_template(service_id, template_id):
         )
         raise InvalidRequest(errors, status_code=400)
 
-    # if the template category is changing, set the process_type to None to remove any priority override
-    if current_app.config["FF_TEMPLATE_CATEGORY"]:
-        if updated_template["template_category_id"] != str(fetched_template.template_category_id):
-            updated_template["process_type"] = None
-
     update_dict = template_schema.load(updated_template)
     if update_dict.archived:
         update_dict.folder = None

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -159,7 +159,6 @@ def update_template_process_type(template_id):
 @template_blueprint.route("/<uuid:template_id>", methods=["POST"])
 def update_template(service_id, template_id):
     fetched_template = dao_get_template_by_id_and_service_id(template_id=template_id, service_id=service_id)
-
     if not service_has_permission(fetched_template.template_type, fetched_template.service.permissions):
         message = "Updating {} templates is not allowed".format(get_public_notify_type_text(fetched_template.template_type))
         errors = {"template_type": [message]}

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -182,7 +182,7 @@ def update_template(service_id, template_id):
 
     # Check if there is a change to make.
     if _template_has_not_changed(current_data, updated_template):
-        return jsonify(data=updated_template), 200
+       return jsonify(data=updated_template), 200
 
     content_over_limit = _content_count_greater_than_limit(updated_template["content"], fetched_template.template_type)
     name_over_limit = _template_name_over_char_limit(
@@ -274,6 +274,8 @@ def get_template_versions(service_id, template_id):
 
 
 def _template_has_not_changed(current_data, updated_template):
+    if not current_data["process_type_column"] == updated_template["process_type"]:
+        return False
     return all(
         current_data[key] == updated_template[key]
         for key in ("name", "content", "subject", "archived", "process_type", "postage", "template_category_id")

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -182,7 +182,7 @@ def update_template(service_id, template_id):
 
     # Check if there is a change to make.
     if _template_has_not_changed(current_data, updated_template):
-       return jsonify(data=updated_template), 200
+        return jsonify(data=updated_template), 200
 
     content_over_limit = _content_count_greater_than_limit(updated_template["content"], fetched_template.template_type)
     name_over_limit = _template_name_over_char_limit(

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -288,13 +288,13 @@ def sample_template_category(
     return create_template_category(
         notify_db,
         notify_db_session,
-        name_en="Category Name",
-        name_fr="Category Name (FR)",
-        description_en="Category Description",
-        description_fr="Category Description (FR)",
-        sms_process_type="normal",
-        email_process_type="normal",
-        hidden=False,
+        name_en=name_en,
+        name_fr=name_fr,
+        description_en=description_en,
+        description_fr=description_fr,
+        sms_process_type=sms_process_type,
+        email_process_type=email_process_type,
+        hidden=hidden,
     )
 
 

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -298,6 +298,56 @@ def sample_template_category(
     )
 
 
+@pytest.fixture(scope="function")
+def sample_template_category_bulk(
+    notify_db,
+    notify_db_session,
+    name_en="Category Low",
+    name_fr="Category Low (FR)",
+    description_en="Category Description",
+    description_fr="Category Description (FR)",
+    sms_process_type="bulk",
+    email_process_type="bulk",
+    hidden=False,
+):
+    return create_template_category(
+        notify_db,
+        notify_db_session,
+        name_en=name_en,
+        name_fr=name_fr,
+        description_en=description_en,
+        description_fr=description_fr,
+        sms_process_type=sms_process_type,
+        email_process_type=email_process_type,
+        hidden=hidden,
+    )
+
+
+@pytest.fixture(scope="function")
+def sample_template_category_priority(
+    notify_db,
+    notify_db_session,
+    name_en="Category Priority",
+    name_fr="Category Priority (FR)",
+    description_en="Category Description",
+    description_fr="Category Description (FR)",
+    sms_process_type="priority",
+    email_process_type="priority",
+    hidden=False,
+):
+    return create_template_category(
+        notify_db,
+        notify_db_session,
+        name_en=name_en,
+        name_fr=name_fr,
+        description_en=description_en,
+        description_fr=description_fr,
+        sms_process_type=sms_process_type,
+        email_process_type=email_process_type,
+        hidden=hidden,
+    )
+
+
 def create_template_category(
     notify_db,
     notify_db_session,

--- a/tests/app/dao/test_templates_dao.py
+++ b/tests/app/dao/test_templates_dao.py
@@ -504,3 +504,36 @@ def test_dao_update_template_category(sample_template, sample_template_category)
     history = TemplateHistory.query.filter_by(id=sample_template.id, version=updated_template.version).one()
     assert not history.template_category_id
     assert history.updated_at == updated_template.updated_at
+
+
+class TestProcessType:
+    def test_process_type_set_correctly(self, sample_service, sample_user, sample_template_category):
+        data = {
+            "name": "Sample Template",
+            "template_type": "sms",
+            "content": "Template content",
+            "service": sample_service,
+            "created_by": sample_user,
+        }
+        # We are not setting the template process_type, hence process_type defaults to "normal", but the value in the DB is empty
+        template = Template(**data)
+        dao_create_template(template)
+        assert template.process_type == "normal"
+        assert template.process_type_column is None
+
+        template.process_type = "priority"
+        dao_update_template(template)
+        assert template.process_type == "priority"
+        assert template.process_type_column == "priority"
+
+        template.process_type = "bulk"
+        dao_update_template(template)
+        assert template.process_type == "bulk"
+        assert template.process_type_column == "bulk"
+
+        template.process_type = None
+        template.template_category_id = sample_template_category.id
+        dao_update_template(template)
+        assert template.template_category_id == sample_template_category.id
+        assert template.process_type == sample_template_category.email_process_type
+        assert template.process_type_column is None

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -1580,20 +1580,17 @@ class TestTemplateCategory:
 
     # ensure that the process_type is overridden when a user changes categories
     @pytest.mark.parametrize(
-        "template_category_id, expected_process_type_column, expected_process_type",
+        "template_category_id, data_process_type, expected_process_type_column, expected_process_type",
         [
             # category doesnt change, process_type should remain as priority
             (
                 "unchanged",
                 "priority",
                 "priority",
+                "priority",
             ),
             # category changes, process_type should be removed
-            (
-                DEFAULT_TEMPLATE_CATEGORY_MEDIUM,
-                None,
-                "normal",
-            ),
+            (DEFAULT_TEMPLATE_CATEGORY_MEDIUM, None, None, "normal"),
         ],
     )
     def test_process_type_should_be_reset_when_template_category_updated(
@@ -1604,6 +1601,7 @@ class TestTemplateCategory:
         admin_request,
         populate_generic_categories,
         template_category_id,
+        data_process_type,
         expected_process_type_column,
         expected_process_type,
         notify_api,
@@ -1621,6 +1619,7 @@ class TestTemplateCategory:
                 _data={
                     "template_category_id": calculated_tc,
                     "redact_personalisation": False,
+                    "process_type": data_process_type,
                 },
                 _expected_status=200,
             )

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -1826,6 +1826,7 @@ class TestTemplateCategory:
                 process_type=process_type,
             )
 
+            tc = sample_template_category
             if template_category == "normal":
                 tc = sample_template_category
             elif template_category == "bulk":
@@ -1888,6 +1889,7 @@ class TestTemplateCategory:
         with set_config_values(notify_api, {"FF_TEMPLATE_CATEGORY": True}):
             service = create_service(service_name="service_1")
 
+            tc = sample_template_category
             if process_type is None:
                 if calculated_process_type == "normal":
                     tc = sample_template_category

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -1628,3 +1628,291 @@ class TestTemplateCategory:
             assert str(template.template_category_id) == calculated_tc
             assert template.process_type_column == expected_process_type_column
             assert template.process_type == expected_process_type
+
+    # TODO remove TEST when FF removed
+    @pytest.mark.parametrize(
+        "template_type, process_type",
+        [
+            (SMS_TYPE, "bulk"),
+            (EMAIL_TYPE, "bulk"),
+            (SMS_TYPE, "normal"),
+            (EMAIL_TYPE, "normal"),
+            (SMS_TYPE, "priority"),
+            (EMAIL_TYPE, "priority"),
+        ],
+    )
+    def test_update_template_override_process_type_ff_off(
+        self, admin_request, sample_user, notify_api, template_type, process_type
+    ):
+        with set_config_values(notify_api, {"FF_TEMPLATE_CATEGORY": False}):
+            service = create_service(service_name="service_1")
+            template = create_template(
+                service,
+                template_type=template_type,
+                template_name="testing template",
+                subject="Template subject",
+                content="Dear Sir/Madam, Hello. Yours Truly, The Government.",
+                template_category=None,
+                process_type="normal",
+            )
+
+            template_data = {
+                "id": str(template.id),
+                "name": "new name",
+                "template_type": template_type,
+                "content": "some content here :)",
+                "service": str(service.id),
+                "created_by": str(sample_user.id),
+                "template_category_id": None,
+                "process_type": process_type,
+            }
+
+            response = admin_request.post(
+                "template.update_template",
+                service_id=service.id,
+                template_id=template.id,
+                _data=template_data,
+                _expected_status=200,
+            )
+            assert response["data"]["process_type"] == process_type
+            assert response["data"]["template_category"] is None
+
+    # TODO remove TEST when FF removed
+    @pytest.mark.parametrize(
+        "template_type, process_type",
+        [
+            (SMS_TYPE, "bulk"),
+            (EMAIL_TYPE, "bulk"),
+            (SMS_TYPE, "normal"),
+            (EMAIL_TYPE, "normal"),
+            (SMS_TYPE, "priority"),
+            (EMAIL_TYPE, "priority"),
+        ],
+    )
+    def test_create_template_default_process_type_ff_off(
+        self, admin_request, sample_user, notify_api, template_type, process_type
+    ):
+        with set_config_values(notify_api, {"FF_TEMPLATE_CATEGORY": False}):
+            service = create_service(service_name="service_1")
+
+            template_data = {
+                "name": "new name",
+                "template_type": template_type,
+                "content": "some content here :)",
+                "subject": "yo",
+                "service": str(service.id),
+                "created_by": str(sample_user.id),
+                "template_category_id": None,
+                "process_type": process_type,
+            }
+
+            response = admin_request.post(
+                "template.create_template", service_id=service.id, _data=template_data, _expected_status=201
+            )
+
+            assert response["data"]["process_type"] == process_type
+            assert response["data"]["template_category"] is None
+
+    @pytest.mark.parametrize(
+        "template_type, initial_process_type, updated_process_type",
+        [
+            (SMS_TYPE, None, "bulk"),
+            (EMAIL_TYPE, None, "bulk"),
+            (SMS_TYPE, None, "normal"),
+            (EMAIL_TYPE, None, "normal"),
+            (SMS_TYPE, None, "priority"),
+            (EMAIL_TYPE, None, "priority"),
+            (SMS_TYPE, "bulk", "bulk"),
+            (EMAIL_TYPE, "bulk", "bulk"),
+            (SMS_TYPE, "bulk", "normal"),
+            (EMAIL_TYPE, "bulk", "normal"),
+            (SMS_TYPE, "bulk", "priority"),
+            (EMAIL_TYPE, "bulk", "priority"),
+        ],
+    )
+    def test_update_template_override_process_type_ff_on(
+        self,
+        admin_request,
+        sample_user,
+        notify_api,
+        sample_template_category,
+        template_type,
+        initial_process_type,
+        updated_process_type,
+    ):
+        with set_config_values(notify_api, {"FF_TEMPLATE_CATEGORY": True}):
+            service = create_service(service_name="service_1")
+            template = create_template(
+                service,
+                template_type=template_type,
+                template_name="testing template",
+                subject="Template subject",
+                content="Dear Sir/Madam, Hello. Yours Truly, The Government.",
+                template_category=sample_template_category,
+                process_type=initial_process_type,
+            )
+
+            template_data = {
+                "id": str(template.id),
+                "name": "new name",
+                "template_type": template_type,
+                "content": "some content here :)",
+                "service": str(service.id),
+                "created_by": str(sample_user.id),
+                "template_category_id": str(sample_template_category.id),
+                "process_type": updated_process_type,
+            }
+
+            response = admin_request.post(
+                "template.update_template",
+                service_id=service.id,
+                template_id=template.id,
+                _data=template_data,
+                _expected_status=200,
+            )
+            assert response["data"]["process_type"] == updated_process_type
+            assert response["data"]["template_category"]["id"] == str(sample_template_category.id)
+
+    @pytest.mark.parametrize(
+        "template_type, process_type, template_category",
+        [
+            (SMS_TYPE, None, "bulk"),
+            (EMAIL_TYPE, None, "bulk"),
+            (SMS_TYPE, None, "normal"),
+            (EMAIL_TYPE, None, "normal"),
+            (SMS_TYPE, None, "priority"),
+            (EMAIL_TYPE, None, "priority"),
+            (SMS_TYPE, "bulk", "bulk"),
+            (EMAIL_TYPE, "bulk", "bulk"),
+            (SMS_TYPE, "bulk", "normal"),
+            (EMAIL_TYPE, "bulk", "normal"),
+            (SMS_TYPE, "bulk", "priority"),
+            (EMAIL_TYPE, "bulk", "priority"),
+            (SMS_TYPE, "normal", "bulk"),
+            (EMAIL_TYPE, "normal", "bulk"),
+            (SMS_TYPE, "normal", "normal"),
+            (EMAIL_TYPE, "normal", "normal"),
+            (SMS_TYPE, "normal", "priority"),
+            (EMAIL_TYPE, "normal", "priority"),
+            (SMS_TYPE, "priority", "bulk"),
+            (EMAIL_TYPE, "priority", "bulk"),
+            (SMS_TYPE, "priority", "normal"),
+            (EMAIL_TYPE, "priority", "normal"),
+            (SMS_TYPE, "priority", "priority"),
+            (EMAIL_TYPE, "priority", "priority"),
+        ],
+    )
+    def test_update_template_change_category_ff_on(
+        self,
+        admin_request,
+        sample_user,
+        notify_api,
+        sample_template_category,
+        template_type,
+        process_type,
+        template_category,
+        sample_template_category_priority,
+        sample_template_category_bulk,
+    ):
+        with set_config_values(notify_api, {"FF_TEMPLATE_CATEGORY": True}):
+            service = create_service(service_name="service_1")
+            template = create_template(
+                service,
+                template_type=template_type,
+                template_name="testing template",
+                subject="Template subject",
+                content="Dear Sir/Madam, Hello. Yours Truly, The Government.",
+                template_category=sample_template_category,
+                process_type=process_type,
+            )
+
+            if template_category == "normal":
+                tc = sample_template_category
+            elif template_category == "bulk":
+                tc = sample_template_category_bulk
+            elif template_category == "priority":
+                tc = sample_template_category_priority
+
+            template_data = {
+                "name": "new name",
+                "template_type": template_type,
+                "content": "some content here :)",
+                "subject": "yo",
+                "service": str(service.id),
+                "created_by": str(sample_user.id),
+                "template_category_id": str(tc.id),
+                "process_type": process_type,
+            }
+
+            response = admin_request.post(
+                "template.update_template",
+                service_id=service.id,
+                template_id=template.id,
+                _data=template_data,
+                _expected_status=200,
+            )
+
+            assert response["data"]["process_type_column"] == process_type
+            assert response["data"]["process_type"] == template_category if process_type is None else process_type
+            assert response["data"]["template_category_id"] == str(tc.id)
+
+    @pytest.mark.parametrize(
+        "template_type, process_type, calculated_process_type",
+        [
+            (SMS_TYPE, "bulk", "bulk"),
+            (EMAIL_TYPE, "bulk", "bulk"),
+            (SMS_TYPE, "normal", "normal"),
+            (EMAIL_TYPE, "normal", "normal"),
+            (SMS_TYPE, "priority", "priority"),
+            (EMAIL_TYPE, "priority", "priority"),
+            (SMS_TYPE, None, "bulk"),
+            (EMAIL_TYPE, None, "bulk"),
+            (SMS_TYPE, None, "normal"),
+            (EMAIL_TYPE, None, "normal"),
+            (SMS_TYPE, None, "priority"),
+            (EMAIL_TYPE, None, "priority"),
+        ],
+    )
+    def test_create_template_with_category_ff_on(
+        self,
+        admin_request,
+        sample_user,
+        notify_api,
+        sample_template_category,
+        template_type,
+        process_type,
+        calculated_process_type,
+        sample_template_category_priority,
+        sample_template_category_bulk,
+    ):
+        with set_config_values(notify_api, {"FF_TEMPLATE_CATEGORY": True}):
+            service = create_service(service_name="service_1")
+
+            if process_type is None:
+                if calculated_process_type == "normal":
+                    tc = sample_template_category
+                elif calculated_process_type == "bulk":
+                    tc = sample_template_category_bulk
+                elif calculated_process_type == "priority":
+                    tc = sample_template_category_priority
+            else:
+                tc = sample_template_category
+
+            template_data = {
+                "name": "new name",
+                "template_type": template_type,
+                "content": "some content here :)",
+                "subject": "yo",
+                "service": str(service.id),
+                "created_by": str(sample_user.id),
+                "template_category_id": str(tc.id),
+                "process_type": process_type,
+            }
+
+            response = admin_request.post(
+                "template.create_template", service_id=service.id, _data=template_data, _expected_status=201
+            )
+
+            assert response["data"]["process_type_column"] == process_type
+            assert response["data"]["process_type"] == calculated_process_type
+            assert response["data"]["template_category_id"] == str(tc.id)


### PR DESCRIPTION
# Summary | Résumé
- add `process_type_column` to `BaseTemplateSchema` to expose actual value to admin
- remove logic that resets `process_type` override when template category changes.  This logic will be moved to admin in another PR.


# Test instructions | Instructions pour tester la modification

Whatever process_type you send through the Template model, should persist in the DB in the process_type column, and persist in the model at Template.process_type_column


# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.