### PR TITLE
add boto call latency for sending to internal sms number

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -491,6 +491,7 @@ class Config(object):
     }
     CELERY_QUEUES: List[Any] = []
     CELERY_DELIVER_SMS_RATE_LIMIT = os.getenv("CELERY_DELIVER_SMS_RATE_LIMIT", "1/s")
+    AWS_SEND_SMS_BOTO_CALL_LATENCY = os.getenv("AWS_SEND_SMS_BOTO_CALL_LATENCY", 0.06) # average delay in production 
 
     CONTACT_FORM_EMAIL_ADDRESS = os.getenv("CONTACT_FORM_EMAIL_ADDRESS", "helpdesk@cds-snc.ca")
 

--- a/app/config.py
+++ b/app/config.py
@@ -491,7 +491,7 @@ class Config(object):
     }
     CELERY_QUEUES: List[Any] = []
     CELERY_DELIVER_SMS_RATE_LIMIT = os.getenv("CELERY_DELIVER_SMS_RATE_LIMIT", "1/s")
-    AWS_SEND_SMS_BOTO_CALL_LATENCY = os.getenv("AWS_SEND_SMS_BOTO_CALL_LATENCY", 0.06) # average delay in production 
+    AWS_SEND_SMS_BOTO_CALL_LATENCY = os.getenv("AWS_SEND_SMS_BOTO_CALL_LATENCY", 0.06)  # average delay in production
 
     CONTACT_FORM_EMAIL_ADDRESS = os.getenv("CONTACT_FORM_EMAIL_ADDRESS", "helpdesk@cds-snc.ca")
 

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -2,9 +2,9 @@ import base64
 import os
 import re
 from datetime import datetime
+from time import sleep
 from typing import Any, Dict, Optional
 from uuid import UUID
-from time import sleep
 
 import phonenumbers
 from flask import current_app
@@ -106,8 +106,10 @@ def send_sms_to_provider(notification):
             notification.reference = send_sms_response(provider.get_name(), notification.to)
             notification.billable_units = template.fragment_count
             update_notification_to_sending(notification, provider)
-            current_app.logger.info(f"Sleeping {current_app.config['AWS_SEND_SMS_BOTO_CALL_LATENCY']} seconds to simulate AWS boto call latency.")
-            sleep(current_app.config["AWS_SEND_SMS_BOTO_CALL_LATENCY"]) # simulate boto3 client send_sms() delay
+            current_app.logger.info(
+                f"Sleeping {current_app.config['AWS_SEND_SMS_BOTO_CALL_LATENCY']} seconds to simulate AWS boto call latency."
+            )
+            sleep(current_app.config["AWS_SEND_SMS_BOTO_CALL_LATENCY"])  # simulate boto3 client send_sms() delay
         else:
             try:
                 template_category_id = template_dict.get("template_category_id")

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -4,6 +4,7 @@ import re
 from datetime import datetime
 from typing import Any, Dict, Optional
 from uuid import UUID
+from time import sleep
 
 import phonenumbers
 from flask import current_app
@@ -99,13 +100,14 @@ def send_sms_to_provider(notification):
 
         elif (
             validate_and_format_phone_number(notification.to, international=notification.international)
-            == Config.INTERNAL_TEST_NUMBER
+            == current_app.config["INTERNAL_TEST_NUMBER"]
         ):
-            current_app.logger.info(f"notification {notification.id} sending to internal test number. Not sending to AWS")
+            current_app.logger.info(f"notification {notification.id} sending to internal test number. Not sending to AWS.")
             notification.reference = send_sms_response(provider.get_name(), notification.to)
             notification.billable_units = template.fragment_count
             update_notification_to_sending(notification, provider)
-
+            current_app.logger.info(f"Sleeping {current_app.config['AWS_SEND_SMS_BOTO_CALL_LATENCY']} seconds to simulate AWS boto call latency.")
+            sleep(current_app.config["AWS_SEND_SMS_BOTO_CALL_LATENCY"]) # simulate boto3 client send_sms() delay
         else:
             try:
                 template_category_id = template_dict.get("template_category_id")


### PR DESCRIPTION
# Summary | Résumé

`sleep` for a bit to simulate the [production average latency of the AWS send_sms network call](https://ca-central-1.console.aws.amazon.com/cloudwatch/home?region=ca-central-1#metricsV2?graph=~(metrics~(~(~'NotificationCanadaCa~'production_notifications_celery_clients_pinpoint_request-time~'metric_type~'timing~(id~'m1)))~view~'timeSeries~stacked~false~region~'ca-central-1~stat~'Average~period~300~title~'p90*20Pinpoint*20request*20time*20in*20ms~start~'-PT3H~end~'P0D)) when we're sending to the `INTERNAL_TEST_NUMBER` (which does not perform the real network call).

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/396

# Test instructions | Instructions pour tester la modification

- send to yourself. You should not see the sleep logging line
- send to 16135550123. You should see the sleep logging line.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [x] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [x] This PR does not significantly alter performance.
- [x] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.