### PR TITLE
got it working

### DIFF
--- a/app/dao/permissions_dao.py
+++ b/app/dao/permissions_dao.py
@@ -67,5 +67,9 @@ class PermissionDAO(DAOClass):
             self.Meta.model.query.filter_by(user_id=user_id).join(Permission.service).filter_by(active=True, id=service_id).all()
         )
 
+    def get_team_members_with_permission(self, service_id, permission):
+        permission_objs = self.Meta.model.query.filter_by(service_id=service_id, permission=permission).join(Permission.user).filter_by(state="active").all()
+        return [p.user for p in permission_objs]
+
 
 permission_dao = PermissionDAO()

--- a/app/dao/users_dao.py
+++ b/app/dao/users_dao.py
@@ -104,7 +104,7 @@ def verify_within_time(user, age=timedelta(seconds=30)):
     return query.count()
 
 
-def get_user_by_id(user_id=None):
+def get_user_by_id(user_id=None) -> User:
     if user_id:
         return User.query.filter_by(id=user_id).one()
     return User.query.filter_by().all()

--- a/app/models.py
+++ b/app/models.py
@@ -645,6 +645,12 @@ class Service(BaseModel, Versioned):
             "research_mode": self.research_mode,
         }
 
+    def get_users_with_permission(self, permission):
+        from app.dao.permissions_dao import permission_dao
+
+        if permission:
+            return permission_dao.get_team_members_with_permission(self.id, permission)
+        return []
 
 class AnnualBilling(BaseModel):
     __tablename__ = "annual_billing"

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -90,6 +90,7 @@ from app.models import (
     EMAIL_TYPE,
     KEY_TYPE_NORMAL,
     LETTER_TYPE,
+    MANAGE_SETTINGS,
     NOTIFICATION_CANCELLED,
     SMS_TYPE,
     EmailBranding,
@@ -97,6 +98,7 @@ from app.models import (
     NotificationType,
     Permission,
     Service,
+    User,
 )
 from app.notifications.process_notifications import (
     persist_notification,
@@ -490,12 +492,22 @@ def add_user_to_service(service_id, user_id):
 def remove_user_from_service(service_id, user_id):
     service = dao_fetch_service_by_id(service_id)
     user = get_user_by_id(user_id=user_id)
+    users_with_manage_settings_perm = service.get_users_with_permission(MANAGE_SETTINGS)
+
     if user not in service.users:
         error = "User not found"
         raise InvalidRequest(error, status_code=404)
 
     elif len(service.users) == 1:
         error = "You cannot remove the only user for a service"
+        raise InvalidRequest(error, status_code=400)
+
+    elif len(service.users) == 2:
+        error = "SERVICE_CANNOT_HAVE_LT_2_MEMBERS"
+        raise InvalidRequest(error, status_code=400)
+
+    elif user in users_with_manage_settings_perm and len(users_with_manage_settings_perm) <= 1:
+        error = "SERVICE_NEEDS_USER_W_MANAGE_SETTINGS_PERM"
         raise InvalidRequest(error, status_code=400)
 
     dao_remove_user_from_service(service, user)

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -98,7 +98,6 @@ from app.models import (
     NotificationType,
     Permission,
     Service,
-    User,
 )
 from app.notifications.process_notifications import (
     persist_notification,


### PR DESCRIPTION
# Summary | Résumé

This PR:
- adds a method on the service object `get_users_with_permission` - this returns a list of active users who belong to the service who have the permission you pass in as an argument
- adds 2 new error responses that are returned when you try to delete a user. `SERVICE_CANNOT_HAVE_LT_2_MEMBERS` and `SERVICE_NEEDS_USER_W_MANAGE_SETTINGS_PERM`. This is to support the "leave team" feature in notification admin 

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1158

# Test instructions | Instructions pour tester la modification

1. run this branch locally
2. run the `feat/remove-yourself` branch of notification-admin locally
3. set up a service with 2 members, one member with all permissions, and the other member missing the "manage settings and team" permission
4. click "leave team" from the "team members" page, confirm, and observe that you get an error about not being able to leave a team with only 2 members
5. add another user to the team who does not have the "manage settings and team" permission, bringing the total to 3 team members.
6. from your user account who does have "manage settings and team" permission, click "leave team" and confirm. You should now see an error about the service needing at least 1 user who can manage settings and team



# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.