### PR TITLE
Improve the formatting of the support emails for PTs

### DIFF
--- a/app/clients/freshdesk.py
+++ b/app/clients/freshdesk.py
@@ -147,7 +147,7 @@ class Freshdesk(object):
         self.email_freshdesk_ticket(
             current_app.config["CONTACT_FORM_EMAIL_ADDRESS"],
             current_app.config["CONTACT_FORM_DIRECT_EMAIL_TEMPLATE_ID"],
-            content_str
+            content_str,
         )
 
     def email_freshdesk_ticket_pt_service(self):
@@ -157,17 +157,19 @@ class Freshdesk(object):
             current_app.logger.error("SENSITIVE_SERVICE_EMAIL not set")
         content = self._generate_ticket()
         # This email will display the form data as a quote block
-        content_str_nice = "\n".join([
-            f"^**Subject**: {content["subject"]}",
-            "^",
-            f"^**User-entered info**:",
-            f"^{content['description'].replace('<br>', '\n').replace('\n', '\n^')}",
-            "^",
-            f"^**User's Email**: {content["email"]}",
-        ])
+        content_str_nice = "\n".join(
+            [
+                f"^**Subject**: {content['subject']}",
+                "^",
+                "^**User-entered info**:",
+                f"^{content['description'].replace('<br>', '\n').replace('\n', '\n^')}",
+                "^",
+                f"^**User's Email**: {content['email']}",
+            ]
+        )
         self.email_freshdesk_ticket(email_address, template_id, content_str_nice)
 
-    def email_freshdesk_ticket(self, email_address, template_id, content_str) -> None:
+    def email_freshdesk_ticket(self, email_address: str, template_id: str, content_str: str) -> None:
         content = self._generate_ticket()
         try:
             template = dao_get_template_by_id(template_id)

--- a/app/clients/freshdesk.py
+++ b/app/clients/freshdesk.py
@@ -142,8 +142,12 @@ class Freshdesk(object):
     def email_freshdesk_ticket_freshdesk_down(self):
         if current_app.config["CONTACT_FORM_EMAIL_ADDRESS"] is None:
             current_app.logger.info("Cannot email contact us form, CONTACT_FORM_EMAIL_ADDRESS is empty")
+        content = self._generate_ticket()
+        content_str = json.dumps(content, indent=4)
         self.email_freshdesk_ticket(
-            current_app.config["CONTACT_FORM_EMAIL_ADDRESS"], current_app.config["CONTACT_FORM_DIRECT_EMAIL_TEMPLATE_ID"]
+            current_app.config["CONTACT_FORM_EMAIL_ADDRESS"],
+            current_app.config["CONTACT_FORM_DIRECT_EMAIL_TEMPLATE_ID"],
+            content_str
         )
 
     def email_freshdesk_ticket_pt_service(self):
@@ -151,9 +155,19 @@ class Freshdesk(object):
         template_id = current_app.config.get("CONTACT_FORM_SENSITIVE_SERVICE_EMAIL_TEMPLATE_ID")
         if not email_address:
             current_app.logger.error("SENSITIVE_SERVICE_EMAIL not set")
-        self.email_freshdesk_ticket(email_address, template_id)
+        content = self._generate_ticket()
+        # This email will display the form data as a quote block
+        content_str_nice = "\n".join([
+            f"^**Subject**: {content["subject"]}",
+            "^",
+            f"^**User-entered info**:",
+            f"^{content['description'].replace('<br>', '\n').replace('\n', '\n^')}",
+            "^",
+            f"^**User's Email**: {content["email"]}",
+        ])
+        self.email_freshdesk_ticket(email_address, template_id, content_str_nice)
 
-    def email_freshdesk_ticket(self, email_address, template_id) -> None:
+    def email_freshdesk_ticket(self, email_address, template_id, content_str) -> None:
         content = self._generate_ticket()
         try:
             template = dao_get_template_by_id(template_id)
@@ -164,11 +178,8 @@ class Freshdesk(object):
                 template_version=template.version,
                 recipient=email_address,
                 service=notify_service,
-                # This email will be badly formatted, but this allows us to re-use the
-                # _generate_description fn without having to duplicate all of that logic to get the
-                # description in plain text.
                 personalisation={
-                    "contact_us_content": json.dumps(content, indent=4),
+                    "contact_us_content": content_str,
                 },
                 notification_type=template.template_type,
                 api_key_id=None,

--- a/tests/app/clients/test_freshdesk.py
+++ b/tests/app/clients/test_freshdesk.py
@@ -347,7 +347,7 @@ class TestEmailFreshdeskSensitiveService:
                 freshdesk_client = freshdesk.Freshdesk(ContactRequest(email_address="user@example.com"))
                 freshdesk_client.email_freshdesk_ticket_pt_service()
 
-                mock_email_ticket.assert_called_once_with("sensitive@test.gov.uk", "template-123")
+                mock_email_ticket.assert_called_once_with("sensitive@test.gov.uk", "template-123", mocker.ANY)
 
     def test_email_freshdesk_ticket_pt_service_no_email(self, mocker, notify_api):
         """Test handling when sensitive service email not configured"""
@@ -362,4 +362,4 @@ class TestEmailFreshdeskSensitiveService:
                 freshdesk_client.email_freshdesk_ticket_pt_service()
 
                 mock_logger.assert_called_once_with("SENSITIVE_SERVICE_EMAIL not set")
-                mock_email_ticket.assert_called_once_with(None, "template-123")
+                mock_email_ticket.assert_called_once_with(None, "template-123", mocker.ANY)


### PR DESCRIPTION
# Summary | Résumé

This PR improves the formatting of the support emails for the "PT service skip Freshdesk" feature while still using the existing `_generate_ticket` method.

This PR removes the `product_id`, 'priority`, `status`, and `tags` data from the email. `priority` and `status` were being hardcoded in this case so those numbers weren't meaningful. `product_id` will always be the same for the prod app. And `tags` are only meaningful to freshdesk. So I think it is safe to remove this data for this feature since it makes the email less confusing for the support team. 

Here is an example:

Before:
![Screenshot 2025-01-24 at 4 41 46 PM](https://github.com/user-attachments/assets/9a3e168c-893d-4b31-8703-93953b5ddb35)

After:
![Screenshot 2025-01-27 at 4 58 15 PM](https://github.com/user-attachments/assets/b0a55d69-4ab5-4dbb-95eb-442d75aeb32c)


## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1738

# Test instructions | Instructions pour tester la modification

1. Set the following in your .env:
```
FF_PT_SERVICE_SKIP_FRESHDESK=true
SENSITIVE_SERVICE_EMAIL=your.email@cds-snc.ca
FRESH_DESK_PRODUCT_ID=42
```
2. checkout branch and run api locally
3. run admin locally
4. set one of your services organisations to be a PT
5. click the "contact us" link
6. submit the support request
7. confirm that you recieve an email with nice formatting


# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.