### PR TITLE
Add `language` column to the `reports` table

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -2738,7 +2738,7 @@ class Report(BaseModel):
     job_id = db.Column(UUID(as_uuid=True), db.ForeignKey("jobs.id"), nullable=True)  # only set if report is for a bulk job
     url = db.Column(db.String(255), nullable=True)  # url to download the report from s3
     status = db.Column(db.String(255), nullable=False)
-    language = db.Column(db.String(2), nullable=False)
+    language = db.Column(db.String(2), nullable=True)
 
     def serialize(self):
         return {

--- a/app/models.py
+++ b/app/models.py
@@ -2694,6 +2694,11 @@ class ReportType(Enum):
     JOB = "job"
 
 
+class ReportLanguage(Enum):
+    EN = "en"
+    FR = "fr"
+
+
 class Report(BaseModel):
     __tablename__ = "reports"
 
@@ -2733,6 +2738,7 @@ class Report(BaseModel):
     job_id = db.Column(UUID(as_uuid=True), db.ForeignKey("jobs.id"), nullable=True)  # only set if report is for a bulk job
     url = db.Column(db.String(255), nullable=True)  # url to download the report from s3
     status = db.Column(db.String(255), nullable=False)
+    language = db.Column(db.String(2), nullable=False)
 
     def serialize(self):
         return {
@@ -2744,4 +2750,5 @@ class Report(BaseModel):
             "completed_at": self.completed_at.strftime(DATETIME_FORMAT) if self.completed_at else None,
             "expires_at": self.expires_at.strftime(DATETIME_FORMAT) if self.expires_at else None,
             "url": self.url,
+            "language": self.language,
         }

--- a/app/report/rest.py
+++ b/app/report/rest.py
@@ -6,7 +6,7 @@ from marshmallow import ValidationError
 from app.dao.reports_dao import create_report, get_reports_for_service
 from app.dao.services_dao import dao_fetch_service_by_id
 from app.errors import InvalidRequest, register_errors
-from app.models import Report, ReportStatus, ReportType
+from app.models import Report, ReportStatus
 from app.schema_validation import validate
 from app.schemas import report_schema
 
@@ -23,11 +23,6 @@ def create_service_report(service_id):
     # Validate basic required fields
     validate(data, {"report_type": {"type": "string", "required": True}})
 
-    # Validate report type is one of the allowed types
-    report_type = data.get("report_type")
-    if report_type not in [rt.value for rt in ReportType]:
-        return jsonify(result="error", message=f"Invalid report type: {report_type}"), 400
-
     # Check service exists
     dao_fetch_service_by_id(service_id)
 
@@ -35,10 +30,11 @@ def create_service_report(service_id):
         # Validate the report data against the schema
         report_data = {
             "id": str(uuid.uuid4()),
-            "report_type": report_type,
+            "report_type": data.get("report_type"),
             "service_id": str(service_id),
             "status": ReportStatus.REQUESTED.value,
             "requesting_user_id": data.get("requesting_user_id"),
+            "language": data.get("language"),
         }
 
         # Validate against the schema

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -841,6 +841,7 @@ class ReportSchema(BaseSchema):
     completed_at = FlexibleDateTime()
     expires_at = FlexibleDateTime()
     url = fields.String()
+    language = fields.String()
 
     @validates("report_type")
     def validate_report_type(self, value):
@@ -851,6 +852,11 @@ class ReportSchema(BaseSchema):
     def validate_status(self, value):
         if value not in [rs.value for rs in models.ReportStatus]:
             raise ValidationError(f"Invalid report status: {value}")
+
+    @validates("language")
+    def validate_language(self, value):
+        if value not in [rs.value for rs in models.ReportLanguage]:
+            raise ValidationError(f"Invalid report language: {value}")
 
 
 # should not be used on its own for dumping - only for loading

--- a/migrations/versions/0478_add_report_language.py
+++ b/migrations/versions/0478_add_report_language.py
@@ -13,7 +13,7 @@ down_revision = '0477_add_created_by_ids'
 
 
 def upgrade():
-    op.add_column('reports', sa.Column('language', sa.String(length=2), nullable=False))
+    op.add_column('reports', sa.Column('language', sa.String(length=2), nullable=True))
 
 def downgrade():
     op.drop_column('reports', 'language')

--- a/migrations/versions/0478_add_report_language.py
+++ b/migrations/versions/0478_add_report_language.py
@@ -1,0 +1,19 @@
+"""
+
+Revision ID: 0478_add_report_language
+Revises: 0477_add_created_by_ids
+Create Date: 2025-04-01 19:24:10.080163
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0478_add_report_language'
+down_revision = '0477_add_created_by_ids'
+
+
+def upgrade():
+    op.add_column('reports', sa.Column('language', sa.String(length=2), nullable=False))
+
+def downgrade():
+    op.drop_column('reports', 'language')

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -635,15 +635,27 @@ def test_run_generate_reports(mocker, notify_db_session, sample_user, sample_ser
 
     # Create some reports in REQUESTED status
     report1 = Report(
-        report_type="email", service_id=sample_service.id, requesting_user_id=sample_user.id, status=ReportStatus.REQUESTED.value
+        report_type="email",
+        service_id=sample_service.id,
+        requesting_user_id=sample_user.id,
+        status=ReportStatus.REQUESTED.value,
+        language="en",
     )
     report2 = Report(
-        report_type="sms", service_id=sample_service.id, requesting_user_id=sample_user.id, status=ReportStatus.REQUESTED.value
+        report_type="sms",
+        service_id=sample_service.id,
+        requesting_user_id=sample_user.id,
+        status=ReportStatus.REQUESTED.value,
+        language="en",
     )
 
     # Create a report with a different status
     report3 = Report(
-        report_type="email", service_id=sample_service.id, requesting_user_id=sample_user.id, status=ReportStatus.GENERATING.value
+        report_type="email",
+        service_id=sample_service.id,
+        requesting_user_id=sample_user.id,
+        status=ReportStatus.GENERATING.value,
+        language="en",
     )
 
     db.session.add_all([report1, report2, report3])

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -1748,6 +1748,7 @@ def sample_report(
     sample_user,
     report_type="email",
     status=ReportStatus.REQUESTED.value,
+    language="en",
 ):
     report = Report(
         service_id=sample_service.id,
@@ -1755,5 +1756,6 @@ def sample_report(
         requesting_user_id=sample_user.id,
         report_type=report_type,
         status=status,
+        language=language,
     )
     return create_report(report)

--- a/tests/app/dao/test_reports_dao.py
+++ b/tests/app/dao/test_reports_dao.py
@@ -15,6 +15,7 @@ def test_create_report(sample_service, notify_db_session):
         report_type=ReportType.SMS.value,
         service_id=sample_service.id,
         status=ReportStatus.REQUESTED.value,
+        language="en",
     )
 
     # Create the report
@@ -45,6 +46,7 @@ def sample_reports(sample_service):
                 status=ReportStatus.REQUESTED.value,
                 url=None,
                 job_id=None,
+                language="en",
             )
         )
 
@@ -59,6 +61,7 @@ def sample_reports(sample_service):
             status=ReportStatus.READY.value,
             url="https://test-bucket.s3.amazonaws.com/test-report.csv",
             job_id=None,
+            language="en",
         )
     )
 

--- a/tests/app/report/test_rest.py
+++ b/tests/app/report/test_rest.py
@@ -5,7 +5,7 @@ from app.models import ReportStatus, ReportType
 
 def test_create_report_succeeds_with_valid_data(admin_request, sample_service, sample_user):
     """Test that creating a report with valid data succeeds"""
-    data = {"report_type": ReportType.EMAIL.value, "requesting_user_id": str(sample_user.id)}
+    data = {"report_type": ReportType.EMAIL.value, "requesting_user_id": str(sample_user.id), "language": "en"}
 
     response = admin_request.post("report.create_service_report", service_id=sample_service.id, _data=data, _expected_status=201)
 
@@ -23,7 +23,7 @@ def test_create_report_with_invalid_report_type(admin_request, sample_service):
     response = admin_request.post("report.create_service_report", service_id=sample_service.id, _data=data, _expected_status=400)
 
     assert response["result"] == "error"
-    assert "Invalid report type" in response["message"]
+    assert "Invalid report type" in str(response["message"])
 
 
 def test_create_report_for_nonexistent_service(admin_request):


### PR DESCRIPTION
# Summary | Résumé

Add a `language` column to the reports table and update the following:
- update `create_service_report` endpoint to add the language
- update tests
- add a migration file

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1807

# Test instructions | Instructions pour tester la modification

1. check this branch out and run locally
2. run `flask db upgrade`
3. verify that you have the new `language` column in your `reports` table

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.