### PR TITLE
Added annotations to auto-manage the sign/unsign input parameters and return

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,6 +21,7 @@
 			},
 			"extensions": [
 				"bungcip.better-toml",
+				"charliermarsh.ruff",
 				"donjayamanne.python-extension-pack",
 				"eamodio.gitlens",
 				"fill-labs.dependi",
@@ -37,7 +38,6 @@
 				"ms-vsliveshare.vsliveshare",
 				"mtxr.sqltools",
 				"mtxr.sqltools-driver-pg",
-				"pmbenjamin.vscode-snyk",
 				"timonwong.shellcheck",
 				"usernamehw.errorlens",
 				"visualstudioexptteam.vscodeintellicode",

--- a/app/annotations.py
+++ b/app/annotations.py
@@ -1,4 +1,4 @@
-from app.encryption import CryptoSigner, SignedNotification, SignedNotifications
+from app.encryption import SignedNotification, SignedNotifications
 from app import signer_notification
 
 # from flask import current_app

--- a/app/annotations.py
+++ b/app/annotations.py
@@ -1,9 +1,10 @@
-from app.encryption import SignedNotification, SignedNotifications
-from app import signer_notification
+from functools import wraps
 
 # from flask import current_app
 from inspect import signature
-from functools import wraps
+
+from app import signer_notification
+from app.encryption import SignedNotification, SignedNotifications
 
 
 def unsign_params(func):

--- a/app/annotations.py
+++ b/app/annotations.py
@@ -1,0 +1,77 @@
+from app.encryption import CryptoSigner, SignedNotification, SignedNotifications
+from app import signer_notification
+
+# from flask import current_app
+from inspect import signature
+from functools import wraps
+
+
+def unsign_params(func):
+    """
+    A decorator that verifies the first argument of the decorated function
+    using `CryptoSigner().verify`.
+    Args:
+        func (callable): The function to be decorated.
+    Returns:
+        callable: The wrapped function with verification, un-signing decorated
+        parameters typed with SignedNotification[s].
+    The decorated function should expect the first argument to be a signed string.
+    The decorator will verify this signed string before calling the decorated function.
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        sig = signature(func)
+
+        # Find the parameter annotated with VerifyAndSign
+        bound_args = sig.bind(*args, **kwargs)
+        bound_args.apply_defaults()
+
+        for param_name, param in sig.parameters.items():
+            if param.annotation in (SignedNotification, SignedNotifications):
+                signed = bound_args.arguments[param_name]
+
+                # Verify the signed string or list of signed strings
+                if param.annotation is SignedNotification:
+                    verified_value = signer_notification.verify(signed)
+                elif param.annotation is SignedNotifications:
+                    verified_value = [
+                        signer_notification.verify(item) for item in signed
+                    ]
+
+                # Replace the signed value with the verified value
+                bound_args.arguments[param_name] = verified_value
+
+        # Call the decorated function with the verified value
+        result = func(*bound_args.args, **bound_args.kwargs)
+        return result
+
+    return wrapper
+
+
+def sign_return(func):
+    """
+    A decorator that signs the result of the decorated function using CryptoSigner.
+    Args:
+        func (callable): The function to be decorated.
+    Returns:
+        callable: The wrapped function that returns a signed result.
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        # Call the decorated function with the verified value
+        result = func(*args, **kwargs)
+
+        if isinstance(result, str):
+            # Sign the str result of the decorated function
+            signed_result = signer_notification.sign(result)
+        elif isinstance(result, list):
+            # Sign the list result of the decorated function
+            signed_result = [signer_notification.sign(item) for item in result]
+        else:
+            signed_result = result
+
+        return signed_result
+
+    return wrapper

--- a/app/annotations.py
+++ b/app/annotations.py
@@ -8,8 +8,8 @@ from functools import wraps
 
 def unsign_params(func):
     """
-    A decorator that verifies the first argument of the decorated function
-    using `CryptoSigner().verify`.
+    A decorator that verifies the SignedNotification|SignedNotifications typed
+    arguments of the decorated function using `CryptoSigner().verify`.
     Args:
         func (callable): The function to be decorated.
     Returns:

--- a/app/annotations.py
+++ b/app/annotations.py
@@ -35,9 +35,7 @@ def unsign_params(func):
                 if param.annotation is SignedNotification:
                     verified_value = signer_notification.verify(signed)
                 elif param.annotation is SignedNotifications:
-                    verified_value = [
-                        signer_notification.verify(item) for item in signed
-                    ]
+                    verified_value = [signer_notification.verify(item) for item in signed]
 
                 # Replace the signed value with the verified value
                 bound_args.arguments[param_name] = verified_value

--- a/app/aws/xray_celery_handlers.py
+++ b/app/aws/xray_celery_handlers.py
@@ -20,7 +20,7 @@ CELERY_NAMESPACE = "celery"
 def xray_before_task_publish(
     sender=None, headers=None, exchange=None, routing_key=None, properties=None, declare=None, retry_policy=None, **kwargs
 ):
-    logger.info(f"xray-celery: before publish: sender={sender}, headers={headers}, kwargs={kwargs}")
+    logger.debug(f"xray-celery: before publish: sender={sender}, headers={headers}, kwargs={kwargs}")
     headers = headers if headers else {}
     task_id = headers.get("id")
     current_segment = xray_recorder.current_segment()
@@ -41,7 +41,7 @@ def xray_before_task_publish(
 
 
 def xray_after_task_publish(headers=None, body=None, exchange=None, routing_key=None, **kwargs):
-    logger.info(
+    logger.debug(
         f"xray-celery: after publish: headers={headers}, body={body}, exchange={exchange}, routing_key={routing_key}, kwargs={kwargs}"
     )
     if xray_recorder.current_subsegment():
@@ -51,7 +51,7 @@ def xray_after_task_publish(headers=None, body=None, exchange=None, routing_key=
 
 
 def xray_task_prerun(task_id=None, task=None, args=None, **kwargs):
-    logger.info(f"xray-celery: prerun: task_id={task_id}, task={task}, kwargs={kwargs}")
+    logger.debug(f"xray-celery: prerun: task_id={task_id}, task={task}, kwargs={kwargs}")
     xray_header = construct_xray_header(task.request)
     segment = xray_recorder.begin_segment(name=task.name, traceid=xray_header.root, parent_id=xray_header.parent)
     segment.save_origin_trace_header(xray_header)
@@ -61,7 +61,7 @@ def xray_task_prerun(task_id=None, task=None, args=None, **kwargs):
 
 
 def xray_task_postrun(task_id=None, task=None, args=None, **kwargs):
-    logger.info(f"xray-celery: postrun: kwargs={kwargs}")
+    logger.debug(f"xray-celery: postrun: kwargs={kwargs}")
     xray_recorder.end_segment()
 
 

--- a/app/encryption.py
+++ b/app/encryption.py
@@ -39,9 +39,7 @@ class CryptoSigner:
             salt (str): The salt to use for signing.
         """
         self.app = app
-        self.secret_key = cast(
-            List[str], [secret_key] if type(secret_key) is str else secret_key
-        )
+        self.secret_key = cast(List[str], [secret_key] if type(secret_key) is str else secret_key)
         self.serializer = URLSafeSerializer(secret_key)
         self.salt = salt
 
@@ -56,9 +54,7 @@ class CryptoSigner:
         """
         return self.serializer.dumps(to_sign, salt=self.salt)
 
-    def sign_with_all_keys(
-        self, to_sign: str | NotificationDictToSign
-    ) -> List[str | bytes]:
+    def sign_with_all_keys(self, to_sign: str | NotificationDictToSign) -> List[str | bytes]:
         """Sign a string or dict with all the individual keys in the class secret key list, and the class salt.
 
         Args:

--- a/app/encryption.py
+++ b/app/encryption.py
@@ -1,10 +1,12 @@
 from typing import Any, List, NewType, Optional, TypedDict, cast
 
 from flask_bcrypt import check_password_hash, generate_password_hash
+
 from itsdangerous import URLSafeSerializer
 from typing_extensions import NotRequired  # type: ignore
 
 SignedNotification = NewType("SignedNotification", str)
+SignedNotifications = NewType("SignedNotifications", List[SignedNotification])
 
 
 class NotificationDictToSign(TypedDict):
@@ -37,7 +39,9 @@ class CryptoSigner:
             salt (str): The salt to use for signing.
         """
         self.app = app
-        self.secret_key = cast(List[str], [secret_key] if type(secret_key) is str else secret_key)
+        self.secret_key = cast(
+            List[str], [secret_key] if type(secret_key) is str else secret_key
+        )
         self.serializer = URLSafeSerializer(secret_key)
         self.salt = salt
 
@@ -52,7 +56,9 @@ class CryptoSigner:
         """
         return self.serializer.dumps(to_sign, salt=self.salt)
 
-    def sign_with_all_keys(self, to_sign: str | NotificationDictToSign) -> List[str | bytes]:
+    def sign_with_all_keys(
+        self, to_sign: str | NotificationDictToSign
+    ) -> List[str | bytes]:
         """Sign a string or dict with all the individual keys in the class secret key list, and the class salt.
 
         Args:

--- a/app/encryption.py
+++ b/app/encryption.py
@@ -1,7 +1,6 @@
 from typing import Any, List, NewType, Optional, TypedDict, cast
 
 from flask_bcrypt import check_password_hash, generate_password_hash
-
 from itsdangerous import URLSafeSerializer
 from typing_extensions import NotRequired  # type: ignore
 

--- a/app/queue.py
+++ b/app/queue.py
@@ -69,8 +69,8 @@ class Queue(ABC):
         can later be used in conjunction with the `acknowledge` function
         to confirm that the polled messages were properly processed.
         This will delete the in-flight messages and these will not get
-        back into the main inbox. Failure to achknowledge the polled
-        messages will get these back into the inbox after a preconfigured
+        back into the main inbox. Failure to acknowledge the polled
+        messages will get these back into the inbox after a pre-configured
         timeout has passed, ready to be retried.
 
         Args:

--- a/app/queue.py
+++ b/app/queue.py
@@ -40,7 +40,9 @@ class Buffer(Enum):
             return f"{self.value}::{str(process_type)}"
         return self.value
 
-    def inflight_prefix(self, suffix: Optional[str] = None, process_type: Optional[str] = None) -> str:
+    def inflight_prefix(
+        self, suffix: Optional[str] = None, process_type: Optional[str] = None
+    ) -> str:
         if process_type and suffix:
             return f"{Buffer.IN_FLIGHT.value}:{str(suffix)}:{str(process_type)}"
         if suffix:
@@ -50,7 +52,12 @@ class Buffer(Enum):
             return f"{Buffer.IN_FLIGHT.value}::{str(process_type)}"
         return f"{Buffer.IN_FLIGHT.value}"
 
-    def inflight_name(self, receipt: UUID = uuid4(), suffix: Optional[str] = None, process_type: Optional[str] = None) -> str:
+    def inflight_name(
+        self,
+        receipt: UUID = uuid4(),
+        suffix: Optional[str] = None,
+        process_type: Optional[str] = None,
+    ) -> str:
         return f"{self.inflight_prefix(suffix, process_type)}:{str(receipt)}"
 
 
@@ -115,7 +122,9 @@ class RedisQueue(Queue):
 
     scripts: Dict[str, Any] = {}
 
-    def __init__(self, suffix=None, expire_inflight_after_seconds=300, process_type=None) -> None:
+    def __init__(
+        self, suffix=None, expire_inflight_after_seconds=300, process_type=None
+    ) -> None:
         """
         Constructor for the Redis Queue
 
@@ -144,7 +153,9 @@ class RedisQueue(Queue):
 
     def poll(self, count=10) -> tuple[UUID, list[str]]:
         receipt = uuid4()
-        in_flight_key = Buffer.IN_FLIGHT.inflight_name(receipt, self._suffix, self._process_type)
+        in_flight_key = Buffer.IN_FLIGHT.inflight_name(
+            receipt, self._suffix, self._process_type
+        )
         results = self.__move_to_inflight(in_flight_key, count)
         if results:
             current_app.logger.info(f"Inflight created: {in_flight_key}")
@@ -159,11 +170,17 @@ class RedisQueue(Queue):
                 self._expire_inflight_after_seconds,
             ]
         else:
