### PR TITLE
removing references to the old configs for xray

### DIFF
--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -49,14 +49,13 @@ class NotifyCelery(Celery):
             task_cls=make_task(app),
         )
 
-        if app.config["AWS_XRAY_ENABLED"]:
-            # Register the xray handlers
-            signals.after_task_publish.connect(xray_after_task_publish)
-            signals.before_task_publish.connect(xray_before_task_publish)
-            signals.task_failure.connect(xray_task_failure)
-            signals.task_postrun.connect(xray_task_postrun)
-            signals.task_prerun.connect(xray_task_prerun)
-            signals.beat_init.connect(xray_task_prerun)
+        # Register the xray handlers
+        signals.after_task_publish.connect(xray_after_task_publish)
+        signals.before_task_publish.connect(xray_before_task_publish)
+        signals.task_failure.connect(xray_task_failure)
+        signals.task_postrun.connect(xray_task_postrun)
+        signals.task_prerun.connect(xray_task_prerun)
+        signals.beat_init.connect(xray_task_prerun)
 
         # See https://docs.celeryproject.org/en/stable/userguide/configuration.html
         self.conf.update(

--- a/app/config.py
+++ b/app/config.py
@@ -240,6 +240,9 @@ class Config(object):
     DEBUG = False
     NOTIFY_LOG_PATH = os.getenv("NOTIFY_LOG_PATH")
 
+    # Xray SDK
+    AWS_XRAY_ENABLED = env.bool("AWS_XRAY_SDK_ENABLED", False) # X-Ray switch leveraged by the SDK
+    
     # Cronitor
     CRONITOR_ENABLED = False
     CRONITOR_KEYS = json.loads(os.getenv("CRONITOR_KEYS", "{}"))

--- a/app/config.py
+++ b/app/config.py
@@ -240,9 +240,6 @@ class Config(object):
     DEBUG = False
     NOTIFY_LOG_PATH = os.getenv("NOTIFY_LOG_PATH")
 
-    # AWS Xray
-    AWS_XRAY_ENABLED = env.bool("AWS_XRAY_ENABLED", False)
-
     # Cronitor
     CRONITOR_ENABLED = False
     CRONITOR_KEYS = json.loads(os.getenv("CRONITOR_KEYS", "{}"))

--- a/app/config.py
+++ b/app/config.py
@@ -241,8 +241,8 @@ class Config(object):
     NOTIFY_LOG_PATH = os.getenv("NOTIFY_LOG_PATH")
 
     # Xray SDK
-    AWS_XRAY_ENABLED = env.bool("AWS_XRAY_SDK_ENABLED", False) # X-Ray switch leveraged by the SDK
-    
+    AWS_XRAY_ENABLED = env.bool("AWS_XRAY_SDK_ENABLED", False)  # X-Ray switch leveraged by the SDK
+
     # Cronitor
     CRONITOR_ENABLED = False
     CRONITOR_KEYS = json.loads(os.getenv("CRONITOR_KEYS", "{}"))

--- a/application.py
+++ b/application.py
@@ -20,9 +20,8 @@ application.wsgi_app = ProxyFix(application.wsgi_app)  # type: ignore
 
 app = create_app(application)
 
-if app.config["AWS_XRAY_ENABLED"]:
-    xray_recorder.configure(service='api')
-    XRayMiddleware(app, xray_recorder)
+xray_recorder.configure(service='api')
+XRayMiddleware(app, xray_recorder)
 
 apig_wsgi_handler = make_lambda_handler(app, binary_support=True)
 

--- a/run_celery.py
+++ b/run_celery.py
@@ -15,8 +15,7 @@ load_dotenv()
 application = Flask("celery")
 create_app(application)
 
-if application.config["AWS_XRAY_ENABLED"]:
-    xray_recorder.configure(service='celery')
-    XRayMiddleware(application, xray_recorder)
+xray_recorder.configure(service='celery')
+XRayMiddleware(application, xray_recorder)
 
 application.app_context().push()


### PR DESCRIPTION
# Summary | Résumé

Changing code to rely on the AWS_XRAY_SDK_ENABLED flag built into XRay SDK to toggle scanning off/on rather than our custom flag.

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/400

# Test instructions | Instructions pour tester la modification
When toggled off or on in the .env files it should be reflected in the Xray scanning/maps

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.