### PR TITLE
Delayed signing of notification from processing to the redis saving

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -59,7 +59,6 @@ from app.dao.service_sms_sender_dao import dao_get_service_sms_senders_by_id
 from app.dao.services_dao import dao_fetch_service_by_id
 from app.dao.templates_dao import dao_get_template_by_id
 from app.email_limit_utils import fetch_todays_email_count
-from app.encryption import SignedNotification
 from app.exceptions import DVLAException
 from app.models import (
     BULK,
@@ -84,7 +83,7 @@ from app.notifications.process_notifications import (
     send_notification_to_queue,
 )
 from app.sms_fragment_utils import fetch_todays_requested_sms_count
-from app.types import VerifiedNotification
+from app.types import SignedNotification, VerifiedNotification
 from app.utils import get_csv_max_rows, get_delivery_queue_for_template, get_fiscal_year
 from app.v2.errors import (
     LiveServiceTooManyRequestsError,
@@ -289,23 +288,25 @@ def save_smss(self, service_id: Optional[str], signed_notifications: List[Signed
             else:
                 reply_to_text = service.get_default_sms_sender()  # type: ignore
 
-        notification: VerifiedNotification = {
-            **_notification,  # type: ignore
-            "notification_id": notification_id,
-            "reply_to_text": reply_to_text,
-            "service": service,
-            "key_type": _notification.get("key_type", KEY_TYPE_NORMAL),
-            "template_id": template.id,
-            "template_version": template.version,
-            "recipient": _notification.get("to"),
-            "personalisation": _notification.get("personalisation"),
-            "notification_type": SMS_TYPE,  # type: ignore
-            "simulated": _notification.get("simulated", None),
-            "api_key_id": _notification.get("api_key", None),
-            "created_at": datetime.utcnow(),
-            "job_id": _notification.get("job", None),
-            "job_row_number": _notification.get("row_number", None),
-        }
+        notification = VerifiedNotification.from_dict(
+            {
+                **_notification,  # type: ignore
+                "notification_id": notification_id,
+                "reply_to_text": reply_to_text,
+                "service": service,
+                "key_type": _notification.get("key_type", KEY_TYPE_NORMAL),
+                "template_id": template.id,
+                "template_version": template.version,
+                "recipient": _notification.get("to"),
+                "personalisation": _notification.get("personalisation"),
+                "notification_type": SMS_TYPE,  # type: ignore
+                "simulated": _notification.get("simulated", None),
+                "api_key_id": _notification.get("api_key", None),
+                "created_at": datetime.utcnow(),
+                "job_id": _notification.get("job", None),
+                "job_row_number": _notification.get("row_number", None),
+            }
+        )
 
         verified_notifications.append(notification)
         notification_id_queue[notification_id] = notification.get("queue")  # type: ignore
@@ -404,26 +405,29 @@ def save_emails(self, _service_id: Optional[str], signed_notifications: List[Sig
             else:
                 reply_to_text = service.get_default_reply_to_email_address()
 
-        notification: VerifiedNotification = {
-            **_notification,  # type: ignore
-            "notification_id": notification_id,
-            "reply_to_text": reply_to_text,
-            "service": service,
-            "key_type": _notification.get("key_type", KEY_TYPE_NORMAL),
-            "template_id": template.id,
-            "template_version": template.version,
-            "recipient": _notification.get("to"),
-            "personalisation": _notification.get("personalisation"),
-            "notification_type": EMAIL_TYPE,  # type: ignore
-            "simulated": _notification.get("simulated", None),
-            "api_key_id": _notification.get("api_key", None),
-            "created_at": datetime.utcnow(),
-            "job_id": _notification.get("job", None),
-            "job_row_number": _notification.get("row_number", None),
-        }
+        verified_notification = VerifiedNotification.from_dict(
+            {
+                **_notification,  # type: ignore
+                "notification_id": notification_id,
+                "reply_to_text": reply_to_text,
+                "service": service,
+                "key_type": _notification.get("key_type", KEY_TYPE_NORMAL),
+                "template_id": template.id,
+                "template_version": template.version,
+                "recipient": _notification.get("to"),
+                "personalisation": _notification.get("personalisation"),
+                "notification_type": EMAIL_TYPE,  # type: ignore
+                "simulated": _notification.get("simulated", None),
+                "api_key_id": _notification.get("api_key", None),
+                "created_at": datetime.utcnow(),
+                "job_id": _notification.get("job", None),
+                "job_row_number": _notification.get("row_number", None),
+                "queue": _notification.get("queue", None),
+            }
+        )
 
-        verified_notifications.append(notification)
-        notification_id_queue[notification_id] = notification.get("queue")  # type: ignore
+        verified_notifications.append(verified_notification)
+        notification_id_queue[notification_id] = verified_notification.queue  # type: ignore
         process_type = template.process_type
 
     try:
@@ -750,6 +754,7 @@ def send_notify_no_reply(self, data):
     template = dao_get_template_by_id(current_app.config["NO_REPLY_TEMPLATE_ID"])
 
     try:
+        # TODO: replace dict creation with VerifiedNotification.from_dict
         data_to_send = [
             dict(
                 template_id=template.id,

--- a/app/encryption.py
+++ b/app/encryption.py
@@ -1,31 +1,7 @@
-from typing import Any, List, NewType, Optional, TypedDict, cast
+from typing import Any, List, cast
 
 from flask_bcrypt import check_password_hash, generate_password_hash
 from itsdangerous import URLSafeSerializer
-from typing_extensions import NotRequired  # type: ignore
-
-SignedNotification = NewType("SignedNotification", str)
-SignedNotifications = NewType("SignedNotifications", List[SignedNotification])
-
-
-class NotificationDictToSign(TypedDict):
-    # todo: remove duplicate keys
-    # todo: remove all NotRequired and decide if key should be there or not
-    id: NotRequired[str]
-    template: str  # actually template_id
-    service_id: NotRequired[str]
-    template_version: int
-    to: str  # recipient
-    reply_to_text: NotRequired[str]
-    personalisation: Optional[dict]
-    simulated: NotRequired[bool]
-    api_key: str
-    key_type: str  # should be ApiKeyType but I can't import that here
-    client_reference: Optional[str]
-    queue: Optional[str]
-    sender_id: Optional[str]
-    job: NotRequired[str]  # actually job_id
-    row_number: Optional[Any]  # should this be int or str?
 
 
 class CryptoSigner:
@@ -42,22 +18,22 @@ class CryptoSigner:
         self.serializer = URLSafeSerializer(secret_key)
         self.salt = salt
 
-    def sign(self, to_sign: str | NotificationDictToSign) -> str | bytes:
+    def sign(self, to_sign: str) -> str | bytes:
         """Sign a string or dict with the class secret key and salt.
 
         Args:
-            to_sign (str | NotificationDictToSign): The string or dict to sign.
+            to_sign (str): The string or dict to sign.
 
         Returns:
             str | bytes: The signed string or bytes.
         """
         return self.serializer.dumps(to_sign, salt=self.salt)
 
-    def sign_with_all_keys(self, to_sign: str | NotificationDictToSign) -> List[str | bytes]:
+    def sign_with_all_keys(self, to_sign: str) -> List[str | bytes]:
         """Sign a string or dict with all the individual keys in the class secret key list, and the class salt.
 
         Args:
-            to_sign (str | NotificationDictToSign): The string or dict to sign.
+            to_sign (str): The string or dict to sign.
 
         Returns:
             List[str | bytes]: A list of signed values.

--- a/app/types.py
+++ b/app/types.py
@@ -1,11 +1,42 @@
+from dataclasses import asdict, dataclass
 from datetime import datetime
-from typing import Optional
+from typing import List, NewType, Optional
 
-from app.encryption import NotificationDictToSign
 from app.models import Job, NotificationType, Service
+from app.queue import QueueMessage
+
+SignedNotification = NewType("SignedNotification", str)
+SignedNotifications = NewType("SignedNotifications", List[SignedNotification])
 
 
-class VerifiedNotification(NotificationDictToSign):
+@dataclass
+class PendingNotification(QueueMessage):
+    # todo: remove duplicate keys
+    # todo: remove all NotRequired and decide if key should be there or not
+    id: str
+    template: str  # actually template_id
+    service_id: str
+    template_version: int
+    to: str  # recipient
+    personalisation: Optional[dict]
+    simulated: bool
+    api_key: str
+    key_type: str  # should be ApiKeyType but can't import that here
+    client_reference: Optional[str]
+    reply_to_text: Optional[str]
+
+    def to_dict(self) -> dict:
+        """Convert the object to a dictionary."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict):
+        """Create an object from a dictionary."""
+        return cls(**data)
+
+
+@dataclass
+class VerifiedNotification(PendingNotification):
     service: Service
     notification_id: str
     template_id: str
@@ -15,3 +46,5 @@ class VerifiedNotification(NotificationDictToSign):
     created_at: datetime
     job_id: Optional[Job]
     job_row_number: Optional[int]
+    # postage: Optional[str]  # for letters
+    # template_postage: Optional[str]  # for letters


### PR DESCRIPTION
# Summary | Résumé

* Delayed signing of notification from processing to the redis saving
* Refactored many types as well to reflect the notification's lifecycle, as well as removed unnecessary fields.

## Related Issues | Cartes liées

* [Add X-Ray Trace ID to Redis Cluster](https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/476)

# Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.