### PR TITLE
Add a table to store annual_limits data

### DIFF
--- a/migrations/versions/0467_add_annual_limits_data.py
+++ b/migrations/versions/0467_add_annual_limits_data.py
@@ -1,0 +1,41 @@
+"""
+Revision ID: 0464_add_annual_limits_data
+Revises: 0463_add_annual_limit_column
+Create Date: 2024-10-31 13:32:00
+"""
+import os
+
+import sqlalchemy as sa
+from alembic import op
+
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "0464_add_annual_limits_data"
+down_revision = "0463_add_annual_limit_column"
+
+
+def upgrade():
+
+    op.create_table(
+        "annual_limits_data",
+        sa.Column("service_id", UUID, nullable=False),
+        sa.Column("time_period", sa.VARCHAR, nullable=False),
+        sa.Column("annual_email_limit", sa.BigInteger, nullable=False),
+        sa.Column("annual_sms_limit", sa.BigInteger, nullable=False),
+        sa.Column("notification_type", sa.Enum(name="notification_type", native_enum=False, create_type=False), nullable=False),
+        sa.Column("notification_count", sa.BigInteger, nullable=False),
+        sa.ForeignKeyConstraint(
+            ["service_id"],
+            ["services.id"],
+            name="fk_service_id"
+        )
+    )
+    op.create_index(
+        "ix_service_id_notification_type",
+        "annual_limits_data",
+        ["service_id", "notification_type"]
+    )
+    
+
+def downgrade():
+    op.drop_table("annual_limits_data")

--- a/migrations/versions/0467_add_annual_limits_data.py
+++ b/migrations/versions/0467_add_annual_limits_data.py
@@ -3,11 +3,8 @@ Revision ID: 0464_add_annual_limits_data
 Revises: 0463_add_annual_limit_column
 Create Date: 2024-10-31 13:32:00
 """
-import os
-
 import sqlalchemy as sa
 from alembic import op
-
 from sqlalchemy.dialects.postgresql import UUID
 
 revision = "0464_add_annual_limits_data"
@@ -15,7 +12,6 @@ down_revision = "0463_add_annual_limit_column"
 
 
 def upgrade():
-
     op.create_table(
         "annual_limits_data",
         sa.Column("service_id", UUID, nullable=False),
@@ -24,18 +20,10 @@ def upgrade():
         sa.Column("annual_sms_limit", sa.BigInteger, nullable=False),
         sa.Column("notification_type", sa.Enum(name="notification_type", native_enum=False, create_type=False), nullable=False),
         sa.Column("notification_count", sa.BigInteger, nullable=False),
-        sa.ForeignKeyConstraint(
-            ["service_id"],
-            ["services.id"],
-            name="fk_service_id"
-        )
+        sa.ForeignKeyConstraint(["service_id"], ["services.id"], name="fk_service_id"),
     )
-    op.create_index(
-        "ix_service_id_notification_type",
-        "annual_limits_data",
-        ["service_id", "notification_type"]
-    )
-    
+    op.create_index("ix_service_id_notification_type", "annual_limits_data", ["service_id", "notification_type"])
+
 
 def downgrade():
     op.drop_table("annual_limits_data")


### PR DESCRIPTION
# Summary | Résumé

Add a table to store data on usage for annual limits per service. This will be used to send a quarterly email to all service owners about their usage.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1681

# Test instructions | Instructions pour tester la modification

Ran flask upgrade locally and you will see the new table
```
notification_api=# \d annual_limits_data
                    Table "public.annual_limits_data"
       Column       |       Type        | Collation | Nullable | Default 
--------------------+-------------------+-----------+----------+---------
 service_id         | uuid              |           | not null | 
 time_period        | character varying |           | not null | 
 annual_email_limit | bigint            |           | not null | 
 annual_sms_limit   | bigint            |           | not null | 
 notification_type  | character varying |           | not null | 
 notification_count | bigint            |           | not null | 
Indexes:
    "ix_service_id_notification_type" btree (service_id, notification_type)
Foreign-key constraints:
    "fk_service_id" FOREIGN KEY (service_id) REFERENCES services(id)
```

# Reviewer checklist | Liste de vérification du réviseur

- [x] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [x] This PR does not significantly alter performance.
- [x] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.