### PR TITLE
Call `generate-report` from the reports endpoint

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -381,11 +381,6 @@ class Config(object):
             "schedule": crontab(),
             "options": {"queue": QueueNames.PERIODIC},
         },
-        "run-generate-reports": {
-            "task": "run-generate-reports",
-            "schedule": crontab(),
-            "options": {"queue": QueueNames.REPORTING},
-        },
         "delete-verify-codes": {
             "task": "delete-verify-codes",
             "schedule": timedelta(minutes=63),

--- a/app/report/rest.py
+++ b/app/report/rest.py
@@ -3,6 +3,8 @@ import uuid
 from flask import Blueprint, current_app, jsonify, request
 from marshmallow import ValidationError
 
+from app.celery.tasks import generate_report
+from app.config import QueueNames
 from app.dao.reports_dao import create_report, get_reports_for_service
 from app.dao.services_dao import dao_fetch_service_by_id
 from app.errors import InvalidRequest, register_errors
@@ -51,6 +53,10 @@ def create_service_report(service_id):
         created_report = create_report(report)
 
         current_app.logger.info(f"Report {created_report.id} created for service {service_id}")
+
+        # start the report generation process in celery
+        current_app.logger.info(f"Calling generate_report for Report ID {report.id}")
+        generate_report.apply_async([report.id], queue=QueueNames.REPORTING)
 
         return jsonify(data=report_schema.dump(created_report)), 201
 

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -46,8 +46,6 @@ from app.models import (
     JOB_STATUS_IN_PROGRESS,
     NOTIFICATION_DELIVERED,
     NOTIFICATION_PENDING_VIRUS_CHECK,
-    Report,
-    ReportStatus,
 )
 from app.v2.errors import JobIncompleteError
 
@@ -626,42 +624,3 @@ def test_mark_jobs_complete(
 
     mark_jobs_complete()
     assert job.job_status == expected_status
-
-
-def test_run_generate_reports(mocker, notify_db_session, sample_user, sample_service):
-    mock_logger = mocker.patch("app.celery.scheduled_tasks.current_app.logger.info")
-    mock_generate_report = mocker.patch("app.celery.scheduled_tasks.generate_report.apply_async")
-
-    # Create some reports in REQUESTED status
-    report1 = Report(
-        report_type="email", service_id=sample_service.id, requesting_user_id=sample_user.id, status=ReportStatus.REQUESTED.value
-    )
-    report2 = Report(
-        report_type="sms", service_id=sample_service.id, requesting_user_id=sample_user.id, status=ReportStatus.REQUESTED.value
-    )
-
-    # Create a report with a different status
-    report3 = Report(
-        report_type="email", service_id=sample_service.id, requesting_user_id=sample_user.id, status=ReportStatus.GENERATING.value
-    )
-
-    db.session.add_all([report1, report2, report3])
-    db.session.commit()
-
-    # Run the task
-    scheduled_tasks.run_generate_reports()
-
-    # Check logging
-    assert mock_logger.call_count == 3
-    mock_logger.assert_any_call("starting run-generate-reports")
-    mock_logger.assert_any_call(f"calling generate_report for Report ID {report1.id}")
-    mock_logger.assert_any_call(f"calling generate_report for Report ID {report2.id}")
-
-    # Check that generate_report was called for the requested reports
-    assert mock_generate_report.call_count == 2
-    mock_generate_report.assert_any_call([report1.id], queue=QueueNames.REPORTING)
-    mock_generate_report.assert_any_call([report2.id], queue=QueueNames.REPORTING)
-
-    # Verify it wasn't called for the report that wasn't in REQUESTED status
-    for call_args in mock_generate_report.call_args_list:
-        assert report3.id not in call_args[0][0]


### PR DESCRIPTION
# Summary | Résumé

This PR simplifies the way reports are generated in celery. Instead of running a scheduled task every minute to get new reports, just add a `generate_reports` async task directly from the endpoint whenever a new report is requested. This speeds up processing time and removes the db call to find new reports that happens every minute. 

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1807

# Test instructions | Instructions pour tester la modification

1. run this branch locally
2. generate a report
3. verify that it is created successfully and you can download it


# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.