### PR TITLE
fix/send delivery receipt for INTERNAL_TEST sms

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -125,7 +125,10 @@ def send_sms_to_provider(notification):
                 if reference == "opted_out":
                     update_notification_to_opted_out(notification, provider)
                 else:
-                    if validate_and_format_phone_number(notification.to, international=notification.international) == current_app.config["INTERNAL_TEST_NUMBER"]:
+                    if (
+                        validate_and_format_phone_number(notification.to, international=notification.international)
+                        == current_app.config["INTERNAL_TEST_NUMBER"]
+                    ):
                         send_sms_response(provider.get_name(), notification.to, reference)
                     update_notification_to_sending(notification, provider)
 

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -125,6 +125,8 @@ def send_sms_to_provider(notification):
                 if reference == "opted_out":
                     update_notification_to_opted_out(notification, provider)
                 else:
+                    if validate_and_format_phone_number(notification.to, international=notification.international) == current_app.config["INTERNAL_TEST_NUMBER"]:
+                        send_sms_response(provider.get_name(), notification.to, reference)
                     update_notification_to_sending(notification, provider)
 
         # Record StatsD stats to compute SLOs


### PR DESCRIPTION
# Summary | Résumé

Broke the smoke test in #2320 because we stopped sending a delivery receipt for SMS to `INTERNAL_TEST_NUMBER`.
Here we add it back in.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/426

# Test instructions | Instructions pour tester la modification

Verify in staging that the smoke test works (ie SMS to 16135550123 are marked "delivered")

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.