### PR TITLE
We want to save the reply_to_email_addresses in the cache

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -608,8 +608,16 @@ class Service(BaseModel, Versioned):
         fields.pop("letter_contact_block", None)
         fields.pop("email_branding", None)
         fields["sms_daily_limit"] = fields.get("sms_daily_limit", 100)
+        reply_to_addresses = fields.get("reply_to_email_addresses", None)
+        fields.pop("reply_to_email_addresses", None)
+        current_service = cls(**fields)
+        # If reply_to_addresses were in the JSON, add them to the service
+        if reply_to_addresses:
+            current_service.reply_to_email_addresses = [
+                ServiceEmailReplyTo(**addr) for addr in reply_to_addresses
+            ]
 
-        return cls(**fields)
+        return current_service
 
     def get_inbound_number(self):
         if self.inbound_number and self.inbound_number.active:

--- a/app/models.py
+++ b/app/models.py
@@ -613,9 +613,7 @@ class Service(BaseModel, Versioned):
         current_service = cls(**fields)
         # If reply_to_addresses were in the JSON, add them to the service
         if reply_to_addresses:
-            current_service.reply_to_email_addresses = [
-                ServiceEmailReplyTo(**addr) for addr in reply_to_addresses
-            ]
+            current_service.reply_to_email_addresses = [ServiceEmailReplyTo(**addr) for addr in reply_to_addresses]
 
         return current_service
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -267,6 +267,18 @@ class ServiceSchema(BaseSchema, UUIDsAsStringsMixin):
     letter_contact_block = fields.Method(serialize="get_letter_contact")
     go_live_at = field_for(models.Service, "go_live_at", format="%Y-%m-%d %H:%M:%S.%f")
     organisation_notes = field_for(models.Service, "organisation_notes")
+    reply_to_email_addresses = fields.Method(models.Service, "serialize_reply_to_email_addresses")
+
+    def serialize_reply_to_email_addresses(self, service):
+        return [
+            {
+                "id": str(reply_to.id),
+                "email_address": reply_to.email_address,
+                "is_default": reply_to.is_default,
+                "archived": reply_to.archived
+            }
+            for reply_to in service.reply_to_email_addresses
+        ]
 
     def get_letter_logo_filename(self, service):
         return service.letter_branding and service.letter_branding.filename
@@ -298,7 +310,6 @@ class ServiceSchema(BaseSchema, UUIDsAsStringsMixin):
             "api_keys",
             "letter_contacts",
             "jobs",
-            "reply_to_email_addresses",
             "service_sms_senders",
             "templates",
             "updated_at",
@@ -776,6 +787,7 @@ class ServiceHistorySchema(Schema):
     email_from = fields.String()
     created_by_id = fields.UUID()
     version = fields.Integer()
+    reply_to_email_addresses = fields.List(fields.String())
 
 
 class ApiKeyHistorySchema(Schema):

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -275,7 +275,7 @@ class ServiceSchema(BaseSchema, UUIDsAsStringsMixin):
                 "id": str(reply_to.id),
                 "email_address": reply_to.email_address,
                 "is_default": reply_to.is_default,
-                "archived": reply_to.archived
+                "archived": reply_to.archived,
             }
             for reply_to in service.reply_to_email_addresses
         ]
