### PR TITLE
Added total running time to gunicorn shutdown hooks

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,7 +1,7 @@
 import os
 import sys
-import traceback
 import time
+import traceback
 
 import gunicorn  # type: ignore
 import newrelic.agent  # See https://bit.ly/2xBVKBH


### PR DESCRIPTION
# Summary | Résumé

Added total running time to gunicorn runner and hooks. 

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/313

# Test instructions | Instructions pour tester la modification

Look for the log when the gunicorn workers are shutting down.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.