### PR TITLE
Pull libexecinfo-dev from alpine 3.16 repo

### DIFF
--- a/ci/Dockerfile.lambda
+++ b/ci/Dockerfile.lambda
@@ -1,4 +1,4 @@
-FROM python:3.10-alpine3.16@sha256:afe68972cc00883d70b3760ee0ffbb7375cf09706c122dda7063ffe64c5be21b
+FROM python:3.10-alpine3.18@sha256:d5ee9613c89c9bd4c4112465d2136512ea8629bce6ff15fa27144f3cc16b5c6b
 
 ENV PYTHONPATH "${PYTHONPATH}:/opt/python/lib/python3.10/site-packages"
 ENV PYTHONDONTWRITEBYTECODE 1
@@ -9,7 +9,10 @@ ENV POETRY_VERSION="1.7.1"
 ENV POETRY_VIRTUALENVS_CREATE="false"
 ENV PATH="${APP_VENV}/bin:${POETRY_HOME}/bin:$PATH"
 
-RUN apk add --no-cache bash build-base git libtool cmake autoconf automake gcc musl-dev postgresql-dev g++ libc6-compat libexecinfo-dev make libffi-dev libmagic libcurl curl-dev rust cargo && rm -rf /var/cache/apk/*
+RUN apk add --no-cache bash build-base git libtool cmake autoconf automake gcc musl-dev postgresql-dev g++ libc6-compat make libffi-dev libmagic libcurl curl-dev rust cargo && rm -rf /var/cache/apk/*
+
+# libexecinfo-dev is required for the newrelic-lambda package but was removed in Alpine 3.17, so we add it via the 3.16 repo
+RUN apk add --no-cache --update --repository=https://dl-cdn.alpinelinux.org/alpine/v3.16/main/ libexecinfo-dev
 
 RUN mkdir -p ${TASK_ROOT}
 WORKDIR ${TASK_ROOT}


### PR DESCRIPTION
# Summary | Résumé

We depend on `libexecinfo-dev` which was removed in Alpine 3.17. This change pulls `libexecinfo-dev` in from the 3.16 Alpine repo so we can still utilize it.

## Related Issues | Cartes liées

* [Action failure](https://github.com/cds-snc/notification-api/actions/runs/11487080226/job/31970816800)

# Test instructions | Instructions pour tester la modification
Run `docker build --no-cache -f ci/Dockerfile.lambda -t your-image-name:tag .` locally and ensure the Dockerfile builds.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.