### PR TITLE
Celery xray

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -1,6 +1,13 @@
 from datetime import datetime, timedelta
 from typing import List, cast
 
+from celery_aws_xray_sdk_extension.handlers import (
+    xray_after_task_publish,
+    xray_before_task_publish,
+    xray_task_failure,
+    xray_task_postrun,
+    xray_task_prerun,
+)
 from flask import current_app
 from notifications_utils.statsd_decorators import statsd
 from sqlalchemy import and_
@@ -49,7 +56,13 @@ from app.models import (
 )
 from app.notifications.process_notifications import send_notification_to_queue
 from app.v2.errors import JobIncompleteError
-from celery import Task
+from celery import Task, signals
+
+signals.after_task_publish.connect(xray_after_task_publish)
+signals.before_task_publish.connect(xray_before_task_publish)
+signals.task_failure.connect(xray_task_failure)
+signals.task_postrun.connect(xray_task_postrun)
+signals.task_prerun.connect(xray_task_prerun)
 
 # https://stackoverflow.com/questions/63714223/correct-type-annotation-for-a-celery-task
 save_smss = cast(Task, save_smss)

--- a/mypy.ini
+++ b/mypy.ini
@@ -87,3 +87,6 @@ ignore_missing_imports = True
 
 [mypy-aws_xray_sdk.*]
 ignore_missing_imports = True
+
+[mypy-celery_aws_xray_sdk_extension.*]
+ignore_missing_imports = True

--- a/poetry.lock
+++ b/poetry.lock
@@ -599,6 +599,20 @@ zookeeper = ["kazoo (>=1.3.1)"]
 zstd = ["zstandard (==0.22.0)"]
 
 [[package]]
+name = "celery-aws-xray-sdk-extension"
+version = "0.1.2"
+description = "Extension for AWS X-Ray SDK which enables tracing of Celery tasks"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "celery-aws-xray-sdk-extension-0.1.2.tar.gz", hash = "sha256:81e8a21259560074cb9dbfd54bf5d47b2d1ba0c64a54d959dd1d960e731186a5"},
+]
+
+[package.dependencies]
+aws-xray-sdk = ">=2.9,<3"
+celery = ">=5,<6"
+
+[[package]]
 name = "certifi"
 version = "2023.11.17"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -4292,4 +4306,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10.9"
-content-hash = "d95fee17c6e12a5dbec8ad0bdb8e256aadee291d2c2306c4b4f11e3db07fe006"
+content-hash = "e9bf32d4804a1e680a135b7b5bbba07ec05a7e7dc3e5ae4d5a2608c282269fef"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ certifi = "^2023.7.22" # pinned for security reasons: https://github.com/cds-snc
 idna = "2.10" # pinned to align with test moto dependency requirements (for <=2.9)
 flask-marshmallow = "0.14.0"
 aws-xray-sdk = "^2.14.0"
+celery-aws-xray-sdk-extension = "^0.1.2"
 
 [tool.poetry.group.test.dependencies]
 flake8 = "6.1.0"

--- a/run_celery.py
+++ b/run_celery.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 import newrelic.agent  # See https://bit.ly/2xBVKBH
+from aws_xray_sdk.core import xray_recorder
+from aws_xray_sdk.ext.flask.middleware import XRayMiddleware
 from dotenv import load_dotenv
 from flask import Flask
 
@@ -12,4 +14,8 @@ load_dotenv()
 
 application = Flask("celery")
 create_app(application)
+
+xray_recorder.configure(service='celery')
+XRayMiddleware(application, xray_recorder)
+
 application.app_context().push()


### PR DESCRIPTION
# Summary | Résumé

Implementing Xray Tracing for Celery Pods (Scheduled Tasks Specifically)

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/400

# Test instructions | Instructions pour tester la modification

Verify in Xray that the Celery Pods are tracing

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.