### PR TITLE
add sensitive service to the schema

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -267,6 +267,7 @@ class ServiceSchema(BaseSchema, UUIDsAsStringsMixin):
     letter_contact_block = fields.Method(serialize="get_letter_contact")
     go_live_at = field_for(models.Service, "go_live_at", format="%Y-%m-%d %H:%M:%S.%f")
     organisation_notes = field_for(models.Service, "organisation_notes")
+    sensitive_service = field_for(models.Service, "sensitive_service")
 
     def get_letter_logo_filename(self, service):
         return service.letter_branding and service.letter_branding.filename
@@ -776,6 +777,7 @@ class ServiceHistorySchema(Schema):
     email_from = fields.String()
     created_by_id = fields.UUID()
     version = fields.Integer()
+    sensitive_service = fields.Boolean()
 
 
 class ApiKeyHistorySchema(Schema):


### PR DESCRIPTION
# Summary | Résumé

Add sensitive_service to the schema so it might be returned to the frontend. 
## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1635

# Test instructions | Instructions pour tester la modification
1. Go to this branch, and use the equivalent branch on the frontend https://github.com/cds-snc/notification-admin/pull/1931
2. When you check redis for a service, you should have a service.sensitive_service (assuming the service is set)

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.