### PR TITLE
Add `feedback_reason` column to the notification table

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1548,6 +1548,7 @@ NOTIFICATION_FAILED = "failed"
 NOTIFICATION_TECHNICAL_FAILURE = "technical-failure"
 NOTIFICATION_TEMPORARY_FAILURE = "temporary-failure"
 NOTIFICATION_PERMANENT_FAILURE = "permanent-failure"
+NOTIFICATION_PINPOINT_FAILURE = "pinpoint-failure"
 NOTIFICATION_PENDING_VIRUS_CHECK = "pending-virus-check"
 NOTIFICATION_VALIDATION_FAILED = "validation-failed"
 NOTIFICATION_VIRUS_SCAN_FAILED = "virus-scan-failed"
@@ -1558,6 +1559,7 @@ NOTIFICATION_STATUS_TYPES_FAILED = [
     NOTIFICATION_TECHNICAL_FAILURE,
     NOTIFICATION_TEMPORARY_FAILURE,
     NOTIFICATION_PERMANENT_FAILURE,
+    NOTIFICATION_PINPOINT_FAILURE,
     NOTIFICATION_VALIDATION_FAILED,
     NOTIFICATION_VIRUS_SCAN_FAILED,
     NOTIFICATION_RETURNED_LETTER,
@@ -1605,6 +1607,7 @@ NOTIFICATION_STATUS_TYPES = [
     NOTIFICATION_TECHNICAL_FAILURE,
     NOTIFICATION_TEMPORARY_FAILURE,
     NOTIFICATION_PERMANENT_FAILURE,
+    NOTIFICATION_PINPOINT_FAILURE,
     NOTIFICATION_PENDING_VIRUS_CHECK,
     NOTIFICATION_VALIDATION_FAILED,
     NOTIFICATION_VIRUS_SCAN_FAILED,
@@ -1739,6 +1742,7 @@ class Notification(BaseModel):
     feedback_subtype = db.Column(db.String, nullable=True)
     ses_feedback_id = db.Column(db.String, nullable=True)
     ses_feedback_date = db.Column(db.DateTime, nullable=True)
+    feedback_reason = db.Column(db.String, nullable=True)
 
     # SMS columns
     sms_total_message_price = db.Column(db.Numeric(), nullable=True)

--- a/app/utils.py
+++ b/app/utils.py
@@ -21,6 +21,7 @@ FAILURE_STATUSES = [
     "temporary-failure",
     "permanent-failure",
     "technical-failure",
+    "pinpoint-failure",
     "virus-scan-failed",
     "validation-failed",
 ]

--- a/migrations/versions/0474_add_feedback_reason_column.py
+++ b/migrations/versions/0474_add_feedback_reason_column.py
@@ -1,0 +1,41 @@
+"""
+
+Revision ID: 0474_add_feedback_reason_column
+Revises: 0473_change_pt_support_email
+Create Date: 2025-02-05 14:40:00 EST
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0474_add_feedback_reason_column"
+down_revision = "0473_change_pt_support_email"
+
+new_notification_status = "pinpoint-failure"
+
+
+def upgrade():
+    op.add_column("notifications", sa.Column("feedback_reason", sa.String(length=255), nullable=True))
+    op.add_column("notification_history", sa.Column("feedback_reason", sa.String(length=255), nullable=True))
+
+    op.create_index(
+        op.f("ix_notifications_feedback_reason"),
+        "notifications",
+        ["feedback_reason"],
+    )
+    op.create_index(
+        op.f("ix_notification_history_feedback_reason"),
+        "notification_history",
+        ["feedback_reason"],
+    )
+
+    op.execute("INSERT INTO notification_status_types (name) VALUES ('{}')".format(new_notification_status))
+
+
+def downgrade():
+    op.drop_index(op.f("ix_notifications_feedback_reason"), table_name="notifications")
+    op.drop_index(op.f("ix_notification_history_feedback_reason"), table_name="notification_history")
+    op.drop_column("notifications", "feedback_reason")
+    op.drop_column("notification_history", "feedback_reason")
+    op.execute("DELETE FROM notification_status_types WHERE name = '{}'".format(new_notification_status))


### PR DESCRIPTION
# Summary | Résumé

This PR adds a new column, `feedback_reason`, to the notifications table. It will be leveraged to track more granular reasons why a notification fails. It also adds a new notification_status `pinpoint-failure`.

E.g. boto validates that the requested resource on AWS can handle the request being made through it. Since we disabled international sending in Pinpoint boto will throw an exception. 

# Test instructions | Instructions pour tester la modification
1. Tests pass
2. `flask db upgrade` and `flask db downgrade` work locally

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.