### PR TITLE
Api gh secrets

### DIFF
--- a/.github/workflows/build_and_push_performance_test.yml
+++ b/.github/workflows/build_and_push_performance_test.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   GITHUB_SHA: ${{ github.sha }}
-  REGISTRY: ${{ secrets.STAGING_ACCOUNT_ID }}.dkr.ecr.ca-central-1.amazonaws.com/notify
+  REGISTRY: ${{ secrets.STAGING_AWS_ACCOUNT_ID }}.dkr.ecr.ca-central-1.amazonaws.com/notify
 
 jobs:
   changes:

--- a/.github/workflows/build_and_push_performance_test.yml
+++ b/.github/workflows/build_and_push_performance_test.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   GITHUB_SHA: ${{ github.sha }}
-  REGISTRY: ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.ca-central-1.amazonaws.com/notify
+  REGISTRY: ${{ secrets.STAGING_ACCOUNT_ID }}.dkr.ecr.ca-central-1.amazonaws.com/notify
 
 jobs:
   changes:
@@ -55,8 +55,8 @@ jobs:
         id: aws-creds
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
           aws-region: ca-central-1
 
       - name: Login to ECR

--- a/.github/workflows/docker-vulnerability-scan.yml
+++ b/.github/workflows/docker-vulnerability-scan.yml
@@ -47,13 +47,13 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOCKERFILE_PATH: "ci/Dockerfile.lambda"
-      DOCKER_IMAGE: "${{ secrets.PRODUCTION_ACCOUNT_ID }}.dkr.ecr.ca-central-1.amazonaws.com/notify/api-lambda"
+      DOCKER_IMAGE: "${{ secrets.PRODUCTION_AWS_ACCOUNT_ID }}.dkr.ecr.ca-central-1.amazonaws.com/notify/api-lambda"
 
     steps:
       - name: Configure credentials to Notify account using OIDC
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.PRODUCTION_ACCOUNT_ID }}:role/notification-api-apply
+          role-to-assume: arn:aws:iam::${{ secrets.PRODUCTION_AWS_ACCOUNT_ID }}:role/notification-api-apply
           role-session-name: NotifyApiGitHubActions
           aws-region: "ca-central-1"
 

--- a/.github/workflows/docker-vulnerability-scan.yml
+++ b/.github/workflows/docker-vulnerability-scan.yml
@@ -47,13 +47,13 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOCKERFILE_PATH: "ci/Dockerfile.lambda"
-      DOCKER_IMAGE: "${{ secrets.PRODUCTION_API_LAMBDA_ECR_ACCOUNT }}.dkr.ecr.ca-central-1.amazonaws.com/notify/api-lambda"
+      DOCKER_IMAGE: "${{ secrets.PRODUCTION_ACCOUNT_ID }}.dkr.ecr.ca-central-1.amazonaws.com/notify/api-lambda"
 
     steps:
       - name: Configure credentials to Notify account using OIDC
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.PRODUCTION_API_LAMBDA_ECR_ACCOUNT }}:role/notification-api-apply
+          role-to-assume: arn:aws:iam::${{ secrets.PRODUCTION_ACCOUNT_ID }}:role/notification-api-apply
           role-session-name: NotifyApiGitHubActions
           aws-region: "ca-central-1"
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -9,8 +9,7 @@ env:
   DOCKER_ORG: public.ecr.aws/v6b8u5o6
   DOCKER_SLUG: public.ecr.aws/v6b8u5o6/notify-api
   KUBECTL_VERSION: '1.23.6'
-  WORKFLOW_PAT: ${{ secrets.WORKFLOW_GITHUB_PAT }}
-  OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+  OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_STAGING }}
 
 permissions:
   id-token: write   # This is required for requesting the OIDC JWT
@@ -59,8 +58,8 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-access-key-id: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
         aws-region: ca-central-1
 
     - name: Install OpenVPN
@@ -89,7 +88,6 @@ jobs:
       uses: "kota65535/github-openvpn-connect-action@cd2ed8a90cc7b060dc4e001143e811b5f7ea0af5"
       with:
         config_file: /var/tmp/staging.ovpn