-            args = [f"{Buffer.IN_FLIGHT.inflight_prefix()}:{self._suffix}*", self._inbox, self._expire_inflight_after_seconds]
+            args = [
+                f"{Buffer.IN_FLIGHT.inflight_prefix()}:{self._suffix}*",
+                self._inbox,
+                self._expire_inflight_after_seconds,
+            ]
         expired = self.scripts[self.LUA_EXPIRE_INFLIGHTS](args=args)
         if expired:
             put_batch_saving_expiry_metric(self.__metrics_logger, self, len(expired))
-            current_app.logger.warning(f"Moved inflights {expired} back to inbox {self._inbox}")
+            current_app.logger.warning(
+                f"Moved inflights {expired} back to inbox {self._inbox}"
+            )
 
     def acknowledge(self, receipt: UUID) -> bool:
         """
@@ -175,7 +192,9 @@ class RedisQueue(Queue):
 
         Returns: True if the inflight was found in that queue and removed, False otherwise
         """
-        inflight_name = Buffer.IN_FLIGHT.inflight_name(receipt, self._suffix, self._process_type)
+        inflight_name = Buffer.IN_FLIGHT.inflight_name(
+            receipt, self._suffix, self._process_type
+        )
         if not self._redis_client.exists(inflight_name):
             current_app.logger.warning(f"Inflight to delete not found: {inflight_name}")
             return False
