### PR TITLE
post perf test start and end to slack

### DIFF
--- a/tests_nightly_performance/execute_and_publish_performance_test.sh
+++ b/tests_nightly_performance/execute_and_publish_performance_test.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Post to Slack
+json='{"text":"Performance tests starting"}'
+curl -X POST -H 'Content-type: application/json' --data "$json" "${PERF_TEST_SLACK_WEBHOOK}"
+
 # Setup
 current_month=$(date "+%Y.%m")
 current_time=$(date "+%Y.%m.%d-%H.%M.%S")
@@ -56,3 +60,7 @@ aws s3 cp "$perf_test_csv_directory_path/" "s3://$perf_test_aws_s3_bucket" --rec
 
 # Cleanup
 rm -rf "${perf_test_csv_directory_path:?}"
+
+# Post to Slack
+json='{"text":"Performance tests complete"}'
+curl -X POST -H 'Content-type: application/json' --data "$json" "${PERF_TEST_SLACK_WEBHOOK}"

--- a/tests_nightly_performance/execute_and_publish_performance_test.sh
+++ b/tests_nightly_performance/execute_and_publish_performance_test.sh
@@ -62,5 +62,5 @@ aws s3 cp "$perf_test_csv_directory_path/" "s3://$perf_test_aws_s3_bucket" --rec
 rm -rf "${perf_test_csv_directory_path:?}"
 
 # Post to Slack
-json='{"text":"Performance tests complete"}'
+json='{"text":":warning: Performance tests complete :rotating-light-blue:"}'
 curl -X POST -H 'Content-type: application/json' --data "$json" "${PERF_TEST_SLACK_WEBHOOK}"

--- a/tests_nightly_performance/execute_and_publish_performance_test.sh
+++ b/tests_nightly_performance/execute_and_publish_performance_test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Post to Slack
-json='{"text":"Performance tests starting"}'
+json='{"text":":warning: Performance tests starting :rotating-light-blue:"}'
 curl -X POST -H 'Content-type: application/json' --data "$json" "${PERF_TEST_SLACK_WEBHOOK}"
 
 # Setup


### PR DESCRIPTION
# Summary | Résumé

Post perf test start and end to slack

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/544

Requires https://github.com/cds-snc/notification-terraform/pull/1793

# Test instructions | Instructions pour tester la modification

None

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.