### PR TITLE
Add email/sms annual limit columns to services table

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -519,6 +519,8 @@ class Config(object):
         "job": "{}-dvla-file-per-job".format(os.getenv("NOTIFY_ENVIRONMENT", "development")),
         "notification": "{}-dvla-letter-api-files".format(os.getenv("NOTIFY_ENVIRONMENT", "development")),
     }
+    SERVICE_ANNUAL_EMAIL_LIMIT = env.int("SERVICE_ANNUAL_EMAIL_LIMIT", 10_000_000)
+    SERVICE_ANNUAL_SMS_LIMIT = env.int("SERVICE_ANNUAL_SMS_LIMIT", 25_000)
 
     FREE_SMS_TIER_FRAGMENT_COUNT = 250000
 
@@ -566,6 +568,7 @@ class Config(object):
     FF_CELERY_CUSTOM_TASK_PARAMS = env.bool("FF_CELERY_CUSTOM_TASK_PARAMS", True)
     FF_CLOUDWATCH_METRICS_ENABLED = env.bool("FF_CLOUDWATCH_METRICS_ENABLED", False)
     FF_SALESFORCE_CONTACT = env.bool("FF_SALESFORCE_CONTACT", False)
+    FF_ANNUAL_LIMIT = env.bool("FF_ANNUAL_LIMIT", False)
 
     # SRE Tools auth keys
     SRE_USER_NAME = "SRE_CLIENT_USER"

--- a/app/models.py
+++ b/app/models.py
@@ -65,6 +65,8 @@ USER_AUTH_TYPE = [SMS_AUTH_TYPE, EMAIL_AUTH_TYPE]
 DELIVERY_STATUS_CALLBACK_TYPE = "delivery_status"
 COMPLAINT_CALLBACK_TYPE = "complaint"
 SERVICE_CALLBACK_TYPES = [DELIVERY_STATUS_CALLBACK_TYPE, COMPLAINT_CALLBACK_TYPE]
+DEFAULT_SMS_ANNUAL_LIMIT = 25000
+DEFAULT_EMAIL_ANNUAL_LIMIT = 10000000
 
 sms_sending_vehicles = db.Enum(*[vehicle.value for vehicle in SmsSendingVehicles], name="sms_sending_vehicles")
 
@@ -565,6 +567,8 @@ class Service(BaseModel, Versioned):
     sensitive_service = db.Column(db.Boolean, nullable=True)
     organisation_id = db.Column(UUID(as_uuid=True), db.ForeignKey("organisation.id"), index=True, nullable=True)
     organisation = db.relationship("Organisation", backref="services")
