### PR TITLE
Add a new DB table: `reports`

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -516,6 +516,40 @@ class Organisation(BaseModel):
         }
 
 
+class Report(BaseModel, Versioned):
+    __tablename__ = "reports"
+
+    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    report_type = db.Column(db.String(255), nullable=False)  # email, sms, job, other types in future
+    requested_at = db.Column(
+        db.DateTime,
+        index=False,
+        unique=False,
+        nullable=False,
+        default=datetime.datetime.utcnow,
+    )
+    completed_at = db.Column(
+        db.DateTime,
+        index=False,
+        unique=False,
+        nullable=False,
+        default=datetime.datetime.utcnow,
+    )
+    expires_at = db.Column(
+        db.DateTime,
+        index=False,
+        unique=False,
+        nullable=True,
+        onupdate=datetime.datetime.utcnow,
+    )
+    requesting_user_id = db.Column(
+        UUID(as_uuid=True), db.ForeignKey("users.id"), nullable=True
+    )  # only set if report is requested by a user
+    service_id = db.Column(UUID(as_uuid=True), db.ForeignKey("services.id"), nullable=False)
+    job_id = db.Column(UUID(as_uuid=True), db.ForeignKey("jobs.id"), nullable=True)  # only set if report is for a bulk job
+    url = db.Column(db.String(), nullable=True)  # url to download the report from s3
+
+
 class Service(BaseModel, Versioned):
     __tablename__ = "services"
 

--- a/app/models.py
+++ b/app/models.py
@@ -516,40 +516,6 @@ class Organisation(BaseModel):
         }
 
 
-class Report(BaseModel, Versioned):
-    __tablename__ = "reports"
-
-    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    report_type = db.Column(db.String(255), nullable=False)  # email, sms, job, other types in future
-    requested_at = db.Column(
-        db.DateTime,
-        index=False,
-        unique=False,
-        nullable=False,
-        default=datetime.datetime.utcnow,
-    )
-    completed_at = db.Column(
-        db.DateTime,
-        index=False,
-        unique=False,
-        nullable=False,
-        default=datetime.datetime.utcnow,
-    )
-    expires_at = db.Column(
-        db.DateTime,
-        index=False,
-        unique=False,
-        nullable=True,
-        onupdate=datetime.datetime.utcnow,
-    )
-    requesting_user_id = db.Column(
-        UUID(as_uuid=True), db.ForeignKey("users.id"), nullable=True
-    )  # only set if report is requested by a user
-    service_id = db.Column(UUID(as_uuid=True), db.ForeignKey("services.id"), nullable=False)
-    job_id = db.Column(UUID(as_uuid=True), db.ForeignKey("jobs.id"), nullable=True)  # only set if report is for a bulk job
-    url = db.Column(db.String(), nullable=True)  # url to download the report from s3
-
-
 class Service(BaseModel, Versioned):
     __tablename__ = "services"
 
@@ -2695,3 +2661,44 @@ class AnnualLimitsData(BaseModel):
         db.Index("ix_service_id_notification_type", "service_id", "notification_type"),
         db.Index("ix_service_id_notification_type_time", "time_period", "service_id", "notification_type"),
     )
+
+
+class Report(BaseModel):
+    __tablename__ = "reports"
+
+    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    report_type = db.Column(db.String(255), nullable=False)  # email, sms, job, other types in future
+    requested_at = db.Column(
+        db.DateTime,
+        index=False,
+        unique=False,
+        nullable=False,
+        default=datetime.datetime.utcnow,
+    )
+    completed_at = db.Column(
+        db.DateTime,
+        index=False,
+        unique=False,
+        nullable=False,
+        default=datetime.datetime.utcnow,
+    )
+    expires_at = db.Column(
+        db.DateTime,
+        index=False,
+        unique=False,
+        nullable=True,
+        onupdate=datetime.datetime.utcnow,
+    )
+    requesting_user_id = db.Column(
+        UUID(as_uuid=True), db.ForeignKey("users.id"), nullable=True
+    )  # only set if report is requested by a user
+    service_id = db.Column(
+        UUID(as_uuid=True),
+        db.ForeignKey("services.id"),
+        unique=False,
+        index=True,
+        nullable=False,
+    )
+    job_id = db.Column(UUID(as_uuid=True), db.ForeignKey("jobs.id"), nullable=True)  # only set if report is for a bulk job
+    url = db.Column(db.String(255), nullable=True)  # url to download the report from s3
+    status = db.Column(db.String(255), nullable=False)

