### PR TITLE
move generate reports to its own queue

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -91,6 +91,7 @@ class QueueNames(object):
     # out Notify.
     RESEARCH_MODE = "research-mode-tasks"
     REPORTING = "reporting-tasks"
+    GENERATE_REPORTS = "generate-reports"
 
     # Queue for scheduled notifications.
     JOBS = "job-tasks"

--- a/app/report/rest.py
+++ b/app/report/rest.py
@@ -56,7 +56,7 @@ def create_service_report(service_id):
 
         # start the report generation process in celery
         current_app.logger.info(f"Calling generate_report for Report ID {report.id}")
-        generate_report.apply_async([report.id], queue=QueueNames.REPORTING)
+        generate_report.apply_async([report.id], queue=QueueNames.GENERATE_REPORTS)
 
         return jsonify(data=report_schema.dump(created_report)), 201
 

--- a/tests/app/report/test_rest.py
+++ b/tests/app/report/test_rest.py
@@ -20,7 +20,7 @@ def test_create_report_succeeds_with_valid_data(mocker, admin_request, sample_se
     generate_report_mock.assert_called_once()
     assert str(generate_report_mock.call_args[0][0][0]) == response["data"]["id"]
     # check the queue name
-    assert generate_report_mock.call_args[1]["queue"] == "reporting-tasks"
+    assert generate_report_mock.call_args[1]["queue"] == "generate-report"
 
 
 def test_create_report_with_invalid_report_type(admin_request, sample_service):


### PR DESCRIPTION
# Summary | Résumé

Move generate reports to its own queue

# Test instructions | Instructions pour tester la modification

Generate a report through the /reports page. It should work as usual

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.