@@ -189,7 +208,9 @@ class RedisQueue(Queue):
         put_batch_saving_metric(self.__metrics_logger, self, 1)
 
     def __move_to_inflight(self, in_flight_key: str, count: int) -> list[str]:
-        results = self.scripts[self.LUA_MOVE_TO_INFLIGHT](args=[self._inbox, in_flight_key, count])
+        results = self.scripts[self.LUA_MOVE_TO_INFLIGHT](
+            args=[self._inbox, in_flight_key, count]
+        )
         decoded = [result.decode("utf-8") for result in results]
         return decoded
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,12 @@ packages = []
 [tool.poetry.scripts]
 notify-api = ""
 
+[tool.ruff]
+ignore = ["D101", "D102", "D103"]
+
+[tool.pylint]
+disable = ["missing-class-docstring", "missing-function-docstring"]
+
 [build-system]
 requires = ["poetry>=1.3.2"]
 build-backend = "poetry.core.masonry.api"

--- a/tests/app/test_annotations.py
+++ b/tests/app/test_annotations.py
@@ -1,14 +1,9 @@
 import pytest
-
-from app.encryption import CryptoSigner, SignedNotification, SignedNotifications
-from app import signer_notification
-
-from app.annotations import (
-    sign_return,
-    unsign_params,
-)
-
 from itsdangerous.exc import BadSignature
