### PR TITLE
tweak INTERNAL_TEST_NUMBER sending

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -20,7 +20,13 @@ from unidecode import unidecode
 from urllib3 import PoolManager
 from urllib3.util import Retry
 
-from app import bounce_rate_client, clients, document_download_client, statsd_client
+from app import (
+    bounce_rate_client,
+    clients,
+    create_uuid,
+    document_download_client,
+    statsd_client,
+)
 from app.celery.research_mode_tasks import send_email_response, send_sms_response
 from app.clients.sms import SmsSendingVehicles
 from app.config import Config
@@ -99,8 +105,9 @@ def send_sms_to_provider(notification):
 
         if service.research_mode or notification.key_type == KEY_TYPE_TEST or sending_to_internal_test_number:
             current_app.logger.info(f"notification {notification.id} is sending to INTERNAL_TEST_NUMBER, no boto call to AWS.")
-            notification.reference = send_sms_response(provider.get_name(), notification.to)
+            notification.reference = str(create_uuid())
             update_notification_to_sending(notification, provider)
+            send_sms_response(provider.get_name(), notification.to, notification.reference)
         else:
             try:
                 template_category_id = template_dict.get("template_category_id")


### PR DESCRIPTION
# Summary | Résumé

When we send to the INTERNAL_TEST_NUMBER we were queueing the fake callback before setting the reference in the notification. This could lead to the callback failing on its first attempt.

Here we set the reference before creating the fake callback.

# Test instructions | Instructions pour tester la modification

Test on staging - make sure SMS to this number get marked delivered.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.