### PR TITLE
put perf test results in a month directory

### DIFF
--- a/bin/execute_and_publish_performance_test.sh
+++ b/bin/execute_and_publish_performance_test.sh
@@ -1,14 +1,17 @@
 #!/bin/bash
 
 # Setup
+current_month=$(date "+%Y.%m")
 current_time=$(date "+%Y.%m.%d-%H.%M.%S")
-perf_test_aws_s3_bucket=${PERF_TEST_AWS_S3_BUCKET:-notify-performance-test-results-staging}
-perf_test_csv_directory_path=${PERF_TEST_CSV_DIRECTORY_PATH:-/tmp/notify_performance_test}
-mkdir -p $perf_test_csv_directory_path/$current_time
+perf_test_aws_s3_bucket="${PERF_TEST_AWS_S3_BUCKET:-notify-performance-test-results-staging}"
+perf_test_csv_directory_path="${PERF_TEST_CSV_DIRECTORY_PATH:-/tmp/notify_performance_test}"
+perf_test_results_folder="$perf_test_csv_directory_path/$current_month/$current_time"
+
+mkdir -p "$perf_test_results_folder"
 
 # Run old performance test and copy results to S3
-locust --headless --config tests-perf/locust/locust.conf --html $perf_test_csv_directory_path/$current_time/index.html --csv $perf_test_csv_directory_path/$current_time/perf_test
-aws s3 cp $perf_test_csv_directory_path/ "s3://$perf_test_aws_s3_bucket" --recursive || exit 1
+locust --headless --config tests-perf/locust/locust.conf --html "$perf_test_results_folder/index.html" --csv "$perf_test_results_folder/perf_test"
+aws s3 cp $"perf_test_csv_directory_path/" "s3://$perf_test_aws_s3_bucket" --recursive || exit 1
 
 # Sleep 15 minutes to allow the system to stabilize
 sleep 900
@@ -21,4 +24,4 @@ if [ "$(date +%u)" -ge 2 ] && [ "$(date +%u)" -le 5 ]; then
 fi
 
 # Cleanup
-rm -rf $perf_test_csv_directory_path/$current_time
+rm -rf "${perf_test_csv_directory_path:?}/${current_time:?}"


### PR DESCRIPTION
# Summary | Résumé

Perf test uses a flat directory of days, this gets really long fast (currently GitHub will not list the full directory). Here we store results in a month / day structure.

Also fixed a bunch of things vscode was complaining about, for example putting quotes around directory name variables.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/521

# Test instructions | Instructions pour tester la modification

After tests run, check that s3 and Github has the new files in the correct directory structure

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.