### PR TITLE
Fix the update for facts notifications

### DIFF
--- a/app/celery/reporting_tasks.py
+++ b/app/celery/reporting_tasks.py
@@ -102,10 +102,10 @@ def create_nightly_notification_status_for_day(process_day):
         current_app.logger.info(
             "create-nightly-notification-status-for-day {} fetched in {} seconds".format(process_day, (end - start).seconds)
         )
-        update_fact_notification_status(transit_data, process_day)
+        update_fact_notification_status(transit_data, process_day, service_ids=chunk)
 
         current_app.logger.info(
             "create-nightly-notification-status-for-day task complete: {} rows updated for day: {}, for service_ids: {}".format(
-                len(transit_data), process_day, service_ids
+                len(transit_data), process_day, chunk
             )
         )

--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -104,9 +104,14 @@ def query_for_fact_status_data(table, start_date, end_date, notification_type, s
     return query.all()
 
 
-def update_fact_notification_status(data, process_day):
+def update_fact_notification_status(data, process_day, service_ids=None):
     table = FactNotificationStatus.__table__
-    FactNotificationStatus.query.filter(FactNotificationStatus.bst_date == process_day).delete()
+    if service_ids:
+        FactNotificationStatus.query.filter(
+            FactNotificationStatus.bst_date == process_day, FactNotificationStatus.service_id.in_(service_ids)
+        ).delete()
+    else:
+        FactNotificationStatus.query.filter(FactNotificationStatus.bst_date == process_day).delete()
 
     for row in data:
         stmt = insert(table).values(

--- a/tests/app/dao/test_fact_notification_status_dao.py
+++ b/tests/app/dao/test_fact_notification_status_dao.py
@@ -105,31 +105,58 @@ def test_update_fact_notification_status(notify_db_session):
     assert new_fact_data[2].notification_count == 1
 
 
-def test__update_fact_notification_status_updates_row(notify_db_session):
-    first_service = create_service(service_name="First Service")
-    first_template = create_template(service=first_service)
-    save_notification(create_notification(template=first_template, status="delivered"))
+class TestUpdateFactNotificationStatus:
+    def test_update_fact_notification_status_updates_row(self, notify_db_session):
+        first_service = create_service(service_name="First Service")
+        first_template = create_template(service=first_service)
+        save_notification(create_notification(template=first_template, status="delivered"))
 
-    process_day = convert_utc_to_local_timezone(datetime.utcnow())
-    data = fetch_notification_status_for_day(process_day=process_day)
-    update_fact_notification_status(data=data, process_day=process_day.date())
+        process_day = convert_utc_to_local_timezone(datetime.utcnow())
+        data = fetch_notification_status_for_day(process_day=process_day)
+        update_fact_notification_status(data=data, process_day=process_day.date())
 
-    new_fact_data = FactNotificationStatus.query.order_by(
-        FactNotificationStatus.bst_date, FactNotificationStatus.notification_type
-    ).all()
-    assert len(new_fact_data) == 1
-    assert new_fact_data[0].notification_count == 1
+        new_fact_data = FactNotificationStatus.query.order_by(
+            FactNotificationStatus.bst_date, FactNotificationStatus.notification_type
+        ).all()
+        assert len(new_fact_data) == 1
+        assert new_fact_data[0].notification_count == 1
 
-    save_notification(create_notification(template=first_template, status="delivered"))
+        save_notification(create_notification(template=first_template, status="delivered"))
 
-    data = fetch_notification_status_for_day(process_day=process_day)
-    update_fact_notification_status(data=data, process_day=process_day.date())
+        data = fetch_notification_status_for_day(process_day=process_day)
+        update_fact_notification_status(data=data, process_day=process_day.date())
 
-    updated_fact_data = FactNotificationStatus.query.order_by(
-        FactNotificationStatus.bst_date, FactNotificationStatus.notification_type
-    ).all()
-    assert len(updated_fact_data) == 1
-    assert updated_fact_data[0].notification_count == 2
+        updated_fact_data = FactNotificationStatus.query.order_by(
+            FactNotificationStatus.bst_date, FactNotificationStatus.notification_type
+        ).all()
+        assert len(updated_fact_data) == 1
+        assert updated_fact_data[0].notification_count == 2
+
+    @freeze_time("2018-10-3T18:00:00")
+    def test_update_fact_notification_status_where_service_id_exits(self, notify_db_session):
+        """
+        We have exisiting data for 2018-1-1 in the facts table, with count = 4, we are going to update facts
+        for that day with only 1 notification, so the count should be updated to 1
+        """
+        service_1 = create_service(service_name="service_1")
+
+        create_ft_notification_status(date(2018, 1, 1), "sms", service_1, count=4)
+        create_ft_notification_status(date(2018, 1, 2), "sms", service_1, count=10)
+
+        first_template = create_template(service=service_1)
+        save_notification(
+            create_notification(template=first_template, status="delivered", created_at=datetime(2018, 1, 1, 12, 0, 0))
+        )
+        data = fetch_notification_status_for_day(process_day=datetime(2018, 1, 1))
+        update_fact_notification_status(data=data, process_day=date(2018, 1, 1), service_ids=[service_1.id])
+        updated_fact_data = FactNotificationStatus.query.order_by(
+            FactNotificationStatus.bst_date, FactNotificationStatus.notification_type
+        ).all()
+        assert len(updated_fact_data) == 2
+        assert (
+            updated_fact_data[0].notification_count == 1
+        )  # this means the data was deleted for 2018-1-1 and count was updated to 1 notification
+        assert updated_fact_data[1].notification_count == 10  # this means the data for 2018-1-2 was not touched
 
 
 def test_fetch_notification_status_for_service_by_month(notify_db_session):


### PR DESCRIPTION
# Summary | Résumé

When we are updating the facts notification table, we don't want to delete all the data for the day, instead we only want to delete the data for the service_ids we are updating. This updates the function so we might do that.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1
* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/1

# Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.