### PR TITLE
Add a `get_service_reports` endpoint

### DIFF
--- a/app/dao/reports_dao.py
+++ b/app/dao/reports_dao.py
@@ -1,3 +1,6 @@
+import datetime
+from typing import List
+
 from app import db
 from app.dao.dao_utils import transactional
 from app.models import Report
@@ -16,3 +19,21 @@ def create_report(report: Report) -> Report:
     db.session.commit()
 
     return report
+
+
+def get_reports_for_service(service_id: str, limit_days: int) -> List[Report]:
+    """
+    Get all reports for a service generated within the specified number of days.
+    Args:
+        service_id: The UUID of the service
+        limit_days: Number of days to look back (default: 30)
+    Returns:
+        List of Report objects sorted by requested_at (newest first)
+    """
+    query = Report.query.filter_by(service_id=service_id)
+
+    if limit_days is not None:
+        date_threshold = datetime.datetime.utcnow() - datetime.timedelta(days=limit_days)
+        query = query.filter(Report.requested_at >= date_threshold)
+
+    return query.order_by(Report.requested_at.desc()).all()

--- a/app/report/rest.py
+++ b/app/report/rest.py
@@ -1,12 +1,14 @@
 import uuid
 
 from flask import Blueprint, current_app, jsonify, request
+from marshmallow import ValidationError
 
-from app.dao.reports_dao import create_report
+from app.dao.reports_dao import create_report, get_reports_for_service
 from app.dao.services_dao import dao_fetch_service_by_id
 from app.errors import register_errors
 from app.models import Report, ReportStatus, ReportType
 from app.schema_validation import validate
+from app.schemas import report_schema
 
 report_blueprint = Blueprint("report", __name__, url_prefix="/service/<uuid:service_id>/report")
 register_errors(report_blueprint)
@@ -18,6 +20,7 @@ def create_service_report(service_id):
 
     data = request.get_json()
 
+    # Validate basic required fields
     validate(data, {"report_type": {"type": "string", "required": True}})
 
     # Validate report type is one of the allowed types
@@ -28,18 +31,44 @@ def create_service_report(service_id):
     # Check service exists
     dao_fetch_service_by_id(service_id)
 
-    # Create the report object
-    report = Report(
-        id=uuid.uuid4(),
-        report_type=report_type,
-        service_id=service_id,
-        status=ReportStatus.REQUESTED.value,
-        requesting_user_id=data.get("requesting_user_id"),
-    )
+    try:
+        # Validate the report data against the schema
+        report_data = {
+            "id": str(uuid.uuid4()),
+            "report_type": report_type,
+            "service_id": str(service_id),
+            "status": ReportStatus.REQUESTED.value,
+            "requesting_user_id": data.get("requesting_user_id"),
+        }
 
-    # Save the report to the database
-    created_report = create_report(report)
+        # Validate against the schema
+        report_schema.load(report_data)
 
-    current_app.logger.info(f"Report {created_report.id} created for service {service_id}")
+        # Create the report object
+        report = Report(**report_data)
 
-    return jsonify(data=created_report.serialize()), 201
+        # Save the report to the database
+        created_report = create_report(report)
+
+        current_app.logger.info(f"Report {created_report.id} created for service {service_id}")
+
+        return jsonify(data=report_schema.dump(created_report)), 201
+
+    except ValidationError as e:
+        return jsonify(result="error", message=str(e)), 400
+
+
+@report_blueprint.route("", methods=["GET"])
+def get_service_reports(service_id):
+    """Get reports for a service with optional days parameter"""
+
+    # Get optional days parameter, default to 30 if not provided
+    limit_days = request.args.get("limit_days", type=int, default=30)
+
+    # Check service exists
+    dao_fetch_service_by_id(service_id)
+
+    reports = get_reports_for_service(service_id, limit_days)
+
+    # Serialize all reports using the schema
+    return jsonify(data=report_schema.dump(reports, many=True)), 200

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -828,6 +828,30 @@ class UnarchivedTemplateSchema(BaseSchema):
             raise ValidationError("Template has been deleted", "template")
 
 
