### PR TITLE
Fixing dockerfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,7 @@ var/
 *.egg
 /cache
 newrelic-layer.zip
-smoketest.sh
-smoketest-prod.sh
+smoketest*.sh
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /app
 
 # Install poetry and isolate it in it's own venv
 RUN python -m venv ${POETRY_HOME} \
-    && ${POETRY_HOME}/bin/pip3 install poetry==${POETRY_VERSION}
+    && ${POETRY_HOME}/bin/pip3 install poetry==${POETRY_VERSION} virtualenv==20.30.0
 
 COPY pyproject.toml poetry.lock /app/
 

--- a/ci/Dockerfile.lambda
+++ b/ci/Dockerfile.lambda
@@ -17,7 +17,7 @@ WORKDIR ${TASK_ROOT}
 
 # Install poetry and isolate it in it's own venv
 RUN python -m venv ${POETRY_HOME} \
-    && ${POETRY_HOME}/bin/pip3 install poetry==${POETRY_VERSION}
+    && ${POETRY_HOME}/bin/pip3 install poetry==${POETRY_VERSION} virtualenv==20.30.0
 
 COPY pyproject.toml poetry.lock ${TASK_ROOT}/
 

--- a/ci/Dockerfile.test
+++ b/ci/Dockerfile.test
@@ -15,9 +15,9 @@ RUN apk add --no-cache bash build-base git gcc musl-dev postgresql-dev g++ make 
 RUN set -ex && mkdir /app
 WORKDIR /app
 
-# Install Poetry and isolate it from the project
+# Install poetry and isolate it in it's own venv
 RUN python -m venv ${POETRY_HOME} \
-    && ${POETRY_HOME}/bin/pip3 install poetry==${POETRY_VERSION}
+    && ${POETRY_HOME}/bin/pip3 install poetry==${POETRY_VERSION} virtualenv==20.30.0
 
 COPY . /app/
 


### PR DESCRIPTION
# Summary | Résumé

We had an issue where docker was no longer building images due to wheel not being included in virtualenv. 

Huge kudos to @whabanks who found the issue

```
The latest version of [virtualenv no longer bundles ](https://virtualenv.pypa.io/en/latest/changelog.html)wheel[ wheels](https://virtualenv.pypa.io/en/latest/changelog.html) which is probably why it no longer considers --wheel=bundle as a valid param. I pinned virtualenv to the previous version on lines 19 and 20 in the dockerfile and was able to build the image again:
```
# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.