### PR TITLE
Removed duplicate message limit validation for jobs

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -119,9 +119,6 @@ def process_job(job_id):
         current_app.logger.warning("Job {} has been cancelled, service {} is inactive".format(job_id, service.id))
         return
 
-    if __sending_limits_for_job_exceeded(service, job, job_id):
-        return
-
     job.job_status = JOB_STATUS_IN_PROGRESS
     job.processing_started = start
     dao_update_job(job)

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -545,6 +545,7 @@ class TestProcessJob:
             queue="-normal-database-tasks",
         )
 
+    @pytest.mark.skip()
     @freeze_time("2016-01-01 11:09:00.061258")
     def test_should_not_process_sms_job_if_would_exceed_send_limits(self, notify_db_session, mocker):
         service = create_service(sms_daily_limit=9)

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -563,23 +563,7 @@ class TestProcessJob:
         assert s3.get_job_from_s3.called is False
         assert tasks.process_rows.called is False
 
-    def test_should_not_process_sms_job_if_would_exceed_send_limits_inc_today(self, notify_db_session, mocker):
-        service = create_service(sms_daily_limit=1)
-        template = create_template(service=service)
-        job = create_job(template=template)
-
-        save_notification(create_notification(template=template, job=job))
-
-        mocker.patch("app.celery.tasks.s3.get_job_from_s3", return_value=load_example_csv("sms"))
-        mocker.patch("app.celery.tasks.process_rows")
-
-        process_job(job.id)
-
-        job = jobs_dao.dao_get_job_by_id(job.id)
-        assert job.job_status == "sending limits exceeded"
-        assert s3.get_job_from_s3.called is False
-        assert tasks.process_rows.called is False
-
+    @pytest.mark.skip()
     def test_should_not_process_job_if_already_pending(self, sample_template, mocker):
         job = create_job(template=sample_template, job_status="scheduled")
 

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -70,7 +70,7 @@ from tests.app.db import (
     create_user,
     save_notification,
 )
-from tests.conftest import set_config, set_config_values
+from tests.conftest import set_config_values
 
 
 class AnyStringWith(str):
@@ -579,7 +579,6 @@ class TestProcessJob:
         assert job.job_status == "sending limits exceeded"
         assert s3.get_job_from_s3.called is False
         assert tasks.process_rows.called is False
-
 
     def test_should_not_process_job_if_already_pending(self, sample_template, mocker):
         job = create_job(template=sample_template, job_status="scheduled")


### PR DESCRIPTION
# Summary | Résumé

This PR removes duplicated message limit validation that was occurring when sending a job via the UI. At that point in the job process we are unable to (for the third time...) check the annual limits as notifications in that job will be counted in Redis already, causing jobs to fail to send if the service was near their annual limit.

## Related Issues | Cartes liées

# Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.