### PR TITLE
Refactor `delete_notifications_older_than_retention_by_type`

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -1,6 +1,6 @@
 import functools
 import string
-from datetime import datetime, time, timedelta, timezone
+from datetime import datetime, timedelta
 
 from flask import current_app
 from itsdangerous import BadSignature
@@ -25,7 +25,10 @@ from werkzeug.datastructures import MultiDict
 
 from app import create_uuid, db, signer_personalisation
 from app.dao.dao_utils import transactional
-from app.dao.date_util import utc_midnight_n_days_ago
+from app.dao.date_util import (
+    get_query_date_based_on_retention_period,
+    utc_midnight_n_days_ago,
+)
 from app.errors import InvalidRequest
 from app.models import (
     EMAIL_TYPE,
@@ -384,7 +387,7 @@ def delete_notifications_older_than_retention_by_type(notification_type, qry_lim
     flexible_data_retention = ServiceDataRetention.query.filter(ServiceDataRetention.notification_type == notification_type).all()
     deleted = 0
     for f in flexible_data_retention:
-        days_of_retention = datetime.combine(datetime.now(timezone.utc) - timedelta(days=f.days_of_retention), time.max)
+        days_of_retention = get_query_date_based_on_retention_period(f.days_of_retention)
 
         insert_update_notification_history(notification_type, days_of_retention, f.service_id)
 
@@ -397,7 +400,7 @@ def delete_notifications_older_than_retention_by_type(notification_type, qry_lim
 
     current_app.logger.info("Deleting {} notifications for services without flexible data retention".format(notification_type))
 
-    seven_days_ago = datetime.combine(datetime.now(timezone.utc) - timedelta(days=7), time.max)
+    seven_days_ago = get_query_date_based_on_retention_period(7)
     services_with_data_retention = [x.service_id for x in flexible_data_retention]
     service_ids_to_purge = db.session.query(Service.id).filter(Service.id.notin_(services_with_data_retention)).all()
 


### PR DESCRIPTION
# Summary | Résumé

This PR updates `delete_notifications_older_than_retention_by_type` to use common date method in `date_utils`, `get_query_date_based_on_retention_period` which should help to make things consistent across the dashboard.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/1651

# Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.