### PR TITLE
Add `/cache-clear` authenticated endpoint

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -184,8 +184,10 @@ def register_blueprint(application):
         requires_auth,
         requires_no_auth,
         requires_sre_auth,
+        requires_cache_clear_auth
     )
     from app.billing.rest import billing_blueprint
+    from app.cache.rest import cache_blueprint
     from app.complaint.complaint_rest import complaint_blueprint
     from app.email_branding.rest import email_branding_blueprint
     from app.events.rest import events as events_blueprint
@@ -268,6 +270,7 @@ def register_blueprint(application):
 
     register_notify_blueprint(application, template_category_blueprint, requires_admin_auth)
 
+    register_notify_blueprint(application, cache_blueprint, requires_cache_clear_auth)
 
 def register_v2_blueprints(application):
     from app.authentication.auth import requires_auth

--- a/app/config.py
+++ b/app/config.py
@@ -570,7 +570,10 @@ class Config(object):
     # SRE Tools auth keys
     SRE_USER_NAME = "SRE_CLIENT_USER"
     SRE_CLIENT_SECRET = os.getenv("SRE_CLIENT_SECRET")
-
+    # cache clear auth keys
+    CACHE_CLEAR_USER_NAME = "CACHE_CLEAR_USER"
+    CACHE_CLEAR_CLIENT_SECRET = os.getenv("CACHE_CLEAR_CLIENT_SECRET")
+    
     @classmethod
     def get_sensitive_config(cls) -> list[str]:
         "List of config keys that contain sensitive information"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ Werkzeug = "3.0.3"
 MarkupSafe = "2.1.5"
 # REVIEW: v2 is using sha512 instead of sha1 by default (in v1)
 itsdangerous = "2.2.0"
-notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", tag = "52.2.8" }
+notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", tag = "52.2.9" }
 
 # rsa = "4.9  # awscli 1.22.38 depends on rsa<4.8
 typing-extensions = "4.10.0"


### PR DESCRIPTION
# Summary | Résumé

This PR adds a new endpoint, `/cache-clear` that can only be called using the cache-clear secret.  This endpoint will be called upon deployment to ensure our redis cache gets flushed each time.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/1612

# Test instructions | Instructions pour tester la modification

- `/cache-clear` can be called when authenticated using a JWT using the specific secret
- `/cache-clear` CANNOT BE  called unauthenticated
- `/cache-clear` CANNOT BE  called when authenticated with the admin secret 
- `/cache-clear` CANNOT BE  called when authenticated with the SRE secret 

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.