### PR TITLE
fix perf test link sending

### DIFF
--- a/tests-perf/locust/locust-notifications.py
+++ b/tests-perf/locust/locust-notifications.py
@@ -3,6 +3,9 @@
 """
 # flake8: noqa
 
+from tests_smoke.smoke.common import job_line, rows_to_csv  # type: ignore
+from locust import HttpUser, constant_pacing, task
+from dotenv import load_dotenv
 import os
 import sys
 from datetime import datetime
@@ -10,9 +13,6 @@ from dataclasses import make_dataclass
 
 sys.path.append(os.path.abspath(os.path.join("..", "tests_smoke")))
 
-from dotenv import load_dotenv
-from locust import HttpUser, constant_pacing, task
-from tests_smoke.smoke.common import job_line, rows_to_csv  # type: ignore
 
 load_dotenv()
 NotifyApiUserTemplateGroup = make_dataclass('NotifyApiUserTemplateGroup', [
@@ -65,7 +65,7 @@ class NotifyApiUser(HttpUser):
     @task(2)
     def send_email_with_link_notifications(self):
         personalisation = {
-            "application_file": {
+            "var": {
                 "file": "Q29udGVudCBvZiBBdHRhY2hlZCBmaWxl",
                 "filename": "attached_file.txt",
                 "sending_method": "link",


### PR DESCRIPTION
# Summary | Résumé

The [template](https://staging.notification.cdssandbox.xyz/services/44c1a3f5-6a11-4952-b6f4-94dd46d009f2/templates/9fb324a5-821d-4b54-9d52-d9ba1fa8373a) we're using to send file links in the perf test has a `((var))` but our perf test code uses `application_file`. We could change the template, but other code could be using it. Safer to change the perf test.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/521

# Test instructions | Instructions pour tester la modification

Perf tests should run with no errors (after we get the annual limits issue fixed)

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.