### PR TITLE
add sms send rate perf test

### DIFF
--- a/.github/workflows/build_and_push_performance_test.yml
+++ b/.github/workflows/build_and_push_performance_test.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'tests-perf/locust/**'
       - 'tests-perf/ops/**'
+      - 'bin/execute_and_publish_performance_test.sh'
 
 env:
   GITHUB_SHA: ${{ github.sha }}

--- a/bin/execute_and_publish_performance_test.sh
+++ b/bin/execute_and_publish_performance_test.sh
@@ -23,5 +23,15 @@ if [ "$(date +%u)" -ge 2 ] && [ "$(date +%u)" -le 5 ]; then
     locust --headless --host https://api.staging.notification.cdssandbox.xyz --locustfile tests-perf/locust/send_rate_email.py --users 5 --run-time 10m --spawn-rate 1
 fi
 
+# Sleep 30 minutes to allow the tests to finish and the system to stabilize
+sleep 1800
+
+# Run sms send rate performance test
+# This configuration should send 4K sms / minute for 5 minutes for 20K sms total.
+# We run this test on Tuesday through Friday (just after midnight UTC) only.
+if [ "$(date +%u)" -ge 2 ] && [ "$(date +%u)" -le 5 ]; then
+    locust --headless --host https://api.staging.notification.cdssandbox.xyz --locustfile tests-perf/locust/send_rate_sms.py --users 2 --run-time 5m --spawn-rate 1
+fi
+
 # Cleanup
 rm -rf "${perf_test_csv_directory_path:?}/${current_time:?}"

--- a/tests-perf/locust/send_rate_sms.py
+++ b/tests-perf/locust/send_rate_sms.py
@@ -1,6 +1,4 @@
-""" send_rate_sms.py
-    isort:skip_file
-"""
+# isort:skip_file
 # flake8: noqa
 
 from tests_smoke.smoke.common import job_line, rows_to_csv  # type: ignore
@@ -48,7 +46,7 @@ class NotifyApiUser(HttpUser):
     @task(1)
     def send_bulk_sms_notifications(self):
         """
-        Send BULK_SIZE emails through the /bulk endpoint
+        Send BULK_SIZE SMS through the /bulk endpoint
         """
 
         json = {

--- a/tests-perf/locust/send_rate_sms.py
+++ b/tests-perf/locust/send_rate_sms.py
@@ -1,0 +1,60 @@
+""" send_rate_sms.py
+    isort:skip_file
+"""
+# flake8: noqa
+
+from tests_smoke.smoke.common import job_line, rows_to_csv  # type: ignore
+from locust import HttpUser, constant_pacing, task
+from dotenv import load_dotenv
+from dataclasses import make_dataclass
+from datetime import datetime
+import sys
+import os
+BULK_SIZE = 2000
+
+
+sys.path.append(os.path.abspath(os.path.join("..", "tests_smoke")))
+
+
+load_dotenv()
+NotifyApiUserTemplateGroup = make_dataclass('NotifyApiUserTemplateGroup', [
+    'bulk_email_id',
+    'email_id',
+    'email_with_attachment_id',
+    'email_with_link_id',
+    'sms_id',
+])
+
+
+class NotifyApiUser(HttpUser):
+
+    wait_time = constant_pacing(60)  # 60 seconds between each task
+    host = os.getenv("PERF_TEST_DOMAIN", "https://api.staging.notification.cdssandbox.xyz")
+
+    def __init__(self, *args, **kwargs):
+        super(NotifyApiUser, self).__init__(*args, **kwargs)
+
+        self.headers = {"Authorization": os.getenv("PERF_TEST_AUTH_HEADER")}
+        self.email = os.getenv("PERF_TEST_EMAIL", "success@simulator.amazonses.com")
+        self.phone_number = os.getenv("PERF_TEST_PHONE_NUMBER", "16135550123")
+        self.template_group = NotifyApiUserTemplateGroup(
+            bulk_email_id=os.getenv("PERF_TEST_BULK_EMAIL_TEMPLATE_ID"),
+            email_id=os.getenv("PERF_TEST_EMAIL_TEMPLATE_ID"),
+            email_with_attachment_id=os.getenv("PERF_TEST_EMAIL_WITH_ATTACHMENT_TEMPLATE_ID"),
+            email_with_link_id=os.getenv("PERF_TEST_EMAIL_WITH_LINK_TEMPLATE_ID"),
+            sms_id=os.getenv("PERF_TEST_SMS_TEMPLATE_ID"),
+        )
+
+    @task(1)
+    def send_bulk_sms_notifications(self):
+        """
+        Send BULK_SIZE emails through the /bulk endpoint
+        """
+
+        json = {
+            "name": f"Send rate test {datetime.utcnow().isoformat()}",
+            "template_id": self.template_group.sms_id,
+            "csv": rows_to_csv([["phone number", "var"], *job_line(self.phone_number, BULK_SIZE)])
+        }
+
+        self.client.post("/v2/notifications/bulk", json=json, headers=self.headers)


### PR DESCRIPTION
# Summary | Résumé

Add a test to the nightly perf test that will max out our SMS sending rate

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/485

# Test instructions | Instructions pour tester la modification

Look at the results of the perf test [here](https://ca-central-1.console.aws.amazon.com/cloudwatch/home?region=ca-central-1#dashboards/dashboard/Notify-System-Overview-SJA-internal-test-SMS).

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.