### PR TITLE
tweak length constraints for new sms fields

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1737,10 +1737,10 @@ class Notification(BaseModel):
     # SMS columns
     sms_total_message_price = db.Column(db.Numeric(), nullable=True)
     sms_total_carrier_fee = db.Column(db.Numeric(), nullable=True)
-    sms_iso_country_code = db.Column(db.String(), nullable=True)
-    sms_carrier_name = db.Column(db.String(), nullable=True)
-    sms_message_encoding = db.Column(db.String(), nullable=True)
-    sms_origination_phone_number = db.Column(db.String(), nullable=True)
+    sms_iso_country_code = db.Column(db.String(2), nullable=True)
+    sms_carrier_name = db.Column(db.String(255), nullable=True)
+    sms_message_encoding = db.Column(db.String(7), nullable=True)
+    sms_origination_phone_number = db.Column(db.String(255), nullable=True)
 
     CheckConstraint(
         """
@@ -2059,7 +2059,7 @@ class NotificationHistory(BaseModel, HistoryModel):
     sms_iso_country_code = db.Column(db.String(2), nullable=True)
     sms_carrier_name = db.Column(db.String(255), nullable=True)
     sms_message_encoding = db.Column(db.String(7), nullable=True)
-    sms_origination_phone_number = db.Column(db.String(16), nullable=True)
+    sms_origination_phone_number = db.Column(db.String(255), nullable=True)
 
     CheckConstraint(
         """


### PR DESCRIPTION
# Summary | Résumé

The origination id can be a long string so we relax the constraint on it. We also make the notifications and history table have the same length constraints.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/438

# Test instructions | Instructions pour tester la modification

Send SMS. Look at the new fields in the database

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [x] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [x] This PR does not significantly alter performance.
- [x] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.