### PR TITLE
Wire the beat tasks signals with X-Ray

### DIFF
--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -55,6 +55,7 @@ class NotifyCelery(Celery):
         signals.task_failure.connect(xray_task_failure)
         signals.task_postrun.connect(xray_task_postrun)
         signals.task_prerun.connect(xray_task_prerun)
+        signals.beat_init.connect(xray_task_prerun)
 
         # See https://docs.celeryproject.org/en/stable/userguide/configuration.html
         self.conf.update(


### PR DESCRIPTION
# Summary | Résumé

The X-RAY integration with the Celery stack produces errors around missing X-Ray segment/sub-segments. This PR hopefully fixes these. This has not been tested locally. We can test in the dev environment first to have a full integrated environment (for X-Ray enabled and working) with no impact on the development pipeline.

## Explanation for the fix

The analysis of the Celery logs reveals that the segment and subsegment only impacts the [Celery periodic tasks](https://docs.celeryq.dev/en/stable/userguide/periodic-tasks.html):

```
[2024-08-20 19:45:39,836: INFO/MainProcess] xray-celery: **before publish: sender: beat-inbox-email-bulk headers**: {'lang': 'py', 'task': 'beat-inbox-email-bulk', 'id': '25421edd-3981-4a0f-a571-6f093224d18a', 'shadow': None, 'eta': None, 'expires': None, 'group': None, 'group_index': None, 'retries': 0, 'timelimit': [None, None], 'root_id': '25421edd-3981-4a0f-a571-6f093224d18a', 'parent_id': None, 'argsrepr': '()', 'kwargsrepr': '{}', 'origin': 'gen7@celery-beat-9cc77d885-4vzbc', 'ignore_result': False, 'replaced_task_nesting': 0, 'stamped_headers': None, 'stamps': {}}",
[2024-08-20 19:45:39,836: ERROR/MainProcess] **cannot find the current segment/subsegment, please make sure you have a segment open**"
[2024-08-20 19:45:39,836: WARNING/MainProcess] **No segment found, cannot begin subsegment beat-inbox-email-bulk.**"
[2024-08-20 19:45:39,836: ERROR/MainProcess] **Failed to create a X-Ray subsegment on task publish**
```

Other Celery tasks that are not periodic in nature do have proper creation of their segments/subsegments. These that execute successfully shows a log for `xray-celery: prerun` prior to have their corresponding task executed. Hence and most likely, the periodic tasks are missing a proper signal wiring to the `xray_celery_handlers.xray_task_prerun` function. A study of the [Celery signals documentation reveals that the `beat_init` signal](https://docs.celeryq.dev/en/v5.3.6/userguide/signals.html#beat-init) can be used to intercept periodic task creation:

> Dispatched when celery beat starts (either standalone or embedded).

Changes in this PR adds the necessary wiring for the celery periodic tasks to call the `xray_celery_handlers.xray_task_prerun` prior to their execution, which should initialize the X-Ray segment. In theory, not tested. 🤞 

I observed from the logs that the `xray_after_task_publish` function is called after the periodic tasks are executed. This would end the subsegment. 

> [!IMPORTANT] 
> As the periodic tasks would reuse the existing signals for ending a segment and subsegment, I am unsure if that should be their proper flow. Because there is a chance that one and only one segment is created for each periodic task and reused for their executions. I think we want one segment per periodic task execution to be created. Hence, we need to double-check that this will be the case for each periodic task execution: one segment for each. If that is not the case, we will need to split the logic for periodic and regular tasks in the logic that ends segment/subsegment and bring in new changes.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/400

# Test instructions | Instructions pour tester la modification

1. Deploy to the dev environment to benefit the fully integrated X-Ray environment.
2. Look at the CloudWatch logs using the eks/application log group and use this query to notice if the error is gone or still present. If still present, we need to get back to the whiteboard.
```
fields @timestamp, log, kubernetes.container_name as app, kubernetes.pod_name as pod_name, @logStream
| filter kubernetes.container_name like /^celery/
| filter @message like /Failed to create a X-Ray subsegment on task publish/
| sort @timestamp desc
| limit 20
```
3. If the logs are confirmed absent, make sure that the normal execution of intercepted signals x-ray logic is executed with a proper call to the `xray_task_prerun` function. You can use this AWS Cloudwatch query and look at the log group statements around one of the query results:
```
fields @timestamp, log, kubernetes.container_name as app, kubernetes.pod_name as pod_name, @logStream
| filter kubernetes.container_name like /^celery/
| filter @message like /Scheduler: Sending due task beat-inbox/
| sort @timestamp desc
| limit 20
```
4. Make sure that pre-logic and post-logic of the X-Ray functions are properly executed for the periodic task.
5. Make sure that pre-logic and post-logic of the X-Ray functions are properly executed for the regular non-periodic tasks as they remain unaffected by these changes.

# Release Instructions | Instructions pour le déploiement

Release to the dev environment first and then deploy to staging once it is confirmed to work.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.