### PR TITLE
Translate the Delivery report headers

### DIFF
--- a/app/aws/s3.py
+++ b/app/aws/s3.py
@@ -214,6 +214,12 @@ def stream_to_s3(
     # Create a file-like object using a BytesIO buffer
     buffer = BytesIO()
 
+    # Add BOM (Byte Order Mark) at the top of the CSV file so FR characters are displayed correctly
+    buffer.write("\ufeff".encode("utf-8"))
+
+    # Reset the buffer's position to the beginning before writing the COPY command output
+    buffer.seek(0, 2)  # Move to the end of the buffer
+
     # Execute the COPY command and write the output to the buffer
     cursor.copy_expert(copy_command, buffer)
 

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -903,6 +903,7 @@ def generate_report(report_id: str):
         generate_csv_from_notifications(
             service_id=report.service_id,
             notification_type=report.report_type,
+            language=report.language,
             days_limit=LIMIT_DAYS,
             s3_bucket=current_app.config["REPORTS_BUCKET_NAME"],
             s3_key=s3_key,

--- a/app/report/rest.py
+++ b/app/report/rest.py
@@ -41,6 +41,7 @@ def create_service_report(service_id):
             "service_id": str(service_id),
             "status": ReportStatus.REQUESTED.value,
             "requesting_user_id": data.get("requesting_user_id"),
+            "language": data.get("language"),
         }
 
         # Validate against the schema

--- a/app/report/utils.py
+++ b/app/report/utils.py
@@ -5,22 +5,24 @@ from app import db
 from app.aws.s3 import stream_to_s3
 from app.models import Job, Notification, Template, User
 
+FR_TRANSLATIONS = {
+    "Recipient": "Destinataire",
+    "Template": "Gabarit",
+    "Type": "Type",
+    "Sent by": "Envoyé par",
+    "Sent by email": "Envoyé par courriel",
+    "Job": "Tâche",
+    "Status": "État",
+    "Sent Time": "Heure d’envoi",
+}
+
 
 class Translate:
     def __init__(self, language="en"):
         """Initialize the Translate class with a language."""
         self.language = language
         self.translations = {
-            "fr": {
-                "Recipient": "Destinataire",
-                "Template": "Gabarit",
-                "Type": "Type",
-                "Sent by": "Envoyé par",
-                "Sent by email": "Envoyé par courriel",
-                "Job": "Tâche",
-                "Status": "État",
-                "Sent Time": "Heure d’envoi",
-            }
+            "fr": FR_TRANSLATIONS,
         }
 
     def _(self, x):

--- a/app/report/utils.py
+++ b/app/report/utils.py
@@ -25,7 +25,7 @@ class Translate:
             "fr": FR_TRANSLATIONS,
         }
 
-    def _(self, x):
+    def translate(self, x):
         """Translate the given string based on the set language."""
         if self.language == "fr" and x in self.translations["fr"]:
             return self.translations["fr"][x]
