### PR TITLE
Fix perf test start / end Slack post

### DIFF
--- a/tests_nightly_performance/Dockerfile
+++ b/tests_nightly_performance/Dockerfile
@@ -8,7 +8,7 @@ ENV POETRY_VERSION="1.7.1"
 ENV POETRY_VIRTUALENVS_CREATE="false"
 ENV PATH="${APP_VENV}/bin:${POETRY_HOME}/bin:$PATH"
 
-RUN apk add --no-cache bash build-base git libtool cmake autoconf automake gcc musl-dev postgresql-dev g++ make libffi-dev libmagic libcurl curl-dev rust cargo postgresql-client && rm -rf /var/cache/apk/*
+RUN apk add --no-cache bash build-base curl git libtool cmake autoconf automake gcc musl-dev postgresql-dev g++ make libffi-dev libmagic libcurl curl-dev rust cargo postgresql-client && rm -rf /var/cache/apk/*
 
 RUN set -ex && mkdir /app
 WORKDIR /app


### PR DESCRIPTION
# Summary | Résumé

Forgot to install curl in the perf test container 🤦 

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/544

# Test instructions | Instructions pour tester la modification

[Tested](https://gcdigital.slack.com/archives/C012W5K734Y/p1741208429992409) by pushing an image with just the curls

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.