### PR TITLE
Bump utils for annual limit client fixes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -69,7 +69,7 @@ jobs:
       run: |
         cp -f .env.example .env
     - name: Checks for new endpoints against AWS WAF rules
-      uses: cds-snc/notification-utils/.github/actions/waffles@52.3.7
+      uses: cds-snc/notification-utils/.github/actions/waffles@52.3.8
       with:
         app-loc: '/github/workspace'
         app-libs: '/github/workspace/env/site-packages'

--- a/poetry.lock
+++ b/poetry.lock
@@ -2657,7 +2657,7 @@ requests = ">=2.0.0"
 
 [[package]]
 name = "notifications-utils"
-version = "52.3.7"
+version = "52.3.8"
 description = "Shared python code for Notification - Provides logging utils etc."
 optional = false
 python-versions = "~3.10.9"
@@ -2693,8 +2693,8 @@ werkzeug = "3.0.4"
 [package.source]
 type = "git"
 url = "https://github.com/cds-snc/notifier-utils.git"
-reference = "52.3.7"
-resolved_reference = "42ded1e06cfac4209c0dd9d3131cf202b8e210bd"
+reference = "52.3.8"
+resolved_reference = "acfde00d2c7bb9713afeb3e67e41cf8bea988e10"
 
 [[package]]
 name = "ordered-set"
@@ -4623,4 +4623,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10.9"
-content-hash = "9f820c94df5fda8d9619bba5e0294cc0a8108e68d7bf73646e5e099157f1fe4a"
+content-hash = "494b12d5034586897256f7b42d41a230813912256dc3ff96a4abf9995894c77f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ Werkzeug = "3.0.4"
 MarkupSafe = "2.1.5"
 # REVIEW: v2 is using sha512 instead of sha1 by default (in v1)
 itsdangerous = "2.2.0"
-notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", tag = "52.3.7" }
+notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", tag = "52.3.8" }
 
 # rsa = "4.9  # awscli 1.22.38 depends on rsa<4.8
 typing-extensions = "4.12.2"


### PR DESCRIPTION
# Summary | Résumé

This PR incorporates bug fixes to the annual limit redis client.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-utils/pull/335

# Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.