### PR TITLE
Func to find service annual stats and send an email

### DIFF
--- a/app/celery/reporting_tasks.py
+++ b/app/celery/reporting_tasks.py
@@ -205,15 +205,14 @@ def _create_quarterly_email_markdown_list(service_info, service_ids, cummulative
 
         markdown_list_en += f"## {service_name} \n"
         markdown_list_fr += f"## {service_name} \n"
-        if email_count:
-            email_percentage = round(float(email_count / email_annual_limit), 4) * 100
-            markdown_list_en += f"Emails: you've sent {email_count} out of {email_annual_limit} ({email_percentage}%)\n"
-            markdown_list_fr += f"Courriels: {email_count} envoyés sur {email_annual_limit} ({email_percentage}%)\n"
 
-        if sms_count:
-            sms_percentage = round(float(sms_count / sms_annual_limit), 4) * 100
-            markdown_list_en += f"Text messages: you've sent {sms_count} out of {sms_annual_limit} ({sms_percentage}%)\n"
-            markdown_list_fr += f"Messages texte : {sms_count} envoyés sur {sms_annual_limit} ({sms_percentage}%)\n"
+        email_percentage = round(float(email_count / email_annual_limit), 4) * 100 if email_count else 0
+        markdown_list_en += f"Emails: you've sent {email_count} out of {email_annual_limit} ({email_percentage}%)\n"
+        markdown_list_fr += f"Courriels: {email_count} envoyés sur {email_annual_limit} ({email_percentage}%)\n"
+
+        sms_percentage = round(float(sms_count / sms_annual_limit), 4) * 100 if sms_count else 0
+        markdown_list_en += f"Text messages: you've sent {sms_count} out of {sms_annual_limit} ({sms_percentage}%)\n"
+        markdown_list_fr += f"Messages texte : {sms_count} envoyés sur {sms_annual_limit} ({sms_percentage}%)\n"
 
         markdown_list_en += "\n"
         markdown_list_fr += "\n"

--- a/app/celery/reporting_tasks.py
+++ b/app/celery/reporting_tasks.py
@@ -226,6 +226,8 @@ def send_quarter_email(process_date):
     quarters_list = get_all_quarters(process_date)
     chunk_size = 50
     iter_user_service_array = iter(user_service_array)
+    start_year = int(quarters_list[0].split("-")[-1])
+    end_year = start_year + 1
 
     while True:
         chunk = list(islice(iter_user_service_array, chunk_size))
@@ -241,11 +243,11 @@ def send_quarter_email(process_date):
             all_service_ids = list(all_service_ids)
             cummulative_data = fetch_quarter_cummulative_stats(quarters_list, all_service_ids)
             cummulative_data_dict = {str(c_data_id): c_data for c_data_id, c_data in cummulative_data}
-            for user_id, email_address, service_ids in chunk:
+            for user_id, _, service_ids in chunk:
                 markdown_list_en, markdown_list_fr = _create_quarterly_email_markdown_list(
                     service_info, service_ids, cummulative_data_dict
                 )
-                send_annual_usage_data(user_id, email_address, markdown_list_en, markdown_list_fr)
+                send_annual_usage_data(user_id, start_year, end_year, markdown_list_en, markdown_list_fr)
         except Exception as e:
             current_app.logger.error("send_quarter_email task failed for for user {} . Error: {}".format(user_id, e))
             continue

--- a/app/celery/reporting_tasks.py
+++ b/app/celery/reporting_tasks.py
@@ -185,10 +185,12 @@ def insert_quarter_data_for_annual_limits(process_day):
                 )
             )
 
+
 def _format_number(number, use_space=False):
     if use_space:
         return "{:,}".format(number).replace(",", " ")
     return "{:,}".format(number)
+
 
 def _create_quarterly_email_markdown_list(service_info, service_ids, cummulative_data_dict):
     """

--- a/app/celery/reporting_tasks.py
+++ b/app/celery/reporting_tasks.py
@@ -185,6 +185,10 @@ def insert_quarter_data_for_annual_limits(process_day):
                 )
             )
 
+def _format_number(number, use_space=False):
+    if use_space:
+        return "{:,}".format(number).replace(",", " ")
+    return "{:,}".format(number)
 
 def _create_quarterly_email_markdown_list(service_info, service_ids, cummulative_data_dict):
     """
