### PR TITLE
Use official 3.10 New Relic later and Debian slim

### DIFF
--- a/bin/get_newrelic_layer.sh
+++ b/bin/get_newrelic_layer.sh
@@ -2,6 +2,6 @@
 
 aws lambda get-layer-version-by-arn \
 --region ca-central-1 \
---arn arn:aws:lambda:ca-central-1:451483290750:layer:NewRelicPython39:12 \
+--arn arn:aws:lambda:ca-central-1:451483290750:layer:NewRelicPython310:39 \
 | jq -r '.Content.Location' \
 | xargs curl -o ../newrelic-layer.zip

--- a/ci/Dockerfile.lambda
+++ b/ci/Dockerfile.lambda
@@ -1,4 +1,4 @@
-FROM python:3.10-alpine3.16@sha256:afe68972cc00883d70b3760ee0ffbb7375cf09706c122dda7063ffe64c5be21b
+FROM python:3.10-slim@sha256:61912260e578182d00b5e163eb4cfb13b35fb8782c98d1df9ed584cec8939097
 
 ENV PYTHONPATH "${PYTHONPATH}:/opt/python/lib/python3.10/site-packages"
 ENV PYTHONDONTWRITEBYTECODE 1
@@ -9,7 +9,8 @@ ENV POETRY_VERSION="1.7.1"
 ENV POETRY_VIRTUALENVS_CREATE="false"
 ENV PATH="${APP_VENV}/bin:${POETRY_HOME}/bin:$PATH"
 
-RUN apk add --no-cache bash build-base git libtool cmake autoconf automake gcc musl-dev postgresql-dev g++ libc6-compat libexecinfo-dev make libffi-dev libmagic libcurl curl-dev rust cargo && rm -rf /var/cache/apk/*
+RUN apt-get update
+RUN apt-get install -y bash git libtool  autoconf automake gcc  g++ make libffi-dev unzip
 
 RUN mkdir -p ${TASK_ROOT}
 WORKDIR ${TASK_ROOT}


### PR DESCRIPTION
# Summary | Résumé

Having issues with the official New Relic layers after 3.9 and alpine. Builds fine but cannot register with AWS Lambda.

Here we
- switch to the recommended Debian distribution (well, Debian-slim).
- download the official New Relic layer for 3.10 rather than using the one we made ourselves. (the download script has been changed to reflect this)

Surprisingly this debian based image is 20% smaller than the current alpine based image. 

We will test this in staging and if all is good we will revert it and see if the 3.12 upgrade works with Debian.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/465

# Test instructions | Instructions pour tester la modification

This has been built and deployed to dev and can be tested there.
- go to the [dev lambda function](https://ca-central-1.console.aws.amazon.com/lambda/home?region=ca-central-1#/functions/api-lambda?tab=testing)
- under the "test" tab choose the template "API Gateway Http API"
- click the "test" button.
- the "executing function" box should eventually turn green. The details say a 404 was returned. 
- To get the status out of api, change the "rawPath" on line 4 to "/" and the "method" on line 48 to "GET". Testing this should result in a 200 and the api status line.
- run the test a bunch (10-20 times).
- after a few minutes your invocations should show up in the [New Relic dashboard](https://one.newrelic.com/nr1-core/lambda/overview/MjY5MTk3NHxJTkZSQXxOQXwyMzIzMjU3MTc4NTM2MzgwMzI4?account=2691974&duration=1800000&filters=%28domain%20%3D%20%27INFRA%27%20AND%20type%20%3D%20%27AWSLAMBDAFUNCTION%27%29&state=c3492efc-5a7e-1f4a-9150-7399c671d2b7)

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [x] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [x] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.