### PR TITLE
Disable x-ray by removing signals registration

### DIFF
--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -2,14 +2,7 @@ import time
 
 from flask import current_app
 
-from app.aws.xray_celery_handlers import (
-    xray_after_task_publish,
-    xray_before_task_publish,
-    xray_task_failure,
-    xray_task_postrun,
-    xray_task_prerun,
-)
-from celery import Celery, Task, signals
+from celery import Celery, Task
 from celery.signals import worker_process_shutdown
 
 
@@ -48,13 +41,6 @@ class NotifyCelery(Celery):
             broker=app.config["BROKER_URL"],
             task_cls=make_task(app),
         )
-
-        # Register the xray handlers
-        signals.after_task_publish.connect(xray_after_task_publish)
-        signals.before_task_publish.connect(xray_before_task_publish)
-        signals.task_failure.connect(xray_task_failure)
-        signals.task_postrun.connect(xray_task_postrun)
-        signals.task_prerun.connect(xray_task_prerun)
 
         # See https://docs.celeryproject.org/en/stable/userguide/configuration.html
         self.conf.update(


### PR DESCRIPTION
# Summary | Résumé

To be extra safe, we want to disable x-ray at the moment for Celery so it does not ship yet. Because it outputs Celery errors and it could trigger some alarms.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/400

# Test instructions | Instructions pour tester la modification

* Check if there are any Celery log output related to X-Ray.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.