### PR TITLE
Add model data for suspended fields

### DIFF
--- a/app/dao/service_callback_api_dao.py
+++ b/app/dao/service_callback_api_dao.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from flask import current_app
 from itsdangerous import BadSignature
@@ -88,3 +88,13 @@ def get_service_complaint_callback_api_for_service(service_id):
 @transactional
 def delete_service_callback_api(service_callback_api):
     db.session.delete(service_callback_api)
+
+
+@transactional
+@version_class(ServiceCallbackApi)
+def suspend_service_callback_api(service_callback_api, updated_by_id):
+    service_callback_api.is_suspended = True
+    service_callback_api.suspended_at = datetime.now(timezone.utc)
+    service_callback_api.updated_by_id = updated_by_id
+    service_callback_api.updated_at = datetime.now(timezone.utc)
+    db.session.add(service_callback_api)

--- a/app/models.py
+++ b/app/models.py
@@ -871,6 +871,8 @@ class ServiceCallbackApi(BaseModel, Versioned):
     updated_at = db.Column(db.DateTime, nullable=True)
     updated_by = db.relationship("User")
     updated_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), index=True, nullable=False)
+    is_suspended = db.Column(db.Boolean, nullable=True, default=False)
+    suspended_at = db.Column(db.DateTime, nullable=True)
 
     __table_args__ = (UniqueConstraint("service_id", "callback_type", name="uix_service_callback_type"),)
 
@@ -893,6 +895,8 @@ class ServiceCallbackApi(BaseModel, Versioned):
             "updated_by_id": str(self.updated_by_id),
             "created_at": self.created_at.strftime(DATETIME_FORMAT),
             "updated_at": self.updated_at.strftime(DATETIME_FORMAT) if self.updated_at else None,
+            "is_suspended": self.is_suspended,
+            "suspended_at": self.suspended_at.strftime(DATETIME_FORMAT) if self.suspended_at else None,
         }
 
 

--- a/tests/app/dao/test_service_callback_api_dao.py
+++ b/tests/app/dao/test_service_callback_api_dao.py
@@ -11,6 +11,7 @@ from app.dao.service_callback_api_dao import (
     reset_service_callback_api,
     resign_service_callbacks,
     save_service_callback_api,
+    suspend_service_callback_api,
 )
 from app.models import ServiceCallbackApi
 from tests.app.db import create_service_callback_api
@@ -221,3 +222,49 @@ class TestResigning:
             callback = ServiceCallbackApi.query.get(initial_callback.id)
             assert callback.bearer_token == bearer_token  # unsigned value is the same
             assert callback._bearer_token != _bearer_token  # signature is different
+
+
+class TestSuspendedServiceCallback:
+    def test_update_service_callback_api(self, sample_service):
+        service_callback_api = ServiceCallbackApi(
+            service_id=sample_service.id,
+            url="https://some_service/callback_endpoint",
+            bearer_token="some_unique_string",
+            updated_by_id=sample_service.users[0].id,
+        )
+
+        save_service_callback_api(service_callback_api)
+        results = ServiceCallbackApi.query.all()
+        assert len(results) == 1
+        saved_callback_api = results[0]
+
+        suspend_service_callback_api(
+            saved_callback_api,
+            updated_by_id=sample_service.users[0].id,
+        )
+        updated_results = ServiceCallbackApi.query.all()
+        assert len(updated_results) == 1
+        updated = updated_results[0]
+        assert updated.id is not None
+        assert updated.service_id == sample_service.id
+        assert updated.updated_by_id == sample_service.users[0].id
+        assert updated.url == "https://some_service/callback_endpoint"
+        assert updated.bearer_token == "some_unique_string"
+        assert updated._bearer_token != "some_unique_string"
+        assert updated.updated_at is not None
+        assert updated.is_suspended is True
+        assert updated.suspended_at is not None
+
+        versioned_results = ServiceCallbackApi.get_history_model().query.filter_by(id=saved_callback_api.id).all()
+        assert len(versioned_results) == 2
+        for x in versioned_results:
+            if x.version == 1:
+                assert x.is_suspended is None
+            elif x.version == 2:
+                assert x.is_suspended is True
+            else:
+                pytest.fail("version should not exist")
+            assert x.id is not None
+            assert x.service_id == sample_service.id
+            assert x.updated_by_id == sample_service.users[0].id
+            assert signer_bearer_token.verify(x._bearer_token) == "some_unique_string"


### PR DESCRIPTION
# Summary | Résumé

Add fields for suspended data on the ServiceCallbackApi table.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1648

# Test instructions | Instructions pour tester la modification

1. check the migration is run 

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.