### PR TITLE
Update get_monthly_notification_stats

### DIFF
--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -622,7 +622,7 @@ def get_monthly_notification_stats(service_id):
         year = int(request.args.get("year", "NaN"))
     except ValueError:
         raise InvalidRequest("Year must be a number", status_code=400)
-    
+
     try:
         exclude_today = request.args.get("exclude_today", "false").lower() in ("true", "1", "yes")
     except ValueError:
@@ -636,10 +636,12 @@ def get_monthly_notification_stats(service_id):
     statistics.add_monthly_notification_status_stats(data, stats)
 
     now = datetime.utcnow()
-    
+
     if not exclude_today:
         if end_date > now:
-            todays_deltas = fetch_notification_status_for_service_for_day(convert_utc_to_local_timezone(now), service_id=service_id)
+            todays_deltas = fetch_notification_status_for_service_for_day(
+                convert_utc_to_local_timezone(now), service_id=service_id
+            )
             statistics.add_monthly_notification_status_stats(data, todays_deltas)
 
     return jsonify(data=data)


### PR DESCRIPTION
# Summary | Résumé

This PR updates the `get_monthly_notification_stats` method to add a parameter to allow exclusion of today's data from the result.

This will allow admin to cache the result of annual data so it doesn't need to be continually fetched.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/1664

# Test instructions | Instructions pour tester la modification
- This does not change how the code works, since the default value for this parameter is `False`, which allows the code to run exactly how it did before this change.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.