### PR TITLE
Revert "Use official 3.10 New Relic later and Debian slim" if needed!!

### DIFF
--- a/bin/get_newrelic_layer.sh
+++ b/bin/get_newrelic_layer.sh
@@ -2,6 +2,6 @@
 
 aws lambda get-layer-version-by-arn \
 --region ca-central-1 \
---arn arn:aws:lambda:ca-central-1:451483290750:layer:NewRelicPython310:39 \
+--arn arn:aws:lambda:ca-central-1:451483290750:layer:NewRelicPython39:12 \
 | jq -r '.Content.Location' \
 | xargs curl -o ../newrelic-layer.zip

--- a/ci/Dockerfile.lambda
+++ b/ci/Dockerfile.lambda
@@ -1,4 +1,4 @@
-FROM python:3.10-slim@sha256:61912260e578182d00b5e163eb4cfb13b35fb8782c98d1df9ed584cec8939097
+FROM python:3.10-alpine3.16@sha256:afe68972cc00883d70b3760ee0ffbb7375cf09706c122dda7063ffe64c5be21b
 
 ENV PYTHONPATH "${PYTHONPATH}:/opt/python/lib/python3.10/site-packages"
 ENV PYTHONDONTWRITEBYTECODE 1
@@ -9,8 +9,7 @@ ENV POETRY_VERSION="1.7.1"
 ENV POETRY_VIRTUALENVS_CREATE="false"
 ENV PATH="${APP_VENV}/bin:${POETRY_HOME}/bin:$PATH"
 
-RUN apt-get update
-RUN apt-get install -y bash git libtool  autoconf automake gcc  g++ make libffi-dev unzip
+RUN apk add --no-cache bash build-base git libtool cmake autoconf automake gcc musl-dev postgresql-dev g++ libc6-compat libexecinfo-dev make libffi-dev libmagic libcurl curl-dev rust cargo && rm -rf /var/cache/apk/*
 
 RUN mkdir -p ${TASK_ROOT}
 WORKDIR ${TASK_ROOT}


### PR DESCRIPTION
Reverts cds-snc/notification-api#2387 in case we need to.