### PR TITLE
Make the job report consistent with the existing feature

### DIFF
--- a/app/report/utils.py
+++ b/app/report/utils.py
@@ -107,7 +107,7 @@ def build_notifications_query(service_id, notification_type, language, notificat
         .outerjoin(j, j.id == n.job_id)
         .outerjoin(u, u.id == n.created_by_id)
         .filter(*query_filters)
-        .order_by(n.job_row_number.asc() if job_id else n.created_at.desc())
+        .order_by(n.created_at.asc() if job_id else n.created_at.desc())
         .subquery()
     )
 


### PR DESCRIPTION
# Summary | Résumé

Make the job report consistent with the existing feature:
- remove the "sent by" and "sent by email" column
- add the row number
- sort by row number

Before:
<img width="569" alt="Screenshot 2025-04-29 at 3 19 06 PM" src="https://github.com/user-attachments/assets/ecf68100-1deb-40a4-8e19-8fe80e421ecc" />

After:
<img width="553" alt="Screenshot 2025-04-29 at 3 18 29 PM" src="https://github.com/user-attachments/assets/c1470e9e-0153-476a-8699-32e91756efc3" />


# Test instructions | Instructions pour tester la modification

1. check out this branch and run with admin `main`
2. send a csv job via admin (or use an existing job for one of your services)
3. click "prepare report"
4. download the report and verify that it matches what you see in the screenshot above

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.