### PR TITLE
Add the rate limit check to the bulk endpoint

### DIFF
--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -183,6 +183,7 @@ def post_bulk():
         raise BadRequestError(message="You should specify either rows or csv", status_code=400)
     template = validate_template_exists(form["template_id"], authenticated_service)
     check_service_has_permission(template.template_type, authenticated_service.permissions)
+    check_rate_limiting(authenticated_service, api_user)
 
     if template.template_type == SMS_TYPE:
         fragments_sent = fetch_todays_requested_sms_count(authenticated_service.id)

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -2463,7 +2463,6 @@ class TestBulkSend:
         use_sender_id,
         has_default_reply_to,
     ):
-        # yyy
         data = {"name": "job_name", "template_id": sample_email_template.id}
         rows = [["email address"], ["foo@example.com"]]
         if data_type == "csv":

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -2854,7 +2854,10 @@ def test_post_bulk_returns_429_if_over_rate_limit(
     create_api_key(service=sample_email_template.service)
     mocker.patch("app.v2.notifications.post_notifications.upload_job_to_s3", return_value=job_id)
     mocker.patch("app.v2.notifications.post_notifications.process_job.apply_async")
-    mocker.patch("app.notifications.validators.redis_store.exceeded_rate_limit", return_value=True)
+    mocker.patch(
+        "app.v2.notifications.post_notifications.check_rate_limiting",
+        side_effect=RateLimitError("LIMIT", "INTERVAL", "TYPE"),
+    )
 
     auth_header = create_authorization_header(service_id=sample_email_template.service.id)
 


### PR DESCRIPTION
# Summary | Résumé

This PR adds the rate limit check to the `v2/notifications/bulk` endpoint.

When `check_rate_limiting` is called, it calls [`exceeded_rate_limit`](https://github.com/cds-snc/notification-utils/blob/main/notifications_utils/clients/redis/redis_client.py#L136-L182) in utils. This adds the current timestamp to the redis sorted set that tracks api calls, and checks if the 1000/minute rate has been exceeded.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1757

# Test instructions | Instructions pour tester la modification

Reproduce the bug
1. check out `main` and run the api locally
2. open pgadmin and change the rate limit for one of your services in the `services` table from `1000` to `10`
3. send 12 api requests to the `v2/notifications/email` endpoint in less than 1 minute
4. observe that you start getting `429` responses with a rate limit error message after 10 requests
5. wait a couple minutes and then send 12 api requests to the `v2/notifications/bulk` endpoint in <1 minute
6. observe that you do not get any `429` responses

Test the fix
1. check out this branch
2. send 12 api requests to the `v2/notifications/bulk` endpoint in <1 minute
6. observe that you do get `429` responses after 10 requests

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.