### PR TITLE
Update date in `dao_get_jobs_by_service_id`

### DIFF
--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -12,6 +12,7 @@ from sqlalchemy import asc, desc, func
 
 from app import db
 from app.dao.dao_utils import transactional
+from app.dao.date_util import get_query_date_based_on_retention_period
 from app.dao.templates_dao import dao_get_template_by_id
 from app.models import (
     JOB_STATUS_CANCELLED,
@@ -58,7 +59,8 @@ def dao_get_jobs_by_service_id(service_id, limit_days=None, page=1, page_size=50
         Job.original_file_name != current_app.config["ONE_OFF_MESSAGE_FILENAME"],
     ]
     if limit_days is not None:
-        query_filter.append(Job.created_at >= midnight_n_days_ago(limit_days))
+        query_filter.append(Job.created_at > get_query_date_based_on_retention_period(limit_days))
+
     if statuses is not None and statuses != [""]:
         query_filter.append(Job.job_status.in_(statuses))
     return (

--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -29,7 +29,6 @@ from app.models import (
     ServiceDataRetention,
     Template,
 )
-from app.utils import midnight_n_days_ago
 
 
 @statsd(namespace="dao")

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -163,16 +163,17 @@ def test_get_jobs_for_service_with_limit_days_param(sample_template):
 @freeze_time("2024-09-25 12:25:00")
 def test_get_jobs_for_service_with_limit_days_edge_case(sample_template):
     one_job = create_job(sample_template)
-    # create 1 job for each day of the last 10 days
-    for i in range(1, 10):
-        create_job(sample_template, created_at=datetime(2024, 9, 25 - i, i, 0, 0))
+    # create 2 jobs for each day of the last 10 days
+    for i in range(1, 11):
+        create_job(sample_template, created_at=datetime(2024, 9, 25 - i, 0, 0, 0))
+        create_job(sample_template, created_at=datetime(2024, 9, 25 - i, 23, 59, 59))
 
     too_old_job = create_job(sample_template, created_at=datetime(2024, 9, 18, 0, 1, 0))
     just_right_job = create_job(sample_template, created_at=datetime(2024, 9, 19, 0, 0, 0))
 
     jobs_limit_days = dao_get_jobs_by_service_id(one_job.service_id, limit_days=7).items
 
-    assert len(jobs_limit_days) == 8  # one for each day: today (1) + the last 6 days (6) + one for just_right_job (1)
+    assert len(jobs_limit_days) == 14  # 2 for one for each day: today (1) + 12 the last 6 days (12) + one for just_right_job (1)
     assert one_job in jobs_limit_days
     assert just_right_job in jobs_limit_days
     assert too_old_job not in jobs_limit_days

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -160,18 +160,22 @@ def test_get_jobs_for_service_with_limit_days_param(sample_template):
     assert old_job not in jobs_limit_days
 
 
-@freeze_time("2017-06-10")
-# This test assumes the local timezone is EST
+@freeze_time("2024-09-25 12:25:00")
 def test_get_jobs_for_service_with_limit_days_edge_case(sample_template):
     one_job = create_job(sample_template)
-    just_after_midnight_job = create_job(sample_template, created_at=datetime(2017, 6, 3, 4, 0, 1))
-    just_before_midnight_job = create_job(sample_template, created_at=datetime(2017, 6, 3, 3, 59, 0))
+    # create 1 job for each day of the last 10 days
+    for i in range(1, 10):
+        create_job(sample_template, created_at=datetime(2024, 9, 25 - i, i, 0, 0))
+
+    too_old_job = create_job(sample_template, created_at=datetime(2024, 9, 18, 0, 1, 0))
+    just_right_job = create_job(sample_template, created_at=datetime(2024, 9, 19, 0, 0, 0))
 
     jobs_limit_days = dao_get_jobs_by_service_id(one_job.service_id, limit_days=7).items
-    assert len(jobs_limit_days) == 2
+
+    assert len(jobs_limit_days) == 8  # one for each day: today (1) + the last 6 days (6) + one for just_right_job (1)
     assert one_job in jobs_limit_days
-    assert just_after_midnight_job in jobs_limit_days
-    assert just_before_midnight_job not in jobs_limit_days
+    assert just_right_job in jobs_limit_days
+    assert too_old_job not in jobs_limit_days
 
 
 def test_get_jobs_for_service_in_processed_at_then_created_at_order(notify_db, notify_db_session, sample_template):

--- a/tests/app/job/test_rest.py
+++ b/tests/app/job/test_rest.py
@@ -751,7 +751,9 @@ def test_get_jobs_with_limit_days(admin_request, sample_template):
             limit_days=7,
         )
 
-    assert len(resp_json["data"]) == 2
+    # get_jobs_by_service should return data from the current day (Monday 9th) and the previous 6 days (Tuesday 3rd)
+    # so only 1 job should be returned
+    assert len(resp_json["data"]) == 1
 
 
 def test_get_jobs_should_return_statistics(admin_request, sample_template):


### PR DESCRIPTION
# Summary | Résumé

This PR updates the date used in `dao_get_jobs_by_service_id` as part of the [Dashboard Errors epic](https://github.com/cds-snc/notification-planning/issues/1651).

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/1651

# Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.