### PR TITLE
Enable NewRelic package reporting to monitor perf improvements

### DIFF
--- a/newrelic.ini
+++ b/newrelic.ini
@@ -202,11 +202,13 @@ package_reporting.enabled = false
 [newrelic:development]
 # monitor_mode = false
 log_level = debug
+package_reporting.enabled = true
 
 [newrelic:staging]
 # app_name = Python Application (Staging)
 # monitor_mode = true
 log_level = debug
+package_reporting.enabled = true
 
 [newrelic:production]
 # monitor_mode = true
@@ -217,5 +219,6 @@ log_level = debug
 [newrelic:dev]
 # monitor_mode = false
 log_level = debug
+package_reporting.enabled = true
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Summary | Résumé

In version 9.1.0 of NewRelic Python agent, there were improvements done on the package reporting. I want to test it out in staging to see if we can keep this feature or should just disable it. 

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/313

# Test instructions | Instructions pour tester la modification

Trigger restart of kubernetes API deployment and monitor timing + potential loop crash. At this time, this is the config for probes that work for the API and with New Relic reporting disabled:

```
        livenessProbe:
          failureThreshold: 3
          httpGet:
            path: /_status?simple=true
            port: 6011
            scheme: HTTP
          initialDelaySeconds: 30
          periodSeconds: 3
          successThreshold: 1
          timeoutSeconds: 1
        name: api
        ports:
        - containerPort: 6011
          protocol: TCP
        readinessProbe:
          failureThreshold: 10
          httpGet:
            path: /_status?simple=true
            port: 6011
            scheme: HTTP
          initialDelaySeconds: 5
          periodSeconds: 3
          successThreshold: 3
          timeoutSeconds: 1
        resources:
          limits:
            cpu: 1200m
            memory: 900Mi
          requests:
            cpu: 200m
            memory: 700Mi
        startupProbe:
          failureThreshold: 20
          httpGet:
            path: /_status?simple=true
            port: 6011
            scheme: HTTP
          initialDelaySeconds: 20
          periodSeconds: 3
          successThreshold: 1
          timeoutSeconds: 1
```

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [x] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [x] This PR does not significantly alter performance.
- [x] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.