### PR TITLE
Add api to suspend a callback

### DIFF
--- a/app/dao/service_callback_api_dao.py
+++ b/app/dao/service_callback_api_dao.py
@@ -73,6 +73,11 @@ def reset_service_callback_api(service_callback_api, updated_by_id, url=None, be
     db.session.add(service_callback_api)
 
 
+def get_service_callback_api_with_service_id(service_id):
+    # There is ONLY one callback configured per service
+    return ServiceCallbackApi.query.filter_by(service_id=service_id).all()
+
+
 def get_service_callback_api(service_callback_api_id, service_id):
     return ServiceCallbackApi.query.filter_by(id=service_callback_api_id, service_id=service_id).first()
 
@@ -92,8 +97,8 @@ def delete_service_callback_api(service_callback_api):
 
 @transactional
 @version_class(ServiceCallbackApi)
-def suspend_service_callback_api(service_callback_api, updated_by_id):
-    service_callback_api.is_suspended = True
+def suspend_unsuspend_service_callback_api(service_callback_api, updated_by_id, suspend=False):
+    service_callback_api.is_suspended = suspend
     service_callback_api.suspended_at = datetime.now(timezone.utc)
     service_callback_api.updated_by_id = updated_by_id
     service_callback_api.updated_at = datetime.now(timezone.utc)

--- a/app/models.py
+++ b/app/models.py
@@ -872,6 +872,7 @@ class ServiceCallbackApi(BaseModel, Versioned):
     updated_by = db.relationship("User")
     updated_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), index=True, nullable=False)
     is_suspended = db.Column(db.Boolean, nullable=True, default=False)
+    # If is_suspended is False and suspended_at is not None, then the callback was suspended and then unsuspended
     suspended_at = db.Column(db.DateTime, nullable=True)
 
     __table_args__ = (UniqueConstraint("service_id", "callback_type", name="uix_service_callback_type"),)

--- a/app/service/callback_rest.py
+++ b/app/service/callback_rest.py
@@ -143,7 +143,7 @@ def suspend_callback_api(service_id):
     suspend_unsuspend = data["suspend_unsuspend"]
 
     suspend_unsuspend_service_callback_api(callback_api[0], updated_by_id, suspend_unsuspend)
-    return jsonify(data=callback_api[0].serialize()), 201
+    return jsonify(data=callback_api[0].serialize()), 200
 
 
 def handle_sql_error(e, table_name):

--- a/app/service/callback_rest.py
+++ b/app/service/callback_rest.py
@@ -4,8 +4,10 @@ from sqlalchemy.exc import SQLAlchemyError
 from app.dao.service_callback_api_dao import (
     delete_service_callback_api,
     get_service_callback_api,
+    get_service_callback_api_with_service_id,
     reset_service_callback_api,
     save_service_callback_api,
+    suspend_unsuspend_service_callback_api,
 )
 from app.dao.service_inbound_api_dao import (
     delete_service_inbound_api,
@@ -127,6 +129,21 @@ def remove_service_callback_api(service_id, callback_api_id):
 
     delete_service_callback_api(callback_api)
     return "", 204
+
+
+@service_callback_blueprint.route("/delivery-receipt-api/suspend-callback", methods=["POST"])
+def suspend_callback_api(service_id):
+    data = request.get_json()
+    callback_api = get_service_callback_api_with_service_id(service_id)
+    if not callback_api:
+        error = "Service delivery receipt callback API not found"
+        raise InvalidRequest(error, status_code=404)
+
+    updated_by_id = data["updated_by_id"]
+    suspend_unsuspend = data["suspend_unsuspend"]
+
+    suspend_unsuspend_service_callback_api(callback_api[0], updated_by_id, suspend_unsuspend)
+    return "", 200
 
 
 def handle_sql_error(e, table_name):

--- a/app/service/callback_rest.py
+++ b/app/service/callback_rest.py
@@ -143,7 +143,7 @@ def suspend_callback_api(service_id):
     suspend_unsuspend = data["suspend_unsuspend"]
 
     suspend_unsuspend_service_callback_api(callback_api[0], updated_by_id, suspend_unsuspend)
-    return "", 200
+    return jsonify(data=callback_api[0].serialize()), 201
 
 
 def handle_sql_error(e, table_name):

--- a/tests/app/dao/test_service_callback_api_dao.py
+++ b/tests/app/dao/test_service_callback_api_dao.py
@@ -11,7 +11,7 @@ from app.dao.service_callback_api_dao import (
     reset_service_callback_api,
     resign_service_callbacks,
     save_service_callback_api,
-    suspend_service_callback_api,
+    suspend_unsuspend_service_callback_api,
 )
 from app.models import ServiceCallbackApi
 from tests.app.db import create_service_callback_api
@@ -238,9 +238,10 @@ class TestSuspendedServiceCallback:
         assert len(results) == 1
         saved_callback_api = results[0]
 
-        suspend_service_callback_api(
+        suspend_unsuspend_service_callback_api(
             saved_callback_api,
             updated_by_id=sample_service.users[0].id,
+            suspend=True,
         )
         updated_results = ServiceCallbackApi.query.all()
         assert len(updated_results) == 1

--- a/tests/app/service/test_callback_rest.py
+++ b/tests/app/service/test_callback_rest.py
@@ -1,5 +1,7 @@
 import uuid
 
+import pytest
+
 from app.models import ServiceCallbackApi, ServiceInboundApi
 from tests.app.db import create_service_callback_api, create_service_inbound_api
 
@@ -196,3 +198,22 @@ def test_delete_service_callback_api(admin_request, sample_service):
 
     assert response is None
     assert ServiceCallbackApi.query.count() == 0
+
+
+class TestSuspendCallbackApi:
+    @pytest.mark.parametrize("suspend_unsuspend", [True, False])
+    def test_suspend_callback_api(self, admin_request, sample_service, suspend_unsuspend):
+        service_callback_api = create_service_callback_api(sample_service)
+
+        data = {
+            "suspend_unsuspend": suspend_unsuspend,
+            "updated_by_id": str(sample_service.users[0].id),
+        }
+        admin_request.post(
+            "service_callback.suspend_callback_api",
+            service_id=sample_service.id,
+            _data=data,
+        )
+        callback = ServiceCallbackApi.query.get(service_callback_api.id)
+        assert callback.is_suspended is suspend_unsuspend
+        assert callback.updated_by_id == sample_service.users[0].id


### PR DESCRIPTION
# Summary | Résumé

We want an API that will set the suspension to false for a given callback

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1648

# Test instructions | Instructions pour tester la modification

You can test it with the admin PR 

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.