### PR TITLE
Update PT support email template

### DIFF
--- a/migrations/versions/0473_change_pt_support_email.py
+++ b/migrations/versions/0473_change_pt_support_email.py
@@ -1,0 +1,91 @@
+"""
+
+Revision ID: 0473_change_pt_support_email
+Revises: 0472_add_direct_email_2
+Create Date: 2025-01-29 00:00:00
+
+"""
+from datetime import datetime
+
+from alembic import op
+from flask import current_app
+
+revision = "0473_change_pt_support_email"
+down_revision = "0472_add_direct_email_2"
+
+new_content = "\n".join(
+    [
+        "Skipping Freshdesk: The user submitting the Contact Us form belongs to a Province/Territory Service.",
+        "",
+        "Contact us form data:",
+        "",
+        "((contact_us_content))",
+        "",
+        "___",
+        "",
+        "Contournement de Freshdesk : l’utilisateur ou utilisatrice ayant soumis le formulaire « Nous joindre » fait partie d’un service provincial/territorial.",
+        "",
+        "Données du formulaire « Nous joindre » :",
+        "",
+        "((contact_us_content))",
+    ]
+)
+
+templates = [
+    {
+        "id": current_app.config["CONTACT_FORM_SENSITIVE_SERVICE_EMAIL_TEMPLATE_ID"],
+        "name": "Contact form direct email - PT service",
+        "template_type": "email",
+        "content": new_content,
+        "subject": "Notify Contact us form for Province/Territory service / Formulaire « Nous joindre » de Notification GC pour un service provincial/territorial",
+        "process_type": "priority",
+    },
+]
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    for template in templates:
+        current_version = conn.execute("select version from templates where id='{}'".format(template["id"])).fetchone()
+        template["version"] = current_version[0] + 1
+
+    template_update = """
+        UPDATE templates SET content = '{}', subject = '{}', version = '{}', updated_at = '{}'
+        WHERE id = '{}'
+    """
+    template_history_insert = """
+        INSERT INTO templates_history (id, name, template_type, created_at, content, archived, service_id, subject,
+        created_by_id, version, process_type, hidden)
+        VALUES ('{}', '{}', '{}', '{}', '{}', False, '{}', '{}', '{}', {}, '{}', false)
+    """
+
+    for template in templates:
+        op.execute(
+            template_update.format(
+                template["content"],
+                template["subject"],
+                template["version"],
+                datetime.utcnow(),
+                template["id"],
+            )
+        )
+
+        op.execute(
+            template_history_insert.format(
+                template["id"],
+                template["name"],
+                template["template_type"],
+                datetime.utcnow(),
+                template["content"],
+                current_app.config["NOTIFY_SERVICE_ID"],
+                template["subject"],
+                current_app.config["NOTIFY_USER_ID"],
+                template["version"],
+                template["process_type"],
+            )
+        )
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
# Summary | Résumé

This update has already been performed manually on templates in Staging and Prod. I'm just making the migration script so that we have the correct content if we ever need to recreate an environment from scratch.

## Related Issues | Cartes liées


# Test instructions | Instructions pour tester la modification

- Check out the branch locally and run `poetry run flask db upgrade`
- visit [this template](http://localhost:6012/services/d6aa2c68-a2d9-4437-ab19-3ae8eb202553/templates/4bf8c15b-7393-463f-b6fe-e3fd1e99a03d) verify that your local copy looks like this:
<img width="1013" alt="Screenshot 2025-01-29 at 3 27 10 PM" src="https://github.com/user-attachments/assets/43cc2e3e-4c1d-4531-86e2-b2a12378a8bf" />


# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.