### PR TITLE
Freshdesk: fix template link

### DIFF
--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -532,7 +532,7 @@ def send_new_template_category_request(user_id):
             service_id=data["service_id"],
             template_category_name_en=data["template_category_name_en"],
             template_category_name_fr=data["template_category_name_fr"],
-            template_id_link=f"https://{current_app.config['ADMIN_BASE_URL']}/services/{data['service_id']}/templates/{data['template_id']}",
+            template_id_link=f"{current_app.config['ADMIN_BASE_URL']}/services/{data['service_id']}/templates/{data['template_id']}",
         )
         contact.tags = ["z_skip_opsgenie", "z_skip_urgent_escalation"]
 


### PR DESCRIPTION
# Summary | Résumé

Fix the template link as we were sending https:// twice
<img width="307" alt="Screenshot 2024-09-23 at 3 58 17 PM" src="https://github.com/user-attachments/assets/11671bd5-d5b8-4686-8894-f0db00e8112e">
