### PR TITLE
Added email message for change in annual limits

### DIFF
--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -270,6 +270,7 @@ def create_service():
     return jsonify(data=service_schema.dump(valid_service)), 201
 
 
+# flake8: noqa: C901
 @service_blueprint.route("/<uuid:service_id>", methods=["POST"])
 def update_service(service_id):
     req_json = request.get_json()

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -375,6 +375,7 @@ def _warn_service_users_about_annual_limit_change(service: Service, notification
         service_id=service.id,
         template_id=current_app.config["ANNUAL_LIMIT_UPDATED_TEMPLATE_ID"],
         personalisation={
+            "service_name": service.name,
             "message_type_en": notification_type,
             "message_type_fr": "Courriel" if notification_type == EMAIL_TYPE else "SMS",
             "message_limit_en": service.email_annual_limit if notification_type == EMAIL_TYPE else service.sms_annual_limit,

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1025,7 +1025,9 @@ def test_update_service_annual_limits(
     limit_field,
     limit_value,
     expected_status,
+    mocker,
 ):
+    mocker.patch("app.service.rest.send_notification_to_service_users")
     admin_request.post(
         "service.update_service",
         service_id=sample_service.id,


### PR DESCRIPTION
# Summary | Résumé

When the annual limits are changed, send a message to the service owners.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1701

# Test instructions | Instructions pour tester la modification
Run locally and check if the email comes

# Reviewer checklist | Liste de vérification du réviseur

- [x] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [x] This PR does not significantly alter performance.
- [x] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.