### PR TITLE
Added error handling for pinpoint errors

### DIFF
--- a/app/clients/sms/aws_pinpoint.py
+++ b/app/clients/sms/aws_pinpoint.py
@@ -4,6 +4,7 @@ import boto3
 import phonenumbers
 
 from app.clients.sms import SmsClient, SmsSendingVehicles
+from app.exceptions import PinpointConflictException, PinpointValidationException
 
 
 class AwsPinpointClient(SmsClient):
@@ -69,8 +70,9 @@ class AwsPinpointClient(SmsClient):
                 if e.response.get("Reason") == "DESTINATION_PHONE_NUMBER_OPTED_OUT":
                     opted_out = True
                 else:
-                    raise e
-
+                    raise PinpointConflictException(e)
+            except self._client.exceptions.ValidationException as e:
+                raise PinpointValidationException(e)
             except Exception as e:
                 self.statsd_client.incr("clients.pinpoint.error")
                 raise e

--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -25,3 +25,15 @@ class InvalidUrlException(Exception):
 
 class DocumentDownloadException(Exception):
     pass
+
+
+class PinpointConflictException(Exception):
+    def __init__(self, original_exception):
+        self.original_exception = original_exception
+        super().__init__(str(original_exception))
+
+
+class PinpointValidationException(Exception):
+    def __init__(self, original_exception):
+        self.original_exception = original_exception
+        super().__init__(str(original_exception))

--- a/tests/app/celery/test_provider_tasks.py
+++ b/tests/app/celery/test_provider_tasks.py
@@ -8,7 +8,11 @@ import app
 from app.celery import provider_tasks
 from app.celery.provider_tasks import deliver_email, deliver_sms, deliver_throttled_sms
 from app.clients.email.aws_ses import AwsSesClientException
-from app.exceptions import NotificationTechnicalFailureException
+from app.exceptions import (
+    NotificationTechnicalFailureException,
+    PinpointConflictException,
+    PinpointValidationException,
+)
 from celery.exceptions import MaxRetriesExceededError
 
 sms_methods = [
@@ -118,6 +122,46 @@ def test_should_go_into_technical_error_if_exceeds_retries_on_deliver_sms_task(
 
     assert sample_notification.status == "technical-failure"
     queued_callback.assert_called_once_with(sample_notification)
+
+
+class TestErrorHandling:
+    @pytest.mark.parametrize("sms_method,sms_method_name", sms_methods)
+    def test_should_not_retry_pinpoint_conflict(
+        self,
+        sample_notification,
+        mocker,
+        sms_method,
+        sms_method_name,
+    ):
+        mocker.patch(
+            "app.delivery.send_to_providers.send_sms_to_provider",
+            side_effect=PinpointConflictException("hello"),
+        )
+        queued_callback = mocker.patch("app.celery.provider_tasks._check_and_queue_callback_task")
+
+        sms_method(sample_notification.id)
+
+        assert sample_notification.status == "permanent-failure"
+        queued_callback.assert_called_once_with(sample_notification)
+
+    @pytest.mark.parametrize("sms_method,sms_method_name", sms_methods)
+    def test_should_not_retry_pinpoint_validation(
+        self,
+        sample_notification,
+        mocker,
+        sms_method,
+        sms_method_name,
+    ):
+        mocker.patch(
+            "app.delivery.send_to_providers.send_sms_to_provider",
+            side_effect=PinpointValidationException("hello"),
+        )
+        queued_callback = mocker.patch("app.celery.provider_tasks._check_and_queue_callback_task")
+
+        sms_method(sample_notification.id)
+
+        assert sample_notification.status == "permanent-failure"
+        queued_callback.assert_called_once_with(sample_notification)
 
 
 def test_should_go_into_technical_error_if_exceeds_retries_on_deliver_email_task(sample_notification, mocker):


### PR DESCRIPTION
# Summary | Résumé

If Pinpoint is throwing an error due to a ConflictError or ValidationError - we do not want to retry the notification. We will store the error so it might be propagated to the frontend in the future.

https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1760