### PR TITLE
Update `get_notifications_for_service`

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -25,7 +25,7 @@ from werkzeug.datastructures import MultiDict
 
 from app import create_uuid, db, signer_personalisation
 from app.dao.dao_utils import transactional
-from app.dao.date_util import utc_midnight_n_days_ago
+from app.dao.date_util import get_query_date_based_on_retention_period
 from app.errors import InvalidRequest
 from app.models import (
     EMAIL_TYPE,
@@ -329,7 +329,7 @@ def get_notifications_for_service(
     filters = [Notification.service_id == service_id]
 
     if limit_days is not None:
-        filters.append(Notification.created_at >= utc_midnight_n_days_ago(limit_days))
+        filters.append(Notification.created_at > get_query_date_based_on_retention_period(limit_days))
 
     if older_than is not None:
         older_than_created_at = db.session.query(Notification.created_at).filter(Notification.id == older_than).as_scalar()

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -1895,13 +1895,15 @@ class TestResigning:
             assert notification.personalisation == personalisation  # unsigned value is the same
             assert notification._personalisation != _personalisation  # signature is different
 
+
 @freeze_time("2024-09-25 12:25:00")
 def test_get_notifications_for_service(sample_template):
     # create notifications for the past 10 days
     for i in range(1, 11):
-        save_notification(create_notification(sample_template, client_reference="xyz",created_at=datetime(2024, 9, 26-i, 23, 59, 59)))
+        save_notification(
+            create_notification(sample_template, client_reference="xyz", created_at=datetime(2024, 9, 26 - i, 23, 59, 59))
+        )
 
     # ensure as we increase limit_days by 1, we get 1 more notification in the total each time
-    for i in range(1, 11):    
+    for i in range(1, 11):
         assert len(get_notifications_for_service(sample_template.service_id, limit_days=i).items) == i
-

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -41,7 +41,6 @@ from app.dao.notifications_dao import (
 )
 from app.dao.organisation_dao import dao_add_service_to_organisation
 from app.models import (
-    EMAIL_TYPE,
     JOB_STATUS_IN_PROGRESS,
     JOB_STATUS_PENDING,
     KEY_TYPE_NORMAL,

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -41,6 +41,7 @@ from app.dao.notifications_dao import (
 )
 from app.dao.organisation_dao import dao_add_service_to_organisation
 from app.models import (
+    EMAIL_TYPE,
     JOB_STATUS_IN_PROGRESS,
     JOB_STATUS_PENDING,
     KEY_TYPE_NORMAL,
@@ -636,11 +637,10 @@ def test_update_notification_sets_status(sample_notification):
 
 
 @freeze_time("2016-01-10")
-# This test assumes the local timezone is EST
 def test_should_limit_notifications_return_by_day_limit_plus_one(sample_template):
     assert len(Notification.query.all()) == 0
 
-    # create one notification a day between 1st and 9th
+    # create one notification a day between 1st and 10th
     for i in range(1, 11):
         past_date = "2016-01-{0:02d} 12:00:00".format(i)
         with freeze_time(past_date):
@@ -653,7 +653,7 @@ def test_should_limit_notifications_return_by_day_limit_plus_one(sample_template
     assert len(all_notifications) == 10
 
     all_notifications = get_notifications_for_service(sample_template.service_id, limit_days=1).items
-    assert len(all_notifications) == 2
+    assert len(all_notifications) == 1
 
 
 def test_creating_notification_does_not_add_notification_history(sample_template):
@@ -1894,3 +1894,14 @@ class TestResigning:
             notification = Notification.query.get(initial_notification.id)
             assert notification.personalisation == personalisation  # unsigned value is the same
             assert notification._personalisation != _personalisation  # signature is different
+
+@freeze_time("2024-09-25 12:25:00")
+def test_get_notifications_for_service(sample_template):
+    # create notifications for the past 10 days
+    for i in range(1, 11):
+        save_notification(create_notification(sample_template, client_reference="xyz",created_at=datetime(2024, 9, 26-i, 23, 59, 59)))
+
+    # ensure as we increase limit_days by 1, we get 1 more notification in the total each time
+    for i in range(1, 11):    
+        assert len(get_notifications_for_service(sample_template.service_id, limit_days=i).items) == i
+

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1727,7 +1727,7 @@ def test_get_notifications_for_service_gets_data_from_correct_timeframe(
     resp = admin_request.get(
         "service.get_all_notifications_for_service", service_id=email_template.service_id, limit_days=7, page_size=1
     )
-    assert resp["total"] == expected_count_of_notifications # 
+    assert resp["total"] == expected_count_of_notifications  #
 
 
 @pytest.mark.parametrize(

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1721,13 +1721,13 @@ def test_get_notifications_for_service_gets_data_from_correct_timeframe(
     for i in range(retention_period):
         for j in range(24):
             save_notification(
-                create_notification(email_template, created_at=datetime(2018, 11, 13 + i, j, 0, 0), status="delivered")
+                create_notification(email_template, created_at=datetime(2018, 11, 14 + i, j, 0, 0), status="delivered")
             )
 
     resp = admin_request.get(
         "service.get_all_notifications_for_service", service_id=email_template.service_id, limit_days=7, page_size=1
     )
-    assert resp["total"] == expected_count_of_notifications
+    assert resp["total"] == expected_count_of_notifications # 
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Summary | Résumé

Update `get_notifications_for_service` to use the same dates for querying as the rest of the app. 

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/1651

# Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.