### PR TITLE
Fix/remove warn keys when annual limits change

### DIFF
--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -314,18 +314,16 @@ def update_service(service_id):
         redis_store.delete(over_sms_daily_limit_cache_key(service_id))
         if not fetched_service.restricted:
             _warn_service_users_about_sms_limit_changed(service_id, current_data)
-    # TODO: abstract this in the annual_limits_client
-    if email_annual_limit_changed:
-        redis_store.delete(f"annual-limit:{service_id}:status:near_email_limit")
-        redis_store.delete(f"annual-limit:{service_id}:status:over_email_limit")
-    if sms_annual_limit_changed:
-        redis_store.delete(f"annual-limit:{service_id}:status:near_sms_limit")
-        redis_store.delete(f"annual-limit:{service_id}:status:over_sms_limit")
-
     if sms_annual_limit_changed:
         _warn_service_users_about_annual_limit_change(service, SMS_TYPE)
+        # TODO: abstract this in the annual_limits_client
+        redis_store.delete(f"annual-limit:{service_id}:status:near_email_limit")
+        redis_store.delete(f"annual-limit:{service_id}:status:over_email_limit")
     if email_annual_limit_changed:
         _warn_service_users_about_annual_limit_change(service, EMAIL_TYPE)
+        # TODO: abstract this in the annual_limits_client
+        redis_store.delete(f"annual-limit:{service_id}:status:near_sms_limit")
+        redis_store.delete(f"annual-limit:{service_id}:status:over_sms_limit")
 
     if service_going_live:
         _warn_services_users_about_going_live(service_id, current_data)

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -314,6 +314,13 @@ def update_service(service_id):
         redis_store.delete(over_sms_daily_limit_cache_key(service_id))
         if not fetched_service.restricted:
             _warn_service_users_about_sms_limit_changed(service_id, current_data)
+    # TODO: abstract this in the annual_limits_client
+    if email_annual_limit_changed:
+        redis_store.delete(f"annual-limit:{service_id}:status:near_email_limit")
+        redis_store.delete(f"annual-limit:{service_id}:status:over_email_limit")
+    if sms_annual_limit_changed:
+        redis_store.delete(f"annual-limit:{service_id}:status:near_sms_limit")
+        redis_store.delete(f"annual-limit:{service_id}:status:over_sms_limit")
 
     if sms_annual_limit_changed:
         _warn_service_users_about_annual_limit_change(service, SMS_TYPE)

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -317,13 +317,13 @@ def update_service(service_id):
     if sms_annual_limit_changed:
         _warn_service_users_about_annual_limit_change(service, SMS_TYPE)
         # TODO: abstract this in the annual_limits_client
-        redis_store.delete(f"annual-limit:{service_id}:status:near_email_limit")
-        redis_store.delete(f"annual-limit:{service_id}:status:over_email_limit")
+        redis_store.delete(f"annual-limit:{service_id}:status:near_sms_limit")
+        redis_store.delete(f"annual-limit:{service_id}:status:over_sms_limit")
     if email_annual_limit_changed:
         _warn_service_users_about_annual_limit_change(service, EMAIL_TYPE)
         # TODO: abstract this in the annual_limits_client
-        redis_store.delete(f"annual-limit:{service_id}:status:near_sms_limit")
-        redis_store.delete(f"annual-limit:{service_id}:status:over_sms_limit")
+        redis_store.delete(f"annual-limit:{service_id}:status:near_email_limit")
+        redis_store.delete(f"annual-limit:{service_id}:status:over_email_limit")
 
     if service_going_live:
         _warn_services_users_about_going_live(service_id, current_data)

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1028,6 +1028,7 @@ def test_update_service_annual_limits(
     mocker,
 ):
     mocker.patch("app.service.rest.send_notification_to_service_users")
+    redis_delete = mocker.patch("app.service.rest.redis_store.delete")
     admin_request.post(
         "service.update_service",
         service_id=sample_service.id,
@@ -1037,6 +1038,16 @@ def test_update_service_annual_limits(
         _expected_status=expected_status,
     )
     assert getattr(sample_service, limit_field) == limit_value
+    if limit_field == "sms_annual_limit":
+        assert redis_delete.call_args_list == [
+            call(f"annual-limit:{sample_service.id}:status:near_sms_limit"),
+            call(f"annual-limit:{sample_service.id}:status:over_sms_limit"),
+        ]
+    if limit_field == "email_annual_limit":
+        assert redis_delete.call_args_list == [
+            call(f"annual-limit:{sample_service.id}:status:near_email_limit"),
+            call(f"annual-limit:{sample_service.id}:status:over_email_limit"),
+        ]
 
 
 def test_get_users_by_service(notify_api, sample_service):


### PR DESCRIPTION
# Summary | Résumé

This PR adds a step when updating annual limits to remove the redis keys associated with having warned the user that they were either approaching their limits, or at their limits.  This way, when they reach those points again after the limits are updated, they will get the warnings.

### Keys
- Email
   - annual-limit:{service_id}:status:near_email_limit
   - annual-limit:{service_id}:status:over_email_limit
- SMS
   - annual-limit:{service_id}:status:near_sms_limit
   - annual-limit:{service_id}:status:over_sms_limit

# Test instructions | Instructions pour tester la modification

- Hit the limit for a service
- Verify the warning/limit keys are visible in redis
- Update the limit
- Verify the warning/limit keys have been removed

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.