+
+from app import signer_notification
+from app.annotations import sign_return, unsign_params
+from app.encryption import CryptoSigner, SignedNotification, SignedNotifications
 
 
 class TestUnsignParamsAnnotation:

--- a/tests/app/test_annotations.py
+++ b/tests/app/test_annotations.py
@@ -1,0 +1,110 @@
+import pytest
+
+from app.encryption import CryptoSigner, SignedNotification, SignedNotifications
+from app import signer_notification
+
+from app.annotations import (
+    sign_return,
+    unsign_params,
+)
+
+from itsdangerous.exc import BadSignature
+
+
+class TestUnsignParamsAnnotation:
+    @pytest.fixture(scope="class", autouse=True)
+    def setup_class(self, notify_api):
+        # We just want to setup the notify_api flask app for tests within the class.
+        pass
+
+    def test_unsign_with_bad_signature_notification(self, notify_api):
+        @unsign_params
+        def annotated_unsigned_function(
+            signed_notification: SignedNotification,
+        ) -> str:
+            return signed_notification
+
+        custom_signer = CryptoSigner()
+        custom_signer.init_app(notify_api, "shhhhh", "salty")
+
+        signed = custom_signer.sign("raw notification")
+        with pytest.raises(BadSignature):
+            annotated_unsigned_function(signed)
+
+    def test_unsign_with_one_signed_notification(self):
+        @unsign_params
+        def func_with_one_signed_notification(
+            signed_notification: SignedNotification,
+        ) -> str:
+            return signed_notification
+
+        signed = signer_notification.sign("raw notification")
+        unsigned = func_with_one_signed_notification(signed)
+        assert unsigned == "raw notification"
+
+    def test_unsign_with_non_SignedNotification_parameter(self):
+        def func_with_one_signed_notification(signed_notification: str):
+            return signed_notification
+
+        signed = "raw notification"
+        unsigned = func_with_one_signed_notification(signed)
+        assert unsigned == "raw notification"
+
+    def test_unsign_with_list_of_signed_notifications(self):
+        @unsign_params
+        def func_with_list_of_signed_notifications(
+            signed_notifications: SignedNotifications,
+        ):
+            return signed_notifications
+
+        signed = [
+            signer_notification.sign(notification)
+            for notification in ["raw notification 1", "raw notification 2"]
+        ]
+        unsigned = func_with_list_of_signed_notifications(signed)
+        assert unsigned == ["raw notification 1", "raw notification 2"]
+
+    def test_unsign_with_empty_list_of_signed_notifications(self):
+        @unsign_params
+        def func_with_list_of_signed_notifications(
+            signed_notifications: SignedNotifications,
+        ):
+            return signed_notifications
+
+        signed = []
+        unsigned = func_with_list_of_signed_notifications(signed)
+        assert unsigned == []
+
+    def test_sign_return(self):
+        @sign_return
+        def func_to_sign_return():
+            return "raw notification"
+
+        signed = func_to_sign_return()
+        assert signer_notification.verify(signed) == "raw notification"
+
+    def test_sign_return_with_list(self):
+        @sign_return
+        def func_to_sign_return():
+            return ["raw notification 1", "raw notification 2"]
+
+        signed = func_to_sign_return()
+        assert [
+            signer_notification.verify(notification) for notification in signed
+        ] == ["raw notification 1", "raw notification 2"]
+
+    def test_sign_return_with_empty_list(self):
+        @sign_return
+        def func_to_sign_return():
+            return []
+
+        signed = func_to_sign_return()
+        assert signed == []
+
+    def test_sign_return_with_non_string_return(self):
+        @sign_return
+        def func_to_sign_return():
+            return 1
+
+        signed = func_to_sign_return()
+        assert signed == 1

