### PR TITLE
Create a custom docker network for the devcontainers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,6 @@
 FROM mcr.microsoft.com/vscode/devcontainers/python:0-3.10@sha256:ef9cc483a593c95e1e83f2cf00b6a0e1ec7df43344416a41ccb3a88aef27beac
 
 ARG KUBENS_VERSION="0.9.4"
-ARG OCTANT_VERSION="0.25.1"
 ENV POETRY_VERSION="1.7.1"
 
 # Install packages
@@ -54,12 +53,6 @@ RUN pip install --upgrade pip
 RUN git clone -b v${KUBENS_VERSION} --single-branch https://github.com/ahmetb/kubectx /opt/kubectx \
     && ln -s /opt/kubectx/kubectx /usr/local/bin/kubectx \
     && ln -s /opt/kubectx/kubens /usr/local/bin/kubens
-
-# Install Octant
-RUN curl -Lo octant.tar.gz https://github.com/vmware-tanzu/octant/releases/download/v${OCTANT_VERSION}/octant_${OCTANT_VERSION}_Linux-64bit.tar.gz \
-    && tar -xvf octant.tar.gz \
-    && mv octant_${OCTANT_VERSION}_Linux-64bit/octant /usr/local/bin/ \
-    && rm -rf octant_${OCTANT_VERSION}_Linux-64bit
 
 COPY .devcontainer/scripts/notify-dev-entrypoint.sh /usr/local/bin/
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update \
     fd-find \
     git \
     iproute2 \
+    iputils-ping \
     less \
     libsodium-dev \
     lsb-release \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
 	"name": "notification-api",
 	"dockerComposeFile": "docker-compose.yml",
-	"service": "dev",
+	"service": "notify-api",
 	"workspaceFolder": "/workspace",
 	"shutdownAction": "stopCompose",
 	"remoteEnv": {
@@ -47,19 +47,14 @@
 	},
 	"features": {
 		"docker-from-docker": {
-			"version": "latest",
 			"moby": true
 		},
 		"kubectl-helm-minikube": {
-			"version": "latest",
 			"helm": "latest",
 			"minikube": "none"
 		},
-		"ghcr.io/devcontainers/features/node:1": {
-			"version": "14.17.4"
-		}
+		"ghcr.io/devcontainers/features/node:1": {}
 	},
 	"postCreateCommand": "notify-dev-entrypoint.sh",
-	"remoteUser": "vscode",
-	
+	"remoteUser": "vscode"
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 
 services:
-  dev:
+  notify-api:
     build:
       context: ..
       dockerfile: .devcontainer/Dockerfile
@@ -18,6 +18,10 @@ services:
       - 6011:6011
     links:
       - db
+    expose:
+      - "6011"
+    networks:
+      - notify-network
 
   db:
     image: postgres:11.22-bullseye@sha256:c886a3236b3d11abc302e64309186c90a69b49e53ccff23fd8c8b057b5b4bce9
@@ -36,6 +40,8 @@ services:
       - "5432"
     ports:
       - "5432:5432"
+    networks:
+      - notify-network
 
   redis:
     image: redis:6.2@sha256:7919fdd5300e7abf7ae95919e6f144b37c55df16553302dbbcc7495a5aa0c079
@@ -45,3 +51,10 @@ services:
       - "6380:6380"
     expose:
       - "6380"
+    networks:
+      - notify-network
+
+networks:
+  notify-network:
+    name:   notify-network
+    driver: bridge


### PR DESCRIPTION
# Summary | Résumé

Create a custom docker network for all vscode containers to communicate between each others.

## Related Issues | Cartes liées

None

# Test instructions | Instructions pour tester la modification

Once you have admin related PR merged and ready, from the terminal, try to ping the admin container:

```
$ ping notify-admin            
PING notify-admin (172.21.0.5) 56(84) bytes of data.
64 bytes from notification-admin_devcontainer-notify-admin-1.notify-network (172.21.0.5): icmp_seq=1 ttl=64 time=0.061 ms
64 bytes from notification-admin_devcontainer-notify-admin-1.notify-network (172.21.0.5): icmp_seq=2 ttl=64 time=0.066 ms
64 bytes from notification-admin_devcontainer-notify-admin-1.notify-network (172.21.0.5): icmp_seq=3 ttl=64 time=0.057 ms
```

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [x] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [x] This PR does not significantly alter performance.
- [x] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.