### PR TITLE
Update `api_key_last_used` for one-off API sends

### DIFF
--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -5,6 +5,7 @@ import uuid
 from datetime import datetime
 from io import StringIO
 
+from app.dao.api_key_dao import update_last_used_api_key
 import werkzeug
 from flask import abort, current_app, jsonify, request
 from notifications_utils import SMS_CHAR_COUNT_LIMIT
@@ -443,6 +444,14 @@ def process_sms_or_email_notification(
     signed_notification_data = signer_notification.sign(_notification)
     notification = {**_notification}
     scheduled_for = form.get("scheduled_for", None)
+
+    # Update the api_key last_used, we will only update this once per job
+    if api_key:
+        api_key_id = api_key.id
+        if api_key_id:
+            api_key_last_used = datetime.utcnow()
+            update_last_used_api_key(api_key_id, api_key_last_used)
+
     if scheduled_for:
         notification = persist_notification(  # keep scheduled notifications using the old code path for now
             template_id=template.id,


### PR DESCRIPTION
# Summary | Résumé

This PR updates the `api_key_last_used` field when a single notification is sent via the API


# Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.