### PR TITLE
Increase the `report` `url` column length to 2000 chars

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -2731,7 +2731,7 @@ class Report(BaseModel):
         nullable=False,
     )
     job_id = db.Column(UUID(as_uuid=True), db.ForeignKey("jobs.id"), nullable=True)  # only set if report is for a bulk job
-    url = db.Column(db.String(800), nullable=True)  # url to download the report from s3
+    url = db.Column(db.String(2000), nullable=True)  # url to download the report from s3
     status = db.Column(db.String(255), nullable=False)
     language = db.Column(db.String(2), nullable=True)
 

--- a/migrations/versions/0479_update_reports_url.py
+++ b/migrations/versions/0479_update_reports_url.py
@@ -1,0 +1,25 @@
+"""
+
+Revision ID: 0479_update_reports_url
+Revises: 0478_update_reports_table
+Create Date: 2025-04-08 18:38:52.786361
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0479_update_reports_url'
+down_revision = '0478_update_reports_table'
+
+
+def upgrade():
+    op.alter_column('reports', 'url',
+               existing_type=sa.VARCHAR(length=800),
+               type_=sa.String(length=2000),
+               existing_nullable=True)
+
+def downgrade():
+    op.alter_column('reports', 'url',
+               existing_type=sa.String(length=2000),
+               type_=sa.VARCHAR(length=800),
+               existing_nullable=True)


### PR DESCRIPTION
# Summary | Résumé

Increase the `report` `url` column length to 2000 chars

We are seeing the following error on staging:
```
2025-04-08T15:36:00.822500406Z stderr F [2025-04-08 15:36:00,820: ERROR/ForkPoolWorker-4] Task generate-
report[0a605206-12fb-4197-81c6-cf81ffcae8da] raised unexpected: 
DataError('(psycopg2.errors.StringDataRightTruncation) value too long for type character varying(800)\n')
```

There isn't an official maximum url length in the AWS docs, and it is possible for the pre-signed url to be more than 1000 chars: [stack overflow](https://stackoverflow.com/questions/70975517/aws-s3-signed-url-length-max#:~:text=There%20is%20no%20official%20limit,S3%20object%20of%201669%20characters.)

The unofficial character limit for a url is 2000 characters, so that seems like a safe limit to use here.

# Test instructions | Instructions pour tester la modification

1. check out the branch
2. run `flask db migrate`
3. verify that the char limit for the `url` column in the `reports` table has been increased to 2000

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.