-        client_key: ${{ secrets.STAGING_OVPN_CLIENT_KEY }}
         echo_config: false       
         
     - name: Configure kubeconfig

--- a/.github/workflows/lambda_production.yml
+++ b/.github/workflows/lambda_production.yml
@@ -45,25 +45,25 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@5a88a04c91d5c6f97aae0d9be790e64d9b1d47b7 # v1.7.1
 
-      # - name: Push containers to ECR
-      #   run: |
-      #     docker push $REGISTRY/${{ matrix.image }}:$IMAGE_TAG
+      - name: Push containers to ECR
+        run: |
+          docker push $REGISTRY/${{ matrix.image }}:$IMAGE_TAG
 
-      # - name: Generate docker SBOM
-      #   uses: cds-snc/security-tools/.github/actions/generate-sbom@34794baf2af592913bb5b51d8df4f8d0acc49b6f # v3.2.0
-      #   env:
-      #     TRIVY_DB_REPOSITORY: ${{ vars.TRIVY_DB_REPOSITORY }}
-      #   with:
-      #     docker_image: "${{ env.REGISTRY }}/${{ matrix.image }}:${{ env.IMAGE_TAG }}"
-      #     dockerfile_path: "ci/Dockerfile.lambda"
-      #     sbom_name: "notification-api-lambda"
-      #     token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Generate docker SBOM
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@34794baf2af592913bb5b51d8df4f8d0acc49b6f # v3.2.0
+        env:
+          TRIVY_DB_REPOSITORY: ${{ vars.TRIVY_DB_REPOSITORY }}
+        with:
+          docker_image: "${{ env.REGISTRY }}/${{ matrix.image }}:${{ env.IMAGE_TAG }}"
+          dockerfile_path: "ci/Dockerfile.lambda"
+          sbom_name: "notification-api-lambda"
+          token: "${{ secrets.GITHUB_TOKEN }}"
 
-      # - name: Logout of Amazon ECR
-      #   run: docker logout ${{ steps.login-ecr.outputs.registry }}
+      - name: Logout of Amazon ECR
+        run: docker logout ${{ steps.login-ecr.outputs.registry }}
 
-      # - name: Notify Slack channel if this job failed
-      #   if: ${{ failure() }}
-      #   run: |
-      #     json="{'text':'<!here> CI is failing in <https://github.com/cds-snc/notification-api/actions/runs/${GITHUB_RUN_ID}|notification-api> !'}"
-      #     curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.SLACK_WEBHOOK }}
+      - name: Notify Slack channel if this job failed
+        if: ${{ failure() }}
+        run: |
+          json="{'text':'<!here> CI is failing in <https://github.com/cds-snc/notification-api/actions/runs/${GITHUB_RUN_ID}|notification-api> !'}"
+          curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/lambda_production.yml
+++ b/.github/workflows/lambda_production.yml
@@ -45,25 +45,25 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@5a88a04c91d5c6f97aae0d9be790e64d9b1d47b7 # v1.7.1
 
-      - name: Push containers to ECR
-        run: |
-          docker push $REGISTRY/${{ matrix.image }}:$IMAGE_TAG
+      # - name: Push containers to ECR
+      #   run: |
+      #     docker push $REGISTRY/${{ matrix.image }}:$IMAGE_TAG
 