+    email_annual_limit = db.Column(db.BigInteger, nullable=False, default=DEFAULT_EMAIL_ANNUAL_LIMIT)
+    sms_annual_limit = db.Column(db.BigInteger, nullable=False, default=DEFAULT_SMS_ANNUAL_LIMIT)
 
     email_branding = db.relationship(
         "EmailBranding",
@@ -608,6 +612,8 @@ class Service(BaseModel, Versioned):
         fields.pop("letter_contact_block", None)
         fields.pop("email_branding", None)
         fields["sms_daily_limit"] = fields.get("sms_daily_limit", 100)
+        fields["email_annual_limit"] = fields.get("email_annual_limit", DEFAULT_EMAIL_ANNUAL_LIMIT)
+        fields["sms_annual_limit"] = fields.get("sms_annual_limit", DEFAULT_SMS_ANNUAL_LIMIT)
 
         return cls(**fields)
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -268,6 +268,8 @@ class ServiceSchema(BaseSchema, UUIDsAsStringsMixin):
     go_live_at = field_for(models.Service, "go_live_at", format="%Y-%m-%d %H:%M:%S.%f")
     organisation_notes = field_for(models.Service, "organisation_notes")
     sensitive_service = field_for(models.Service, "sensitive_service")
+    email_annual_limit = field_for(models.Service, "email_annual_limit")
+    sms_annual_limit = field_for(models.Service, "sms_annual_limit")
 
     def get_letter_logo_filename(self, service):
         return service.letter_branding and service.letter_branding.filename

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -276,6 +276,8 @@ def update_service(service_id):
     service_name_changed = fetched_service.name != req_json.get("name", fetched_service.name)
     message_limit_changed = fetched_service.message_limit != req_json.get("message_limit", fetched_service.message_limit)
     sms_limit_changed = fetched_service.sms_daily_limit != req_json.get("sms_daily_limit", fetched_service.sms_daily_limit)
+    email_annual_limit_changed = fetched_service.email_annual_limit != req_json.get("email_annual_limit", fetched_service.email_annual_limit)
+    sms_annual_limit_changed = fetched_service.sms_annual_limit != req_json.get("sms_annual_limit", fetched_service.sms_annual_limit)
     current_data = dict(service_schema.dump(fetched_service).items())
 
     current_data.update(request.get_json())
@@ -304,6 +306,12 @@ def update_service(service_id):
         redis_store.delete(over_sms_daily_limit_cache_key(service_id))
         if not fetched_service.restricted:
             _warn_service_users_about_sms_limit_changed(service_id, current_data)
+    # if sms_annual_limit_changed:
+        # TODO: Delete cache for sms annual limit (if used)
+        # TODO: Warn users about SMS annual limit change
+    # if email_annual_limit_changed:
+        # TODO: Delete cache for email annual limit (if used)
+        # TODO: Warn users about email annual limit change
 
     if service_going_live:
         _warn_services_users_about_going_live(service_id, current_data)
@@ -327,6 +335,14 @@ def update_service(service_id):
             current_app.logger.exception(e)
 
     return jsonify(data=service_schema.dump(fetched_service)), 200
+
+
+def _warn_service_users_about_annual_email_limit_changed(service_id, data):
+    pass
+
+
+def _warn_service_users_about_annual_sms_limit_changed(service_id, data):
+    pass
 
 
 def _warn_service_users_about_message_limit_changed(service_id, data):

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -276,8 +276,12 @@ def update_service(service_id):
     service_name_changed = fetched_service.name != req_json.get("name", fetched_service.name)
     message_limit_changed = fetched_service.message_limit != req_json.get("message_limit", fetched_service.message_limit)
     sms_limit_changed = fetched_service.sms_daily_limit != req_json.get("sms_daily_limit", fetched_service.sms_daily_limit)
-    email_annual_limit_changed = fetched_service.email_annual_limit != req_json.get("email_annual_limit", fetched_service.email_annual_limit)
-    sms_annual_limit_changed = fetched_service.sms_annual_limit != req_json.get("sms_annual_limit", fetched_service.sms_annual_limit)
+    email_annual_limit_changed = fetched_service.email_annual_limit != req_json.get(
+        "email_annual_limit", fetched_service.email_annual_limit
+    )
+    sms_annual_limit_changed = fetched_service.sms_annual_limit != req_json.get(
+        "sms_annual_limit", fetched_service.sms_annual_limit
+    )
     current_data = dict(service_schema.dump(fetched_service).items())
 
     current_data.update(request.get_json())
@@ -306,12 +310,14 @@ def update_service(service_id):
         redis_store.delete(over_sms_daily_limit_cache_key(service_id))
         if not fetched_service.restricted:
             _warn_service_users_about_sms_limit_changed(service_id, current_data)
-    # if sms_annual_limit_changed:
-        # TODO: Delete cache for sms annual limit (if used)
-        # TODO: Warn users about SMS annual limit change
-    # if email_annual_limit_changed:
-        # TODO: Delete cache for email annual limit (if used)
-        # TODO: Warn users about email annual limit change
+
+    if current_app.config["FF_ANNUAL_LIMIT"]:
+        if sms_annual_limit_changed:
+            # TODO: Delete cache for sms annual limit (if used)
+            _warn_service_users_about_annual_sms_limit_changed(service_id, current_data)
+        if email_annual_limit_changed:
+            # TODO: Delete cache for email annual limit (if used)
+            _warn_service_users_about_annual_email_limit_changed(service_id, current_data)
 
     if service_going_live:
         _warn_services_users_about_going_live(service_id, current_data)

--- a/migrations/versions/0462_add_annual_limit_column.py
+++ b/migrations/versions/0462_add_annual_limit_column.py
@@ -1,0 +1,58 @@
+"""
+Revision ID: 0462_add_annual_limit_column
+Revises: 0461_add_rtl_column_templates
+Create Date: 2024-06-27 13:32:00
+"""
+import os
+
+from app import config
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0462_add_annual_limit_column"
+down_revision = "0461_add_rtl_column_templates"
+
+cfg = config.configs[os.environ["NOTIFY_ENVIRONMENT"]] # type: ignore
+default_email_annual_limit = str(cfg.SERVICE_ANNUAL_EMAIL_LIMIT)
+default_sms_annual_limit = str(cfg.SERVICE_ANNUAL_SMS_LIMIT)
+
+
+def upgrade():
+    # Add the new column to the templates table
+    op.add_column("services", sa.Column("email_annual_limit", sa.BigInteger(), nullable=True, server_default=default_email_annual_limit))
+    op.add_column("services", sa.Column("sms_annual_limit", sa.BigInteger(), nullable=True, server_default=default_sms_annual_limit))
+    # Add the new column to the templates_history table
+    op.add_column("services_history", sa.Column("email_annual_limit", sa.BigInteger(), nullable=True, server_default=default_email_annual_limit))
+    op.add_column("services_history", sa.Column("sms_annual_limit", sa.BigInteger(), nullable=True, server_default=default_sms_annual_limit))
+
+    # Set the default values for existing services
+    op.execute(f"""
+            UPDATE services
+            SET email_annual_limit = {default_email_annual_limit},
+            sms_annual_limit = {default_sms_annual_limit}
+        """
+    )
+    # Since sms / email annual limit have been statically set to 25k and 10mil respectively
+    # we can update all service history rows safely
+    op.execute(f"""
+            UPDATE services_history
+            SET email_annual_limit = {default_email_annual_limit},
+            sms_annual_limit = {default_sms_annual_limit}
+        """
+    )
+
+    op.alter_column("services", "email_annual_limit", nullable=False)
+    op.alter_column("services", "sms_annual_limit", nullable=False)
+    op.alter_column("services_history", "email_annual_limit", nullable=False)
+    op.alter_column("services_history", "sms_annual_limit", nullable=False)
+
+
+def downgrade():
+    # Remove the column from the services table
+    op.drop_column("services", "email_annual_limit")
+    op.drop_column("services", "sms_annual_limit")
+
+    # Remove the column from the services_history table
+    op.drop_column("services_history", "email_annual_limit")
+    op.drop_column("services_history", "sms_annual_limit")

--- a/migrations/versions/0462_add_annual_limit_column.py
+++ b/migrations/versions/0462_add_annual_limit_column.py
@@ -5,29 +5,39 @@ Create Date: 2024-06-27 13:32:00
 """
 import os
 
-from app import config
-
 import sqlalchemy as sa
 from alembic import op
+
+from app import config
 
 revision = "0462_add_annual_limit_column"
 down_revision = "0461_add_rtl_column_templates"
 
-cfg = config.configs[os.environ["NOTIFY_ENVIRONMENT"]] # type: ignore
+cfg = config.configs[os.environ["NOTIFY_ENVIRONMENT"]]  # type: ignore
 default_email_annual_limit = str(cfg.SERVICE_ANNUAL_EMAIL_LIMIT)
 default_sms_annual_limit = str(cfg.SERVICE_ANNUAL_SMS_LIMIT)
 
 
 def upgrade():
     # Add the new column to the templates table
-    op.add_column("services", sa.Column("email_annual_limit", sa.BigInteger(), nullable=True, server_default=default_email_annual_limit))
-    op.add_column("services", sa.Column("sms_annual_limit", sa.BigInteger(), nullable=True, server_default=default_sms_annual_limit))
+    op.add_column(
+        "services", sa.Column("email_annual_limit", sa.BigInteger(), nullable=True, server_default=default_email_annual_limit)
+    )
+    op.add_column(
+        "services", sa.Column("sms_annual_limit", sa.BigInteger(), nullable=True, server_default=default_sms_annual_limit)
+    )
     # Add the new column to the templates_history table
-    op.add_column("services_history", sa.Column("email_annual_limit", sa.BigInteger(), nullable=True, server_default=default_email_annual_limit))
-    op.add_column("services_history", sa.Column("sms_annual_limit", sa.BigInteger(), nullable=True, server_default=default_sms_annual_limit))
+    op.add_column(
+        "services_history",
+        sa.Column("email_annual_limit", sa.BigInteger(), nullable=True, server_default=default_email_annual_limit),
+    )
+    op.add_column(
+        "services_history", sa.Column("sms_annual_limit", sa.BigInteger(), nullable=True, server_default=default_sms_annual_limit)
+    )
 
     # Set the default values for existing services
-    op.execute(f"""
+    op.execute(
+        f"""
             UPDATE services
             SET email_annual_limit = {default_email_annual_limit},
             sms_annual_limit = {default_sms_annual_limit}
@@ -35,7 +45,8 @@ def upgrade():
     )
     # Since sms / email annual limit have been statically set to 25k and 10mil respectively
     # we can update all service history rows safely
-    op.execute(f"""
+    op.execute(
+        f"""
             UPDATE services_history
             SET email_annual_limit = {default_email_annual_limit},
             sms_annual_limit = {default_sms_annual_limit}


### PR DESCRIPTION
# Summary | Résumé

This PR adds two new columns to track a service's annual limits:
- `email_annual_limit`
- `sms_annual_limit`

## Related Issues | Cartes liées


# Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.