### PR TITLE
Fix job sending limit validation

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -39,6 +39,9 @@ from app.aws.metrics import (
     put_batch_saving_bulk_processed,
 )
 from app.config import Config, Priorities, QueueNames
+from app.dao.fact_notification_status_dao import (
+    fetch_notification_status_totals_for_service_by_fiscal_year,
+)
 from app.dao.inbound_sms_dao import dao_get_inbound_sms_by_id
 from app.dao.jobs_dao import dao_get_in_progress_jobs, dao_get_job_by_id, dao_update_job
 from app.dao.notifications_dao import (
@@ -81,7 +84,7 @@ from app.notifications.process_notifications import (
 )
 from app.sms_fragment_utils import fetch_todays_requested_sms_count
 from app.types import VerifiedNotification
-from app.utils import get_csv_max_rows, get_delivery_queue_for_template
+from app.utils import get_csv_max_rows, get_delivery_queue_for_template, get_fiscal_year
 from app.v2.errors import (
     LiveServiceTooManyRequestsError,
     LiveServiceTooManySMSRequestsError,
@@ -208,26 +211,28 @@ def __sending_limits_for_job_exceeded(service, job: Job, job_id):
 
     if job.template.template_type == SMS_TYPE:
         total_post_send = fetch_todays_requested_sms_count(service.id) + job.notification_count
+        total_sent_this_fiscal = fetch_notification_status_totals_for_service_by_fiscal_year(
+            service.id, get_fiscal_year(datetime.utcnow()), notification_type=SMS_TYPE
+        )
+        send_exceeds_annual_limit = (total_post_send + total_sent_this_fiscal) > service.sms_annual_limit
+        send_exceeds_daily_limit = total_post_send > service.sms_daily_limit
 
-        if total_post_send > service.sms_annual_limit and current_app.config["FF_ANNUAL_LIMIT"]:
-            error_message = (
-                f"Job {job_id} size {job.notification_count} error. SMS annual limit {service.sms_annual_limit} exceeded."
-            )
-        elif total_post_send > service.sms_daily_limit:
-            error_message = (
-                f"Job {job_id} size {job.notification_count} error. SMS daily limit {service.sms_daily_limit} exceeded."
-            )
+        if send_exceeds_annual_limit and current_app.config["FF_ANNUAL_LIMIT"]:
+            error_message = f"SMS annual limit of {service.sms_annual_limit} would be exceeded if job {job_id} is sent. Job size: {job.notification_count} Total SMS sent this fiscal + job size: {total_post_send + total_sent_this_fiscal} Over by: {total_post_send + total_sent_this_fiscal - service.sms_annual_limit}"
+        elif send_exceeds_daily_limit:
+            error_message = f"SMS daily limit of {service.sms_daily_limit} would be exceeded if job {job_id} is sent. Job size: {job.notification_count} Total SMS sent today + job size: {total_post_send} Over by: {total_post_send - service.sms_daily_limit}"
     else:
         total_post_send = fetch_todays_email_count(service.id) + job.notification_count
+        total_sent_this_fiscal = fetch_notification_status_totals_for_service_by_fiscal_year(
+            service.id, get_fiscal_year(datetime.utcnow()), notification_type=EMAIL_TYPE
+        )
+        send_exceeds_annual_limit = (total_post_send + total_sent_this_fiscal) > service.email_annual_limit
+        send_exceeds_daily_limit = total_post_send > service.message_limit
 
-        if total_post_send > service.email_annual_limit and current_app.config["FF_ANNUAL_LIMIT"]:
-            error_message = (
-                f"Job {job_id} size {job.notification_count} error. Email annual limit {service.sms_annual_limit} exceeded."
-            )
-        elif total_post_send > service.message_limit:
-            error_message = (
-                f"Job {job_id} size {job.notification_count} error. SMS daily limit {service.sms_daily_limit} exceeded."
-            )
+        if send_exceeds_annual_limit and current_app.config["FF_ANNUAL_LIMIT"]:
+            error_message = f"Email annual limit of {service.email_annual_limit} would be exceeded if job {job_id} is sent. Job size: {job.notification_count} Total email sent this fiscal + job size: {total_post_send + total_sent_this_fiscal} Over limit by: {total_post_send + total_sent_this_fiscal - service.email_annual_limit}"
+        elif send_exceeds_daily_limit:
+            error_message = f"Email daily limit of {service.email_annual_limit} would be exceeded if job {job_id} is sent. Job size: {job.notification_count} Total email sent today + job size: {total_post_send + total_sent_this_fiscal} Over limit by: {total_post_send + total_sent_this_fiscal - service.email_annual_limit}"
 
     if error_message:
         job.job_status = JOB_STATUS_SENDING_LIMITS_EXCEEDED


### PR DESCRIPTION
# Summary | Résumé
This PR updates annual and daily limit validation that takes place before a job begins processing in the back end. 

- `__sending_limits_for_job_exceeded` should now properly check job size against a services annual limits
- Error logging when annual or daily limits would be exceeded now include: job size, daily/annual limits, total_sent_today / total_send_this_fiscal, and how far over the limit a service would be if the job were to be sent.

# Test instructions | Instructions pour tester la modification

1. Send a job that would go over the annual limit  and one that would go over the daily limit
2. Check cloudwatch logs for the error logging
3. Send is prevented

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.