### PR TITLE
get perf test host from variable

### DIFF
--- a/tests_nightly_performance/locust.conf
+++ b/tests_nightly_performance/locust.conf
@@ -1,5 +1,3 @@
-# master.conf in current directory
-host = https://api.staging.notification.cdssandbox.xyz
 spawn-rate = 20
 run-time = 10m
 headless = true

--- a/tests_nightly_performance/src/blast_api.py
+++ b/tests_nightly_performance/src/blast_api.py
@@ -12,6 +12,7 @@ BULK_SIZE = 2000
 class NotifyApiUser(HttpUser):
 
     wait_time = constant_pacing(60)  # 60 seconds between each task
+    host = Config.HOST
 
     def __init__(self, *args, **kwargs):
         super(NotifyApiUser, self).__init__(*args, **kwargs)

--- a/tests_nightly_performance/src/common.py
+++ b/tests_nightly_performance/src/common.py
@@ -18,6 +18,7 @@ class Config:
     EMAIL_TEMPLATE_ID_ONE_VAR = os.environ.get("PERF_TEST_EMAIL_TEMPLATE_ID_ONE_VAR")
     SMS_TEMPLATE_ID_ONE_VAR = os.environ.get("PERF_TEST_SMS_TEMPLATE_ID_ONE_VAR")
     API_KEY = os.environ.get("PERF_TEST_API_KEY")
+    HOST = os.environ.get("PERF_TEST_DOMAIN", "https://api.staging.notification.cdssandbox.xyz")
 
     @staticmethod
     def check():

--- a/tests_nightly_performance/src/email_send_rate.py
+++ b/tests_nightly_performance/src/email_send_rate.py
@@ -9,6 +9,7 @@ BULK_SIZE = 2000
 class NotifyApiUser(HttpUser):
 
     wait_time = constant_pacing(60)  # 60 seconds between each task
+    host = Config.HOST
 
     def __init__(self, *args, **kwargs):
         super(NotifyApiUser, self).__init__(*args, **kwargs)

--- a/tests_nightly_performance/src/sms_send_rate.py
+++ b/tests_nightly_performance/src/sms_send_rate.py
@@ -9,6 +9,7 @@ BULK_SIZE = 2000
 class NotifyApiUser(HttpUser):
 
     wait_time = constant_pacing(60)  # 60 seconds between each task
+    host = Config.HOST
 
     def __init__(self, *args, **kwargs):
         super(NotifyApiUser, self).__init__(*args, **kwargs)


### PR DESCRIPTION
# Summary | Résumé

There's a variable to set the host but we're not using it, just hard coding to staging :/

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/484

# Test instructions | Instructions pour tester la modification

Tested on dev

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.