@@ -207,12 +211,20 @@ def _create_quarterly_email_markdown_list(service_info, service_ids, cummulative
         markdown_list_fr += f"## {service_name} \n"
 
         email_percentage = round(float(email_count / email_annual_limit), 4) * 100 if email_count else 0
-        markdown_list_en += f"Emails: you've sent {email_count} out of {email_annual_limit} ({email_percentage}%)\n"
-        markdown_list_fr += f"Courriels: {email_count} envoyés sur {email_annual_limit} ({email_percentage}%)\n"
+        email_count_en = _format_number(email_count)
+        email_annual_limit_en = _format_number(email_annual_limit)
+        email_count_fr = _format_number(email_count, use_space=True)
+        email_annual_limit_fr = _format_number(email_annual_limit, use_space=True)
+        markdown_list_en += f"Emails: you've sent {email_count_en} out of {email_annual_limit_en} ({email_percentage}%)\n"
+        markdown_list_fr += f"Courriels: {email_count_fr} envoyés sur {email_annual_limit_fr} ({email_percentage}%)\n"
 
         sms_percentage = round(float(sms_count / sms_annual_limit), 4) * 100 if sms_count else 0
-        markdown_list_en += f"Text messages: you've sent {sms_count} out of {sms_annual_limit} ({sms_percentage}%)\n"
-        markdown_list_fr += f"Messages texte : {sms_count} envoyés sur {sms_annual_limit} ({sms_percentage}%)\n"
+        sms_count_en = _format_number(sms_count)
+        sms_annual_limit_en = _format_number(sms_annual_limit)
+        sms_count_fr = _format_number(sms_count, use_space=True)
+        sms_annual_limit_fr = _format_number(sms_annual_limit, use_space=True)
+        markdown_list_en += f"Text messages: you've sent {sms_count_en} out of {sms_annual_limit_en} ({sms_percentage}%)\n"
+        markdown_list_fr += f"Messages texte : {sms_count_fr} envoyés sur {sms_annual_limit_fr} ({sms_percentage}%)\n"
 
         markdown_list_en += "\n"
         markdown_list_fr += "\n"

--- a/app/celery/reporting_tasks.py
+++ b/app/celery/reporting_tasks.py
@@ -206,11 +206,14 @@ def _create_quarterly_email_markdown_list(service_info, service_ids, cummulative
         markdown_list_en += f"## {service_name} \n"
         markdown_list_fr += f"## {service_name} \n"
         if email_count:
-            email_percentage = round(float(email_count / email_annual_limit), 2) * 100
-            markdown_list_en += f"you've sent {email_count} out of {email_annual_limit} {email_percentage}\n"
+            email_percentage = round(float(email_count / email_annual_limit), 4) * 100
+            markdown_list_en += f"Emails: you've sent {email_count} out of {email_annual_limit} ({email_percentage}%)\n"
+            markdown_list_fr += f"Courriels: {email_count} envoyés sur {email_annual_limit} ({email_percentage}%)\n"
+
         if sms_count:
-            sms_percentage = round(float(sms_count / sms_annual_limit), 2) * 100
+            sms_percentage = round(float(sms_count / sms_annual_limit), 4) * 100
             markdown_list_en += f"Text messages: you've sent {sms_count} out of {sms_annual_limit} ({sms_percentage}%)\n"
+            markdown_list_fr += f"Messages texte : {sms_count} envoyés sur {sms_annual_limit} ({sms_percentage}%)\n"
 
         markdown_list_en += "\n"
         markdown_list_fr += "\n"
@@ -248,6 +251,7 @@ def send_quarter_email(process_date):
                     service_info, service_ids, cummulative_data_dict
                 )
                 send_annual_usage_data(user_id, start_year, end_year, markdown_list_en, markdown_list_fr)
+                current_app.logger.info("send_quarter_email task completed for user {} ".format(user_id))
         except Exception as e:
             current_app.logger.error("send_quarter_email task failed for for user {} . Error: {}".format(user_id, e))
             continue

--- a/app/config.py
+++ b/app/config.py
@@ -503,6 +503,49 @@ class Config(object):
             "schedule": crontab(hour=9, minute=0),  # 4:00 EST in UTC
             "options": {"queue": QueueNames.PERIODIC},
         },
