### PR TITLE
Feat/scaffold UI test user on demand

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -262,7 +262,7 @@ def register_blueprint(application):
 
     register_notify_blueprint(application, template_category_blueprint, requires_admin_auth)
 
-    register_notify_blueprint(application, cypress_blueprint, requires_no_auth, "/cypress")
+    register_notify_blueprint(application, cypress_blueprint, requires_admin_auth, "/cypress")
 
 def register_v2_blueprints(application):
     from app.authentication.auth import requires_auth

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -207,7 +207,7 @@ def register_blueprint(application):
         template_statistics as template_statistics_blueprint,
     )
     from app.user.rest import user_blueprint
-
+    from app.cypress.rest import cypress_blueprint
     register_notify_blueprint(application, service_blueprint, requires_admin_auth, "/service")
 
     register_notify_blueprint(application, user_blueprint, requires_admin_auth, "/user")
@@ -262,6 +262,7 @@ def register_blueprint(application):
 
     register_notify_blueprint(application, template_category_blueprint, requires_admin_auth)
 
+    register_notify_blueprint(application, cypress_blueprint, requires_no_auth, "/cypress")
 
 def register_v2_blueprints(application):
     from app.authentication.auth import requires_auth

--- a/app/config.py
+++ b/app/config.py
@@ -344,6 +344,9 @@ class Config(object):
     DEFAULT_TEMPLATE_CATEGORY_MEDIUM = "f75d6706-21b7-437e-b93a-2c0ab771e28e"
     DEFAULT_TEMPLATE_CATEGORY_HIGH = "c4f87d7c-a55b-4c0f-91fe-e56c65bb1871"
 
+    # UUIDs for Cypress tests
+    CYPRESS_SERVICE = "c6e8d4f1-6999-4b0f-8f3e-0e1f7b7b1f1e"
+    
     # Allowed service IDs able to send HTML through their templates.
     ALLOW_HTML_SERVICE_IDS: List[str] = [id.strip() for id in os.getenv("ALLOW_HTML_SERVICE_IDS", "").split(",")]
 

--- a/app/cypress/rest.py
+++ b/app/cypress/rest.py
@@ -1,22 +1,27 @@
 import uuid
 from flask import Blueprint, jsonify, request
 
+from app import db
+from app.dao.services_dao import dao_add_user_to_service
+from app.dao.templates_dao import dao_update_template
 from app.dao.users_dao import save_model_user
 from app.errors import register_errors
-from app.models import User
+from app.models import LoginEvent, Permission, Service, ServiceUser, Template, TemplateHistory, User, VerifyCode
 
 cypress_blueprint = Blueprint("cypress", __name__)
 register_errors(cypress_blueprint)
 
+CYPRESS_SERVICE_ID = "5c8a0501-2aa8-433a-ba51-cefb8063ab93"
+NOTIFY_TEST_USER_ID = "5e8fdc9b-4080-430d-962a-8065a1a17274"
 
