### PR TITLE
Dial down perf test

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,2 @@
 *.env
-tests*
+tests/

--- a/tests-perf/locust/locust.conf
+++ b/tests-perf/locust/locust.conf
@@ -1,7 +1,7 @@
 # master.conf in current directory
 locustfile = tests-perf/locust/locust-notifications.py
 host = https://api.staging.notification.cdssandbox.xyz
-users = 3000
+users = 300
 spawn-rate = 20
 run-time = 10m
 


### PR DESCRIPTION
# Summary | Résumé

The perf test now causes a lot of 500 and other errors when it runs :/ This PR scales it back until we can properly investigate.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/523

# Test instructions | Instructions pour tester la modification

After it runs check for staging errors around 7 pm EST.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.