### PR TITLE
fix: add fallback value for cypress migration

### DIFF
--- a/migrations/versions/0466_add_cypress_data.py
+++ b/migrations/versions/0466_add_cypress_data.py
@@ -28,14 +28,13 @@ service_id = current_app.config["CYPRESS_SERVICE_ID"]
 email_template_id = current_app.config["CYPRESS_SMOKE_TEST_EMAIL_TEMPLATE_ID"]
 sms_template_id = current_app.config["CYPRESS_SMOKE_TEST_SMS_TEMPLATE_ID"]
 default_category_id = current_app.config["DEFAULT_TEMPLATE_CATEGORY_LOW"]
+cypress_user_pw = current_app.config.get(
+    "CYPRESS_USER_PW_SECRET", uuid.uuid4().hex[:32]  # if env var isn't present, use a random password
+)
 
 
 def upgrade():
-    password = hashpw(
-        hashlib.sha256(
-            (current_app.config["CYPRESS_USER_PW_SECRET"] + current_app.config["DANGEROUS_SALT"]).encode("utf-8")
-        ).hexdigest()
-    )
+    password = hashpw(hashlib.sha256((cypress_user_pw + current_app.config["DANGEROUS_SALT"]).encode("utf-8")).hexdigest())
     current_year = get_current_financial_year_start_year()
     default_limit = 250000
 


### PR DESCRIPTION
# Summary | Résumé

This PR adds a fallback for the cypress secret so that migrations will continue to work even if it isn't in the `.env` file.

# Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.