### PR TITLE
Add sensitive services

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -594,3 +594,8 @@ def dao_fetch_service_creator(service_id: uuid.UUID) -> User:
         .one()
     )
     return query
+
+
+def dao_fetch_service_ids_of_sensitive_services():
+    sensitive_service_ids = Service.query.filter(Service.sensitive_service.is_(True)).with_entities(Service.id).all()
+    return [service_id for (service_id,) in sensitive_service_ids]

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -598,4 +598,4 @@ def dao_fetch_service_creator(service_id: uuid.UUID) -> User:
 
 def dao_fetch_service_ids_of_sensitive_services():
     sensitive_service_ids = Service.query.filter(Service.sensitive_service.is_(True)).with_entities(Service.id).all()
-    return [service_id for (service_id,) in sensitive_service_ids]
+    return [str(service_id) for (service_id,) in sensitive_service_ids]

--- a/app/models.py
+++ b/app/models.py
@@ -562,7 +562,7 @@ class Service(BaseModel, Versioned):
     go_live_at = db.Column(db.DateTime, nullable=True)
     sending_domain = db.Column(db.String(255), nullable=True, unique=False)
     organisation_notes = db.Column(db.String(255), nullable=True, unique=False)
-
+    sensitive_service = db.Column(db.Boolean, nullable=True)
     organisation_id = db.Column(UUID(as_uuid=True), db.ForeignKey("organisation.id"), index=True, nullable=True)
     organisation = db.relationship("Organisation", backref="services")
 

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -74,6 +74,7 @@ from app.dao.services_dao import (
     dao_fetch_live_services_data,
     dao_fetch_service_by_id,
     dao_fetch_service_creator,
+    dao_fetch_service_ids_of_sensitive_services,
     dao_fetch_todays_stats_for_all_services,
     dao_fetch_todays_stats_for_service,
     dao_remove_user_from_service,
@@ -1047,6 +1048,12 @@ def modify_service_data_retention(service_id, data_retention_id):
         )
 
     return "", 204
+
+
+@service_blueprint.route("/sensitive-service-ids", methods=["GET"])
+def get_sensitive_service_ids():
+    data = dao_fetch_service_ids_of_sensitive_services()
+    return jsonify(data=data), 200
 
 
 @service_blueprint.route("/monthly-data-by-service")

--- a/migrations/versions/0459_add_sensitive.py
+++ b/migrations/versions/0459_add_sensitive.py
@@ -1,0 +1,20 @@
+"""
+Revision ID: 0459_add_sensitive
+Revises: 0458_drop_null_history
+Create Date: 2024-06-25 13:32:00
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0459_add_sensitive"
+down_revision = "0458_drop_null_history"
+
+
+def upgrade():
+    op.add_column("services", sa.Column("sensitive_service", sa.Boolean(), nullable=True))
+    op.create_index(op.f("ix_service_sensitive_service"), "services", ["sensitive_service"], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f("ix_service_sensitive_service"), table_name="services")
+    op.drop_column("services", "sensitive_service")

--- a/migrations/versions/0459_add_sensitive.py
+++ b/migrations/versions/0459_add_sensitive.py
@@ -13,8 +13,12 @@ down_revision = "0458_drop_null_history"
 def upgrade():
     op.add_column("services", sa.Column("sensitive_service", sa.Boolean(), nullable=True))
     op.create_index(op.f("ix_service_sensitive_service"), "services", ["sensitive_service"], unique=False)
+    op.add_column("services_history", sa.Column("sensitive_service", sa.Boolean(), nullable=True))
+    op.create_index(op.f("ix_service_history_sensitive_service"), "services_history", ["sensitive_service"], unique=False)
 
 
 def downgrade():
     op.drop_index(op.f("ix_service_sensitive_service"), table_name="services")
     op.drop_column("services", "sensitive_service")
+    op.drop_index(op.f("ix_service_history_sensitive_service"), table_name="services_history")
+    op.drop_column("services_history", "sensitive_service")

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -29,6 +29,7 @@ from app.dao.services_dao import (
     dao_fetch_service_by_id,
     dao_fetch_service_by_inbound_number,
     dao_fetch_service_creator,
+    dao_fetch_service_ids_of_sensitive_services,
     dao_fetch_stats_for_service,
     dao_fetch_todays_stats_for_all_services,
     dao_fetch_todays_stats_for_service,
@@ -1567,3 +1568,16 @@ class TestServiceEmailLimits:
             )
         )
         assert fetch_todays_total_message_count(service.id) == 11
+
+
+class TestSensitiveService:
+    def test_sensitive_service(self, notify_db, notify_db_session):
+        service = create_service(service_name="test service", sensitive_service=True)
+        assert service.sensitive_service is True
+
+        sensitive_service = dao_fetch_service_ids_of_sensitive_services()
+        assert [str(service.id)] == sensitive_service
+
+    def test_non_sensitive_service(self, notify_db, notify_db_session):
+        sensitive_service = dao_fetch_service_ids_of_sensitive_services()
+        assert sensitive_service == []

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -116,6 +116,7 @@ def create_service(
     go_live_at=None,
     crown=True,
     organisation=None,
+    sensitive_service=None,
 ):
     if check_if_service_exists:
         service = Service.query.filter_by(name=service_name).first()
@@ -132,6 +133,7 @@ def create_service(
             go_live_user=go_live_user,
             go_live_at=go_live_at,
             crown=crown,
+            sensitive_service=sensitive_service,
         )
         dao_create_service(
             service,

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -3253,3 +3253,27 @@ class TestSerializationofServiceReplyto:
         assert json_resp["data"]["name"] == sample_service.name
         assert json_resp["data"]["id"] == str(sample_service.id)
         assert json_resp["data"]["reply_to_email_addresses"] == []
+
+
+class TestGetSensitiveServiceids:
+    def test_get_sensitive_service_id(self, client, notify_db, notify_db_session):
+        service = create_service(service_name="service1", sensitive_service=True)
+        auth_header = create_authorization_header()
+        resp = client.get(
+            "/service/sensitive-service-ids",
+            headers=[auth_header],
+        )
+        assert resp.status_code == 200
+        json_resp = resp.json
+        assert json_resp["data"] == [str(service.id)]
+
+    def test_no_sensitive_services(self, client, notify_db, notify_db_session):
+        assert Service.query.count() == 0
+        auth_header = create_authorization_header()
+        resp = client.get(
+            "/service/sensitive-service-ids",
+            headers=[auth_header],
+        )
+        assert resp.status_code == 200
+        json_resp = resp.json
+        assert json_resp["data"] == []


### PR DESCRIPTION
# Summary | Résumé

Currently, Admin has a flag in the application where self._sensitive_services has all the IDs of sensitive services (which is pulled from config). We need to change this as this list is getting to large for config size limits.
This PR:
1. Adds a new field called sensitive_service in the services table
2. Adds an API to get all the sensitive services ids - this will be passed on to admin

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1635
*
# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.