### PR TITLE
Skip subsegment creation if segment is missing in current thread context

### DIFF
--- a/app/aws/xray_celery_handlers.py
+++ b/app/aws/xray_celery_handlers.py
@@ -33,9 +33,11 @@ def xray_before_task_publish(
             subsegment.put_metadata("task_id", task_id, namespace=CELERY_NAMESPACE)
             inject_trace_header(headers, subsegment)
         else:
-            logger.error("Failed to create a X-Ray subsegment on task publish", extra={"celery": {"task_id": task_id}})
+            logger.error(
+                "xray-celery: Failed to create a X-Ray subsegment on task publish", extra={"celery": {"task_id": task_id}}
+            )
     else:
-        logger.warn("No parent segment found for task {task_id} when trying to create subsegment", task_id)
+        logger.warn("xray-celery: No parent segment found for task {task_id} when trying to create subsegment", task_id)
 
 
 def xray_after_task_publish(headers=None, body=None, exchange=None, routing_key=None, **kwargs):
@@ -45,7 +47,9 @@ def xray_after_task_publish(headers=None, body=None, exchange=None, routing_key=
     if xray_recorder.current_subsegment():
         xray_recorder.end_subsegment()
     else:
-        logger.warn("Skipping subsegment closing after publish as no subsegment was found: {headers}", headers=headers)
+        logger.warn(
+            "xray-celery: Skipping subsegment closing after publish as no subsegment was found: {headers}", headers=headers
+        )
 
 
 def xray_task_prerun(task_id=None, task=None, args=None, **kwargs):
@@ -68,7 +72,7 @@ def xray_task_failure(task_id=None, exception=None, **kwargs):
     segment = xray_recorder.current_segment()
     if not segment:
         logger.error(
-            "Failed to get the current X-Ray segment on task failure", extra={"celery": {"task_id": kwargs.get("task_id")}}
+            "xray-celery: Failed to get the current segment on task failure", extra={"celery": {"task_id": kwargs.get("task_id")}}
         )
         return
 

--- a/app/aws/xray_celery_handlers.py
+++ b/app/aws/xray_celery_handlers.py
@@ -35,7 +35,7 @@ def xray_before_task_publish(
         else:
             logger.error("Failed to create a X-Ray subsegment on task publish", extra={"celery": {"task_id": task_id}})
     else:
-        logger.warn("No segment found for task {task_id}", task_id)
+        logger.warn("No parent segment found for task {task_id} when trying to create subsegment", task_id)
 
 
 def xray_after_task_publish(headers=None, body=None, exchange=None, routing_key=None, **kwargs):

--- a/app/aws/xray_celery_handlers.py
+++ b/app/aws/xray_celery_handlers.py
@@ -26,7 +26,7 @@ def xray_before_task_publish(
     current_segment = xray_recorder.current_segment()
     # Checks if there is a current segment to create a subsegment,
     # otherwise we might be in a starter task. The prerun handler will
-    # create the segment for us.
+    # create the segment for us down the road as it will be called after.
     if current_segment:
         subsegment = xray_recorder.begin_subsegment(name=sender, namespace="remote")
         if subsegment:

--- a/app/aws/xray_celery_handlers.py
+++ b/app/aws/xray_celery_handlers.py
@@ -42,7 +42,10 @@ def xray_after_task_publish(headers=None, body=None, exchange=None, routing_key=
     logger.info(
         f"xray-celery: after publish: headers={headers}, body={body}, exchange={exchange}, routing_key={routing_key}, kwargs={kwargs}"
     )
-    xray_recorder.end_subsegment()
+    if xray_recorder.current_subsegment():
+        xray_recorder.end_subsegment()
+    else:
+        logger.warn("Skipping subsegment closing after publish as no subsegment was found: {headers}", headers=headers)
 
 
 def xray_task_prerun(task_id=None, task=None, args=None, **kwargs):

--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -51,16 +51,11 @@ class NotifyCelery(Celery):
 
         if app.config["AWS_XRAY_ENABLED"]:
             # Register the xray handlers
-            def handle_beat_signal(sender=None, **kwargs):
-                app.logger.info("Beat signal received: sender={}, kwargs={}".format(sender, kwargs))
-
             signals.after_task_publish.connect(xray_after_task_publish)
             signals.before_task_publish.connect(xray_before_task_publish)
             signals.task_failure.connect(xray_task_failure)
             signals.task_postrun.connect(xray_task_postrun)
             signals.task_prerun.connect(xray_task_prerun)
-            signals.beat_init.connect(handle_beat_signal)
-            signals.beat_embedded_init.connect(handle_beat_signal)
 
         # See https://docs.celeryproject.org/en/stable/userguide/configuration.html
         self.conf.update(

--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -51,12 +51,16 @@ class NotifyCelery(Celery):
 
         if app.config["AWS_XRAY_ENABLED"]:
             # Register the xray handlers
+            def handle_beat_signal(sender=None, **kwargs):
+                app.logger.info("Beat signal received: sender={}, kwargs={}".format(sender, kwargs))
+
             signals.after_task_publish.connect(xray_after_task_publish)
             signals.before_task_publish.connect(xray_before_task_publish)
             signals.task_failure.connect(xray_task_failure)
             signals.task_postrun.connect(xray_task_postrun)
             signals.task_prerun.connect(xray_task_prerun)
-            signals.beat_init.connect(xray_task_prerun)
+            signals.beat_init.connect(handle_beat_signal)
+            signals.beat_embedded_init.connect(handle_beat_signal)
 
         # See https://docs.celeryproject.org/en/stable/userguide/configuration.html
         self.conf.update(


### PR DESCRIPTION
# Summary | Résumé

There is a possible situation when a Celery periodic task starts itself and has no segment in the current thread context. This will lead to errors as a subsegment will be created without a parent segment, which is required.

We can opt to skip the subsegment creation as this would normally be applied in a context of a parent task that would call down the current task. If there is no current segment, skip the creation of the subsegment and let the prerun signal handler to create the segment later down the road.

The same applies on closing the subsegment on the `after_task_publish` signal, i.e. check if a current subsegment exists before closing and if not, log a warning along with the task details to know on which one that happened, which should be a periodic tasks.

Also, I added missing parameters on the x-ray signal handler functions and log these to inspect what really is in there and which options we could open up with these.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/400

# Test instructions | Instructions pour tester la modification

Deploy to staging and

1. Make sure all the pods redeploy normally.
2. Query CloudWatch with the following query to make sure that there are no errors anymore:
```
fields @timestamp, log, kubernetes.container_name as app, kubernetes.pod_name as pod_name, @logStream
| filter kubernetes.container_name like /^celery/
| filter @message like /Failed to create a X-Ray subsegment on task publish/
| sort @timestamp desc
| limit 20
```
3. Target a task ID from one of the beat workers using this query...
```
fields @timestamp, log, kubernetes.container_name as app, kubernetes.pod_name as pod_name, @logStream
| filter kubernetes.container_name like /^celery/
| filter @message like /Scheduler: Sending due task beat-inbox/
| sort @timestamp desc
| limit 20
```
...and make sure that the `before_task_publish` signals do not execute for the periodic tasks, and that the `task_prerun` signals execute properly for the periodic tasks.
4. Look at the CloudWatch X-Ray trace map in the AWS console and verify that the Celery tasks are present for both regular non-periodic tasks and periodic ones.

# Release Instructions | Instructions pour le déploiement

Make sure that all pods deploy correctly. There is initialization code that did prevent the Celery and API pods to successfully launch in previous X-Ray SDK extension fixes.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.