@@ -51,19 +51,19 @@ def build_notifications_query(service_id, notification_type, language, days_limi
     j = aliased(Job)
     u = aliased(User)
 
-    _ = Translate(language)._
+    translate = Translate(language).translate
 
     # Build the query using SQLAlchemy
     return (
         db.session.query(
-            n.to.label(_("Recipient")),
-            t.name.label(_("Template")),
-            n.notification_type.label(_("Type")),
-            func.coalesce(u.name, "").label(_("Sent by")),
-            func.coalesce(u.email_address, "").label(_("Sent by email")),
-            func.coalesce(j.original_file_name, "").label(_("Job")),
-            n.status.label(_("Status")),
-            func.to_char(n.created_at, "YYYY-MM-DD HH24:MI:SS").label(_("Sent Time")),
+            n.to.label(translate("Recipient")),
+            t.name.label(translate("Template")),
+            n.notification_type.label(translate("Type")),
+            func.coalesce(u.name, "").label(translate("Sent by")),
+            func.coalesce(u.email_address, "").label(translate("Sent by email")),
+            func.coalesce(j.original_file_name, "").label(translate("Job")),
+            n.status.label(translate("Status")),
+            func.to_char(n.created_at, "YYYY-MM-DD HH24:MI:SS").label(translate("Sent Time")),
         )
         .join(t, t.id == n.template_id)
         .outerjoin(j, j.id == n.job_id)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -841,6 +841,7 @@ class ReportSchema(BaseSchema):
     completed_at = FlexibleDateTime()
     expires_at = FlexibleDateTime()
     url = fields.String()
+    language = fields.String()
 
     requesting_user = fields.Nested(
         UserSchema,

--- a/tests/app/aws/test_s3.py
+++ b/tests/app/aws/test_s3.py
@@ -324,7 +324,7 @@ def test_stream_to_s3(notify_api, mocker):
     stream_to_s3(bucket_name, object_key, copy_command, cursor_mock)
 
     cursor_mock.copy_expert.assert_called_once_with(copy_command, buffer_mock.return_value)
-    buffer_mock.return_value.seek.assert_called_once_with(0)
+    buffer_mock.return_value.seek.assert_has_calls([call(0, 2), call(0)])
     s3_client_mock.return_value.upload_fileobj.assert_called_once_with(
         Fileobj=buffer_mock.return_value,
         Bucket=bucket_name,

--- a/tests/app/report/test_rest.py
+++ b/tests/app/report/test_rest.py
@@ -6,12 +6,13 @@ from app.models import ReportStatus, ReportType
 def test_create_report_succeeds_with_valid_data(mocker, admin_request, sample_service, sample_user):
     """Test that creating a report with valid data succeeds"""
     generate_report_mock = mocker.patch("app.report.rest.generate_report.apply_async")
-    data = {"report_type": ReportType.EMAIL.value, "requesting_user_id": str(sample_user.id)}
+    data = {"report_type": ReportType.EMAIL.value, "requesting_user_id": str(sample_user.id), "language": "en"}
 
     response = admin_request.post("report.create_service_report", service_id=sample_service.id, _data=data, _expected_status=201)
 
     assert response["data"]["report_type"] == ReportType.EMAIL.value
     assert response["data"]["service_id"] == str(sample_service.id)
+    assert response["data"]["language"] == "en"
     assert response["data"]["status"] == ReportStatus.REQUESTED.value
     assert "id" in response["data"]
     assert "requested_at" in response["data"]

--- a/tests/app/report/test_utils.py
+++ b/tests/app/report/test_utils.py
@@ -6,24 +6,17 @@ from app.report.utils import (
 )
 
 
-def test_mock_translate_function():
-    """Test the mock translation function behaves as expected"""
-    _ = Translate(language="en")._
-    assert _("Test") == "Test"
-    assert _("Status") == "Status"
-
-
-def test_translate_default_language():
-    _ = Translate(language="en")._
-    assert _("Recipient") == "Recipient"
-    assert _("Nonexistent") == "Nonexistent"
+def test_translate_en():
+    translate = Translate(language="en").translate
+    assert translate("Recipient") == "Recipient"
+    assert translate("Nonexistent") == "Nonexistent"
 
 
 def test_translate_french_language():
-    translator = Translate(language="fr")
-    assert translator._("Recipient") == "Destinataire"
-    assert translator._("Template") == "Gabarit"
-    assert translator._("Nonexistent") == "Nonexistent"
+    translate = Translate(language="fr").translate
+    assert translate("Recipient") == "Destinataire"
+    assert translate("Template") == "Gabarit"
+    assert translate("Nonexistent") == "Nonexistent"
 
 
 class TestGenerateCsvFromNotifications:

--- a/tests/app/report/test_utils.py
+++ b/tests/app/report/test_utils.py
@@ -34,7 +34,7 @@ class TestGenerateCsvFromNotifications:
         days_limit = 14
         s3_bucket = "test-bucket"
         s3_key = "test-key.csv"
-
+        language = "en"
         # When
         with patch("app.report.utils.build_notifications_query") as mock_build_query:
             with patch("app.report.utils.compile_query_for_copy") as mock_compile_query:
@@ -43,9 +43,9 @@ class TestGenerateCsvFromNotifications:
                     mock_compile_query.return_value = "mock copy command"
 
                     # Call the function
-                    generate_csv_from_notifications(service_id, notification_type, days_limit, s3_bucket, s3_key)
+                    generate_csv_from_notifications(service_id, notification_type, language, days_limit, s3_bucket, s3_key)
 
                     # Then
-                    mock_build_query.assert_called_once_with(service_id, notification_type, days_limit)
+                    mock_build_query.assert_called_once_with(service_id, notification_type, language, days_limit)
                     mock_compile_query.assert_called_once_with("mock query")
                     mock_stream.assert_called_once_with("mock copy command", s3_bucket, s3_key)

--- a/tests/app/report/test_utils.py
+++ b/tests/app/report/test_utils.py
@@ -1,11 +1,8 @@
 from unittest.mock import patch
 
 from app.report.utils import (
-    CSV_FIELDNAMES,
     _l,
     generate_csv_from_notifications,
-    get_csv_file_data,
-    serialized_notification_to_csv,
 )
 
 
@@ -13,113 +10,6 @@ def test_mock_translate_function():
     """Test the mock translation function behaves as expected"""
     assert _l("Test") == "Test"
     assert _l("Status") == "Status"
-
-
-def test_serialized_notification_to_csv_with_en_language():
-    """Test serialized_notification_to_csv with English language"""
-    test_notification = {
-        "recipient": "test@example.com",
-        "template_name": "Test Template",
-        "template_type": "email",
-        "created_by_name": "Test User",
-        "created_by_email_address": "user@example.com",
-        "job_name": "Test Job",
-        "status": "delivered",
-        "created_at": "2023-01-01 12:00:00",
-    }
-
-    result = serialized_notification_to_csv(test_notification, lang="en")
-    expected = "test@example.com,Test Template,email,Test User,user@example.com,Test Job,delivered,2023-01-01 12:00:00\n"
-    assert result == expected
-
-
-def test_serialized_notification_to_csv_with_empty_fields():
-    """Test serialized_notification_to_csv with empty fields"""
-    test_notification = {
-        "recipient": "test@example.com",
-        "template_name": "Test Template",
-        "template_type": "email",
-        "created_by_name": None,
-        "created_by_email_address": None,
-        "job_name": None,
-        "status": "delivered",
-        "created_at": "2023-01-01 12:00:00",
-    }
-
-    result = serialized_notification_to_csv(test_notification)
-    expected = "test@example.com,Test Template,email,,,,delivered,2023-01-01 12:00:00\n"
-    assert result == expected
-
-
-def test_get_csv_file_data():
-    """Test get_csv_file_data generates correct CSV file"""
-    test_notifications = [
-        {
-            "recipient": "test1@example.com",
-            "template_name": "Template 1",
-            "template_type": "email",
-            "created_by_name": "User 1",
-            "created_by_email_address": "user1@example.com",
-            "job_name": "Job 1",
-            "status": "delivered",
-            "created_at": "2023-01-01 12:00:00",
-        },
-        {
-            "recipient": "test2@example.com",
-            "template_name": "Template 2",
-            "template_type": "sms",
-            "created_by_name": "User 2",
-            "created_by_email_address": "user2@example.com",
-            "job_name": "Job 2",
-            "status": "failed",
-            "created_at": "2023-01-02 12:00:00",
-        },
-    ]
-
-    result = get_csv_file_data(test_notifications)
-
-    # Check for UTF-8 encoding
-    assert isinstance(result, bytes)
-    result_str = result.decode("utf-8")
-
-    # Check for BOM
-    assert result_str.startswith("\ufeff")
-
-    # Check CSV content
-    lines = result_str.strip().split("\n")
-    assert len(lines) == 3  # Header + 2 rows
-
-    # Check header
-    header = lines[0]
-    for field in CSV_FIELDNAMES:
-        assert field in header
-
-    # Check data rows
-    assert "test1@example.com" in lines[1]
-    assert "test2@example.com" in lines[2]
-    assert "Template 1" in lines[1]
-    assert "Template 2" in lines[2]
-
-
-def test_get_csv_file_data_empty_list():
-    """Test get_csv_file_data with empty list"""
-    result = get_csv_file_data([])
-
-    # Check for UTF-8 encoding
-    assert isinstance(result, bytes)
-    result_str = result.decode("utf-8")
-
-    # Check for BOM
-    assert result_str.startswith("\ufeff")
-
-    # Check CSV content
-    lines = result_str.strip().split("\n")
-    assert len(lines) == 1  # Only header
-
-    # Check header
-    header = lines[0]
-    for field in CSV_FIELDNAMES:
-        assert field in header
 
 
 class TestGenerateCsvFromNotifications:

--- a/tests/app/report/test_utils.py
+++ b/tests/app/report/test_utils.py
@@ -1,15 +1,29 @@
 from unittest.mock import patch
 
 from app.report.utils import (
-    _l,
+    Translate,
     generate_csv_from_notifications,
 )
 
 
 def test_mock_translate_function():
     """Test the mock translation function behaves as expected"""
-    assert _l("Test") == "Test"
-    assert _l("Status") == "Status"
+    _ = Translate(language="en")._
+    assert _("Test") == "Test"
+    assert _("Status") == "Status"
+
+
+def test_translate_default_language():
+    _ = Translate(language="en")._
+    assert _("Recipient") == "Recipient"
+    assert _("Nonexistent") == "Nonexistent"
+
+
+def test_translate_french_language():
+    translator = Translate(language="fr")
+    assert translator._("Recipient") == "Destinataire"
+    assert translator._("Template") == "Gabarit"
+    assert translator._("Nonexistent") == "Nonexistent"
 
 
 class TestGenerateCsvFromNotifications:


### PR DESCRIPTION
# Summary | Résumé

This PR:
- adds the language to the report creation endpoint so that it will be stored in the db
- adds logic to translate the headers in the "Delivery report"
- removes unused code and tests that are not needed now that we are doing translation as part of the postgres "copy" command
- add some unit tests

I will translate the values as a follow up PR

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1846

# Test instructions | Instructions pour tester la modification

1. check out this branch
2. run locally with admin `main`
3. switch your language to french in admin and generate a report
4. download the report and open it
5. observe that the headers in the report are in french 

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.