### PR TITLE
tweak smoke test for dev

### DIFF
--- a/.devcontainer/scripts/notify-dev-entrypoint.sh
+++ b/.devcontainer/scripts/notify-dev-entrypoint.sh
@@ -28,7 +28,7 @@ echo -e "complete -F __start_kubectl k" >> ~/.zshrc
 echo -e "alias smoke-local='cd /workspace && cp .env_smoke_local tests_smoke/.env && poetry run make smoke-test-local'" >> ~/.zshrc
 echo -e "alias smoke-staging='cd /workspace && cp .env_smoke_staging tests_smoke/.env && poetry run make smoke-test'" >> ~/.zshrc
 echo -e "alias smoke-prod='cd /workspace && cp .env_smoke_prod tests_smoke/.env && poetry run make smoke-test'" >> ~/.zshrc
-echo -e "alias smoke-dev='cd /workspace && cp .env_smoke_dev tests_smoke/.env && poetry run make smoke-test'" >> ~/.zshrc
+echo -e "alias smoke-dev='cd /workspace && cp .env_smoke_dev tests_smoke/.env && poetry run make smoke-test-dev'" >> ~/.zshrc
 
 echo -e "# fzf key bindings and completion" >> ~/.zshrc
 echo -e "source /usr/share/doc/fzf/examples/key-bindings.zsh" >> ~/.zshrc

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,10 @@ format:
 smoke-test:
 	cd tests_smoke && poetry run python smoke_test.py
 
+.PHONY: smoke-test-dev
+smoke-test-dev:
+	cd tests_smoke && poetry run python smoke_test.py --nofiles --nocsv
+
 .PHONY: smoke-test-local
 smoke-test-local:
 	cd tests_smoke && poetry run python smoke_test.py --local --nofiles

--- a/tests_smoke/smoke_test.py
+++ b/tests_smoke/smoke_test.py
@@ -10,6 +10,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-l", "--local", default=False, action='store_true', help="run locally, do not check for delivery success (default false)")
     parser.add_argument("--nofiles", default=False, action='store_true', help="do not send files (default false)")
+    parser.add_argument("--nocsv", default=False, action='store_true', help="do not send with admin csv uploads (default false)")
     args = parser.parse_args()
 
     print("API Smoke test\n")
@@ -19,7 +20,8 @@ if __name__ == "__main__":
 
     for notification_type in [Notification_type.EMAIL, Notification_type.SMS]:
         test_admin_one_off(notification_type, local=args.local)
-        test_admin_csv(notification_type, local=args.local)
+        if not args.nocsv:
+            test_admin_csv(notification_type, local=args.local)
         test_api_one_off(notification_type, local=args.local)
         test_api_bulk(notification_type, local=args.local)
 


### PR DESCRIPTION
# Summary | Résumé

Tweak the smoke test so `smoke-dev` runs but omits things dev currently can't do (sending files and admin csv upload)

# Test instructions | Instructions pour tester la modification

- set up a .`env_smoke_dev` in the repo root dir
- run `smoke-dev`
- see emails and sms send successfully!

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [x] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [x] This PR does not significantly alter performance.
- [x] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.