--- a/app/models.py
+++ b/app/models.py
@@ -2663,6 +2663,18 @@ class AnnualLimitsData(BaseModel):
     )
 
 
+class ReportStatus(Enum):
+    REQUESTED = "requested"
+    GENERATING = "generating"
+    READY = "ready"
+
+
+class ReportType(Enum):
+    SMS = "sms"
+    EMAIL = "email"
+    JOB = "job"
+
+
 class Report(BaseModel):
     __tablename__ = "reports"
 
@@ -2679,7 +2691,7 @@ class Report(BaseModel):
         db.DateTime,
         index=False,
         unique=False,
-        nullable=False,
+        nullable=True,
         default=datetime.datetime.utcnow,
     )
     expires_at = db.Column(

--- a/migrations/versions/0476_add_reports_table.py
+++ b/migrations/versions/0476_add_reports_table.py
@@ -18,7 +18,7 @@ def upgrade():
     sa.Column('id', postgresql.UUID(as_uuid=True), nullable=False),
     sa.Column('report_type', sa.String(length=255), nullable=False),
     sa.Column('requested_at', sa.DateTime(), nullable=False),
-    sa.Column('completed_at', sa.DateTime(), nullable=False),
+    sa.Column('completed_at', sa.DateTime(), nullable=True),
     sa.Column('expires_at', sa.DateTime(), nullable=True),
     sa.Column('requesting_user_id', postgresql.UUID(as_uuid=True), nullable=True),
     sa.Column('service_id', postgresql.UUID(as_uuid=True), nullable=False),

--- a/migrations/versions/0476_add_reports_table.py
+++ b/migrations/versions/0476_add_reports_table.py
@@ -1,0 +1,38 @@
+"""
+
+Revision ID: 0476_add_reports_table
+Revises: 0475_change_notification_status
+Create Date: 2025-03-19 20:10:55.451309
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0476_add_reports_table'
+down_revision = '0475_change_notification_status'
+
+
+def upgrade():
+    op.create_table('reports',
+    sa.Column('id', postgresql.UUID(as_uuid=True), nullable=False),
+    sa.Column('report_type', sa.String(length=255), nullable=False),
+    sa.Column('requested_at', sa.DateTime(), nullable=False),
+    sa.Column('completed_at', sa.DateTime(), nullable=False),
+    sa.Column('expires_at', sa.DateTime(), nullable=True),
+    sa.Column('requesting_user_id', postgresql.UUID(as_uuid=True), nullable=True),
+    sa.Column('service_id', postgresql.UUID(as_uuid=True), nullable=False),
+    sa.Column('job_id', postgresql.UUID(as_uuid=True), nullable=True),
+    sa.Column('url', sa.String(length=255), nullable=True),
+    sa.Column('status', sa.String(length=255), nullable=False),
+    sa.ForeignKeyConstraint(['job_id'], ['jobs.id'], ),
+    sa.ForeignKeyConstraint(['requesting_user_id'], ['users.id'], ),
+    sa.ForeignKeyConstraint(['service_id'], ['services.id'], ),
+    sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_reports_service_id'), 'reports', ['service_id'], unique=False)
+    
+
+def downgrade():
+    op.drop_index(op.f('ix_reports_service_id'), table_name='reports')
+    op.drop_table('reports')

--- a/tests/app/notifications/rest/test_send_notification.py
+++ b/tests/app/notifications/rest/test_send_notification.py
@@ -416,8 +416,10 @@ def test_should_block_api_call_if_over_annual_limit_and_allow_if_under_limit(
     expected_error_message,
     annual_limit,
 ):
-    with notify_api.test_request_context(), set_config(notify_api, "FF_ANNUAL_LIMIT", True), set_config(
-        notify_api, "REDIS_ENABLED", True
+    with (
+        notify_api.test_request_context(),
+        set_config(notify_api, "FF_ANNUAL_LIMIT", True),
+        set_config(notify_api, "REDIS_ENABLED", True),
     ):
         with notify_api.test_client() as client:
             service = create_sample_service(

--- a/tests_nightly_performance/src/blast_api.py
+++ b/tests_nightly_performance/src/blast_api.py
@@ -10,7 +10,6 @@ BULK_SIZE = 2000
 
 
 class NotifyApiUser(HttpUser):
-
     wait_time = constant_pacing(60)  # 60 seconds between each task
     host = Config.HOST
 
@@ -48,8 +47,8 @@ class NotifyApiUser(HttpUser):
                     "file": "Q29udGVudCBvZiBBdHRhY2hlZCBmaWxl",
                     "filename": "attached_file.txt",
                     "sending_method": "attach",
-                }
-            }
+                },
+            },
         }
         self.client.post("/v2/notifications/email", json=json, headers=self.headers)
 
@@ -64,7 +63,7 @@ class NotifyApiUser(HttpUser):
                     "filename": "attached_file.txt",
                     "sending_method": "link",
                 }
-            }
+            },
         }
         self.client.post("/v2/notifications/email", json=json, headers=self.headers)
 
@@ -73,6 +72,6 @@ class NotifyApiUser(HttpUser):
         json = {
             "name": f"Email send rate test {datetime.utcnow().isoformat()}",
             "template_id": Config.EMAIL_TEMPLATE_ID_ONE_VAR,
-            "csv": rows_to_csv([["email address", "var"], *generate_job_rows(Config.EMAIL_ADDRESS, 2)])
+            "csv": rows_to_csv([["email address", "var"], *generate_job_rows(Config.EMAIL_ADDRESS, 2)]),
         }
         self.client.post("/v2/notifications/bulk", json=json, headers=self.headers)

--- a/tests_nightly_performance/src/email_send_rate.py
+++ b/tests_nightly_performance/src/email_send_rate.py
@@ -7,7 +7,6 @@ BULK_SIZE = 2000
 
 
 class NotifyApiUser(HttpUser):
-
     wait_time = constant_pacing(60)  # 60 seconds between each task
     host = Config.HOST
 
@@ -21,6 +20,6 @@ class NotifyApiUser(HttpUser):
         json = {
             "name": f"Email send rate test {datetime.utcnow().isoformat()}",
             "template_id": Config.EMAIL_TEMPLATE_ID_ONE_VAR,
-            "csv": rows_to_csv([["email address", "var"], *generate_job_rows(Config.EMAIL_ADDRESS, BULK_SIZE)])
+            "csv": rows_to_csv([["email address", "var"], *generate_job_rows(Config.EMAIL_ADDRESS, BULK_SIZE)]),
         }
         self.client.post("/v2/notifications/bulk", json=json, headers=self.headers)

--- a/tests_nightly_performance/src/sms_send_rate.py
+++ b/tests_nightly_performance/src/sms_send_rate.py
@@ -7,7 +7,6 @@ BULK_SIZE = 2000
 
 
 class NotifyApiUser(HttpUser):
-
     wait_time = constant_pacing(60)  # 60 seconds between each task
     host = Config.HOST
 
@@ -21,6 +20,6 @@ class NotifyApiUser(HttpUser):
         json = {
             "name": f"SMS send rate test {datetime.utcnow().isoformat()}",
             "template_id": Config.SMS_TEMPLATE_ID_ONE_VAR,
-            "csv": rows_to_csv([["phone number", "var"], *generate_job_rows(Config.PHONE_NUMBER, BULK_SIZE)])
+            "csv": rows_to_csv([["phone number", "var"], *generate_job_rows(Config.PHONE_NUMBER, BULK_SIZE)]),
         }
         self.client.post("/v2/notifications/bulk", json=json, headers=self.headers)


### PR DESCRIPTION
# Summary | Résumé

This PR adds a new table to capture metadata for reports, to support the new async reports feature.

Note: there are a few random formatting changes that Ruff is forcing me to do

Here is a design where some of the data from this table will be used: https://www.figma.com/design/rzjRLTIzVjM4sHpzI6e0Xl/Reports-%2F-Rapports?node-id=35-1228&t=EaEFXy9k4CMRdvus-4

The lifecycle of a report will be roughly this:
1. user clicks a button to "generate" a report
2. a row is added to the `reports` table with status `"requested"`
3. a celery task picks up the requested report, changes the status to `"generating"` and starts to create the CSV file in an S3 bucket
4. once finished, the status is changed to `"ready"`
5. the report is shown as available to download in notification-admin
6. after 3 days, we reach the `expires_at` time and the report is no longer available to download 

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1804

# Test instructions | Instructions pour tester la modification

- check out this branch
- run `flask db upgrade`
- view the database and ensure that the `reports` table has been created as expected

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.