### PR TITLE
Update to the annual limits emails

### DIFF
--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -514,7 +514,7 @@ def send_near_annual_limit_warning_email(service: Service, notification_type: No
         message_limit_fr = "{:,}".format(service.email_annual_limit).replace(",", " ")
         message_limit_en = service.email_annual_limit
         message_type_fr = "courriels"
-        message_type_en = "emails" 
+        message_type_en = "emails"
         remaining_en = "{:,}".format(service.email_annual_limit - count_en)
         remaining_fr = "{:,}".format(service.email_annual_limit - count_en).replace(",", " ")
     else:

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -498,8 +498,8 @@ def send_annual_limit_reached_email(service: Service, notification_type: Notific
         template_id=current_app.config["REACHED_ANNUAL_LIMIT_TEMPLATE_ID"],
         personalisation={
             "service_name": service.name,
-            "message_type_en": notification_type,
-            "message_type_fr": "Courriel" if notification_type == EMAIL_TYPE else "SMS",
+            "message_type_en": "emails" if notification_type == EMAIL_TYPE else "text messages",
+            "message_type_fr": "courriels" if notification_type == EMAIL_TYPE else "messages texte",
             "fiscal_end": fiscal_end,
             "hyperlink_to_page_en": f"{current_app.config['ADMIN_BASE_URL']}/services/{service.id}/monthly",
             "hyperlink_to_page_fr": f"{current_app.config['ADMIN_BASE_URL']}/services/{service.id}/monthly?lang=fr",
@@ -513,15 +513,17 @@ def send_near_annual_limit_warning_email(service: Service, notification_type: No
     if notification_type == EMAIL_TYPE:
         message_limit_fr = "{:,}".format(service.email_annual_limit).replace(",", " ")
         message_limit_en = service.email_annual_limit
-        message_type_fr = "Courriel"
-        remaining_en = service.email_annual_limit - count_en
-        remaining_fr = "{:,}".format(remaining_en).replace(",", " ")
+        message_type_fr = "courriels"
+        message_type_en = "emails" 
+        remaining_en = "{:,}".format(service.email_annual_limit - count_en)
+        remaining_fr = "{:,}".format(service.email_annual_limit - count_en).replace(",", " ")
     else:
         message_limit_fr = "{:,}".format(service.sms_annual_limit).replace(",", " ")
         message_limit_en = service.sms_annual_limit
-        message_type_fr = "sms"
-        remaining_en = service.sms_annual_limit - count_en
-        remaining_fr = "{:,}".format(remaining_en).replace(",", " ")
+        message_type_en = "text messages"
+        message_type_fr = "messages texte"
+        remaining_en = "{:,}".format(service.sms_annual_limit - count_en)
+        remaining_fr = "{:,}".format(service.sms_annual_limit - count_en).replace(",", " ")
 
     send_notification_to_service_users(
         service_id=service.id,
@@ -534,29 +536,10 @@ def send_near_annual_limit_warning_email(service: Service, notification_type: No
             "count_fr": count_fr,
             "message_limit_en": message_limit_en,
             "message_limit_fr": message_limit_fr,
-            "message_type_en": notification_type,
+            "message_type_en": message_type_en,
             "message_type_fr": message_type_fr,
             "remaining_en": remaining_en,
             "remaining_fr": remaining_fr,
-            "hyperlink_to_page_en": f"{current_app.config['ADMIN_BASE_URL']}/services/{service.id}/monthly",
-            "hyperlink_to_page_fr": f"{current_app.config['ADMIN_BASE_URL']}/services/{service.id}/monthly?lang=fr",
-        },
-        include_user_fields=["name"],
-    )
-
-
-def send_annual_limit_updated_email(service: Service, notification_type: NotificationType, fiscal_end: int):
-    send_notification_to_service_users(
-        service_id=service.id,
-        template_id=current_app.config["ANNUAL_LIMIT_UPDATED_TEMPLATE_ID"],
-        personalisation={
-            "service_name": service.name,
-            "message_type_en": notification_type,
-            "message_type_fr": "Courriel" if notification_type == EMAIL_TYPE else "SMS",
-            "message_limit_en": service.email_annual_limit if notification_type == EMAIL_TYPE else service.sms_annual_limit,
-            "message_limit_fr": "{:,}".format(
-                service.email_annual_limit if notification_type == EMAIL_TYPE else service.sms_annual_limit
-            ).replace(",", " "),
             "hyperlink_to_page_en": f"{current_app.config['ADMIN_BASE_URL']}/services/{service.id}/monthly",
             "hyperlink_to_page_fr": f"{current_app.config['ADMIN_BASE_URL']}/services/{service.id}/monthly?lang=fr",
         },

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -383,9 +383,9 @@ def _warn_service_users_about_annual_limit_change(service: Service, notification
         template_id=current_app.config["ANNUAL_LIMIT_UPDATED_TEMPLATE_ID"],
         personalisation={
             "service_name": service.name,
-            "message_type_en": notification_type,
-            "message_type_fr": "Courriel" if notification_type == EMAIL_TYPE else "SMS",
-            "message_limit_en": service.email_annual_limit if notification_type == EMAIL_TYPE else service.sms_annual_limit,
+            "message_type_en": "emails" if notification_type == EMAIL_TYPE else "text messages",
+            "message_type_fr": "courriels" if notification_type == EMAIL_TYPE else "messages texte",
+            "message_limit_en": "{:,}".format(service.email_annual_limit) if notification_type == EMAIL_TYPE else "{:,}".format(service.sms_annual_limit),
             "message_limit_fr": "{:,}".format(
                 service.email_annual_limit if notification_type == EMAIL_TYPE else service.sms_annual_limit
             ).replace(",", " "),

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -385,7 +385,9 @@ def _warn_service_users_about_annual_limit_change(service: Service, notification
             "service_name": service.name,
             "message_type_en": "emails" if notification_type == EMAIL_TYPE else "text messages",
             "message_type_fr": "courriels" if notification_type == EMAIL_TYPE else "messages texte",
-            "message_limit_en": "{:,}".format(service.email_annual_limit) if notification_type == EMAIL_TYPE else "{:,}".format(service.sms_annual_limit),
+            "message_limit_en": "{:,}".format(service.email_annual_limit)
+            if notification_type == EMAIL_TYPE
+            else "{:,}".format(service.sms_annual_limit),
             "message_limit_fr": "{:,}".format(
                 service.email_annual_limit if notification_type == EMAIL_TYPE else service.sms_annual_limit
             ).replace(",", " "),

--- a/migrations/versions/0471_edit_limit_emails2.py
+++ b/migrations/versions/0471_edit_limit_emails2.py
@@ -1,0 +1,184 @@
+"""empty message
+
+Revision ID: 0471_edit_limit_emails2
+Revises: 0470_change_default_limit
+Create Date: 2016-06-01 14:17:01.963181
+
+"""
+
+from datetime import datetime
+
+from alembic import op
+from flask import current_app
+
+revision = "0471_edit_limit_emails2"
+down_revision = "0470_change_default_limit"
+
+
+near_annual_limit_template_id = current_app.config["NEAR_ANNUAL_LIMIT_TEMPLATE_ID"]
+reached_annual_limit_template_id = current_app.config["REACHED_ANNUAL_LIMIT_TEMPLATE_ID"]
+annual_limit_updated_template_id = current_app.config["ANNUAL_LIMIT_UPDATED_TEMPLATE_ID"]
+status_template_category_id = "55eb1137-6dc6-4094-9031-f61124a279dc"
+information_template_category_id = "207b293c-2ae5-48e8-836d-fcabd60b2153"
+template_ids = [
+    near_annual_limit_template_id,
+    reached_annual_limit_template_id,
+    annual_limit_updated_template_id,
+]
+
+annual_limit_updated = "\n".join(
+    [
+        "(la version française suit)",
+        "",
+        "Hello ((name)),",
+        "",
+        "You can now send ((message_limit_en)) ((message_type_en)) per fiscal year.",
+        "",
+        "For more information, visit the usage report for your [service](((hyperlink_to_page_en))).",
+        "",
+        "The GC Notify Team",
+        "",
+        "---",
+        "",
+        "Bonjour ((name)),",
+        "",
+        "Vous pouvez maintenant envoyer ((message_limit_fr)) ((message_type_fr)) par exercice financier.",
+        "",
+        "Pour en savoir plus, consultez le rapport d’utilisation pour votre [service](((hyperlink_to_page_fr))).",
+        "",
+        "L’équipe Notification GC",
+    ]
+)
+
+annual_limit_reached = "\n".join(
+    [
+        "(la version française suit)",
+        "",
+        "Hello ((name)),",
+        "",
+        "0 ((message_type_en)) remaining until April ((fiscal_end)).",
+        "",
+        "GC Notify has annual and daily sending limits. This message is about your annual limit.",
+        "We’ve paused ((message_type_en)) sending until your limit resets on April 1, ((fiscal_end)).",
+        "",
+        "For more information, visit the usage report for your [service](((hyperlink_to_page_en))).",
+        "",
+        "The GC Notify team",
+        "",
+        "---",
+        "",
+        "Bonjour ((name)),",
+        "",
+        "0 ((message_type_fr)) restant d’ici avril ((fiscal_end)).",
+        "",
+        "Le service Notification GC comporte des limites annuelles et quotidiennes. Ce message concerne votre limite annuelle.",
+        "Nous avons suspendu l’envoi de ((message_type_fr)) jusqu’à la réinitialisation de votre limite le 1er avril ((fiscal_end)).",
+        "",
+        "Pour en savoir plus, consultez le rapport d’utilisation pour [votre service](((hyperlink_to_page_fr))).",
+        "",
+        "L’équipe Notification GC",
+        "",
+    ]
+)
+
+near_annual_limit = "\n".join(
+    [
+        "(la version française suit)",
+        "",
+        "Hello ((name)),",
+        "",
+        "GC Notify has annual and daily sending limits. This message is about your annual limit.",
+        "",
+        "((service_name)) has sent ((count_en)) out of its limit of ((message_limit_en)) ((message_type_en)) per fiscal year.",
+        "((service_name)) has ((remaining_en)) ((message_type_en)) remaining until April 1, ((fiscal_end)).",
+        "",
+        "For more information, visit the usage report for your [service](((hyperlink_to_page_en))).",
+        "",
+        "The GC Notify Team",
+        "",
+        "---",
+        "",
+        "Bonjour ((name)),",
+        "",
+        "Le service Notification GC comporte des limites annuelles et quotidiennes. Ce message concerne votre limite annuelle.",
+        "",
+        "((service_name)) a envoyé ((count_fr)) ((message_type_fr)) et sa limite d’envoi est fixée à ((message_limit_fr)) ((message_type_fr)) par exercice financier.",
+        "((service_name)) peut encore envoyer ((remaining_fr)) ((message_type_fr)) d’ici le 1er avril ((fiscal_end)).",
+        "",
+        "Pour en savoir plus, consultez le rapport d’utilisation pour votre [service](((hyperlink_to_page_fr))).",
+        "",
+        "L’équipe Notification GC",
+        "",
+    ]
+)
+
+def upgrade():
+    conn = op.get_bind()
+
+    templates = [
+        {
+            "id": near_annual_limit_template_id,
+            "name": "Near annual limit",
+            "subject": " Alert for ((service_name)) | # Alerte pour ((service_name)).",
+            "content": near_annual_limit,
+            "template_category_id": status_template_category_id,
+        },
+        {
+            "id": reached_annual_limit_template_id,
+            "name": "Annual limit reached",
+            "subject": "Alert for ((service_name)) | # Alerte pour ((service_name))",
+            "content": annual_limit_reached,
+            "template_category_id": status_template_category_id,
+        },
+        {
+            "id": annual_limit_updated_template_id,
+            "name": "Annual limit updated",
+            "subject": "Annual limit update for ((service_name)) | Nous avons mis à jour la limite annuelle pour ((service_name))",
+            "content": annual_limit_updated,
+            "template_category_id": status_template_category_id,
+        },
+    ]
+
+    template_update = """
+        UPDATE templates SET content = '{}', subject = '{}', version = '{}', updated_at = '{}', template_category_id = '{}'
+        WHERE id = '{}'
+    """
+    template_history_insert = """
+        INSERT INTO templates_history (id, name, template_type, created_at, content, archived, service_id, subject,
+        created_by_id, version, hidden, template_category_id)
+        VALUES ('{}', '{}', '{}', '{}', '{}', False, '{}', '{}', '{}', {}, false, '{}')
+    """
+
+    for template in templates:
+        current_version = conn.execute("select version from templates where id='{}'".format(template["id"])).fetchone()
+        name = conn.execute("select name from templates where id='{}'".format(template["id"])).fetchone()
+        template["version"] = current_version[0] + 1
+        template["name"] = name[0]
+        op.execute(
+            template_update.format(
+                template["content"],
+                template["subject"],
+                template["version"],
+                datetime.utcnow(),
+                template["template_category_id"],
+                template["id"],
+            )
+        )
+        op.execute(
+            template_history_insert.format(
+                template["id"],
+                template["name"],
+                "email",
+                datetime.utcnow(),
+                template["content"],
+                current_app.config["NOTIFY_SERVICE_ID"],
+                template["subject"],
+                current_app.config["NOTIFY_USER_ID"],
+                template["version"],
+                template["template_category_id"],
+            )
+        )
+
+
+def downgrade():
+    pass

--- a/migrations/versions/0471_edit_limit_emails2.py
+++ b/migrations/versions/0471_edit_limit_emails2.py
@@ -112,6 +112,7 @@ near_annual_limit = "\n".join(
     ]
 )
 
+
 def upgrade():
     conn = op.get_bind()
 


### PR DESCRIPTION
# Summary | Résumé

This PR updates the annual limit emails to:
- use the correct terms for notification types (emails/courriels and text messages/messages texte)
- use thousands separators in both french and english for long numbers
- properly link to the usage report page
- fix missing space in one of the templates

# Test instructions | Instructions pour tester la modification
## Scenarios
### SMS
- Update your annual **SMS** limit
   - [x] thousands separator is used for long numbers
   - [x] "emails" and "courriels" used for email limit content
   - [x] "text messages" and "messages texte" used for sms limit content
   - [x] there is a space between the annual limit and the message type (i.e. `4,000 emails` and NOT `4,000emails`)
   - [x] usage report works in both english and french
- Send more than 80% of your annual **SMS** limit
   - [x] thousands separator is used for long numbers
   - [x] "emails" and "courriels" used for email limit content
   - [x] "text messages" and "messages texte" used for sms limit content
   - [x] there is a space between the annual limit and the message type (i.e. `4,000 emails` and NOT `4,000emails`)
   - [ ] usage report works in both english and french
- Reach 100% of your annual **SMS** limit
   - [x] thousands separator is used for long numbers
   - [x] "emails" and "courriels" used for email limit content
   - [x] "text messages" and "messages texte" used for sms limit content
   - [x] there is a space between the annual limit and the message type (i.e. `4,000 emails` and NOT `4,000emails`)
   - [x] usage report works in both english and french

### EMAIL
-  Update your annual **email** limit
   - [x] thousands separator is used for long numbers
   - [x] "emails" and "courriels" used for email limit content
   - [x] "text messages" and "messages texte" used for sms limit content
   - [x] there is a space between the annual limit and the message type (i.e. `4,000 emails` and NOT `4,000emails`)
   - [x] usage report works in both english and french
- Send more than 80% of your annual **email** limit
   - [x] thousands separator is used for long numbers
   - [x] "emails" and "courriels" used for email limit content
   - [x] "text messages" and "messages texte" used for sms limit content
   - [x] there is a space between the annual limit and the message type (i.e. `4,000 emails` and NOT `4,000emails`)
   - [x] usage report works in both english and french
- Reach 100% of your annual **email** limit
   - [x] thousands separator is used for long numbers
   - [x] "emails" and "courriels" used for email limit content
   - [x] "text messages" and "messages texte" used for sms limit content
   - [x] there is a space between the annual limit and the message type (i.e. `4,000 emails` and NOT `4,000emails`)
   - [x] usage report works in both english and french

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.