### PR TITLE
Remove date conversion

### DIFF
--- a/app/celery/process_pinpoint_receipts_tasks.py
+++ b/app/celery/process_pinpoint_receipts_tasks.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Union
 
 from flask import current_app, json
@@ -120,7 +120,7 @@ def process_pinpoint_results(self, response):
             if not annual_limit_client.was_seeded_today(service_id):
                 annual_limit_client.set_seeded_at(service_id)
                 notifications_to_seed = fetch_notification_status_for_service_for_day(
-                    convert_utc_to_local_timezone(datetime.utcnow()),
+                    datetime.now(timezone.utc),
                     service_id=service_id,
                 )
                 annual_limit_client.seed_annual_limit_notifications(

--- a/app/celery/process_pinpoint_receipts_tasks.py
+++ b/app/celery/process_pinpoint_receipts_tasks.py
@@ -3,7 +3,6 @@ from typing import Union
 
 from flask import current_app, json
 from notifications_utils.statsd_decorators import statsd
-from notifications_utils.timezones import convert_utc_to_local_timezone
 from sqlalchemy.orm.exc import NoResultFound
 
 from app import annual_limit_client, notify_celery, statsd_client

--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from flask import current_app, json
 from notifications_utils.statsd_decorators import statsd
@@ -97,7 +97,7 @@ def process_ses_results(self, response):  # noqa: C901
             if not annual_limit_client.was_seeded_today(service_id):
                 annual_limit_client.set_seeded_at(service_id)
                 notifications_to_seed = fetch_notification_status_for_service_for_day(
-                    convert_utc_to_local_timezone(datetime.utcnow()),
+                    convert_utc_to_local_timezone(datetime.now(timezone.utc)),
                     service_id=service_id,
                 )
                 annual_limit_client.seed_annual_limit_notifications(

--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -2,7 +2,6 @@ from datetime import datetime, timezone
 
 from flask import current_app, json
 from notifications_utils.statsd_decorators import statsd
-from notifications_utils.timezones import convert_utc_to_local_timezone
 from sqlalchemy.orm.exc import NoResultFound
 
 from app import annual_limit_client, bounce_rate_client, notify_celery, statsd_client
@@ -97,7 +96,7 @@ def process_ses_results(self, response):  # noqa: C901
             if not annual_limit_client.was_seeded_today(service_id):
                 annual_limit_client.set_seeded_at(service_id)
                 notifications_to_seed = fetch_notification_status_for_service_for_day(
-                    convert_utc_to_local_timezone(datetime.now(timezone.utc)),
+                    datetime.now(timezone.utc),
                     service_id=service_id,
                 )
                 annual_limit_client.seed_annual_limit_notifications(

--- a/app/celery/process_sns_receipts_tasks.py
+++ b/app/celery/process_sns_receipts_tasks.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from flask import current_app, json
 from notifications_utils.statsd_decorators import statsd
@@ -77,7 +77,7 @@ def process_sns_results(self, response):
             if not annual_limit_client.was_seeded_today(service_id):
                 annual_limit_client.set_seeded_at(service_id)
                 notifications_to_seed = fetch_notification_status_for_service_for_day(
-                    convert_utc_to_local_timezone(datetime.utcnow()),
+                    convert_utc_to_local_timezone(datetime.now(timezone.utc)),
                     service_id=service_id,
                 )
                 annual_limit_client.seed_annual_limit_notifications(

--- a/app/celery/process_sns_receipts_tasks.py
+++ b/app/celery/process_sns_receipts_tasks.py
@@ -2,7 +2,6 @@ from datetime import datetime, timezone
 
 from flask import current_app, json
 from notifications_utils.statsd_decorators import statsd
-from notifications_utils.timezones import convert_utc_to_local_timezone
 from sqlalchemy.orm.exc import NoResultFound
 
 from app import annual_limit_client, notify_celery, statsd_client
@@ -77,7 +76,7 @@ def process_sns_results(self, response):
             if not annual_limit_client.was_seeded_today(service_id):
                 annual_limit_client.set_seeded_at(service_id)
                 notifications_to_seed = fetch_notification_status_for_service_for_day(
-                    convert_utc_to_local_timezone(datetime.now(timezone.utc)),
+                    datetime.now(timezone.utc),
                     service_id=service_id,
                 )
                 annual_limit_client.seed_annual_limit_notifications(

--- a/app/dao/date_util.py
+++ b/app/dao/date_util.py
@@ -103,7 +103,7 @@ def utc_midnight_n_days_ago(number_of_days):
     """
     Returns utc midnight a number of days ago.
     """
-    return get_midnight(datetime.utcnow() - timedelta(days=number_of_days))
+    return get_midnight(datetime.now(timezone.utc) - timedelta(days=number_of_days))
 
 
 def get_query_date_based_on_retention_period(retention_period):

--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -247,6 +247,9 @@ def fetch_notification_stats_for_trial_services():
 
 
 def fetch_notification_status_for_service_for_day(bst_day, service_id):
+    # Fetch data from bst_day 00:00:00 to bst_day 23:59:59
+    # bst_dat is currently in UTC and the return is in UTC
+    bst_day = bst_day.replace(hour=0, minute=0, second=0)
     return (
         db.session.query(
             # return current month as a datetime so the data has the same shape as the ft_notification_status query
@@ -256,8 +259,8 @@ def fetch_notification_status_for_service_for_day(bst_day, service_id):
             func.count().label("count"),
         )
         .filter(
-            Notification.created_at >= get_local_timezone_midnight_in_utc(bst_day),
-            Notification.created_at < get_local_timezone_midnight_in_utc(bst_day + timedelta(days=1)),
+            Notification.created_at >= bst_day,
+            Notification.created_at < bst_day + timedelta(days=1),
             Notification.service_id == service_id,
             Notification.key_type != KEY_TYPE_TEST,
         )

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -1,5 +1,5 @@
 import itertools
-from datetime import datetime
+from datetime import datetime, timezone
 
 from flask import Blueprint, current_app, jsonify, request
 from notifications_utils.clients.redis import (
@@ -651,10 +651,10 @@ def get_monthly_notification_stats(service_id):
     stats = fetch_notification_status_for_service_by_month(start_date, end_date, service_id)
     statistics.add_monthly_notification_status_stats(data, stats)
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     # TODO FF_ANNUAL_LIMIT removal
     if not current_app.config["FF_ANNUAL_LIMIT"] and end_date > now:
-        todays_deltas = fetch_notification_status_for_service_for_day(convert_utc_to_local_timezone(now), service_id=service_id)
+        todays_deltas = fetch_notification_status_for_service_for_day(now, service_id=service_id)
         statistics.add_monthly_notification_status_stats(data, todays_deltas)
 
     return jsonify(data=data)

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -652,8 +652,10 @@ def get_monthly_notification_stats(service_id):
     statistics.add_monthly_notification_status_stats(data, stats)
 
     now = datetime.now(timezone.utc)
+    # end_date doesn't have tzinfo, so we need to remove it from now
+    end_date_now = now.replace(tzinfo=None)
     # TODO FF_ANNUAL_LIMIT removal
-    if not current_app.config["FF_ANNUAL_LIMIT"] and end_date > now:
+    if not current_app.config["FF_ANNUAL_LIMIT"] and end_date > end_date_now:
         todays_deltas = fetch_notification_status_for_service_for_day(now, service_id=service_id)
         statistics.add_monthly_notification_status_stats(data, todays_deltas)
 


### PR DESCRIPTION
# Summary | Résumé
For this func:
1. We were taking today's UTC and converting it to midnight in a given timezone, we they were converting it back to UTC. 
2. We changed the callers and the actual function to fix this

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1717

# Testing:
- Test things locally by setting up this PR on localhost
