### PR TITLE
Rename xray service to Notify

### DIFF
--- a/application.py
+++ b/application.py
@@ -5,7 +5,7 @@ import os
 
 import newrelic.agent  # See https://bit.ly/2xBVKBH
 from apig_wsgi import make_lambda_handler
-from aws_xray_sdk.core import xray_recorder, patch_all
+from aws_xray_sdk.core import patch_all, xray_recorder
 from aws_xray_sdk.ext.flask.middleware import XRayMiddleware
 from dotenv import load_dotenv
 from flask import Flask

--- a/application.py
+++ b/application.py
@@ -5,7 +5,7 @@ import os
 
 import newrelic.agent  # See https://bit.ly/2xBVKBH
 from apig_wsgi import make_lambda_handler
-from aws_xray_sdk.core import xray_recorder
+from aws_xray_sdk.core import xray_recorder, patch_all
 from aws_xray_sdk.ext.flask.middleware import XRayMiddleware
 from dotenv import load_dotenv
 from flask import Flask
@@ -13,6 +13,8 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 
 from app import create_app
 from app.aws.xray.context import NotifyContext
+
+patch_all()
 
 load_dotenv()
 

--- a/application.py
+++ b/application.py
@@ -21,7 +21,7 @@ application.wsgi_app = ProxyFix(application.wsgi_app)  # type: ignore
 
 app = create_app(application)
 
-xray_recorder.configure(service='api', context=NotifyContext())
+xray_recorder.configure(service='Notify', context=NotifyContext())
 XRayMiddleware(app, xray_recorder)
 
 apig_wsgi_handler = make_lambda_handler(app, binary_support=True)

--- a/application.py
+++ b/application.py
@@ -5,7 +5,7 @@ import os
 
 import newrelic.agent  # See https://bit.ly/2xBVKBH
 from apig_wsgi import make_lambda_handler
-from aws_xray_sdk.core import patch_all, xray_recorder
+from aws_xray_sdk.core import xray_recorder
 from aws_xray_sdk.ext.flask.middleware import XRayMiddleware
 from dotenv import load_dotenv
 from flask import Flask
@@ -13,8 +13,6 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 
 from app import create_app
 from app.aws.xray.context import NotifyContext
-
-patch_all()
 
 load_dotenv()
 

--- a/run_celery.py
+++ b/run_celery.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import newrelic.agent  # See https://bit.ly/2xBVKBH
-from aws_xray_sdk.core import xray_recorder, patch_all
+from aws_xray_sdk.core import patch_all, xray_recorder
 from aws_xray_sdk.ext.flask.middleware import XRayMiddleware
 from dotenv import load_dotenv
 from flask import Flask

--- a/run_celery.py
+++ b/run_celery.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python
 import newrelic.agent  # See https://bit.ly/2xBVKBH
-from aws_xray_sdk.core import patch_all, xray_recorder
+from aws_xray_sdk.core import xray_recorder
 from aws_xray_sdk.ext.flask.middleware import XRayMiddleware
 from dotenv import load_dotenv
 from flask import Flask
 
 from app.aws.xray.context import NotifyContext
-
-patch_all()
 
 newrelic.agent.initialize()  # noqa: E402
 

--- a/run_celery.py
+++ b/run_celery.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 import newrelic.agent  # See https://bit.ly/2xBVKBH
-from aws_xray_sdk.core import xray_recorder
+from aws_xray_sdk.core import xray_recorder, patch_all
 from aws_xray_sdk.ext.flask.middleware import XRayMiddleware
 from dotenv import load_dotenv
 from flask import Flask
 
 from app.aws.xray.context import NotifyContext
+
+patch_all()
 
 newrelic.agent.initialize()  # noqa: E402
 

--- a/run_celery.py
+++ b/run_celery.py
@@ -17,7 +17,7 @@ load_dotenv()
 application = Flask("celery")
 create_app(application)
 
-xray_recorder.configure(service='celery', context=NotifyContext())
+xray_recorder.configure(service='Notify', context=NotifyContext())
 XRayMiddleware(application, xray_recorder)
 
 application.app_context().push()


### PR DESCRIPTION
# Summary | Résumé

Simply renaming the xray SDK service name (across the API, Admin and Celery Code) to Notify to see if traffic will be traced through the stack.

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/400

## Testing Steps
- After API and Admin are both deployed to staging, check the Xray maps and see if they are linked as the same service