@@ -285,9 +285,7 @@ class ServiceSchema(BaseSchema, UUIDsAsStringsMixin):
             reply_to_email_addresses = []
             for reply_to in in_data["reply_to_email_addresses"]:
                 reply_to_email_address = ServiceEmailReplyTo(
-                    email_address=reply_to["email_address"],
-                    is_default=reply_to["is_default"],
-                    archived=reply_to["archived"]
+                    email_address=reply_to["email_address"], is_default=reply_to["is_default"], archived=reply_to["archived"]
                 )
                 reply_to_email_addresses.append(reply_to_email_address)
             in_data["reply_to_email_addresses"] = reply_to_email_addresses

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -81,6 +81,7 @@ from tests.app.db import (
     create_notification,
     create_notification_history,
     create_organisation,
+    create_reply_to_email,
     create_service,
     create_service_with_defined_sms_sender,
     create_service_with_inbound_number,
@@ -607,30 +608,61 @@ def test_get_service_by_id_returns_service(notify_db_session):
     assert dao_fetch_service_by_id(service.id).name == "testing"
 
 
-def test_get_service_by_id_uses_redis_cache_when_use_cache_specified(notify_db_session, mocker):
-    sample_service = create_service(service_name="testing", email_from="testing")
-    service_json = {"data": service_schema.dump(sample_service)}
+class TestServiceCache:
+    def test_get_service_by_id_uses_redis_cache_when_use_cache_specified(self, notify_db_session, mocker):
+        sample_service = create_service(service_name="testing", email_from="testing")
+        service_json = {"data": service_schema.dump(sample_service)}
 
-    service_json["data"]["all_template_folders"] = ["b5035a31-b1da-42f8-b2b8-ce2acaa0b819"]
-    service_json["data"]["annual_billing"] = ["8676fa80-a97b-43e7-8318-ee905de2d652", "a0751f79-984b-4d9e-9edd-42457fd458e9"]
-    service_json["data"]["email_branding"] = "d51a41b2-c420-48a9-a8c5-e88444013020"
-    service_json["data"]["inbound_number"] = "aa129e4b-d37c-493a-84da-62a31a8199e3"
-    service_json["data"]["inbound_sms"] = ["fsdfdsfdsfdsfdsfsdf"]
-    service_json["data"]["service_callback_api"] = ["wfeewfwefewfewfewfewfew"]
-    service_json["data"]["service_data_retention"] = ["fdsfsdfsdfsdfsdfdsf"]
+        service_json["data"]["all_template_folders"] = ["b5035a31-b1da-42f8-b2b8-ce2acaa0b819"]
+        service_json["data"]["annual_billing"] = ["8676fa80-a97b-43e7-8318-ee905de2d652", "a0751f79-984b-4d9e-9edd-42457fd458e9"]
+        service_json["data"]["email_branding"] = "d51a41b2-c420-48a9-a8c5-e88444013020"
+        service_json["data"]["inbound_number"] = "aa129e4b-d37c-493a-84da-62a31a8199e3"
+        service_json["data"]["inbound_sms"] = ["fsdfdsfdsfdsfdsfsdf"]
+        service_json["data"]["service_callback_api"] = ["wfeewfwefewfewfewfewfew"]
+        service_json["data"]["service_data_retention"] = ["fdsfsdfsdfsdfsdfdsf"]
 
-    mocked_redis_get = mocker.patch.object(
-        redis_store,
-        "get",
-        return_value=bytes(
-            json.dumps(service_json, default=lambda o: o.hex if isinstance(o, uuid.UUID) else None), encoding="utf-8"
-        ),
-    )
+        mocked_redis_get = mocker.patch.object(
+            redis_store,
+            "get",
+            return_value=bytes(
+                json.dumps(service_json, default=lambda o: o.hex if isinstance(o, uuid.UUID) else None), encoding="utf-8"
+            ),
+        )
 
-    service = dao_fetch_service_by_id(sample_service.id, use_cache=True)
+        service = dao_fetch_service_by_id(sample_service.id, use_cache=True)
 
-    assert mocked_redis_get.called
-    assert str(sample_service.id) == service.id
+        assert mocked_redis_get.called
+        assert str(sample_service.id) == service.id
+
+    def test_get_service_with_reply_to_from_cache_and_db(self, notify_db_session, mocker):
+        sample_service = create_service(service_name="testing", email_from="testing")
+        create_reply_to_email(sample_service, "test@mail.com")
+        service_json = {"data": service_schema.dump(sample_service)}
+
+        service_json["data"]["all_template_folders"] = ["b5035a31-b1da-42f8-b2b8-ce2acaa0b819"]
+        service_json["data"]["annual_billing"] = ["8676fa80-a97b-43e7-8318-ee905de2d652", "a0751f79-984b-4d9e-9edd-42457fd458e9"]
+        service_json["data"]["email_branding"] = "d51a41b2-c420-48a9-a8c5-e88444013020"
+        service_json["data"]["inbound_number"] = "aa129e4b-d37c-493a-84da-62a31a8199e3"
+        service_json["data"]["inbound_sms"] = ["fsdfdsfdsfdsfdsfsdf"]
+        service_json["data"]["service_callback_api"] = ["wfeewfwefewfewfewfewfew"]
+        service_json["data"]["service_data_retention"] = ["fdsfsdfsdfsdfsdfdsf"]
+
+        mocked_redis_get = mocker.patch.object(
+            redis_store,
+            "get",
+            return_value=bytes(
+                json.dumps(service_json, default=lambda o: o.hex if isinstance(o, uuid.UUID) else None), encoding="utf-8"
+            ),
+        )
+
+        service = dao_fetch_service_by_id(sample_service.id, use_cache=True)
+
+        assert mocked_redis_get.called
+        assert str(sample_service.id) == service.id
+        assert str(service.reply_to_email_addresses[0].id) == str(sample_service.reply_to_email_addresses[0].id)
+
+        service = dao_fetch_service_by_id(sample_service.id, use_cache=False)
+        assert str(service.reply_to_email_addresses[0].id) == str(sample_service.reply_to_email_addresses[0].id)
 
 
 def test_create_service_returns_service_with_default_permissions(notify_db_session):

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -2623,14 +2623,15 @@ def test_is_email_from_unique_returns_400_when_email_from_does_not_exist(admin_r
     assert response["message"][1]["email_from"] == ["Can't be empty"]
 
 
-def test_get_email_reply_to_addresses_when_there_are_no_reply_to_email_addresses(client, sample_service):
-    response = client.get(
-        "/service/{}/email-reply-to".format(sample_service.id),
-        headers=[create_authorization_header()],
-    )
+class TestServiceEmailReplyTo:
+    def test_get_email_reply_to_addresses_when_there_are_no_reply_to_email_addresses(self, client, sample_service):
+        response = client.get(
+            "/service/{}/email-reply-to".format(sample_service.id),
+            headers=[create_authorization_header()],
+        )
 
-    assert json.loads(response.get_data(as_text=True)) == []
-    assert response.status_code == 200
+        assert json.loads(response.get_data(as_text=True)) == []
+        assert response.status_code == 200
 
 
 def test_get_email_reply_to_addresses_with_one_email_address(client, notify_db, notify_db_session):
@@ -3223,3 +3224,32 @@ def test_get_monthly_notification_data_by_service(mocker, admin_request):
 
     dao_mock.assert_called_once_with(start_date, end_date)
     assert response == []
+
+
+class TestSerializationofServiceReplyto:
+    def test_get_service(self, client, sample_service):
+        sample_service.reply_to_email = "something@service.com"
+        create_reply_to_email(service=sample_service, email_address="new@service.com")
+        auth_header = create_authorization_header()
+        resp = client.get(
+            "/service/{}".format(sample_service.id),
+            headers=[auth_header],
+        )
+        assert resp.status_code == 200
+        json_resp = resp.json
+        assert json_resp["data"]["name"] == sample_service.name
+        assert json_resp["data"]["id"] == str(sample_service.id)
+        assert json_resp["data"]["reply_to_email_addresses"][0]["email_address"] == "new@service.com"
+
+    def test_get_service_no_reply_to(self, client, sample_service):
+        sample_service.reply_to_email = "something@service.com"
+        auth_header = create_authorization_header()
+        resp = client.get(
+            "/service/{}".format(sample_service.id),
+            headers=[auth_header],
+        )
+        assert resp.status_code == 200
+        json_resp = resp.json
+        assert json_resp["data"]["name"] == sample_service.name
+        assert json_resp["data"]["id"] == str(sample_service.id)
+        assert json_resp["data"]["reply_to_email_addresses"] == []


### PR DESCRIPTION
# Summary | Résumé

We are not currently storing the reply_to_email_addresses which is a field on the Service model, to show up when we retrieve the Service from the cache. This meant that the reply_to_address was empty for the end user which is incorrect

Two parts:
1. The service gets added to the cache when the admin gets loaded - we needed to change the model Schema so we send the reply_to_email_addresses to the admin
2. We need to change the model to_json, so we might appropriately set the reply_to_email_addresses as a ServiceReplytoEmail model

# Testing:
[ ] Set the reply_to_email_address
[ ] Stay on the main branch: Send an email using the csv method  - it will send an email WITHOUT the reply-to set
[ ] Switch to this branch: Send an email using the csv method - it will send an email WITH the reply-to set

Example:
<img width="384" alt="Screenshot 2024-08-14 at 4 24 24 PM" src="https://github.com/user-attachments/assets/6dc67698-92a4-45e0-922d-249b99a7c615">

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1633

# Reviewer checklist | Liste de vérification du réviseur

- [x] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [x] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.