### PR TITLE
Simplify annual limits seeding logic

### DIFF
--- a/app/annual_limit_utils.py
+++ b/app/annual_limit_utils.py
@@ -16,27 +16,56 @@ from app.models import EMAIL_TYPE, SMS_TYPE
 from app.utils import get_fiscal_year, prepare_notification_counts_for_seeding
 
 
+def seed_annual_limit_counts(service_id: UUID) -> None:
+    """
+    Seed the annual limit counts for a service. This is called when the service is created or updated.
+    """
+    today = datetime.now(timezone.utc)
+    annual_data_sms = fetch_notification_status_totals_for_service_by_fiscal_year(
+        service_id, get_fiscal_year(today), notification_type=SMS_TYPE
+    )
+    annual_data_email = fetch_notification_status_totals_for_service_by_fiscal_year(
+        service_id, get_fiscal_year(today), notification_type=EMAIL_TYPE
+    )
+    data = prepare_notification_counts_for_seeding(
+        fetch_notification_status_for_service_for_day(
+            datetime.now(timezone.utc),
+            service_id=service_id,
+        )
+    )
+    data[TOTAL_SMS_FISCAL_YEAR_TO_YESTERDAY] = annual_data_sms
+    data[TOTAL_EMAIL_FISCAL_YEAR_TO_YESTERDAY] = annual_data_email
+
+    # The below function will also set the SEEDED_AT key for notifications_v2 in redis
+    annual_limit_client.seed_annual_limit_notifications(service_id, data)
+    return data
+
+
 @requires_feature("REDIS_ENABLED")
 def get_annual_limit_notifications_v2(service_id: UUID) -> dict:
     if not annual_limit_client.was_seeded_today(service_id):
-        today = datetime.now(timezone.utc)
-        annual_data_sms = fetch_notification_status_totals_for_service_by_fiscal_year(
-            service_id, get_fiscal_year(today), notification_type=SMS_TYPE
-        )
-        annual_data_email = fetch_notification_status_totals_for_service_by_fiscal_year(
-            service_id, get_fiscal_year(today), notification_type=EMAIL_TYPE
-        )
-        data = prepare_notification_counts_for_seeding(
-            fetch_notification_status_for_service_for_day(
-                datetime.now(timezone.utc),
-                service_id=service_id,
-            )
-        )
-        data[TOTAL_SMS_FISCAL_YEAR_TO_YESTERDAY] = annual_data_sms
-        data[TOTAL_EMAIL_FISCAL_YEAR_TO_YESTERDAY] = annual_data_email
-
-        # The below function will also set the SEEDED_AT key for notifications_v2 in redis
-        annual_limit_client.seed_annual_limit_notifications(service_id, data)
-        return data
+        seed_annual_limit_counts(service_id)
     else:
         return annual_limit_client.get_all_notification_counts(service_id)
+
+
+@requires_feature("REDIS_ENABLED")
+def increment_notification_failed(service_id: UUID, notification_type) -> None:
+    if not annual_limit_client.was_seeded_today(service_id):
+        seed_annual_limit_counts(service_id)
+    else:
+        if notification_type == EMAIL_TYPE:
+            annual_limit_client.increment_email_failed(service_id)
+        elif notification_type == SMS_TYPE:
+            annual_limit_client.increment_sms_failed(service_id)
+
+
+@requires_feature("REDIS_ENABLED")
+def increment_notification_delivered(service_id: UUID, notification_type) -> None:
+    if not annual_limit_client.was_seeded_today(service_id):
+        seed_annual_limit_counts(service_id)
+    else:
+        if notification_type == EMAIL_TYPE:
+            annual_limit_client.increment_email_delivered(service_id)
+        elif notification_type == SMS_TYPE:
+            annual_limit_client.increment_sms_delivered(service_id)

--- a/app/annual_limit_utils.py
+++ b/app/annual_limit_utils.py
@@ -44,13 +44,13 @@ def seed_annual_limit_counts(service_id: UUID) -> None:
 @requires_feature("REDIS_ENABLED")
 def get_annual_limit_notifications_v2(service_id: UUID) -> dict:
     if not annual_limit_client.was_seeded_today(service_id):
-        seed_annual_limit_counts(service_id)
+        return seed_annual_limit_counts(service_id)
     else:
         return annual_limit_client.get_all_notification_counts(service_id)
 
 
 @requires_feature("REDIS_ENABLED")