+class ReportSchema(BaseSchema):
+    class Meta:
+        unknown = EXCLUDE
+
+    id = fields.UUID()
+    report_type = fields.String()
+    service_id = fields.UUID()
+    status = fields.String()
+    requested_at = FlexibleDateTime()
+    completed_at = FlexibleDateTime()
+    expires_at = FlexibleDateTime()
+    url = fields.String()
+
+    @validates("report_type")
+    def validate_report_type(self, value):
+        if value not in [rt.value for rt in models.ReportType]:
+            raise ValidationError(f"Invalid report type: {value}")
+
+    @validates("status")
+    def validate_status(self, value):
+        if value not in [rs.value for rs in models.ReportStatus]:
+            raise ValidationError(f"Invalid report status: {value}")
+
+
 # should not be used on its own for dumping - only for loading
 create_user_schema = UserSchema()
 user_update_schema_load_json = UserUpdateAttributeSchema(load_json=True, partial=True)
@@ -860,3 +884,4 @@ provider_details_schema = ProviderDetailsSchema()
 provider_details_history_schema = ProviderDetailsHistorySchema()
 day_schema = DaySchema()
 unarchived_template_schema = UnarchivedTemplateSchema()
+report_schema = ReportSchema()

--- a/tests/app/dao/test_reports_dao.py
+++ b/tests/app/dao/test_reports_dao.py
@@ -1,6 +1,10 @@
+import datetime
 import uuid
 
-from app.dao.reports_dao import create_report
+import pytest
+from freezegun import freeze_time
+
+from app.dao.reports_dao import create_report, get_reports_for_service
 from app.models import Report, ReportStatus, ReportType
 
 
@@ -21,3 +25,122 @@ def test_create_report(sample_service, notify_db_session):
     assert created_report.report_type == ReportType.SMS.value
     assert created_report.service_id == sample_service.id
     assert created_report.status == ReportStatus.REQUESTED.value
