### PR TITLE
Add schema validation for `reports`

### DIFF
--- a/app/report/rest.py
+++ b/app/report/rest.py
@@ -1,12 +1,14 @@
 import uuid
 
 from flask import Blueprint, current_app, jsonify, request
+from marshmallow import ValidationError
 
 from app.dao.reports_dao import create_report
 from app.dao.services_dao import dao_fetch_service_by_id
 from app.errors import register_errors
 from app.models import Report, ReportStatus, ReportType
 from app.schema_validation import validate
+from app.schemas import report_schema
 
 report_blueprint = Blueprint("report", __name__, url_prefix="/service/<uuid:service_id>/report")
 register_errors(report_blueprint)
@@ -18,6 +20,7 @@ def create_service_report(service_id):
 
     data = request.get_json()
 
+    # Validate basic required fields
     validate(data, {"report_type": {"type": "string", "required": True}})
 
     # Validate report type is one of the allowed types
@@ -28,18 +31,28 @@ def create_service_report(service_id):
     # Check service exists
     dao_fetch_service_by_id(service_id)
 
-    # Create the report object
-    report = Report(
-        id=uuid.uuid4(),
-        report_type=report_type,
-        service_id=service_id,
-        status=ReportStatus.REQUESTED.value,
-        requesting_user_id=data.get("requesting_user_id"),
-    )
+    try:
+        # Validate the report data against the schema
+        report_data = {
+            "id": str(uuid.uuid4()),
+            "report_type": report_type,
+            "service_id": str(service_id),
+            "status": ReportStatus.REQUESTED.value,
+            "requesting_user_id": data.get("requesting_user_id"),
+        }
 
-    # Save the report to the database
-    created_report = create_report(report)
+        # Validate against the schema
+        report_schema.load(report_data)
 
-    current_app.logger.info(f"Report {created_report.id} created for service {service_id}")
+        # Create the report object
+        report = Report(**report_data)
 
-    return jsonify(data=created_report.serialize()), 201
+        # Save the report to the database
+        created_report = create_report(report)
+
+        current_app.logger.info(f"Report {created_report.id} created for service {service_id}")
+
+        return jsonify(data=report_schema.dump(created_report)), 201
+
+    except ValidationError as e:
+        return jsonify(result="error", message=str(e)), 400

--- a/app/report/rest.py
+++ b/app/report/rest.py
@@ -5,7 +5,7 @@ from marshmallow import ValidationError
 
 from app.dao.reports_dao import create_report
 from app.dao.services_dao import dao_fetch_service_by_id
-from app.errors import register_errors
+from app.errors import InvalidRequest, register_errors
 from app.models import Report, ReportStatus, ReportType
 from app.schema_validation import validate
 from app.schemas import report_schema
@@ -54,5 +54,6 @@ def create_service_report(service_id):
 
         return jsonify(data=report_schema.dump(created_report)), 201
 
-    except ValidationError as e:
-        return jsonify(result="error", message=str(e)), 400
+    except ValidationError as err:
+        errors = err.messages
+        raise InvalidRequest(errors, status_code=400)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -828,6 +828,30 @@ class UnarchivedTemplateSchema(BaseSchema):
             raise ValidationError("Template has been deleted", "template")
 
 
+class ReportSchema(BaseSchema):
+    class Meta:
+        unknown = EXCLUDE
+
+    id = fields.UUID()
+    report_type = fields.String()
+    service_id = fields.UUID()
+    status = fields.String()
+    requested_at = FlexibleDateTime()
+    completed_at = FlexibleDateTime()
+    expires_at = FlexibleDateTime()
+    url = fields.String()
+
+    @validates("report_type")
+    def validate_report_type(self, value):
+        if value not in [rt.value for rt in models.ReportType]:
+            raise ValidationError(f"Invalid report type: {value}")
+
+    @validates("status")
+    def validate_status(self, value):
+        if value not in [rs.value for rs in models.ReportStatus]:
+            raise ValidationError(f"Invalid report status: {value}")
+
+
 # should not be used on its own for dumping - only for loading
 create_user_schema = UserSchema()
 user_update_schema_load_json = UserUpdateAttributeSchema(load_json=True, partial=True)
@@ -860,3 +884,4 @@ provider_details_schema = ProviderDetailsSchema()
 provider_details_history_schema = ProviderDetailsHistorySchema()
 day_schema = DaySchema()
 unarchived_template_schema = UnarchivedTemplateSchema()
+report_schema = ReportSchema()


### PR DESCRIPTION
# Summary | Résumé

Add marshmallow schema validation for `reports`

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1805

# Test instructions | Instructions pour tester la modification

Tests should pass.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.