-def increment_notification_failed(service_id: UUID, notification_type) -> None:
+def increment_notifications_failed(service_id: UUID, notification_type) -> None:
     if not annual_limit_client.was_seeded_today(service_id):
         seed_annual_limit_counts(service_id)
     else:
@@ -61,7 +61,7 @@ def increment_notification_failed(service_id: UUID, notification_type) -> None:
 
 
 @requires_feature("REDIS_ENABLED")
-def increment_notification_delivered(service_id: UUID, notification_type) -> None:
+def increment_notifications_delivered(service_id: UUID, notification_type) -> None:
     if not annual_limit_client.was_seeded_today(service_id):
         seed_annual_limit_counts(service_id)
     else:

--- a/app/celery/process_pinpoint_receipts_tasks.py
+++ b/app/celery/process_pinpoint_receipts_tasks.py
@@ -6,7 +6,7 @@ from notifications_utils.statsd_decorators import statsd
 from sqlalchemy.orm.exc import NoResultFound
 
 from app import annual_limit_client, notify_celery, statsd_client
-from app.annual_limit_utils import increment_notification_delivered, increment_notification_failed
+from app.annual_limit_utils import increment_notifications_delivered, increment_notifications_failed
 from app.config import QueueNames
 from app.dao import notifications_dao
 from app.models import (
@@ -118,7 +118,7 @@ def process_pinpoint_results(self, response):
             )
             # TODO FF_ANNUAL_LIMIT removal
             if current_app.config["FF_ANNUAL_LIMIT"]:
-                increment_notification_failed(service_id=service_id, notification_type=SMS_TYPE)
+                increment_notifications_failed(service_id=service_id, notification_type=SMS_TYPE)
                 current_app.logger.info(
                     f"Incremented sms_delivered count in Redis. Service: {service_id} Notification: {notification.id} Current counts: {annual_limit_client.get_all_notification_counts(service_id)}"
                 )
@@ -129,7 +129,7 @@ def process_pinpoint_results(self, response):
 
             # TODO FF_ANNUAL_LIMIT removal
             if current_app.config["FF_ANNUAL_LIMIT"]:
-                increment_notification_delivered(service_id=service_id, notification_type=SMS_TYPE)
+                increment_notifications_delivered(service_id=service_id, notification_type=SMS_TYPE)
                 current_app.logger.info(
                     f"Incremented sms_delivered count in Redis. Service: {service_id} Notification: {notification.id} Current counts: {annual_limit_client.get_all_notification_counts(service_id)}"
                 )

--- a/app/celery/process_pinpoint_receipts_tasks.py
+++ b/app/celery/process_pinpoint_receipts_tasks.py
@@ -6,7 +6,7 @@ from notifications_utils.statsd_decorators import statsd
 from sqlalchemy.orm.exc import NoResultFound
 
 from app import annual_limit_client, notify_celery, statsd_client
-from app.annual_limit_utils import get_annual_limit_notifications_v2
+from app.annual_limit_utils import increment_notification_delivered, increment_notification_failed
 from app.config import QueueNames
 from app.dao import notifications_dao
 from app.models import (
@@ -16,6 +16,7 @@ from app.models import (
     NOTIFICATION_TECHNICAL_FAILURE,
     NOTIFICATION_TEMPORARY_FAILURE,
     PINPOINT_PROVIDER,
+    SMS_TYPE,
 )
 from app.notifications.callbacks import _check_and_queue_callback_task
 from celery.exceptions import Retry
@@ -108,14 +109,6 @@ def process_pinpoint_results(self, response):
         )
 
         service_id = notification.service_id
