### PR TITLE
Code Fix for Xray Errors in Celery

### DIFF
--- a/app/aws/xray_celery_handlers.py
+++ b/app/aws/xray_celery_handlers.py
@@ -47,9 +47,7 @@ def xray_after_task_publish(headers=None, body=None, exchange=None, routing_key=
     if xray_recorder.current_subsegment():
         xray_recorder.end_subsegment()
     else:
-        logger.warn(
-            f"xray-celery: Skipping subsegment closing after publish as no subsegment was found: {headers}"
-        )
+        logger.warn(f"xray-celery: Skipping subsegment closing after publish as no subsegment was found: {headers}")
 
 
 def xray_task_prerun(task_id=None, task=None, args=None, **kwargs):

--- a/app/aws/xray_celery_handlers.py
+++ b/app/aws/xray_celery_handlers.py
@@ -37,7 +37,7 @@ def xray_before_task_publish(
                 "xray-celery: Failed to create a X-Ray subsegment on task publish", extra={"celery": {"task_id": task_id}}
             )
     else:
-        logger.warn("xray-celery: No parent segment found for task {task_id} when trying to create subsegment", task_id)
+        logger.warn(f"xray-celery: No parent segment found for task {task_id} when trying to create subsegment")
 
 
 def xray_after_task_publish(headers=None, body=None, exchange=None, routing_key=None, **kwargs):

--- a/app/aws/xray_celery_handlers.py
+++ b/app/aws/xray_celery_handlers.py
@@ -48,7 +48,7 @@ def xray_after_task_publish(headers=None, body=None, exchange=None, routing_key=
         xray_recorder.end_subsegment()
     else:
         logger.warn(
-            "xray-celery: Skipping subsegment closing after publish as no subsegment was found: {headers}", headers=headers
+            f"xray-celery: Skipping subsegment closing after publish as no subsegment was found: {headers}"
         )
 
 


### PR DESCRIPTION
# Summary | Résumé

Cloudwatch was logging errors for celery:
`logger.warn(\n  File \"/usr/local/lib/python3.10/logging/__init__.py\", line 1494, in warn\n    self.warning(msg, *args, **kwargs)\n  File \"/usr/local/lib/python3.10/logging/__init__.py\", line 1489, in warning\n    self._log(WARNING, msg, args, **kwargs)\nTypeError: Logger._log() got an unexpected keyword argument 'headers'","stream":"stderr","time":"2024-09-04T17:58:48.904435306Z"}`

This was related to a minor string formatting error in our code.

## Related Issues | Cartes liées
https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/400

# Test instructions | Instructions pour tester la modification
Once deployed to Staging, check here to see if the celery errors have stopped being logged:
[Here](https://ca-central-1.console.aws.amazon.com/cloudwatch/home?region=ca-central-1#logsV2:logs-insights$3FqueryDetail$3D~(end~0~start~-10800~timeType~'RELATIVE~tz~'LOCAL~unit~'seconds~editorString~'fields*20*40timestamp*2c*20log*2c*20kubernetes.container_name*20as*20app*2c*20kubernetes.pod_name*20as*20pod_name*2c*20*40logStream*0a*7c*20filter*20kubernetes.container_name*20like*20*2f*5ecelery*2f*0a*7c*20filter*20strcontains*28*40message*2c*20*27ERROR*27*29*0a~queryId~'e74dcf31-19bb-41f1-9cf1-467f8fa19827~source~(~'*2faws*2fcontainerinsights*2fnotification-canada-ca-staging-eks-cluster*2fapplication))
)



# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.