### PR TITLE
Increasing the gunicorn graceful timeout at 40s

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -43,8 +43,8 @@ if on_aws:
     #
     # Kubernetes config:
     # https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
-    graceful_timeout = 25
-    timeout = 30
+    graceful_timeout = 35
+    timeout = 40
 
 
 def on_starting(server):


### PR DESCRIPTION
# Summary | Résumé

Increasing the gunicorn graceful timeout at 35 seconds and hard timeout at 40 seconds. The previous config of 25g/30h was not high enough for NewRelic increased load.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/313

# Test instructions | Instructions pour tester la modification

Watch k8s pods restart in staging env.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.