### PR TITLE
updating upload artifact

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -111,14 +111,14 @@ jobs:
       env:
         GITHUB_SHA: ${{ github.sha }}
       run: |
-        echo "DOCKER_TAG=${GITHUB_SHA::7}" >> $GITHUB_ENV
+        DOCKER_TAG=${GITHUB_SHA::7}
         curl -L \
         -X POST \
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: Bearer ${{ secrets.MANIFESTS_WORKFLOW_TOKEN }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/cds-snc/notification-manifests/dispatches \
-          -d '{"event_type":"update-docker-image","client_payload":{"component":"API","docker_tag":"${{ env.DOCKER_TAG }}"}}'
+          -d '{"event_type":"update-docker-image","client_payload":{"component":"API","docker_tag":"$DOCKER_TAG"}}'
 
     - name: my-app-install token
       id: notify-pr-bot

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,7 +45,7 @@ jobs:
       run: poetry run make test
     - name: Upload pytest logs on failure
       if: ${{ failure() }}
-      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
       with:
         name: pytest-logs
         path: |


### PR DESCRIPTION
# Summary | Résumé

updating an action because of this:
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/


# Test instructions | Instructions pour tester la modification

just check our tests on the repo to make sure they work

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.