### PR TITLE
Update `bootstrap.sh` so it works with `poetry`

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -7,4 +7,4 @@ make generate-version-file
 poetry install --only test
 
 # Upgrade databases
-flask db upgrade
+poetry run flask db upgrade


### PR DESCRIPTION
# Summary | Résumé

This is a file that (as far as I know) is only used if you need to set up a new database from scratch.

Without the `poetry run` I was getting the error `command not found: flask`.

# Test instructions | Instructions pour tester la modification

You could try running this locally.