### PR TITLE
Switch to using postgres `copy` and stream csv data to s3

### DIFF
--- a/app/aws/s3.py
+++ b/app/aws/s3.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import datetime, timedelta
+from io import BytesIO
 from typing import List
 
 import botocore
@@ -205,8 +206,6 @@ def stream_to_s3(bucket_name, object_key, copy_command, cursor):
     config = TransferConfig(multipart_threshold=1024 * 25, max_concurrency=10)
 
     # Create a file-like object using a BytesIO buffer
-    from io import BytesIO
-
     buffer = BytesIO()
 
     # Execute the COPY command and write the output to the buffer

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -50,7 +50,6 @@ from app.dao.notifications_dao import (
     dao_get_notification_history_by_reference,
     get_latest_sent_notification_for_job,
     get_notification_by_id,
-    get_notifications_for_service,
     total_hard_bounces_grouped_by_hour,
     total_notifications_grouped_by_hour,
 )
@@ -78,7 +77,6 @@ from app.models import (
     SMS_TYPE,
     Job,
     Notification,
-    Report,
     ReportStatus,
     Service,
     Template,
@@ -87,7 +85,7 @@ from app.notifications.process_notifications import (
     persist_notifications,
     send_notification_to_queue,
 )
-from app.report.utils import generate_csv_from_notifications, get_csv_file_data
+from app.report.utils import generate_csv_from_notifications
 from app.sms_fragment_utils import fetch_todays_requested_sms_count
 from app.types import VerifiedNotification
 from app.utils import get_csv_max_rows, get_delivery_queue_for_template, get_fiscal_year
@@ -931,37 +929,3 @@ def generate_report(report_id: str):
         report.status = ReportStatus.ERROR.value
         update_report(report)
         raise
-
-
-def create_report_in_s3(report: Report) -> str:
-    """Creates a report in S3 and returns the URL"""
-    page = 1
-    all_notifications = []
-
-    # Continue fetching pages until we get a page with fewer items than PAGE_SIZE
-    # which indicates we've reached the last page
-    while True:
-        pagination = get_notifications_for_service(
-            report.service_id,
-            page=page,
-            page_size=PAGE_SIZE,
-            filter_dict={"template_type": report.report_type},
-            limit_days=LIMIT_DAYS,
-            include_jobs=True,
-            format_for_csv=True,
-        )
-
-        page_items = pagination.items
-        all_notifications.extend(page_items)
-
-        # If there is no next page, we are done
-        if not pagination.has_next:
-            break
-
-        # Move to the next page
-        page += 1
-
-    serialized_notifications = [notification.serialize_for_csv() for notification in all_notifications]
-    file_data = get_csv_file_data(serialized_notifications)
-    url = s3.upload_report_to_s3(service_id=report.service_id, report_id=report.id, file_data=file_data)
-    return url

--- a/app/report/utils.py
+++ b/app/report/utils.py
@@ -1,6 +1,13 @@
 from io import StringIO
 from typing import Any
 
+from sqlalchemy import func, text
+from sqlalchemy.orm import aliased
+
+from app import db
+from app.aws.s3 import stream_to_s3
+from app.models import Job, Notification, Template, User
+
 CSV_FIELDNAMES = [
     "Recipient",
     "Template",
@@ -44,3 +51,54 @@ def get_csv_file_data(serialized_notifications: list[Any], lang="en") -> bytes:
     string = csv_file.getvalue()
     encoded_string = string.encode("utf-8")
     return encoded_string
+
+
+def generate_csv_from_notifications(service_id, notification_type, days_limit=7, s3_bucket=None, s3_key=None):
+    """
+    Generate CSV using SQLAlchemy for improved compatibility and type safety, and stream it directly to S3.
+    """
+    # Create aliases for the tables to make the query more readable
+    n = aliased(Notification)
+    t = aliased(Template)
+    j = aliased(Job)
+    u = aliased(User)
+
+    # Build the query using SQLAlchemy
+    query = (
+        db.session.query(
+            n.to.label("Recipient"),
+            t.name.label("Template"),
+            n.notification_type.label("Type"),
+            func.coalesce(u.name, "").label("Sent by"),
+            func.coalesce(u.email_address, "").label("Sent by email"),
+            func.coalesce(j.original_file_name, "").label("Job"),
+            n.status.label("Status"),
+            func.to_char(n.created_at, "YYYY-MM-DD HH24:MI:SS").label("Time"),
+        )
+        .join(t, t.id == n.template_id)
+        .outerjoin(j, j.id == n.job_id)
+        .outerjoin(u, u.id == n.created_by_id)
+        .filter(
+            n.service_id == service_id,
+            n.notification_type == notification_type,
+            n.created_at > func.now() - text(f"interval '{days_limit} days'"),
+        )
+        .order_by(n.created_at.desc())
+    )
+
+    # Use COPY TO with the SQLAlchemy query
+    conn = db.engine.raw_connection()
+    try:
+        cursor = conn.cursor()
+        # Compile the query to a string
+        compiled_query = f"COPY ({query.statement.compile(dialect=db.engine.dialect, compile_kwargs={'literal_binds': True})}) TO STDOUT WITH CSV HEADER"
+
+        # Stream the data directly to S3
+        stream_to_s3(
+            bucket_name=s3_bucket,
+            object_key=s3_key,
+            copy_command=compiled_query,
+            cursor=cursor,
+        )
+    finally:
+        conn.close()

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -2334,8 +2334,9 @@ class TestGenerateReport:
     @freeze_time("2022-01-01 12:00:00")
     def test_generate_report_success(self, mocker, notify_db_session, sample_report):
         expected_url = "https://example.com/report.csv"
-        mocker.patch("app.celery.tasks.create_report_in_s3", return_value=expected_url)
+        mocker.patch("app.celery.tasks.generate_csv_from_notifications")
         update_report_mock = mocker.patch("app.celery.tasks.update_report")
+        mocker.patch("app.celery.tasks.s3.generate_presigned_url", return_value=expected_url)
 
         generate_report(str(sample_report.id))
 
@@ -2350,7 +2351,7 @@ class TestGenerateReport:
         assert updated_report.expires_at.date() == datetime(2022, 1, 1).date() + timedelta(days=3)
 
     def test_generate_report_error_handling(self, mocker, notify_db_session, sample_report):
-        mocker.patch("app.celery.tasks.create_report_in_s3", side_effect=Exception("Test error"))
+        mocker.patch("app.celery.tasks.generate_csv_from_notifications", side_effect=Exception("Test error"))
         update_report_mock = mocker.patch("app.celery.tasks.update_report")
 
         # Execute and expect exception

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -2,7 +2,7 @@ import json
 import uuid
 from datetime import datetime, timedelta
 from unittest import mock
-from unittest.mock import ANY, MagicMock, Mock, call, patch
+from unittest.mock import MagicMock, Mock, call
 
 import pytest
 import requests_mock
@@ -13,7 +13,7 @@ from notifications_utils.template import SMSMessageTemplate, WithSubjectTemplate
 from requests import RequestException
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from tests.app import load_example_csv
-from tests.app.conftest import create_sample_email_template, create_sample_service, create_sample_template
+from tests.app.conftest import create_sample_service, create_sample_template
 from tests.app.db import (
     create_inbound_sms,
     create_job,
@@ -39,7 +39,6 @@ from app.celery import provider_tasks, tasks
 from app.celery.tasks import (
     acknowledge_receipt,
     choose_database_queue,
-    create_report_in_s3,
     generate_report,
     get_template_class,
     handle_batch_error_and_forward,
@@ -2361,59 +2360,3 @@ class TestGenerateReport:
         # Assert report is marked as error
         # Should have called update_report twice (once to mark as generating, once as error)
         assert update_report_mock.call_count == 2
-
-
-@pytest.mark.parametrize(
-    "page_size, n_notifications",
-    [
-        (2, 6),
-        (2, 5),
-    ],
-)
-def test_create_report_in_s3_pagination(
-    notify_db, mocker, notify_db_session, sample_report, sample_service, page_size, n_notifications
-):
-    """
-    Test that create_report_in_s3 properly paginates through all notifications
-    when fetching data for a report.
-    """
-    sample_template = create_sample_email_template(notify_db, notify_db_session, service=sample_service)
-
-    for i in range(n_notifications):
-        notification = create_notification(
-            sample_template,
-            to_field=f"recipient{i}@example.com",
-            status="delivered",
-            created_at=datetime.utcnow() - timedelta(hours=i),
-        )
-        save_notification(notification)
-
-    # Patch the PAGE_SIZE constant to a smaller value for testing
-    page_size_patch = patch("app.celery.tasks.PAGE_SIZE", page_size)
-
-    # Mock the s3 upload function to avoid actual S3 operations
-    mock_upload = mocker.patch("app.celery.tasks.s3.upload_report_to_s3", return_value="https://example.com/report.csv")
-
-    # Mock the CSV file generation to verify the notifications
-    mock_get_csv_file_data = mocker.patch("app.celery.tasks.get_csv_file_data")
-
-    with page_size_patch:
-        # Verify the result URL matches what we expect
-        assert create_report_in_s3(sample_report) == "https://example.com/report.csv"
-
-        # Verify that s3.upload_report_to_s3 was called with the right parameters
-        mock_upload.assert_called_once_with(service_id=sample_service.id, report_id=sample_report.id, file_data=ANY)
-
-        # Verify that get_csv_file_data was called with a list of serialized notifications
-        mock_get_csv_file_data.assert_called_once()
-
-        # Extract the args passed to get_csv_file_data
-        serialized_notifications = mock_get_csv_file_data.call_args[0][0]
-
-        # Verify that all 8 notifications were passed to get_csv_file_data
-        assert len(serialized_notifications) == n_notifications
-
-        # Check that we have notifications from all pages by verifying unique recipients
-        recipients = {notification["recipient"] for notification in serialized_notifications}
-        expected_recipients = {f"recipient{i}@example.com" for i in range(n_notifications)}
-        assert recipients == expected_recipients


### PR DESCRIPTION
# Summary | Résumé

This PR:
- uses the "copy" feature in postgresql https://www.postgresql.org/docs/current/sql-copy.html 
- reduces memory usage in the celery worker by streaming the csv data to s3, rather than trying to store the whole csv file in memory
- adds tests for this

I'd like to test this on staging with our perf test service to see how it does with a large file.

# Test instructions | Instructions pour tester la modification

- check out the branch locally
- generate a report
- verify that the report looks correct

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.