### PR TITLE
catch and reraise pinpoint errors

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -43,6 +43,8 @@ from app.exceptions import (
     MalwareDetectedException,
     MalwareScanInProgressException,
     NotificationTechnicalFailureException,
+    PinpointConflictException,
+    PinpointValidationException,
 )
 from app.models import (
     BRANDING_BOTH_EN,
@@ -126,6 +128,8 @@ def send_sms_to_provider(notification):
                     service_id=notification.service_id,
                     sending_vehicle=sending_vehicle,
                 )
+            except (PinpointConflictException, PinpointValidationException) as e:
+                raise e
             except Exception as e:
                 notification.billable_units = template.fragment_count
                 dao_update_notification(notification)


### PR DESCRIPTION
# Summary | Résumé

The code path is:
`provider_tasks.py _deliver_sms`
->
`send_to_provider.py send_sms_to_provider`
->
`aws_pinpoint.py send_sms`

In this PR: https://github.com/cds-snc/notification-api/pull/2430
I wrongly assumed if I raise in the last step and catch the error in the first step, we should be okay.

After testing on staging: 
I found that after the Pinpoint error was raised, this func was raising an error:
```

"log": "  File \"/app/app/dao/provider_details_dao.py\", line 27, in get_provider_details_by_identifier",     "stream": "stderr",     "time": "2025-01-28T21:50:00.745570699Z" } | {"_p":"F","kubernetes":{"annotations":{"kubectl.kubernetes.io/restartedAt":"2025-01-22T11:02:19-05:00","kubernetes.io/config.seen":"2025-01-28T21:40:11.970146584Z","kubernetes.io/config.source":"api"},"container_hash":"public.ecr.aws/cds-snc/notify-api@sha256:494f12e04649486af6082df8850cead57ba45ff57ea54ef03b704ef673544a44","container_image":"public.ecr.aws/cds-snc/notify-api:02de90e","container_name":"notify-celery-primary","docker_id":"b8acdc325ce70e1bfe58653537727ef030edd31acf757a0eeb1253479cadec56","host":"ip-10-0-62-19.ca-central-1.compute.internal","labels":{"app":"notify-celery-primary","pod-template-hash":"6f889f7fc4"},"namespace_name":"notification-canada-ca","pod_id":"0e772571-02c5-4f53-8b2e-9847c7e72ab0","pod_name":"notify-celery-primary-6f889f7fc4-xwxr5"},"log":" File \"/app/app/dao/provider_details_dao.py\", line 27, in get_provider_details_by_identifier","stream":"stderr","time":"2025-01-28T21:50:00.745570699Z"}
-- | --
  | 2025-01-28T16:50:00.745-05:00{     "_p": "F",     "kubernetes": {         "annotations": {             "kubectl.kubernetes.io/restartedAt": "2025-01-22T11:02:19-05:00",             "kubernetes.io/config.seen": "2025-01-28T21:40:11.970146584Z",             "kubernetes.io/config.source": "api"         },         "container_hash": "public.ecr.aws/cds-snc/notify-api@sha256:494f12e04649486af6082df8850cead57ba45ff57ea54ef03b704ef673544a44",         "container_image": "public.ecr.aws/cds-snc/notify-api:02de90e",         "container_name": "notify-celery-primary",         "docker_id": "b8acdc325ce70e1bfe58653537727ef030edd31acf757a0eeb1253479cadec56",         "host": "ip-10-0-62-19.ca-central-1.compute.internal",         "labels": {             "app": "notify-celery-primary",             "pod-template-hash": "6f889f7fc4"         },         "namespace_name": "notification-canada-ca",         "pod_id": "0e772571-02c5-4f53-8b2e-9847c7e72ab0",         "pod_name": "notify-celery-primary-6f889f7fc4-xwxr5"     },     "log": "    return ProviderDetails.query.filter_by(identifier=identifier).one()",     "stream": "stderr",     "time": "2025-01-28T21:50:00.74557373Z" }

```
Therefore the exception being raised was the general Exception as seen here: 
https://github.com/cds-snc/notification-api/blob/2cb260dc2dbf24ab04d00f025a6af4f80e3fcd8d/app/delivery/send_to_providers.py#L129-L133


and not the Pinppoint Exceptions. This PR should fix that
