### PR TITLE
Added back logging signals for beat workers

### DIFF
--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -51,12 +51,16 @@ class NotifyCelery(Celery):
 
         if app.config["AWS_XRAY_ENABLED"]:
             # Register the xray handlers
+            def handle_beat_signal(sender=None, **kwargs):
+                app.logger.info("Beat signal received: sender={}, kwargs={}".format(sender, kwargs))
+
             signals.after_task_publish.connect(xray_after_task_publish)
             signals.before_task_publish.connect(xray_before_task_publish)
             signals.task_failure.connect(xray_task_failure)
             signals.task_postrun.connect(xray_task_postrun)
             signals.task_prerun.connect(xray_task_prerun)
-            signals.beat_init.connect(xray_task_prerun)
+            signals.beat_init.connect(handle_beat_signal)
+            signals.beat_embedded_init.connect(handle_beat_signal)
 
         # See https://docs.celeryproject.org/en/stable/userguide/configuration.html
         self.conf.update(


### PR DESCRIPTION
# Summary | Résumé

Added back logging signals for beat workers

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/400

# Test instructions | Instructions pour tester la modification

No testing. 

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.