+
+
+@pytest.fixture
+def sample_reports(sample_service):
+    """Create a set of sample reports for testing"""
+    reports = []
+    # Create reports with different dates
+    for i in range(5):
+        days_ago = 5 - i  # 5, 4, 3, 2, 1 days ago
+        report_date = datetime.datetime.utcnow() - datetime.timedelta(days=days_ago)
+        reports.append(
+            Report(
+                id=uuid.uuid4(),
+                service_id=sample_service.id,
+                report_type=ReportType.SMS.value,
+                requested_at=report_date,
+                status=ReportStatus.REQUESTED.value,
+                url=None,
+                job_id=None,
+            )
+        )
+
+    # Also add an older report (outside default limit)
+    old_report_date = datetime.datetime.utcnow() - datetime.timedelta(days=35)
+    reports.append(
+        Report(
+            id=uuid.uuid4(),
+            service_id=sample_service.id,
+            report_type=ReportType.EMAIL.value,
+            requested_at=old_report_date,
+            status=ReportStatus.READY.value,
+            url="https://test-bucket.s3.amazonaws.com/test-report.csv",
+            job_id=None,
+        )
+    )
+
+    return reports
+
+
+@freeze_time("2023-01-15 12:00:00")
+def test_get_reports_for_service_with_limit(sample_service, sample_reports, mocker):
+    """Test getting reports with a day limit applies filter correctly"""
+    # Mock the query processing
+    mock_query = mocker.patch("app.models.Report.query")
+    mock_filter_by = mock_query.filter_by.return_value
+    mock_filter = mock_filter_by.filter.return_value
+    mock_order_by = mock_filter.order_by.return_value
+    mock_all = mock_order_by.all
+
+    # Set up the return value to be the subset of reports within the time limit
+    expected_reports = [r for r in sample_reports if (datetime.datetime.utcnow() - r.requested_at).days <= 7]
+    mock_all.return_value = expected_reports
+
+    # Call function with 7 day limit
+    result = get_reports_for_service(sample_service.id, limit_days=7)
+
+    # Assertions
+    mock_query.filter_by.assert_called_once_with(service_id=sample_service.id)
+    assert mock_filter_by.filter.called
+    assert mock_filter.order_by.called
+    assert result == expected_reports
+    assert len(result) == 5  # All but the oldest report
+
+
+def test_get_reports_for_service_empty_result(sample_service, mocker):
+    """Test when no reports exist for a service"""
+    # Mock the query processing
+    mock_query = mocker.patch("app.models.Report.query")
+    mock_filter_by = mock_query.filter_by.return_value
+    mock_filter = mock_filter_by.filter.return_value
+    mock_order_by = mock_filter.order_by.return_value
+    mock_order_by.all.return_value = []
+
+    # Call function
+    result = get_reports_for_service(sample_service.id, limit_days=30)
+
+    # Assertions
+    assert result == []
+
+
+@freeze_time("2023-01-15 12:00:00")
+def test_get_reports_for_service_sorting(sample_service, mocker):
+    """Test that reports are sorted by requested_at in descending order"""
+    # Create a set of reports with different timestamps
+    today = datetime.datetime.utcnow()
+    reports = [
+        Report(
+            id=uuid.uuid4(),
+            service_id=sample_service.id,
+            requested_at=today - datetime.timedelta(days=1),
+            status=ReportStatus.READY.value,
+        ),
+        Report(id=uuid.uuid4(), service_id=sample_service.id, requested_at=today, status=ReportStatus.READY.value),
+        Report(
+            id=uuid.uuid4(),
+            service_id=sample_service.id,
+            requested_at=today - datetime.timedelta(days=2),
+            status=ReportStatus.READY.value,
+        ),
+    ]
+
+    # Expected order: today, today-1, today-2
+    expected_order = [reports[1], reports[0], reports[2]]
+
+    # Mock the query processing
+    mock_query = mocker.patch("app.models.Report.query")
+    mock_filter_by = mock_query.filter_by.return_value
+    mock_filter = mock_filter_by.filter.return_value
+    mock_order_by = mock_filter.order_by.return_value
+    mock_order_by.all.return_value = expected_order
+
+    # Call function
+    result = get_reports_for_service(sample_service.id, limit_days=30)
+
+    # Assertions
+    assert result == expected_order
+    mock_filter.order_by.assert_called_once()
+    # Check that the first report has the most recent date
+    assert result[0].requested_at > result[1].requested_at > result[2].requested_at

--- a/tests/app/report/test_rest.py
+++ b/tests/app/report/test_rest.py
@@ -31,3 +31,54 @@ def test_create_report_for_nonexistent_service(admin_request):
     data = {"report_type": ReportType.SMS.value}
 
     admin_request.post("report.create_service_report", service_id=uuid.uuid4(), _data=data, _expected_status=404)