-        # Flags if seeding has occurred. Since we seed after updating the notification status in the DB then the current notification
-        # is included in the fetch_notification_status_for_service_for_day call below, thus we don't need to increment the count.
-        notifications_to_seed = None
-
-        if current_app.config["FF_ANNUAL_LIMIT"]:
-            if not annual_limit_client.was_seeded_today(service_id):
-                notifications_to_seed = get_annual_limit_notifications_v2(service_id)
-
         if notification_status != NOTIFICATION_DELIVERED:
             current_app.logger.info(
                 (
@@ -125,9 +118,7 @@ def process_pinpoint_results(self, response):
             )
             # TODO FF_ANNUAL_LIMIT removal
             if current_app.config["FF_ANNUAL_LIMIT"]:
-                # Only increment if we didn't just seed.
-                if notifications_to_seed is None:
-                    annual_limit_client.increment_sms_failed(service_id)
+                increment_notification_failed(service_id=service_id, notification_type=SMS_TYPE)
                 current_app.logger.info(
                     f"Incremented sms_delivered count in Redis. Service: {service_id} Notification: {notification.id} Current counts: {annual_limit_client.get_all_notification_counts(service_id)}"
                 )
@@ -138,9 +129,7 @@ def process_pinpoint_results(self, response):
 
             # TODO FF_ANNUAL_LIMIT removal
             if current_app.config["FF_ANNUAL_LIMIT"]:
-                # Only increment if we didn't just seed.
-                if notifications_to_seed is None:
-                    annual_limit_client.increment_sms_delivered(service_id)
+                increment_notification_delivered(service_id=service_id, notification_type=SMS_TYPE)
                 current_app.logger.info(
                     f"Incremented sms_delivered count in Redis. Service: {service_id} Notification: {notification.id} Current counts: {annual_limit_client.get_all_notification_counts(service_id)}"
                 )

--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -5,10 +5,10 @@ from notifications_utils.statsd_decorators import statsd
 from sqlalchemy.orm.exc import NoResultFound
 
 from app import annual_limit_client, bounce_rate_client, notify_celery, statsd_client
-from app.annual_limit_utils import get_annual_limit_notifications_v2
+from app.annual_limit_utils import increment_notifications_delivered, increment_notifications_failed
 from app.config import QueueNames
 from app.dao import notifications_dao
-from app.models import NOTIFICATION_DELIVERED, NOTIFICATION_PERMANENT_FAILURE
+from app.models import EMAIL_TYPE, NOTIFICATION_DELIVERED, NOTIFICATION_PERMANENT_FAILURE
 from app.notifications.callbacks import _check_and_queue_callback_task
 from app.notifications.notifications_ses_callback import (
     _check_and_queue_complaint_callback_task,
@@ -84,15 +84,6 @@ def process_ses_results(self, response):  # noqa: C901
                 bounce_response=aws_response_dict.get("bounce_response", None),
             )
 
-        service_id = notification.service_id
-        # Flags if seeding has occurred. Since we seed after updating the notification status in the DB then the current notification
-        # is included in the fetch_notification_status_for_service_for_day call below, thus we don't need to increment the count.
-        notifications_to_seed = None
-        # Check if we have already seeded the annual limit counts for today
-        if current_app.config["FF_ANNUAL_LIMIT"]:
-            if not annual_limit_client.was_seeded_today(service_id):
-                notifications_to_seed = get_annual_limit_notifications_v2(service_id)
-
         if not aws_response_dict["success"]:
             current_app.logger.info(
                 "SES delivery failed: notification id {} and reference {} has error found. Status {}".format(
@@ -100,9 +91,7 @@ def process_ses_results(self, response):  # noqa: C901
                 )
             )
             if current_app.config["FF_ANNUAL_LIMIT"]:
-                # Only increment if we didn't just seed.
-                if notifications_to_seed is None:
-                    annual_limit_client.increment_email_failed(notification.service_id)
+                increment_notifications_failed(service_id=notification.service_id, notification_type=EMAIL_TYPE)
                 current_app.logger.info(
                     f"Incremented email_failed count in Redis. Service: {notification.service_id} Notification: {notification.id} Current counts: {annual_limit_client.get_all_notification_counts(notification.service_id)}"
                 )
@@ -111,9 +100,7 @@ def process_ses_results(self, response):  # noqa: C901
                 "SES callback return status of {} for notification: {}".format(notification_status, notification.id)
             )
             if current_app.config["FF_ANNUAL_LIMIT"]:
-                # Only increment if we didn't just seed.
-                if notifications_to_seed is None:
-                    annual_limit_client.increment_email_delivered(notification.service_id)
+                increment_notifications_delivered(service_id=notification.service_id, notification_type=EMAIL_TYPE)
                 current_app.logger.info(
                     f"Incremented email_delivered count in Redis. Service: {notification.service_id} Notification: {notification.id} current counts: {annual_limit_client.get_all_notification_counts(notification.service_id)}"
                 )


### PR DESCRIPTION
# Summary | Résumé

This PR moves the logic for seeding annual limits data out of the receipt processing code. This logic should always be the same. This way the code to process receipts from different providers only needs to know when to increment the failed or the delivered counts.
 
Draft for now - lots of tests to fix.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1909

# Test instructions | Instructions pour tester la modification

TBD

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.