### PR TITLE
incident fix maybe

### DIFF
--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -15,7 +15,7 @@ from app import redis_store
 from app.celery import provider_tasks
 from app.celery.letters_pdf_tasks import create_letters_pdf
 from app.config import QueueNames
-from app.dao.api_key_dao import update_last_used_api_key
+# from app.dao.api_key_dao import update_last_used_api_key
 from app.dao.notifications_dao import (
     bulk_insert_notifications,
     dao_create_notification,
@@ -134,8 +134,9 @@ def persist_notification(
             if redis_store.get(redis.daily_limit_cache_key(service.id)):
                 redis_store.incr(redis.daily_limit_cache_key(service.id))
         current_app.logger.info("{} {} created at {}".format(notification_type, notification_id, notification_created_at))
-        if api_key_id:
-            update_last_used_api_key(api_key_id, notification_created_at)
+        # try to fix an incident
+        # if api_key_id:
+        # update_last_used_api_key(api_key_id, notification_created_at)
     return notification
 
 
@@ -366,8 +367,9 @@ def persist_notifications(notifications: List[VerifiedNotification]) -> List[Not
         api_key_id = notification.get("api_key_id")
         if api_key_id:
             api_key_last_used = datetime.utcnow()
-    if api_key_last_used:
-        update_last_used_api_key(api_key_id, api_key_last_used)
+    # try to fix an incident
+    # if api_key_last_used:
+        # update_last_used_api_key(api_key_id, api_key_last_used)
     bulk_insert_notifications(lofnotifications)
 
     return lofnotifications

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -15,6 +15,7 @@ from app import redis_store
 from app.celery import provider_tasks
 from app.celery.letters_pdf_tasks import create_letters_pdf
 from app.config import QueueNames
+
 # from app.dao.api_key_dao import update_last_used_api_key
 from app.dao.notifications_dao import (
     bulk_insert_notifications,
@@ -302,7 +303,7 @@ def persist_notifications(notifications: List[VerifiedNotification]) -> List[Not
     """
 
     lofnotifications = []
-    api_key_last_used = None
+    api_key_last_used = None  # noqa: F841
 
     for notification in notifications:
         notification_created_at = notification.get("created_at") or datetime.utcnow()
@@ -366,10 +367,10 @@ def persist_notifications(notifications: List[VerifiedNotification]) -> List[Not
         # We will only update the api key once
         api_key_id = notification.get("api_key_id")
         if api_key_id:
-            api_key_last_used = datetime.utcnow()
+            api_key_last_used = datetime.utcnow()  # noqa: F841
     # try to fix an incident
     # if api_key_last_used:
-        # update_last_used_api_key(api_key_id, api_key_last_used)
+    # update_last_used_api_key(api_key_id, api_key_last_used)
     bulk_insert_notifications(lofnotifications)
 
     return lofnotifications

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -14,11 +14,10 @@ from sqlalchemy.exc import SQLAlchemyError
 from app.celery.utils import CeleryParams
 from app.config import QueueNames
 from app.dao.service_sms_sender_dao import dao_update_service_sms_sender
-from app.models import (
+from app.models import (  # ApiKey,
     BULK,
     NORMAL,
     PRIORITY,
-    ApiKey,
     Notification,
     NotificationHistory,
     ScheduledNotification,

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -411,8 +411,10 @@ class TestPersistNotification:
         assert persisted_notification[0].service == sample_job.service
 
         # Test that the api key last_used_timestamp got updated
-        api_key = ApiKey.query.get(sample_api_key.id)
-        assert api_key.last_used_timestamp is not None
+
+        # incident fix - should revert this later
+        # api_key = ApiKey.query.get(sample_api_key.id)
+        # assert api_key.last_used_timestamp is not None
 
     def test_persist_notifications_reply_to_text_is_original_value_if_sender_is_changed_later(
         self, sample_template, sample_api_key, mocker
@@ -894,8 +896,9 @@ class TestTransformNotification:
 
         assert persisted_notification.to == recipient
         assert persisted_notification.normalised_to == expected_recipient_normalised
-        api_key = ApiKey.query.get(sample_api_key.id)
-        assert api_key.last_used_timestamp is not None
+        # incident fix - should revert this later
+        # api_key = ApiKey.query.get(sample_api_key.id)
+        # assert api_key.last_used_timestamp is not None
 
 
 class TestDBSaveAndSendNotification:


### PR DESCRIPTION
# Summary | Résumé

We are in an incident where updating the api key last_used is locking the database #1731 

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1
* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/1

# Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.