### PR TITLE
turn off first perf test for now

### DIFF
--- a/bin/execute_and_publish_performance_test.sh
+++ b/bin/execute_and_publish_performance_test.sh
@@ -1,17 +1,19 @@
 #!/bin/bash
 
+# For now let's not do the old perf test, just the email send rate test
+
 # Setup
-current_time=$(date "+%Y.%m.%d-%H.%M.%S")
-perf_test_aws_s3_bucket=${PERF_TEST_AWS_S3_BUCKET:-notify-performance-test-results-staging}
-perf_test_csv_directory_path=${PERF_TEST_CSV_DIRECTORY_PATH:-/tmp/notify_performance_test}
-mkdir -p $perf_test_csv_directory_path/$current_time
+# current_time=$(date "+%Y.%m.%d-%H.%M.%S")
+# perf_test_aws_s3_bucket=${PERF_TEST_AWS_S3_BUCKET:-notify-performance-test-results-staging}
+# perf_test_csv_directory_path=${PERF_TEST_CSV_DIRECTORY_PATH:-/tmp/notify_performance_test}
+# mkdir -p $perf_test_csv_directory_path/$current_time
 
-# Run old performance test and copy results to S3
-locust --headless --config tests-perf/locust/locust.conf --html $perf_test_csv_directory_path/$current_time/index.html --csv $perf_test_csv_directory_path/$current_time/perf_test
-aws s3 cp $perf_test_csv_directory_path/ "s3://$perf_test_aws_s3_bucket" --recursive || exit 1
+# # Run old performance test and copy results to S3
+# locust --headless --config tests-perf/locust/locust.conf --html $perf_test_csv_directory_path/$current_time/index.html --csv $perf_test_csv_directory_path/$current_time/perf_test
+# aws s3 cp $perf_test_csv_directory_path/ "s3://$perf_test_aws_s3_bucket" --recursive || exit 1
 
-# Sleep 15 minutes to allow the system to stabilize
-sleep 900
+# # Sleep 15 minutes to allow the system to stabilize
+# sleep 900
 
 # Run email send rate performance test
 # This configuration should send 10K emails / minute for 10 minutes for 100K emails total.


### PR DESCRIPTION
# Summary | Résumé

First perf test is causing lots of errors.
This PR turns it off for now, just leaving the send rate test.

# Test instructions | Instructions pour tester la modification

See if it works without errors...

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.