### PR TITLE
Add utility endpoint for e2e cypress testing

### DIFF
--- a/app/dao/service_callback_api_dao.py
+++ b/app/dao/service_callback_api_dao.py
@@ -55,7 +55,7 @@ def resign_service_callbacks(resign: bool, unsafe: bool = False):
 @transactional
 @version_class(ServiceCallbackApi)
 def save_service_callback_api(service_callback_api):
-    service_callback_api.id = create_uuid()
+    service_callback_api.id = create_uuid() if not service_callback_api.id else service_callback_api.id
     service_callback_api.created_at = datetime.utcnow()
     db.session.add(service_callback_api)
 
@@ -93,6 +93,18 @@ def get_service_complaint_callback_api_for_service(service_id) -> ServiceCallbac
 @transactional
 def delete_service_callback_api(service_callback_api):
     db.session.delete(service_callback_api)
+
+
+# Used by Cypress to clean up test data
+@transactional
+def delete_service_callback_api_history(service_callback_api: ServiceCallbackApi):
+    callback_history = (
+        service_callback_api.get_history_model()
+        .query.filter_by(service_id=service_callback_api.service_id, id=service_callback_api.id)
+        .all()
+    )
+    for history in callback_history:
+        db.session.delete(history)
 
 
 @transactional

--- a/app/service/service_callback_api_schema.py
+++ b/app/service/service_callback_api_schema.py
@@ -6,6 +6,7 @@ create_service_callback_api_schema = {
     "type": "object",
     "title": "Create service callback/inbound api",
     "properties": {
+        "id": uuid,
         "url": https_url,
         "bearer_token": {"type": "string", "minLength": 10},
         "updated_by_id": uuid,


### PR DESCRIPTION
# Summary | Résumé
This PR adds a utility Admin endpoint that supports Cypress UI tests. 

- Allow specifying a desired `id` when saving a callback so we can more easily manage test data in the DB
- The utility endpoint cleans up the `service_callback_api` and `service_callback_api_history` table in the DB

## Related Issues | Cartes liées
* https://github.com/cds-snc/notification-admin/pull/1955

# Test instructions | Instructions pour tester la modification

1. Pull down this PR and run it locally
2. Run the Cypress tests found in [this PR](https://github.com/cds-snc/notification-admin/pull/1955)

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.