--- a/tests/app/test_annotations.py
+++ b/tests/app/test_annotations.py
@@ -57,10 +57,7 @@ class TestUnsignParamsAnnotation:
         ):
             return signed_notifications
 
-        signed = [
-            signer_notification.sign(notification)
-            for notification in ["raw notification 1", "raw notification 2"]
-        ]
+        signed = [signer_notification.sign(notification) for notification in ["raw notification 1", "raw notification 2"]]
         unsigned = func_with_list_of_signed_notifications(signed)
         assert unsigned == ["raw notification 1", "raw notification 2"]
 
@@ -89,9 +86,10 @@ class TestUnsignParamsAnnotation:
             return ["raw notification 1", "raw notification 2"]
 
         signed = func_to_sign_return()
-        assert [
-            signer_notification.verify(notification) for notification in signed
-        ] == ["raw notification 1", "raw notification 2"]
+        assert [signer_notification.verify(notification) for notification in signed] == [
+            "raw notification 1",
+            "raw notification 2",
+        ]
 
     def test_sign_return_with_empty_list(self):
         @sign_return

--- a/tests/app/test_encryption.py
+++ b/tests/app/test_encryption.py
@@ -47,9 +47,7 @@ class TestEncryption:
         signer2.init_app(notify_api, ["s2", "s3"], "salt")
         assert signer2.verify(signer1.sign("this")) == "this"
 
