### PR TITLE
Improve performance of `update_last_used_api_key` fn

### DIFF
--- a/app/dao/api_key_dao.py
+++ b/app/dao/api_key_dao.py
@@ -70,9 +70,18 @@ def expire_api_key(service_id, api_key_id):
 
 @transactional
 def update_last_used_api_key(api_key_id, last_used=None) -> None:
-    api_key = ApiKey.query.filter_by(id=api_key_id).one()
-    api_key.last_used_timestamp = last_used if last_used else datetime.utcnow()
-    db.session.add(api_key)
+    """
+    Update the last_used_timestamp of an API key using a direct SQLAlchemy update.
+    Using update() directly is more efficient than loading the model instance.
+    Setting `synchronize_session=False` improves performance and can be used since we 
+    don't need to access the updated value in the same session.
+    """
+    timestamp = last_used if last_used else datetime.utcnow()
+    
+    ApiKey.query.filter_by(id=api_key_id).update(
+        {"last_used_timestamp": timestamp},
+        synchronize_session=False
+    )
 
 
 @transactional

--- a/app/dao/api_key_dao.py
+++ b/app/dao/api_key_dao.py
@@ -73,15 +73,12 @@ def update_last_used_api_key(api_key_id, last_used=None) -> None:
     """
     Update the last_used_timestamp of an API key using a direct SQLAlchemy update.
     Using update() directly is more efficient than loading the model instance.
-    Setting `synchronize_session=False` improves performance and can be used since we 
+    Setting `synchronize_session=False` improves performance and can be used since we
     don't need to access the updated value in the same session.
     """
     timestamp = last_used if last_used else datetime.utcnow()
-    
-    ApiKey.query.filter_by(id=api_key_id).update(
-        {"last_used_timestamp": timestamp},
-        synchronize_session=False
-    )
+
+    ApiKey.query.filter_by(id=api_key_id).update({"last_used_timestamp": timestamp}, synchronize_session=False)
 
 
 @transactional


### PR DESCRIPTION
# Summary | Résumé

I re-wrote the query in this function to be more performant (hopefully). Using update() directly should be more efficient than the previous query. I tested locally to make sure the `last_used_timestamp` is still being set correctly.

I'd like to see what effect this has on the DB load during our nightly performance tests.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1769

# Test instructions | Instructions pour tester la modification

Run locally and verify that the api key `last_used_timestamp` gets updated when you send a notification via the local api. You can see it in admin on the following page: API Integration > API Keys

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.