+        # quarterly queue
+        "insert-quarter-data-for-annual-limits-q1": {
+            "task": "insert-quarter-data-for-annual-limits",
+            "schedule": crontab(
+                minute=0, hour=23, day_of_month=1, month_of_year=7
+            ),  # Running this at the end of the day on 1st July
+            "options": {"queue": QueueNames.PERIODIC},
+        },
+        "insert-quarter-data-for-annual-limits-q2": {
+            "task": "insert-quarter-data-for-annual-limits",
+            "schedule": crontab(
+                minute=0, hour=23, day_of_month=1, month_of_year=10
+            ),  # Running this at the end of the day on 1st Oct
+            "options": {"queue": QueueNames.PERIODIC},
+        },
+        "insert-quarter-data-for-annual-limits-q3": {
+            "task": "insert-quarter-data-for-annual-limits",
+            "schedule": crontab(
+                minute=0, hour=23, day_of_month=1, month_of_year=1
+            ),  # Running this at the end of the day on 1st Jan
+            "options": {"queue": QueueNames.PERIODIC},
+        },
+        "send-quarterly-email-q1": {
+            "task": "send-quarterly-email",
+            "schedule": crontab(
+                minute=0, hour=23, day_of_month=2, month_of_year=7
+            ),  # Running this at the end of the day on 2nd July
+            "options": {"queue": QueueNames.PERIODIC},
+        },
+        "send-quarterly-email-q2": {
+            "task": "send-quarterly-email",
+            "schedule": crontab(
+                minute=0, hour=23, day_of_month=2, month_of_year=10
+            ),  # Running this at the end of the day on 2nd Oct
+            "options": {"queue": QueueNames.PERIODIC},
+        },
+        "send-quarterly-email-q3": {
+            "task": "send-quarterly-email",
+            "schedule": crontab(
+                minute=0, hour=23, day_of_month=3, month_of_year=1
+            ),  # Running this at the end of the day on 2nd Jan
+            "options": {"queue": QueueNames.PERIODIC},
+        },
     }
     CELERY_QUEUES: List[Any] = []
     CELERY_DELIVER_SMS_RATE_LIMIT = os.getenv("CELERY_DELIVER_SMS_RATE_LIMIT", "1/s")

--- a/app/config.py
+++ b/app/config.py
@@ -525,6 +525,13 @@ class Config(object):
             ),  # Running this at the end of the day on 1st Jan
             "options": {"queue": QueueNames.PERIODIC},
         },
