### PR TITLE
Use dryrun for sms to INTERNAL_TEST_NUMBER

### DIFF
--- a/app/clients/sms/aws_pinpoint.py
+++ b/app/clients/sms/aws_pinpoint.py
@@ -52,13 +52,19 @@ class AwsPinpointClient(SmsClient):
                         ConfigurationSetName=self.current_app.config["AWS_PINPOINT_CONFIGURATION_SET_NAME"],
                     )
                 else:
+                    dryrun = destinationNumber == self.current_app.config["INTERNAL_TEST_NUMBER"]
                     response = self._client.send_text_message(
                         DestinationPhoneNumber=destinationNumber,
                         OriginationIdentity=pool_id,
                         MessageBody=content,
                         MessageType=messageType,
                         ConfigurationSetName=self.current_app.config["AWS_PINPOINT_CONFIGURATION_SET_NAME"],
+                        DryRun=dryrun,
                     )
+                    if dryrun:
+                        self.current_app.logger.info(
+                            f"Dry run enabled for SMS to {self.current_app.config['INTERNAL_TEST_NUMBER']} with message id {response.get('MessageId')}. SMS not sent by AWS."
+                        )
             except self._client.exceptions.ConflictException as e:
                 if e.response.get("Reason") == "DESTINATION_PHONE_NUMBER_OPTED_OUT":
                     opted_out = True

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -2,7 +2,6 @@ import base64
 import os
 import re
 from datetime import datetime
-from time import sleep
 from typing import Any, Dict, Optional
 from uuid import UUID
 
@@ -97,19 +96,6 @@ def send_sms_to_provider(notification):
         if service.research_mode or notification.key_type == KEY_TYPE_TEST:
             notification.reference = send_sms_response(provider.get_name(), notification.to)
             update_notification_to_sending(notification, provider)
-
-        elif (
-            validate_and_format_phone_number(notification.to, international=notification.international)
-            == current_app.config["INTERNAL_TEST_NUMBER"]
-        ):
-            current_app.logger.info(f"notification {notification.id} sending to internal test number. Not sending to AWS.")
-            notification.reference = send_sms_response(provider.get_name(), notification.to)
-            notification.billable_units = template.fragment_count
-            update_notification_to_sending(notification, provider)
-            current_app.logger.info(
-                f"Sleeping {current_app.config['AWS_SEND_SMS_BOTO_CALL_LATENCY']} seconds to simulate AWS boto call latency."
-            )
-            sleep(current_app.config["AWS_SEND_SMS_BOTO_CALL_LATENCY"])  # simulate boto3 client send_sms() delay
         else:
             try:
                 template_category_id = template_dict.get("template_category_id")

--- a/tests/app/clients/test_aws_pinpoint.py
+++ b/tests/app/clients/test_aws_pinpoint.py
@@ -31,6 +31,7 @@ def test_send_sms_sends_to_default_pool(notify_api, mocker, sample_template, tem
         MessageBody=content,
         MessageType="TRANSACTIONAL",
         ConfigurationSetName="config_set_name",
+        DryRun=False,
     )
 
 
@@ -59,6 +60,7 @@ def test_send_sms_sends_notify_sms_to_shortcode_pool(notify_api, mocker, sample_
         MessageBody=content,
         MessageType="TRANSACTIONAL",
         ConfigurationSetName="config_set_name",
+        DryRun=False,
     )
 
 
@@ -123,6 +125,7 @@ def test_respects_sending_vehicle_if_FF_enabled(notify_api, mocker, sample_templ
         MessageBody=content,
         MessageType="TRANSACTIONAL",
         ConfigurationSetName="config_set_name",
+        DryRun=False,
     )
 
 
@@ -150,4 +153,34 @@ def test_send_sms_sends_international_without_pool_id(notify_api, mocker, sample
         MessageBody=content,
         MessageType="TRANSACTIONAL",
         ConfigurationSetName="config_set_name",
+    )
+
+
+@pytest.mark.serial
+@pytest.mark.parametrize("template_id", [None, "uuid"])
+def test_send_sms_used_dryrun_for_tests(notify_api, mocker, sample_template, template_id):
+    boto_mock = mocker.patch.object(aws_pinpoint_client, "_client", create=True)
+    mocker.patch.object(aws_pinpoint_client, "statsd_client", create=True)
+    content = "foo"
+    reference = "ref"
+    to = "+16135550123"
+    with set_config_values(
+        notify_api,
+        {
+            "AWS_PINPOINT_SC_POOL_ID": "sc_pool_id",
+            "AWS_PINPOINT_DEFAULT_POOL_ID": "default_pool_id",
+            "AWS_PINPOINT_CONFIGURATION_SET_NAME": "config_set_name",
+            "AWS_PINPOINT_SC_TEMPLATE_IDS": [],
+            "INTERNAL_TEST_NUMBER": to,
+        },
+    ):
+        aws_pinpoint_client.send_sms(to, content, reference=reference, template_id=template_id)
+
+    boto_mock.send_text_message.assert_called_once_with(
+        DestinationPhoneNumber=to,
+        OriginationIdentity="default_pool_id",
+        MessageBody=content,
+        MessageType="TRANSACTIONAL",
+        ConfigurationSetName="config_set_name",
+        DryRun=True,
     )

--- a/tests/app/clients/test_aws_pinpoint.py
+++ b/tests/app/clients/test_aws_pinpoint.py
@@ -158,7 +158,7 @@ def test_send_sms_sends_international_without_pool_id(notify_api, mocker, sample
 
 @pytest.mark.serial
 @pytest.mark.parametrize("template_id", [None, "uuid"])
-def test_send_sms_used_dryrun_for_tests(notify_api, mocker, sample_template, template_id):
+def test_send_sms_uses_dryrun_for_tests(notify_api, mocker, sample_template, template_id):
     boto_mock = mocker.patch.object(aws_pinpoint_client, "_client", create=True)
     mocker.patch.object(aws_pinpoint_client, "statsd_client", create=True)
     content = "foo"

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -410,24 +410,6 @@ def test_should_not_send_sms_message_when_message_is_empty_or_whitespace(sample_
     assert Notification.query.get(notification.id).status == "technical-failure"
 
 
-def test_should_not_send_sms_message_to_internal_test_number(sample_service, mocker):
-    template = create_template(sample_service)
-    notification = save_notification(
-        create_notification(
-            template=template,
-            to_field=Config.INTERNAL_TEST_NUMBER,
-            status="created",
-            reply_to_text=sample_service.get_default_sms_sender(),
-        )
-    )
-    mocker.patch("app.delivery.send_to_providers.send_sms_response", return_value="reference")
-    send_mock = mocker.patch("app.aws_sns_client.send_sms")
-    send_to_providers.send_sms_to_provider(notification)
-
-    send_mock.assert_not_called()
-    assert Notification.query.get(notification.id).status == "sent"
-
-
 def test_send_sms_should_use_template_version_from_notification_not_latest(sample_template, mocker):
     db_notification = save_notification(
         create_notification(


### PR DESCRIPTION
# Summary | Résumé

Instead of faking a boto call for SMS to our `INTERNAL_TEST_NUMBER` we can do a real boto call with the parameter `DryRun` set to `True`. This should give us better timing estimates and still not cost anything (Dryrun does not actually send the message or charge us).

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/426

# Test instructions | Instructions pour tester la modification

Send to +16135550123. See in the logs `Dry run enabled for SMS to +16135550123`...
 
# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.