### PR TITLE
Moving xray code to a more centralized location

### DIFF
--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -1,9 +1,22 @@
 import time
 
+from celery_aws_xray_sdk_extension.handlers import (
+    xray_after_task_publish,
+    xray_before_task_publish,
+    xray_task_failure,
+    xray_task_postrun,
+    xray_task_prerun,
+)
 from flask import current_app
 
-from celery import Celery, Task
+from celery import Celery, Task, signals
 from celery.signals import worker_process_shutdown
+
+signals.after_task_publish.connect(xray_after_task_publish)
+signals.before_task_publish.connect(xray_before_task_publish)
+signals.task_failure.connect(xray_task_failure)
+signals.task_postrun.connect(xray_task_postrun)
+signals.task_prerun.connect(xray_task_prerun)
 
 
 @worker_process_shutdown.connect  # type: ignore

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -1,13 +1,6 @@
 from datetime import datetime, timedelta
 from typing import List, cast
 
-from celery_aws_xray_sdk_extension.handlers import (
-    xray_after_task_publish,
-    xray_before_task_publish,
-    xray_task_failure,
-    xray_task_postrun,
-    xray_task_prerun,
-)
 from flask import current_app
 from notifications_utils.statsd_decorators import statsd
 from sqlalchemy import and_
@@ -56,13 +49,7 @@ from app.models import (
 )
 from app.notifications.process_notifications import send_notification_to_queue
 from app.v2.errors import JobIncompleteError
-from celery import Task, signals
-
-signals.after_task_publish.connect(xray_after_task_publish)
-signals.before_task_publish.connect(xray_before_task_publish)
-signals.task_failure.connect(xray_task_failure)
-signals.task_postrun.connect(xray_task_postrun)
-signals.task_prerun.connect(xray_task_prerun)
+from celery import Task
 
 # https://stackoverflow.com/questions/63714223/correct-type-annotation-for-a-celery-task
 save_smss = cast(Task, save_smss)


### PR DESCRIPTION
# Summary | Résumé

Rearranging some code for better organization and potentially better efficiency.

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/400

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [x] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.