### PR TITLE
Get the gc-org data from s3

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -233,8 +233,8 @@ class Config(object):
     SALESFORCE_USERNAME = os.getenv("SALESFORCE_USERNAME")
     SALESFORCE_PASSWORD = os.getenv("SALESFORCE_PASSWORD")
     SALESFORCE_SECURITY_TOKEN = os.getenv("SALESFORCE_SECURITY_TOKEN")
-    CRM_GITHUB_PERSONAL_ACCESS_TOKEN = os.getenv("CRM_GITHUB_PERSONAL_ACCESS_TOKEN")
-    CRM_ORG_LIST_URL = os.getenv("CRM_ORG_LIST_URL")
+    GC_ORGANISATIONS_BUCKET_NAME = os.getenv("GC_ORGANISATIONS_BUCKET_NAME")
+    GC_ORGANISATIONS_FILENAME = os.getenv("GC_ORGANISATIONS_FILENAME", "all.json")
 
     # Logging
     DEBUG = False
@@ -748,9 +748,8 @@ class Test(Development):
     API_HOST_NAME = "http://localhost:6011"
 
     TEMPLATE_PREVIEW_API_HOST = "http://localhost:9999"
-    CRM_GITHUB_PERSONAL_ACCESS_TOKEN = "test-token"
-    CRM_ORG_LIST_URL = "https://test-url.com"
     FAILED_LOGIN_LIMIT = 0
+    GC_ORGANISATIONS_BUCKET_NAME = "test-gc-organisations"
 
 
 class Production(Config):

--- a/app/service/utils.py
+++ b/app/service/utils.py
@@ -2,11 +2,11 @@ import itertools
 import json
 from typing import Optional
 
-from app.aws.s3 import get_s3_file
 from flask import current_app
 from notifications_utils.recipients import allowed_to_send_to
 from sqlalchemy.orm.exc import NoResultFound
 
+from app.aws.s3 import get_s3_file
 from app.dao.organisation_dao import dao_get_organisation_by_id
 from app.dao.service_data_retention_dao import insert_service_data_retention
 from app.models import (

--- a/app/service/utils.py
+++ b/app/service/utils.py
@@ -70,7 +70,7 @@ def safelisted_members(service, key_type, is_simulated=False, allow_safelisted_r
 def get_gc_organisation_data() -> list[dict]:
     "Returns the dataset from the gc-organisations repo, which we cache in s3"
     file_data = get_s3_file(
-        current_app.config["GC_ORGANISATION_DATA_BUCKET_NAME"],
+        current_app.config["GC_ORGANISATIONS_BUCKET_NAME"],
         current_app.config["GC_ORGANISATIONS_FILENAME"],
     )
 

--- a/app/service/utils.py
+++ b/app/service/utils.py
@@ -2,7 +2,7 @@ import itertools
 import json
 from typing import Optional
 
-import requests
+from app.aws.s3 import get_s3_file
 from flask import current_app
 from notifications_utils.recipients import allowed_to_send_to
 from sqlalchemy.orm.exc import NoResultFound
@@ -68,14 +68,13 @@ def safelisted_members(service, key_type, is_simulated=False, allow_safelisted_r
 
 
 def get_gc_organisation_data() -> list[dict]:
-    "Returns the dataset from the gc-organisations repo"
-    response = requests.get(
-        current_app.config["CRM_ORG_LIST_URL"],
-        headers={"Authorization": f'token {current_app.config["CRM_GITHUB_PERSONAL_ACCESS_TOKEN"]}'},
+    "Returns the dataset from the gc-organisations repo, which we cache in s3"
+    file_data = get_s3_file(
+        current_app.config["GC_ORGANISATION_DATA_BUCKET_NAME"],
+        current_app.config["GC_ORGANISATIONS_FILENAME"],
     )
-    response.raise_for_status()
 
-    account_data = json.loads(response.text)
+    account_data = json.loads(file_data)
     return account_data
 
 


### PR DESCRIPTION
# Summary | Résumé

This PR switches where we are loading the gc-organisation data from to S3 to improve reliability.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1151

# Test instructions | Instructions pour tester la modification

Run locally with the following new line in your .env file:
```
GC_ORGANISATIONS_BUCKET_NAME=notification-canada-ca-staging-gc-organisations
```

Run the admin app and test creating a new service with an organisation from the dropdown list. You should be able to create the service successfully with no API errors.

# Release Instructions | Instructions pour le déploiement

None. The new env variable is already in staging and prod.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.