### PR TITLE
Adding Config switch for Xray

### DIFF
--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -49,13 +49,14 @@ class NotifyCelery(Celery):
             task_cls=make_task(app),
         )
 
-        # Register the xray handlers
-        signals.after_task_publish.connect(xray_after_task_publish)
-        signals.before_task_publish.connect(xray_before_task_publish)
-        signals.task_failure.connect(xray_task_failure)
-        signals.task_postrun.connect(xray_task_postrun)
-        signals.task_prerun.connect(xray_task_prerun)
-        signals.beat_init.connect(xray_task_prerun)
+        if app.config["AWS_XRAY_ENABLED"] == "true":
+            # Register the xray handlers
+            signals.after_task_publish.connect(xray_after_task_publish)
+            signals.before_task_publish.connect(xray_before_task_publish)
+            signals.task_failure.connect(xray_task_failure)
+            signals.task_postrun.connect(xray_task_postrun)
+            signals.task_prerun.connect(xray_task_prerun)
+            signals.beat_init.connect(xray_task_prerun)
 
         # See https://docs.celeryproject.org/en/stable/userguide/configuration.html
         self.conf.update(

--- a/app/config.py
+++ b/app/config.py
@@ -240,6 +240,9 @@ class Config(object):
     DEBUG = False
     NOTIFY_LOG_PATH = os.getenv("NOTIFY_LOG_PATH")
 
+    # AWS Xray
+    AWS_XRAY_ENABLED = os.getenv("AWS_XRAY_ENABLED", "false")
+
     # Cronitor
     CRONITOR_ENABLED = False
     CRONITOR_KEYS = json.loads(os.getenv("CRONITOR_KEYS", "{}"))

--- a/application.py
+++ b/application.py
@@ -20,8 +20,9 @@ application.wsgi_app = ProxyFix(application.wsgi_app)  # type: ignore
 
 app = create_app(application)
 
-xray_recorder.configure(service='api')
-XRayMiddleware(app, xray_recorder)
+if app.config["AWS_XRAY_ENABLED"] == "true":
+    xray_recorder.configure(service='api')
+    XRayMiddleware(app, xray_recorder)
 
 apig_wsgi_handler = make_lambda_handler(app, binary_support=True)
 

--- a/run_celery.py
+++ b/run_celery.py
@@ -15,7 +15,8 @@ load_dotenv()
 application = Flask("celery")
 create_app(application)
 
-xray_recorder.configure(service='celery')
-XRayMiddleware(application, xray_recorder)
+if application.config["AWS_XRAY_ENABLED"] == "true":
+    xray_recorder.configure(service='celery')
+    XRayMiddleware(application, xray_recorder)
 
 application.app_context().push()


### PR DESCRIPTION
# Summary | Résumé

Adding logic to rely upon an environment variable to turn Xray Tracing on or off

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/400

# Test instructions | Instructions pour tester la modification

- Update the .env file on staging from true to false (or vice versa) on staging
- Deploy the app on staging
- Verify the Xray tracing/maps to see if it's on or off depending on configuration

# Release Instructions | Instructions pour le déploiement

Verify the config value in the production .env file to ensure it's what we want it to be.

# Reviewer checklist | Liste de vérification du réviseur

- [x] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [x] This PR does not significantly alter performance.
- [x] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.