### PR TITLE
Updating Docker Image Tags for Helm Release Process

### DIFF
--- a/.github/actions/call-manifests-update-docker-tag.yaml
+++ b/.github/actions/call-manifests-update-docker-tag.yaml
@@ -2,9 +2,6 @@ name: Call Manifests Update Docker Tag
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
 
 jobs:
   update-docker-tag-in-manifests:

--- a/.github/workflows/call-manifests-update-docker-tag.yaml
+++ b/.github/workflows/call-manifests-update-docker-tag.yaml
@@ -1,0 +1,30 @@
+name: Call Manifests Update Docker Tag
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  update-docker-tag-in-manifests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set Docker Tag
+        run: echo "DOCKER_TAG=${GITHUB_SHA::7}" >> $GITHUB_ENV
+        env:
+          GITHUB_SHA: ${{ github.sha }}
+
+      - name: Trigger repository_dispatch
+        run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.MANIFESTS_WORKFLOW_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/cds-snc/notification-manifests/dispatches \
+            -d '{"event_type":"update-docker-image","client_payload":{"component":"API","docker_tag":"${{ env.DOCKER_TAG }}"}}'

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -94,7 +94,7 @@ jobs:
       run: |
         aws eks update-kubeconfig --name notification-canada-ca-staging-eks-cluster     
 
-    - name: Update images in staging
+    - name: Update images in staging (Kustomize)
       run: |
         DOCKER_TAG=${GITHUB_SHA::7}
         kubectl set image deployment.apps/notify-api notify-api=$DOCKER_SLUG:$DOCKER_TAG -n=notification-canada-ca --kubeconfig=$HOME/.kube/config
@@ -107,6 +107,8 @@ jobs:
         kubectl set image deployment.apps/notify-celery-email-send-primary notify-celery-email-send-primary=$DOCKER_SLUG:$DOCKER_TAG -n=notification-canada-ca --kubeconfig=$HOME/.kube/config
         kubectl set image deployment.apps/notify-celery-email-send-scalable notify-celery-email-send-scalable=$DOCKER_SLUG:$DOCKER_TAG -n=notification-canada-ca --kubeconfig=$HOME/.kube/config        
 
+    - name: Update images in staging (Helm)
+      uses: ./.github/actions/call-manifests-update-docker-tag.yaml
 
     - name: my-app-install token
       id: notify-pr-bot


### PR DESCRIPTION
# Summary | Résumé

Adding a workflow that runs on merge to main, calls a workflow in manifests to update the docker image tag in our manifests configuration files.

# Test instructions | Instructions pour tester la modification

> watch that this runs on merge to main, and then check to see if the file has been updated in manifests here: 
https://github.com/cds-snc/notification-manifests/blob/main/helmfile/overrides/staging.env

## Related Issues | Cartes liées
https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/491


# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.