### PR TITLE
Change how the exception handling will work

### DIFF
--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -43,12 +43,12 @@ def process_ses_results(self, response):  # noqa: C901
         ses_message = json.loads(response["Message"])
         notification_type = ses_message["notificationType"]
 
-        if notification_type == "Complaint":
-            _check_and_queue_complaint_callback_task(*handle_complaint(ses_message))
-            return True
-
-        reference = ses_message["mail"]["messageId"]
         try:
+            if notification_type == "Complaint":
+                _check_and_queue_complaint_callback_task(*handle_complaint(ses_message))
+                return True
+
+            reference = ses_message["mail"]["messageId"]
             notification = notifications_dao.dao_get_notification_by_reference(reference)
         except NoResultFound:
             try:


### PR DESCRIPTION
# Summary | Résumé

Getting errors in prd that a notification can't be found when it goes into 
```
_check_and_queue_complaint_callback_task(*handle_complaint(ses_message))
```
Changing this so that this might be caught in an error handler

# Test instructions | Instructions pour tester la modification
Will test on staging

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.