### PR TITLE
Improve callback failure logging to include service_id

### DIFF
--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -136,7 +136,7 @@ def timeout_notifications():
         if service_callback_api:
             signed_notification = create_delivery_status_callback_data(notification, service_callback_api)
             send_delivery_status_to_service.apply_async(
-                [str(notification.id), signed_notification],
+                [str(notification.id), signed_notification, notification.service_id],
                 queue=QueueNames.CALLBACKS,
             )
 

--- a/app/celery/service_callback_tasks.py
+++ b/app/celery/service_callback_tasks.py
@@ -10,7 +10,7 @@ from app.config import QueueNames
 
 @notify_celery.task(bind=True, name="send-delivery-status", max_retries=5, default_retry_delay=300)
 @statsd(namespace="tasks")
-def send_delivery_status_to_service(self, notification_id, signed_status_update):
+def send_delivery_status_to_service(self, notification_id, signed_status_update, service_id):
     status_update = signer_delivery_status.verify(signed_status_update)
 
     data = {
@@ -27,6 +27,7 @@ def send_delivery_status_to_service(self, notification_id, signed_status_update)
     }
     _send_data_to_service_callback_api(
         self,
+        service_id,
         data,
         status_update["service_callback_api_url"],
         status_update["service_callback_api_bearer_token"],
@@ -36,7 +37,7 @@ def send_delivery_status_to_service(self, notification_id, signed_status_update)
 
 @notify_celery.task(bind=True, name="send-complaint", max_retries=5, default_retry_delay=300)
 @statsd(namespace="tasks")
-def send_complaint_to_service(self, complaint_data):
+def send_complaint_to_service(self, complaint_data, service_id):
     complaint = signer_complaint.verify(complaint_data)
 
     data = {
@@ -49,6 +50,7 @@ def send_complaint_to_service(self, complaint_data):
 
     _send_data_to_service_callback_api(
         self,
+        service_id,
         data,
         complaint["service_callback_api_url"],
         complaint["service_callback_api_bearer_token"],
@@ -56,10 +58,12 @@ def send_complaint_to_service(self, complaint_data):
     )
 
 
-def _send_data_to_service_callback_api(self, data, service_callback_url, token, function_name):
+def _send_data_to_service_callback_api(self, service_id, data, service_callback_url, token, function_name):
     notification_id = data["notification_id"] if "notification_id" in data else data["id"]
     try:
-        current_app.logger.info("{} sending {} to {}".format(function_name, notification_id, service_callback_url))
+        current_app.logger.info(
+            "{} sending {} to {} service: {}".format(function_name, notification_id, service_callback_url, service_id)
+        )
         response = request(
             method="POST",
             url=service_callback_url,
@@ -72,13 +76,13 @@ def _send_data_to_service_callback_api(self, data, service_callback_url, token, 
         )
 
         current_app.logger.info(
-            f"{function_name} sending {notification_id} to {service_callback_url}, response {response.status_code}"
+            f"{function_name} sent {notification_id} to {service_callback_url} service: {service_id}, response {response.status_code}"
         )
 
         response.raise_for_status()
     except RequestException as e:
         current_app.logger.warning(
-            f"{function_name} request failed for notification_id: {notification_id} and url: {service_callback_url}. exc: {e}"
+            f"{function_name} request failed for notification_id: {notification_id} to url: {service_callback_url} for service: {service_id} exc: {e}"
         )
         # Retry if the response status code is server-side or 429 (too many requests).
         if not isinstance(e, HTTPError) or e.response.status_code >= 500 or e.response.status_code == 429:
@@ -86,5 +90,5 @@ def _send_data_to_service_callback_api(self, data, service_callback_url, token, 
                 self.retry(queue=QueueNames.CALLBACKS_RETRY)
             except self.MaxRetriesExceededError:
                 current_app.logger.warning(
-                    "Retry: {function_name} has retried the max num of times for callback url {service_callback_url} and notification_id: {notification_id}"
+                    "Retry: {function_name} has retried the max num of times for callback url {service_callback_url} notification_id: {notification_id} service: {service_id}"
                 )

--- a/app/commands/support.py
+++ b/app/commands/support.py
@@ -117,7 +117,7 @@ def replay_service_callbacks(file_name, service_id):
             "service_callback_api_bearer_token": callback_api.bearer_token,
         }
         signed_status_update = signer_delivery_status.sign(data)
-        send_delivery_status_to_service.apply_async([str(n.id), signed_status_update], queue=QueueNames.CALLBACKS)
+        send_delivery_status_to_service.apply_async([str(n.id), signed_status_update, service_id], queue=QueueNames.CALLBACKS)
 
     print(
         "Replay service status for service: {}. Sent {} notification status updates to the queue".format(

--- a/app/notifications/callbacks.py
+++ b/app/notifications/callbacks.py
@@ -23,7 +23,9 @@ def _check_and_queue_callback_task(notification):
             return
 
         notification_data = create_delivery_status_callback_data(notification, service_callback_api)
-        send_delivery_status_to_service.apply_async([str(notification.id), notification_data], queue=QueueNames.CALLBACKS)
+        send_delivery_status_to_service.apply_async(
+            [str(notification.id), notification_data, notification.service_id], queue=QueueNames.CALLBACKS
+        )
 
 
 def create_delivery_status_callback_data(notification, service_callback_api):

--- a/app/notifications/notifications_ses_callback.py
+++ b/app/notifications/notifications_ses_callback.py
@@ -206,4 +206,4 @@ def _check_and_queue_complaint_callback_task(complaint, notification, recipient)
     service_callback_api = get_service_complaint_callback_api_for_service(service_id=notification.service_id)
     if service_callback_api:
         complaint_data = create_complaint_callback_data(complaint, notification, service_callback_api, recipient)
-        send_complaint_to_service.apply_async([complaint_data], queue=QueueNames.CALLBACKS)
+        send_complaint_to_service.apply_async([complaint_data, notification.service_id], queue=QueueNames.CALLBACKS)

--- a/app/notifications/process_client_response.py
+++ b/app/notifications/process_client_response.py
@@ -53,7 +53,7 @@ def _process_for_status(notification_status, client_name, provider_reference):
         if service_callback_api:
             signed_notification = create_delivery_status_callback_data(notification, service_callback_api)
             send_delivery_status_to_service.apply_async(
-                [str(notification.id), signed_notification],
+                [str(notification.id), signed_notification, notification.service_id],
                 queue=QueueNames.CALLBACKS,
             )
 

--- a/tests/app/celery/test_nightly_tasks.py
+++ b/tests/app/celery/test_nightly_tasks.py
@@ -244,7 +244,7 @@ def test_timeout_notifications_sends_status_update_to_service(client, sample_tem
     timeout_notifications()
 
     signed_data = create_delivery_status_callback_data(notification, callback_api)
-    mocked.assert_called_once_with([str(notification.id), signed_data], queue=QueueNames.CALLBACKS)
+    mocked.assert_called_once_with([str(notification.id), signed_data, notification.service_id], queue=QueueNames.CALLBACKS)
 
 
 def test_send_daily_performance_stats_calls_does_not_send_if_inactive(client, mocker):

--- a/tests/app/celery/test_process_pinpoint_receipts_tasks.py
+++ b/tests/app/celery/test_process_pinpoint_receipts_tasks.py
@@ -239,4 +239,6 @@ def test_process_pinpoint_results_calls_service_callback(sample_template, notify
         statsd_client.incr.assert_any_call("callback.pinpoint.delivered")
         updated_notification = get_notification_by_id(notification.id)
         signed_data = create_delivery_status_callback_data(updated_notification, callback_api)
-        mock_send_status.assert_called_once_with([str(notification.id), signed_data], queue="service-callbacks")
+        mock_send_status.assert_called_once_with(
+            [str(notification.id), signed_data, notification.service_id], queue="service-callbacks"
+        )

--- a/tests/app/celery/test_process_ses_receipts_tasks.py
+++ b/tests/app/celery/test_process_ses_receipts_tasks.py
@@ -121,7 +121,9 @@ def test_ses_callback_should_update_notification_status(notify_db, notify_db_ses
         statsd_client.incr.assert_any_call("callback.ses.delivered")
         updated_notification = Notification.query.get(notification.id)
         encrypted_data = create_delivery_status_callback_data(updated_notification, callback_api)
-        send_mock.assert_called_once_with([str(notification.id), encrypted_data], queue="service-callbacks")
+        send_mock.assert_called_once_with(
+            [str(notification.id), encrypted_data, notification.service_id], queue="service-callbacks"
+        )
 
 
 def test_ses_callback_dont_change_hard_bounce_status(sample_template, mocker):

--- a/tests/app/celery/test_process_sns_receipts_tasks.py
+++ b/tests/app/celery/test_process_sns_receipts_tasks.py
@@ -188,4 +188,4 @@ def test_process_sns_results_calls_service_callback(sample_template, notify_db_s
         statsd_client.incr.assert_any_call("callback.sns.delivered")
         updated_notification = get_notification_by_id(notification.id)
         signed_data = create_delivery_status_callback_data(updated_notification, callback_api)
-        send_mock.assert_called_once_with([str(notification.id), signed_data], queue="service-callbacks")
+        send_mock.assert_called_once_with([str(notification.id), signed_data, notification.service_id], queue="service-callbacks")

--- a/tests/app/notifications/test_callbacks.py
+++ b/tests/app/notifications/test_callbacks.py
@@ -86,7 +86,7 @@ def test_check_and_queue_callback_task_calls_delivery_task(
         _check_and_queue_callback_task(notification)
 
         mock_apply_async.assert_called_once_with(
-            [str(notification.id), create_delivery_status_callback_data(notification, callback_api)],
+            [str(notification.id), create_delivery_status_callback_data(notification, callback_api), notification.service_id],
             queue="service-callbacks",
         )
 


### PR DESCRIPTION
# Summary | Résumé

This PR adds the `service_id` to our callback failure logs so we do not have to track down the service based on the `notification_id` when we need to send warning / suspension emails.


# Test instructions | Instructions pour tester la modification

Observe logging post-merge to ensure the `service_id` is present.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.