### PR TITLE
Unify filename size limit

### DIFF
--- a/app/schema_validation/definitions.py
+++ b/app/schema_validation/definitions.py
@@ -30,13 +30,11 @@ personalisation = {
                     "binaryEncoding": "base64",
                 },
                 "sending_method": {"type": "string", "enum": ["attach", "link"]},
+                "filename": {"minLength": 3, "maxLength": 255},
             },
             "required": ["file", "sending_method"],
             "if": {"properties": {"sending_method": {"const": "attach"}}},
-            "then": {
-                "required": ["filename"],
-                "properties": {"filename": {"minLength": 3, "maxLength": 255}},
-            },
+            "then": {"required": ["filename"]},
         }
     },
 }


### PR DESCRIPTION
# Summary | Résumé

Schema validation now validates that length of `filename` does not exceed 255 characters when the user uses the `link` method to attach a file via the V2 api.

# Test instructions | Instructions pour tester la modification

1. Send an email with an attachment via the API using [attachment_content.txt](https://github.com/user-attachments/files/18293115/attachment_content.txt) for the `personalisation`.
2. Note the following error is returned:
```
"status_code": 400,
    "errors": [
        {
            "error": "ValidationError",
            "message": "personalisation <content of the property> is too long
        }
```

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.