### PR TITLE
use utils tag instead of branch

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2693,8 +2693,8 @@ werkzeug = "3.0.4"
 [package.source]
 type = "git"
 url = "https://github.com/cds-snc/notifier-utils.git"
-reference = "task/pre-3.12-recipient-csv-annual-limit-validation-MERGE_IN_TO_MAIN"
-resolved_reference = "82750a3c3c8466c804b687896abd24cf39c3bfbd"
+reference = "53.1.0"
+resolved_reference = "ec2de5f266cdb79c3931588040d1665a845b8c86"
 
 [[package]]
 name = "ordered-set"
@@ -4641,4 +4641,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.12.7"
-content-hash = "fb4aea86fb759b74efb7f40aef08f0fd9ce214d6238b01468ddc3c633833f0b5"
+content-hash = "2f8a60a2105cf509f81540d2ee722678ee83b01d4808142663d2c352df4a6215"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ Werkzeug = "3.0.4"
 MarkupSafe = "2.1.5"
 # REVIEW: v2 is using sha512 instead of sha1 by default (in v1)
 itsdangerous = "2.2.0"
-notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", branch = "task/pre-3.12-recipient-csv-annual-limit-validation-MERGE_IN_TO_MAIN"}
+notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", tag = "53.1.0" }
 
 # rsa = "4.9  # awscli 1.22.38 depends on rsa<4.8
 typing-extensions = "4.12.2"


### PR DESCRIPTION
# Summary | Résumé

switch to utils tag 53.1.0 instead of branch

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/465

# Test instructions | Instructions pour tester la modification

Test in staging. Verify annual limits in particular.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.