### PR TITLE
Remove unused celery queue

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -104,7 +104,6 @@ class QueueNames(object):
     RETRY = "retry-tasks"
 
     NOTIFY = "notify-internal-tasks"
-    PROCESS_FTP = "process-ftp-tasks"
     CREATE_LETTERS_PDF = "create-letters-pdf-tasks"
     CALLBACKS = "service-callbacks"
     CALLBACKS_RETRY = "service-callbacks-retry"


### PR DESCRIPTION
# Summary | Résumé

Both the queue name and the variable it is assigned to only appear in this file.