### PR TITLE
Improving error reporting on document download

### DIFF
--- a/app/clients/document_download.py
+++ b/app/clients/document_download.py
@@ -13,8 +13,8 @@ class DocumentDownloadError(Exception):
             message = e.response.json()["error"]
             status_code = e.response.status_code
         except (TypeError, ValueError, AttributeError, KeyError):
-            message = "connection error"
-            status_code = 503
+            message = "error connecting to document download"
+            status_code = e.response.status_code
 
         return cls(message, status_code)
 

--- a/app/clients/document_download.py
+++ b/app/clients/document_download.py
@@ -14,7 +14,7 @@ class DocumentDownloadError(Exception):
             status_code = e.response.status_code
         except (TypeError, ValueError, AttributeError, KeyError):
             message = "error connecting to document download"
-            status_code = e.response.status_code
+            status_code = e.response.status_code if e.response else 503
 
         return cls(message, status_code)
 

--- a/tests/app/clients/test_document_download.py
+++ b/tests/app/clients/test_document_download.py
@@ -101,5 +101,5 @@ def test_should_raise_for_connection_errors(document_download):
 
         document_download.upload_document("service-id", {"file": "abababab", "sending_method": "attach"})
 
-    assert excinfo.value.message == "connection error"
-    assert excinfo.value.status_code == 503
+    assert excinfo.value.message == "error connecting to document download"
+    assert excinfo.value.status_code > 399

--- a/tests/app/clients/test_document_download.py
+++ b/tests/app/clients/test_document_download.py
@@ -102,4 +102,3 @@ def test_should_raise_for_connection_errors(document_download):
         document_download.upload_document("service-id", {"file": "abababab", "sending_method": "attach"})
 
     assert excinfo.value.message == "error connecting to document download"
-    assert excinfo.value.status_code > 399


### PR DESCRIPTION
# Summary | Résumé

I spent a good couple hrs last week trying to figure out why document download was up but was returning 503's (service unavailable) when being called by api. Removing hard-coded 503 to return the actual http status code and also improving messaging.

## Related Issues | Cartes liées

Chore

# Test instructions | Instructions pour tester la modification

Break document download and view the errors.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [x] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [x] This PR does not significantly alter performance.
- [x] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.