-    def test_should_unsafe_verify_content_signed_with_different_secrets(
-        self, notify_api
-    ):
+    def test_should_unsafe_verify_content_signed_with_different_secrets(self, notify_api):
         signer1 = CryptoSigner()
         signer2 = CryptoSigner()
         signer1.init_app(notify_api, "secret1", "salt")

--- a/tests/app/test_encryption.py
+++ b/tests/app/test_encryption.py
@@ -4,6 +4,13 @@ from itsdangerous import BadSignature
 from app.encryption import CryptoSigner
 
 
+@pytest.fixture()
+def crypto_signer(notify_api):
+    signer = CryptoSigner()
+    signer.init_app(notify_api, "secret", "salt")
+    yield signer
+
+
 class TestEncryption:
     def test_sign_and_verify(self, notify_api):
         signer = CryptoSigner()
@@ -40,7 +47,9 @@ class TestEncryption:
         signer2.init_app(notify_api, ["s2", "s3"], "salt")
         assert signer2.verify(signer1.sign("this")) == "this"
 
-    def test_should_unsafe_verify_content_signed_with_different_secrets(self, notify_api):
+    def test_should_unsafe_verify_content_signed_with_different_secrets(
+        self, notify_api
+    ):
         signer1 = CryptoSigner()
         signer2 = CryptoSigner()
         signer1.init_app(notify_api, "secret1", "salt")
@@ -54,4 +63,7 @@ class TestEncryption:
         signer2.init_app(notify_api, "s2", "salt")
         signer12 = CryptoSigner()
         signer12.init_app(notify_api, ["s1", "s2"], "salt")
-        assert signer12.sign_with_all_keys("this") == [signer2.sign("this"), signer1.sign("this")]
+        assert signer12.sign_with_all_keys("this") == [
+            signer2.sign("this"),
+            signer1.sign("this"),
+        ]


### PR DESCRIPTION
# Summary | Résumé

Added utility annotations `@unsign_params` and `@sign_return`.

The `@unsign_params` will inspect the decorated function for parameters with the `SignedNotification` and `SignedNotifications` types. When it finds these, it will attempt to run the `CryptoSigner.verify` method and replace the original parameter's value with the newly unsigned value, for the decorated function to receive the unsigned value. This removes the burden to handle this operation which happens often in the code base in a cross-cut manner. The `SignedNotification` type is meant to handle atomic value whereas the `SignedNotifications` is meant for list of `SignedNotifications` (alias `str` type). 

This annotation is not used in any place at the moment. This PR is meant to only introduce the utility. Next PRs will introduce its usage across the code base after tests with it works. 

## Related Issues | Cartes liées

* [Add X-Ray Trace ID to Redis Cluster](https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/476)

# Test instructions | Instructions pour tester la modification

The feature is included in unit-tests. This should not trigger any regression as this is not used anywhere in the code yet. 

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.