### PR TITLE
Revert "Task/fix stats"

### DIFF
--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -649,13 +649,13 @@ def get_monthly_notification_stats(service_id):
     data = statistics.create_empty_monthly_notification_status_stats_dict(year)
 
     stats = fetch_notification_status_for_service_by_month(start_date, end_date, service_id)
-    # statistics.add_monthly_notification_status_stats(data, stats)
+    statistics.add_monthly_notification_status_stats(data, stats)
 
     now = datetime.utcnow()
     # TODO FF_ANNUAL_LIMIT removal
     if not current_app.config["FF_ANNUAL_LIMIT"] and end_date > now:
         todays_deltas = fetch_notification_status_for_service_for_day(convert_utc_to_local_timezone(now), service_id=service_id)
-        # statistics.add_monthly_notification_status_stats(data, todays_deltas)
+        statistics.add_monthly_notification_status_stats(data, todays_deltas)
 
     return jsonify(data=data)
 

--- a/tests/app/service/test_statistics_rest.py
+++ b/tests/app/service/test_statistics_rest.py
@@ -132,7 +132,6 @@ def test_get_service_notification_statistics_with_unknown_service(admin_request)
     }
 
 
-@pytest.mark.skip(reason="This test is failing due to an incident fix.")
 @pytest.mark.parametrize(
     "kwargs, expected_json",
     [
@@ -147,7 +146,6 @@ def test_get_monthly_notification_stats_returns_errors(admin_request, sample_ser
     assert response == expected_json
 
 
-@pytest.mark.skip(reason="This test is failing due to an incident fix.")
 def test_get_monthly_notification_stats_returns_404_if_no_service(admin_request):
     response = admin_request.get(
         "service.get_monthly_notification_stats",
@@ -157,7 +155,6 @@ def test_get_monthly_notification_stats_returns_404_if_no_service(admin_request)
     assert response == {"message": "No result found", "result": "error"}
 
 
-@pytest.mark.skip(reason="This test is failing due to an incident fix.")
 def test_get_monthly_notification_stats_returns_empty_stats_with_correct_dates(admin_request, sample_service):
     response = admin_request.get(
         "service.get_monthly_notification_stats",
@@ -185,7 +182,6 @@ def test_get_monthly_notification_stats_returns_empty_stats_with_correct_dates(a
         assert val == {"sms": {}, "email": {}, "letter": {}}
 
 
-@pytest.mark.skip(reason="This test is failing due to an incident fix.")
 def test_get_monthly_notification_stats_returns_stats(admin_request, sample_service):
     sms_t1 = create_template(sample_service)
     sms_t2 = create_template(sample_service)
@@ -225,7 +221,6 @@ def test_get_monthly_notification_stats_returns_stats(admin_request, sample_serv
     }
 
 
-@pytest.mark.skip(reason="This test is failing due to an incident fix.")
 @freeze_time("2016-06-05 00:00:00")
 # This test assumes the local timezone is EST
 def test_get_monthly_notification_stats_combines_todays_data_and_historic_stats(admin_request, notify_api, sample_template):
@@ -267,7 +262,6 @@ def test_get_monthly_notification_stats_combines_todays_data_and_historic_stats(
 
 
 # This test assumes the local timezone is EST
-@pytest.mark.skip(reason="This test is failing due to an incident fix.")
 def test_get_monthly_notification_stats_ignores_test_keys(admin_request, sample_service):
     create_ft_notification_status(datetime(2016, 6, 1), service=sample_service, key_type=KEY_TYPE_NORMAL, count=1)
     create_ft_notification_status(datetime(2016, 6, 1), service=sample_service, key_type=KEY_TYPE_TEAM, count=2)
@@ -283,7 +277,6 @@ def test_get_monthly_notification_stats_ignores_test_keys(admin_request, sample_
 
 
 # This test assumes the local timezone is EST
-@pytest.mark.skip(reason="This test is failing due to an incident fix.")
 def test_get_monthly_notification_stats_checks_dates(admin_request, sample_service):
     t = create_template(sample_service)
     create_ft_notification_status(datetime(2016, 3, 31), template=t, notification_status="created")
@@ -303,7 +296,6 @@ def test_get_monthly_notification_stats_checks_dates(admin_request, sample_servi
     assert response["data"]["2017-03"]["sms"] == {"delivered": 1}
 
 
-@pytest.mark.skip(reason="This test is failing due to an incident fix.")
 def test_get_monthly_notification_stats_only_gets_for_one_service(admin_request, notify_api, notify_db_session):
     services = [create_service(), create_service(service_name="2")]
 


### PR DESCRIPTION
Reverts cds-snc/notification-api#2401

I believe this PR: https://github.com/cds-snc/notification-admin/pull/2029
will fix the issue that was being caused by sending the wrong year.