### PR TITLE
Turnoff Freshdesk in all environments except production

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -221,7 +221,7 @@ class Config(object):
     FRESH_DESK_PRODUCT_ID = os.getenv("FRESH_DESK_PRODUCT_ID")
     FRESH_DESK_API_URL = os.getenv("FRESH_DESK_API_URL")
     FRESH_DESK_API_KEY = os.getenv("FRESH_DESK_API_KEY")
-    FRESH_DESK_ENABLED = env.bool("FRESH_DESK_ENABLED", True)
+    FRESH_DESK_ENABLED = env.bool("FRESH_DESK_ENABLED", False)
 
     # Salesforce
     SALESFORCE_DOMAIN = os.getenv("SALESFORCE_DOMAIN")
@@ -753,6 +753,7 @@ class Test(Development):
 
 
 class Production(Config):
+    FRESH_DESK_ENABLED = env.bool("FRESH_DESK_ENABLED", True)
     NOTIFY_EMAIL_DOMAIN = os.getenv("NOTIFY_EMAIL_DOMAIN", "notification.canada.ca")
     NOTIFY_ENVIRONMENT = "production"
     # CSV_UPLOAD_BUCKET_NAME = 'live-notifications-csv-upload'
@@ -770,14 +771,17 @@ class Production(Config):
 
 
 class Staging(Production):
+    FRESH_DESK_ENABLED = env.bool("FRESH_DESK_ENABLED", False)
     NOTIFY_ENVIRONMENT = "staging"
 
 
 class Scratch(Production):
+    FRESH_DESK_ENABLED = env.bool("FRESH_DESK_ENABLED", False)
     NOTIFY_ENVIRONMENT = "scratch"
 
 
 class Dev(Production):
+    FRESH_DESK_ENABLED = env.bool("FRESH_DESK_ENABLED", False)
     NOTIFY_ENVIRONMENT = "dev"
 
 


### PR DESCRIPTION
# Summary | Résumé

* Turnoff Freshdesk in all environments except production

By default, freshdesk should be off in all environments except production. 

## Related Issues | Cartes liées

* None

# Test instructions | Instructions pour tester la modification

Trigger freshdesk tickets in each environment.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.