### PR TITLE
broken migration to test db-migration-failure-critical DO NOT MERGE

### DIFF
--- a/migrations/versions/0473_broken_migration.py
+++ b/migrations/versions/0473_broken_migration.py
@@ -1,0 +1,20 @@
+"""
+
+Revision ID: 0473_broken_migration
+Revises: 0472_add_direct_email_2
+Create Date: 2025-01-21 19:45:54.021107
+
+"""
+from alembic import op
+
+revision = "0473_broken_migration"
+down_revision = "0472_add_direct_email_2"
+
+
+def upgrade():
+    conn = op.get_bind()
+    conn.execute("ALTER TABLE no_such_table ALTER COLUMN nope SET DEFAULT 0")
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
# Summary | Résumé

A broken migration (!)
This should set off the `db-migration-failure-critical` alarm in staging.

Will test by building the image locally and manually deploying to the staging k8s cluster

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/21

# Test instructions | Instructions pour tester la modification

locally can run
```
flask db upgrade
```
to verify that the migration fails. You can then run
```
flask db current
```
to verify that the database hasn't changed, ie you're still on migration 0472

# Release Instructions | Instructions pour le déploiement

Don't even think of it.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.