### PR TITLE
Automatically generate the VPN config instead of reading from 1pass

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -73,9 +73,9 @@ jobs:
         curl -o 1pass.deb https://downloads.1password.com/linux/debian/amd64/stable/1password-cli-amd64-latest.deb
         sudo dpkg -i 1pass.deb
 
-    - name: One Password Fetch
+    - name: Fetch VPN
       run: |
-        op read op://4eyyuwddp6w4vxlabrr2i2duxm/"Staging Github Actions VPN"/notesPlain > /var/tmp/staging.ovpn
+        curl https://raw.githubusercontent.com/cds-snc/notification-manifests/refs/heads/main/scripts/createVPNConfig.sh | bash -s staging
 
     - name: Connect to VPN
       uses: "kota65535/github-openvpn-connect-action@cd2ed8a90cc7b060dc4e001143e811b5f7ea0af5"


### PR DESCRIPTION
# Summary | Résumé

This will modify the build and push github workflow to auto-generate the VPN config rather than relying on 1password. This way when we make changes to the VPN, we don't have to make changes to any other repositories.

## Related Issues | Cartes liées

chore

# Test instructions | Instructions pour tester la modification

Verify that docker build/push works upon merge to main

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.