+
+
+def test_get_service_reports_returns_reports_with_default_limit(admin_request, sample_service, mocker):
+    """Test that getting reports for a service with default limit succeeds"""
+    # Mock the get_reports_for_service function
+    mock_get_reports = mocker.patch("app.report.rest.get_reports_for_service")
+    mock_reports = [
+        mocker.Mock(
+            id=uuid.uuid4(), report_type=ReportType.EMAIL.value, service_id=sample_service.id, status=ReportStatus.REQUESTED.value
+        )
+    ]
+    mock_get_reports.return_value = mock_reports
+
+    response = admin_request.get("report.get_service_reports", service_id=sample_service.id)
+
+    assert response["data"]
+    # Verify the default limit of 30 days was used
+    mock_get_reports.assert_called_once_with(sample_service.id, 30)
+
+
+def test_get_service_reports_with_custom_days_limit(admin_request, sample_service, mocker):
+    """Test that getting reports with a custom days limit succeeds"""
+    mock_get_reports = mocker.patch("app.report.rest.get_reports_for_service")
+    mock_reports = [
+        mocker.Mock(
+            id=uuid.uuid4(), report_type=ReportType.SMS.value, service_id=sample_service.id, status=ReportStatus.REQUESTED.value
+        )
+    ]
+    mock_get_reports.return_value = mock_reports
+
+    custom_days = 7
+    response = admin_request.get("report.get_service_reports", service_id=sample_service.id, limit_days=custom_days)
+
+    assert response["data"]
+    # Verify the custom limit was used
+    mock_get_reports.assert_called_once_with(sample_service.id, custom_days)
+
+
+def test_get_service_reports_for_nonexistent_service(admin_request):
+    """Test that getting reports for a nonexistent service returns a 404 error"""
+    admin_request.get("report.get_service_reports", service_id=uuid.uuid4(), _expected_status=404)
+
+
+def test_get_service_reports_returns_empty_list_when_no_reports(admin_request, sample_service, mocker):
+    """Test that endpoint returns empty list when no reports exist for service"""
+    mock_get_reports = mocker.patch("app.report.rest.get_reports_for_service", return_value=[])
+
+    response = admin_request.get("report.get_service_reports", service_id=sample_service.id)
+
+    assert response["data"] == []
+    mock_get_reports.assert_called_once()

--- a/tests/app/report/test_rest.py
+++ b/tests/app/report/test_rest.py
@@ -35,14 +35,15 @@ def test_create_report_for_nonexistent_service(admin_request):
 
 def test_get_service_reports_returns_reports_with_default_limit(admin_request, sample_service, mocker):
     """Test that getting reports for a service with default limit succeeds"""
-    # Mock the get_reports_for_service function
-    mock_get_reports = mocker.patch("app.report.rest.get_reports_for_service")
     mock_reports = [
-        mocker.Mock(
-            id=uuid.uuid4(), report_type=ReportType.EMAIL.value, service_id=sample_service.id, status=ReportStatus.REQUESTED.value
-        )
+        {
+            "id": uuid.uuid4(),
+            "report_type": ReportType.EMAIL.value,
+            "service_id": sample_service.id,
+            "status": ReportStatus.REQUESTED.value,
+        }
     ]
-    mock_get_reports.return_value = mock_reports
+    mock_get_reports = mocker.patch("app.report.rest.get_reports_for_service", return_value=mock_reports)
 
     response = admin_request.get("report.get_service_reports", service_id=sample_service.id)
 
@@ -53,13 +54,15 @@ def test_get_service_reports_returns_reports_with_default_limit(admin_request, s
 
 def test_get_service_reports_with_custom_days_limit(admin_request, sample_service, mocker):
     """Test that getting reports with a custom days limit succeeds"""
-    mock_get_reports = mocker.patch("app.report.rest.get_reports_for_service")
     mock_reports = [
-        mocker.Mock(
-            id=uuid.uuid4(), report_type=ReportType.SMS.value, service_id=sample_service.id, status=ReportStatus.REQUESTED.value
-        )
+        {
+            "id": uuid.uuid4(),
+            "report_type": ReportType.SMS.value,
+            "service_id": sample_service.id,
+            "status": ReportStatus.REQUESTED.value,
+        }
     ]
-    mock_get_reports.return_value = mock_reports
+    mock_get_reports = mocker.patch("app.report.rest.get_reports_for_service", return_value=mock_reports)
 
     custom_days = 7
     response = admin_request.get("report.get_service_reports", service_id=sample_service.id, limit_days=custom_days)


### PR DESCRIPTION
# Summary | Résumé

This PR:
- adds a new endpoint `get_service_reports` that returns all reports for a service that have been requested within `limit_days` (so we can avoid displaying a bunch of expired reports from a year ago on the page)
- adds a new dao function for this: `get_reports_for_service`
- adds unit tests for the above

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1805

# Test instructions | Instructions pour tester la modification

- tests pass
- code looks good

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.