### PR TITLE
add file to perf test GitHub action filter

### DIFF
--- a/.github/workflows/build_and_push_performance_test.yml
+++ b/.github/workflows/build_and_push_performance_test.yml
@@ -30,6 +30,7 @@ jobs:
             performance-test: 
               - 'tests-perf/**'
               - 'tests_smoke/**'
+              - 'bin/execute_and_publish_performance_test.sh'
 
   build-push-and-deploy:
     if: ${{ needs.changes.outputs.images != '[]' }}


### PR DESCRIPTION
# Summary | Résumé

In #2449 I didn't realize there's a filter down in the middle of the file :/

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/485

# Test instructions | Instructions pour tester la modification

🤞 

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.