### PR TITLE
Get multiple pages of notifications for delivery reports

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -914,17 +914,33 @@ def generate_report(report_id: str):
 
 def create_report_in_s3(report: Report) -> str:
     """Creates a report in S3 and returns the URL"""
-    pagination = get_notifications_for_service(
-        report.service_id,
-        page=1,
-        page_size=PAGE_SIZE,
-        filter_dict={"template_type": report.report_type},
-        limit_days=LIMIT_DAYS,
-        include_jobs=True,
-        format_for_csv=True,
-    )
-    serialized_notifications = [notification.serialize_for_csv() for notification in pagination.items]
-    # todo: make this work if there are multiple pages
+    page = 1
+    all_notifications = []
+
+    # Continue fetching pages until we get a page with fewer items than PAGE_SIZE
+    # which indicates we've reached the last page
+    while True:
+        pagination = get_notifications_for_service(
+            report.service_id,
+            page=page,
+            page_size=PAGE_SIZE,
+            filter_dict={"template_type": report.report_type},
+            limit_days=LIMIT_DAYS,
+            include_jobs=True,
+            format_for_csv=True,
+        )
+
+        page_items = pagination.items
+        all_notifications.extend(page_items)
+
+        # If we got fewer items than PAGE_SIZE or exactly 0 items, we've reached the last page
+        if len(page_items) < PAGE_SIZE:
+            break
+
+        # Move to the next page
+        page += 1
+
+    serialized_notifications = [notification.serialize_for_csv() for notification in all_notifications]
     file_data = get_csv_file_data(serialized_notifications)
     url = s3.upload_report_to_s3(service_id=report.service_id, report_id=report.id, file_data=file_data)
     return url

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -2,7 +2,7 @@ import json
 import uuid
 from datetime import datetime, timedelta
 from unittest import mock
-from unittest.mock import MagicMock, Mock, call
+from unittest.mock import ANY, MagicMock, Mock, call, patch
 
 import pytest
 import requests_mock
@@ -13,7 +13,7 @@ from notifications_utils.template import SMSMessageTemplate, WithSubjectTemplate
 from requests import RequestException
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from tests.app import load_example_csv
-from tests.app.conftest import create_sample_service, create_sample_template
+from tests.app.conftest import create_sample_email_template, create_sample_service, create_sample_template
 from tests.app.db import (
     create_inbound_sms,
     create_job,
@@ -39,6 +39,7 @@ from app.celery import provider_tasks, tasks
 from app.celery.tasks import (
     acknowledge_receipt,
     choose_database_queue,
+    create_report_in_s3,
     generate_report,
     get_template_class,
     handle_batch_error_and_forward,
@@ -2360,3 +2361,51 @@ class TestGenerateReport:
         # Assert report is marked as error
         # Should have called update_report twice (once to mark as generating, once as error)
         assert update_report_mock.call_count == 2
+
+
+def test_create_report_in_s3_pagination(notify_db, mocker, notify_db_session, sample_report, sample_service):
+    """
+    Test that create_report_in_s3 properly paginates through all notifications
+    when fetching data for a report.
+    """
+
+    sample_template = create_sample_email_template(notify_db, notify_db_session, service=sample_service)
+
+    for i in range(8):
+        notification = create_notification(
+            sample_template,
+            to_field=f"recipient{i}@example.com",
+            status="delivered",
+            created_at=datetime.utcnow() - timedelta(hours=i),
+        )
+        save_notification(notification)
+
+    # Patch the PAGE_SIZE constant to a smaller value for testing
+    page_size_patch = patch("app.celery.tasks.PAGE_SIZE", 3)
+
+    # Mock the s3 upload function to avoid actual S3 operations
+    mock_upload = mocker.patch("app.celery.tasks.s3.upload_report_to_s3", return_value="https://example.com/report.csv")
+
+    # Mock the CSV file generation to verify the notifications
+    mock_get_csv_file_data = mocker.patch("app.celery.tasks.get_csv_file_data")
+
+    with page_size_patch:
+        # Verify the result URL matches what we expect
+        assert create_report_in_s3(sample_report) == "https://example.com/report.csv"
+
+        # Verify that s3.upload_report_to_s3 was called with the right parameters
+        mock_upload.assert_called_once_with(service_id=sample_service.id, report_id=sample_report.id, file_data=ANY)
+
+        # Verify that get_csv_file_data was called with a list of serialized notifications
+        mock_get_csv_file_data.assert_called_once()
+
+        # Extract the args passed to get_csv_file_data
+        serialized_notifications = mock_get_csv_file_data.call_args[0][0]
+
+        # Verify that all 8 notifications were passed to get_csv_file_data
+        assert len(serialized_notifications) == 8
+
+        # Check that we have notifications from all pages by verifying unique recipients
+        recipients = {notification["recipient"] for notification in serialized_notifications}
+        expected_recipients = {f"recipient{i}@example.com" for i in range(8)}
+        assert recipients == expected_recipients


### PR DESCRIPTION
# Summary | Résumé

This PR:
- adds logic to get multiple pages of notifications for delivery reports
- adds an integration test for this

## Related Issues | Cartes liées

TBC

# Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.