-@cypress_blueprint.route("/start_test_suite/<email_name>", methods=["GET"])
+@cypress_blueprint.route("/create_user/<email_name>", methods=["GET"])
 def create_test_user(email_name):
     # Create the user
     data = {
         "id": uuid.uuid4(),
         "name": "Notify UI testing account",
         "email_address": f"notify-ui-tests+{email_name}@cds-snc.ca",
-        "password": "", # TODO: move this to a secret!
+        "password": "1a38490122e3455643d7b7d5f9f98c00765aed1a2b27227cb915f33737f2040f", # TODO: move this to a secret!
         "mobile_number": "9025555555",
         "state": "active",
         "blocked": False,
@@ -26,19 +31,64 @@ def create_test_user(email_name):
     save_model_user(user)
 
     # add user to cypress service w/ full permissions
+    service = Service.query.filter_by(id="5c8a0501-2aa8-433a-ba51-cefb8063ab93").first()
+    permissions = []
+    for p in ["manage_users", "manage_templates", "manage_settings", "send_texts", "send_emails", "send_letters", "manage_api_keys", "view_activity"]:
+        permissions.append(Permission(permission=p))
+    
+    dao_add_user_to_service(service, user, permissions=permissions)
+
     # things to delete
     # login_events
     # verify_codes
 
     return jsonify(user.serialize()), 201
 
-@cypress_blueprint.route("/end_test_suite/<email_name>", methods=["GET"])
-def create_test_user(email_name):
-    # Delete the user
-    # Things to remove:
-    # login_events
-    # verify_codes
-    # user
-    
 
-    return jsonify(message="yo"), 201
+@cypress_blueprint.route("/destroy_user/<email_name>", methods=["GET"])
+def destroy_user(email_name):
+    user = User.query.filter_by(email_address=f"notify-ui-tests+{email_name}@cds-snc.ca").first()
+    
+    if not user:
+        return
+    
+    # update the created_by field for each template to use id NOTIFY_TEST_USER_ID
+    templates = Template.query.filter_by(created_by=user).all()
+    for template in templates:
+        template.created_by_id = NOTIFY_TEST_USER_ID
+        dao_update_template(template)
+
+    # update the created_by field for each template to use id NOTIFY_TEST_USER_ID
+    history_templates = TemplateHistory.query.filter_by(created_by=user).all()
+    for templateh in history_templates:
+        templateh.created_by_id = NOTIFY_TEST_USER_ID
+        db.session.add(templateh)
+
+    # remove all the login events for this user
+    LoginEvent.query.filter_by(user=user).delete()
+
+    # remove all permissions for this user
+    Permission.query.filter_by(user=user).delete()
+    
+    # remove user_to_service entries
+    ServiceUser.query.filter_by(user_id=user.id).delete()
+
+    # remove verify codes
+    VerifyCode.query.filter_by(user=user).delete()
+    
+    # remove the user
+    User.query.filter_by(email_address=f"notify-ui-tests+{email_name}@cds-snc.ca").delete()
+
+    db.session.commit()
+
+    return jsonify(message="Zeds dead, baby"), 201
+
+@cypress_blueprint.route("/cleanup", methods=["GET"])
+def cleanup_users():
+    users = User.query.filter(User.email_address.like(f"%notify-ui-tests+%@cds-snc.ca%"))
+
+    # loop through users and call destroy_user on each one
+    for user in users:
+        user_email = user.email_address.split("+")[1].split("@")[0]
+        print(user_email)
+        destroy_user(user_email)

--- a/app/cypress/rest.py
+++ b/app/cypress/rest.py
@@ -1,0 +1,44 @@
+import uuid
+from flask import Blueprint, jsonify, request
+
+from app.dao.users_dao import save_model_user
+from app.errors import register_errors
+from app.models import User
+
+cypress_blueprint = Blueprint("cypress", __name__)
+register_errors(cypress_blueprint)
+
+
+@cypress_blueprint.route("/start_test_suite/<email_name>", methods=["GET"])
+def create_test_user(email_name):
+    # Create the user
+    data = {
+        "id": uuid.uuid4(),
+        "name": "Notify UI testing account",
+        "email_address": f"notify-ui-tests+{email_name}@cds-snc.ca",
+        "password": "", # TODO: move this to a secret!
+        "mobile_number": "9025555555",
+        "state": "active",
+        "blocked": False,
+    }
+    
+    user = User(**data)
+    save_model_user(user)
+
+    # add user to cypress service w/ full permissions
+    # things to delete
+    # login_events
+    # verify_codes
+
+    return jsonify(user.serialize()), 201
+
+@cypress_blueprint.route("/end_test_suite/<email_name>", methods=["GET"])
+def create_test_user(email_name):
+    # Delete the user
+    # Things to remove:
+    # login_events
+    # verify_codes
+    # user
+    
+
+    return jsonify(message="yo"), 201


### PR DESCRIPTION
# Summary | Résumé
- Add API to create cypress test users and clean them up on demand

## Related Issues | Cartes liées


# Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.