### PR TITLE
Add a new run_celery script for delivery receipts

### DIFF
--- a/scripts/run_celery_delivery.sh
+++ b/scripts/run_celery_delivery.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+# Runs celery with only the delivery-receipts queue.
+
+echo "Start celery, concurrency: ${CELERY_CONCURRENCY-4}"
+
+celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency="${CELERY_CONCURRENCY-4}" -Q delivery-receipts


### PR DESCRIPTION
# Summary | Résumé

Add a new run_celery script to use for a new delivery-receipts deployment of celery pods.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/473

# Test instructions | Instructions pour tester la modification

none really, this doesn't work locally...

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.