+        "insert-quarter-data-for-annual-limits-q4": {
+            "task": "insert-quarter-data-for-annual-limits",
+            "schedule": crontab(
+                minute=0, hour=23, day_of_month=1, month_of_year=1
+            ),  # Running this at the end of the day on 1st April
+            "options": {"queue": QueueNames.PERIODIC},
+        },
         "send-quarterly-email-q1": {
             "task": "send-quarterly-email",
             "schedule": crontab(

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -905,8 +905,8 @@ def send_annual_usage_data(user_id, start_year, end_year, markdown_en, markdown_
         service=service,
         personalisation={
             "name": user.name,
-            "start_year": "2020",
-            "end_year": "2021",
+            "start_year": start_year,
+            "end_year": end_year,
             "data_for_each_service_en": markdown_en,
             "data_for_each_service_fr": markdown_fr,
         },

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -888,7 +888,7 @@ def _update_alert(user_to_update, changes=None):
     send_notification_to_queue(saved_notification, False, queue=QueueNames.NOTIFY)
 
 
-def send_annual_usage_data(user_id, email_address, markdown_en, markdown_fr):
+def send_annual_usage_data(user_id, start_year, end_year, markdown_en, markdown_fr):
     """
     We are sending a notification to the user to inform them that their annual usage
     per service.
@@ -901,12 +901,14 @@ def send_annual_usage_data(user_id, email_address, markdown_en, markdown_fr):
     saved_notification = persist_notification(
         template_id=template.id,
         template_version=template.version,
-        recipient=email_address,
+        recipient=user.email_address,
         service=service,
         personalisation={
             "name": user.name,
-            "markdown_en": markdown_en,
-            "markdown_fr": markdown_fr,
+            "start_year": "2020",
+            "end_year": "2021",
+            "data_for_each_service_en": markdown_en,
+            "data_for_each_service_fr": markdown_fr,
         },
         notification_type=template.template_type,
         api_key_id=None,

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -886,3 +886,34 @@ def _update_alert(user_to_update, changes=None):
     )
 
     send_notification_to_queue(saved_notification, False, queue=QueueNames.NOTIFY)
+
+
+def send_annual_usage_data(user_id, email_address, markdown_en, markdown_fr):
+    """
+    We are sending a notification to the user to inform them that their annual usage
+    per service.
+
+    """
+    user = get_user_by_id(user_id=user_id)
+    template = dao_get_template_by_id(current_app.config["ANNUAL_LIMIT_QUARTERLY_USAGE_TEMPLATE_ID"])
+    service = Service.query.get(current_app.config["NOTIFY_SERVICE_ID"])
+
+    saved_notification = persist_notification(
+        template_id=template.id,
+        template_version=template.version,
+        recipient=email_address,
+        service=service,
+        personalisation={
+            "name": user.name,
+            "markdown_en": markdown_en,
+            "markdown_fr": markdown_fr,
+        },
+        notification_type=template.template_type,
+        api_key_id=None,
+        key_type=KEY_TYPE_NORMAL,
+        reply_to_text=service.get_default_reply_to_email_address(),
+    )
+
+    send_notification_to_queue(saved_notification, False, queue=QueueNames.NOTIFY)
+
+    return jsonify({}), 204

--- a/tests/app/celery/test_reporting_tasks.py
+++ b/tests/app/celery/test_reporting_tasks.py
@@ -630,7 +630,8 @@ class TestSendQuarterEmail:
         send_quarter_email(datetime(2018, 4, 1))
         assert send_mock.call_args(
             sample_user.id,
-            sample_user.email_address,
+            2018,
+            2019,
             markdown_list_en,
             markdown_list_fr,
         )

--- a/tests/app/celery/test_reporting_tasks.py
+++ b/tests/app/celery/test_reporting_tasks.py
@@ -625,7 +625,7 @@ class TestSendQuarterEmail:
         service_2.users = [sample_user]
         send_mock = mocker.patch("app.celery.reporting_tasks.send_annual_usage_data")
 
-        markdown_list_en = "## service_1 \nText messages: you've sent 4 out of 25000 (0.0%)\n\n## service_2 \nText messages: you've sent 1100 out of 25000 (4.0%)\n\n"
+        markdown_list_en = "## service_1 \nText messages: you've sent 4 out of 25,000 (0.0%)\n\n## service_2 \nText messages: you've sent 1 100 out of 25 000 (4.0%)\n\n"
         markdown_list_fr = "## service_1 \n\n## service_2 \n\n"
         send_quarter_email(datetime(2018, 4, 1))
         assert send_mock.call_args(

--- a/tests/app/dao/test_annual_limits_data_dao.py
+++ b/tests/app/dao/test_annual_limits_data_dao.py
@@ -3,7 +3,11 @@ from datetime import datetime
 
 import pytest
 
-from app.dao.annual_limits_data_dao import get_previous_quarter, insert_quarter_data
+from app.dao.annual_limits_data_dao import (
+    fetch_quarter_cummulative_stats,
+    get_previous_quarter,
+    insert_quarter_data,
+)
 from app.models import AnnualLimitsData, Service
 from tests.app.db import create_service
 
@@ -53,3 +57,29 @@ class TestInsertQuarterData:
             service_info,
         )
         assert AnnualLimitsData.query.filter_by(service_id=service_2.id).first().notification_count == 500
+
+
+class TestFetchCummulativeStats:
+    def test_fetch_quarter_cummulative_stats(self, notify_db_session):
+        service_1 = create_service(service_name="service_1")
+        service_2 = create_service(service_name="service_2")
+
+        service_info = {x.id: (x.email_annual_limit, x.sms_annual_limit) for x in Service.query.all()}
+        NotificationData = namedtuple("NotificationData", ["service_id", "notification_type", "notification_count"])
+
+        data = [
+            NotificationData(service_1.id, "sms", 4),
+            NotificationData(service_2.id, "sms", 1100),
+            NotificationData(service_1.id, "email", 2),
+        ]
+        insert_quarter_data(data, "Q1-2018", service_info)
+
+        data2 = [NotificationData(service_1.id, "sms", 5)]
+        insert_quarter_data(data2, "Q2-2018", service_info)
+
+        result = fetch_quarter_cummulative_stats(["Q1-2018", "Q2-2018"], [service_1.id, service_2.id])
+        for service_id, counts in result:
+            if service_id == service_1.id:
+                assert counts == {"sms": 9, "email": 2}
+            if service_id == service_2.id:
+                assert counts == {"sms": 1100}


### PR DESCRIPTION
# Summary | Résumé

Completed and merged in this PR: https://github.com/cds-snc/notification-api/pull/2345
1. Funcs to take notification counts per service, per quarter and store it in the annual_limits_data table
2. Funcs to decide what quarter we should be finding data for depending on today's current date.

In this PR:
1. Jobs to insert the data into the facts table. This job runs on the first day of every quarter (other than April 1)
2. Func to get all active services for all active users (user_id, lof(service_ids))
3. Func to find cumulative data about a service from annual_limits_data table
4. Celery task that will send an email with the cumulative data to each user_id, for all their services

## Testing locally:
Run this branch locally and open up a python REPL. This assumes you have a service with a lot of messages sent under your user.
```
from flask import Flask
from app import create_app
from datetime import datetime

x = datetime(2025, 1, 1)
app = create_app(Flask('notify-api'))

from app.celery.reporting_tasks import insert_quarter_data_for_annual_limits, send_quarter_email

with app.app_context():
    insert_quarter_data_for_annual_limits(x)

with app.app_context():
    send_quarter_email(x)
```

## What the email looks like:

<img width="641" alt="Screenshot 2024-11-19 at 5 44 12 PM" src="https://github.com/user-attachments/assets/8b2ad083-20c1-45f9-b0b4-4fe6555aa467">


## Related Issues | Cartes liées

You can run the reporting func locally (after inserting data in the annual_limits_data table), and see that it creates the outline of an email to send

# Release Instructions | Instructions pour le déploiement

We need to run the job for inserting the data for Q1 and Q2 2024.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.