### PR TITLE
updating code to use booleans rather than 'true''false'

### DIFF
--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -49,7 +49,7 @@ class NotifyCelery(Celery):
             task_cls=make_task(app),
         )
 
-        if app.config["AWS_XRAY_ENABLED"] == "true":
+        if app.config["AWS_XRAY_ENABLED"]:
             # Register the xray handlers
             signals.after_task_publish.connect(xray_after_task_publish)
             signals.before_task_publish.connect(xray_before_task_publish)

--- a/app/config.py
+++ b/app/config.py
@@ -241,7 +241,7 @@ class Config(object):
     NOTIFY_LOG_PATH = os.getenv("NOTIFY_LOG_PATH")
 
     # AWS Xray
-    AWS_XRAY_ENABLED = os.getenv("AWS_XRAY_ENABLED", "false")
+    AWS_XRAY_ENABLED = env.bool("AWS_XRAY_ENABLED", False)
 
     # Cronitor
     CRONITOR_ENABLED = False

--- a/application.py
+++ b/application.py
@@ -20,7 +20,7 @@ application.wsgi_app = ProxyFix(application.wsgi_app)  # type: ignore
 
 app = create_app(application)
 
-if app.config["AWS_XRAY_ENABLED"] == "true":
+if app.config["AWS_XRAY_ENABLED"]:
     xray_recorder.configure(service='api')
     XRayMiddleware(app, xray_recorder)
 

--- a/run_celery.py
+++ b/run_celery.py
@@ -15,7 +15,7 @@ load_dotenv()
 application = Flask("celery")
 create_app(application)
 
-if application.config["AWS_XRAY_ENABLED"] == "true":
+if application.config["AWS_XRAY_ENABLED"]:
     xray_recorder.configure(service='celery')
     XRayMiddleware(application, xray_recorder)
 


### PR DESCRIPTION
# Summary | Résumé

just a code tweak to handle our xray config env variable as a boolean rather than a string

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/400

# Test instructions | Instructions pour tester la modification

nothing... everything should work the same as before

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.