-      - name: Generate docker SBOM
-        uses: cds-snc/security-tools/.github/actions/generate-sbom@34794baf2af592913bb5b51d8df4f8d0acc49b6f # v3.2.0
-        env:
-          TRIVY_DB_REPOSITORY: ${{ vars.TRIVY_DB_REPOSITORY }}
-        with:
-          docker_image: "${{ env.REGISTRY }}/${{ matrix.image }}:${{ env.IMAGE_TAG }}"
-          dockerfile_path: "ci/Dockerfile.lambda"
-          sbom_name: "notification-api-lambda"
-          token: "${{ secrets.GITHUB_TOKEN }}"
+      # - name: Generate docker SBOM
+      #   uses: cds-snc/security-tools/.github/actions/generate-sbom@34794baf2af592913bb5b51d8df4f8d0acc49b6f # v3.2.0
+      #   env:
+      #     TRIVY_DB_REPOSITORY: ${{ vars.TRIVY_DB_REPOSITORY }}
+      #   with:
+      #     docker_image: "${{ env.REGISTRY }}/${{ matrix.image }}:${{ env.IMAGE_TAG }}"
+      #     dockerfile_path: "ci/Dockerfile.lambda"
+      #     sbom_name: "notification-api-lambda"
+      #     token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Logout of Amazon ECR
-        run: docker logout ${{ steps.login-ecr.outputs.registry }}
+      # - name: Logout of Amazon ECR
+      #   run: docker logout ${{ steps.login-ecr.outputs.registry }}
 
-      - name: Notify Slack channel if this job failed
-        if: ${{ failure() }}
-        run: |
-          json="{'text':'<!here> CI is failing in <https://github.com/cds-snc/notification-api/actions/runs/${GITHUB_RUN_ID}|notification-api> !'}"
-          curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.SLACK_WEBHOOK }}
+      # - name: Notify Slack channel if this job failed
+      #   if: ${{ failure() }}
+      #   run: |
+      #     json="{'text':'<!here> CI is failing in <https://github.com/cds-snc/notification-api/actions/runs/${GITHUB_RUN_ID}|notification-api> !'}"
+      #     curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/lambda_production.yml
+++ b/.github/workflows/lambda_production.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 env:
-  REGISTRY: ${{ secrets.PRODUCTION_API_LAMBDA_ECR_ACCOUNT }}.dkr.ecr.ca-central-1.amazonaws.com/notify
+  REGISTRY: ${{ secrets.PRODUCTION_ACCOUNT_ID }}.dkr.ecr.ca-central-1.amazonaws.com/notify
 
 jobs:
   build-and-push:
@@ -25,8 +25,8 @@ jobs:
         id: aws-creds
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
-          aws-access-key-id: ${{ secrets.PRODUCTION_ECR_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.PRODUCTION_ECR_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
           aws-region: ca-central-1
 
       - name: Set Docker image tag

--- a/.github/workflows/lambda_production.yml
+++ b/.github/workflows/lambda_production.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 env:
-  REGISTRY: ${{ secrets.PRODUCTION_ACCOUNT_ID }}.dkr.ecr.ca-central-1.amazonaws.com/notify
+  REGISTRY: ${{ secrets.PRODUCTION_AWS_ACCOUNT_ID }}.dkr.ecr.ca-central-1.amazonaws.com/notify
 
 jobs:
   build-and-push:

--- a/.github/workflows/lambda_staging.yml
+++ b/.github/workflows/lambda_staging.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 env:
-  REGISTRY: ${{ secrets.STAGING_API_LAMBDA_ECR_ACCOUNT }}.dkr.ecr.ca-central-1.amazonaws.com/notify
+  REGISTRY: ${{ secrets.STAGING_ACCOUNT_ID }}.dkr.ecr.ca-central-1.amazonaws.com/notify
 
 jobs:
   build-push-and-deploy:
@@ -25,8 +25,8 @@ jobs:
         id: aws-creds
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
-          aws-access-key-id: ${{ secrets.STAGING_ECR_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.STAGING_ECR_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
           aws-region: ca-central-1
 
       - name: Build container

--- a/.github/workflows/lambda_staging.yml
+++ b/.github/workflows/lambda_staging.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 env:
-  REGISTRY: ${{ secrets.STAGING_ACCOUNT_ID }}.dkr.ecr.ca-central-1.amazonaws.com/notify
+  REGISTRY: ${{ secrets.STAGING_AWS_ACCOUNT_ID }}.dkr.ecr.ca-central-1.amazonaws.com/notify
 
 jobs:
   build-push-and-deploy:


### PR DESCRIPTION
# Summary | Résumé

Second take on switching to the github managed api secrets. I resolved the original issue where this was not working due to missing secrets.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/299

# Test instructions | Instructions pour tester la modification

Verify all workflows still work

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.