### PR TITLE
Add date utility for retention queries

### DIFF
--- a/app/dao/date_util.py
+++ b/app/dao/date_util.py
@@ -1,5 +1,5 @@
 import os
-from datetime import date, datetime, time, timedelta
+from datetime import date, datetime, time, timedelta, timezone
 
 import pytz
 from notifications_utils.strftime_codes import no_pad_month
@@ -104,3 +104,10 @@ def utc_midnight_n_days_ago(number_of_days):
     Returns utc midnight a number of days ago.
     """
     return get_midnight(datetime.utcnow() - timedelta(days=number_of_days))
+
+
+def get_query_date_based_on_retention_period(retention_period):
+    """
+    Computes a date to be used when querying for notifications based on retention period
+    """
+    return datetime.combine(datetime.now(timezone.utc) - timedelta(days=retention_period), time.max)


### PR DESCRIPTION
# Summary | Résumé

This PR adds a utility function that will compute the date value to use when query notifications based on retention date.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/1651

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [x] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [x] This PR does not significantly alter performance.
- [x] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.