### PR TITLE
Fix mapping by adding a double check

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -82,7 +82,7 @@ jobs:
         cp -f .env.example .env
 
     - name: Checks for new endpoints against AWS WAF rules
-      uses: cds-snc/notification-utils/.github/actions/waffles@53.2.1
+      uses: cds-snc/notification-utils/.github/actions/waffles@53.2.2
       with:
         app-loc: '/github/workspace'
         app-libs: '/github/workspace/env/site-packages'

--- a/app/annual_limit_utils.py
+++ b/app/annual_limit_utils.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timezone
+from typing import Tuple
 from uuid import UUID
 
+from flask import current_app
 from notifications_utils.clients.redis.annual_limit import (
     TOTAL_EMAIL_FISCAL_YEAR_TO_YESTERDAY,
     TOTAL_SMS_FISCAL_YEAR_TO_YESTERDAY,
@@ -16,27 +18,63 @@ from app.models import EMAIL_TYPE, SMS_TYPE
 from app.utils import get_fiscal_year, prepare_notification_counts_for_seeding
 
 
+def seed_data_in_redis(service_id: UUID) -> dict:
+    """
+    Seed the annual limit notification counts for a service in redis.
+    """
+    today = datetime.now(timezone.utc)
+    annual_data_sms = fetch_notification_status_totals_for_service_by_fiscal_year(
+        service_id, get_fiscal_year(today), notification_type=SMS_TYPE
+    )
+    annual_data_email = fetch_notification_status_totals_for_service_by_fiscal_year(
+        service_id, get_fiscal_year(today), notification_type=EMAIL_TYPE
+    )
+    data = prepare_notification_counts_for_seeding(
+        fetch_notification_status_for_service_for_day(
+            datetime.now(timezone.utc),
+            service_id=service_id,
+        )
+    )
+    data[TOTAL_SMS_FISCAL_YEAR_TO_YESTERDAY] = annual_data_sms
+    data[TOTAL_EMAIL_FISCAL_YEAR_TO_YESTERDAY] = annual_data_email
+
+    # The below function will also set the SEEDED_AT key for notifications_v2 in redis
+    annual_limit_client.seed_annual_limit_notifications(service_id, data)
+    return data
+
+
 @requires_feature("REDIS_ENABLED")
 def get_annual_limit_notifications_v2(service_id: UUID) -> dict:
     if not annual_limit_client.was_seeded_today(service_id):
-        today = datetime.now(timezone.utc)
-        annual_data_sms = fetch_notification_status_totals_for_service_by_fiscal_year(
-            service_id, get_fiscal_year(today), notification_type=SMS_TYPE
-        )
-        annual_data_email = fetch_notification_status_totals_for_service_by_fiscal_year(
-            service_id, get_fiscal_year(today), notification_type=EMAIL_TYPE
-        )
-        data = prepare_notification_counts_for_seeding(
-            fetch_notification_status_for_service_for_day(
-                datetime.now(timezone.utc),
-                service_id=service_id,
-            )
-        )
-        data[TOTAL_SMS_FISCAL_YEAR_TO_YESTERDAY] = annual_data_sms
-        data[TOTAL_EMAIL_FISCAL_YEAR_TO_YESTERDAY] = annual_data_email
-
-        # The below function will also set the SEEDED_AT key for notifications_v2 in redis
-        annual_limit_client.seed_annual_limit_notifications(service_id, data)
+        data = seed_data_in_redis(service_id)
         return data
     else:
-        return annual_limit_client.get_all_notification_counts(service_id)
+        annual_data = annual_limit_client.get_all_notification_counts(service_id)
+        if TOTAL_EMAIL_FISCAL_YEAR_TO_YESTERDAY in annual_data:
+            return annual_data
+        else:
+            data = seed_data_in_redis(service_id)
+            current_app.logger.info(
+                f"Service {service_id} missing seed data. "
+                f"Original Data in redis: {annual_data}. "
+                f"New Data in redis: {data}."
+            )
+            return data
+
+
+def get_annual_limit_notifications_v3(service_id: UUID) -> Tuple[dict, bool]:
+    if not annual_limit_client.was_seeded_today(service_id):
+        data = seed_data_in_redis(service_id)
+        return (data, True)
+    else:
+        annual_data = annual_limit_client.get_all_notification_counts(service_id)
+        if TOTAL_EMAIL_FISCAL_YEAR_TO_YESTERDAY in annual_data:
+            return (annual_data, False)
+        else:
+            data = seed_data_in_redis(service_id)
+            current_app.logger.info(
+                f"Service {service_id} missing seed data. "
+                f"Original Data in redis: {annual_data}. "
+                f"New Data in redis: {data}."
+            )
+            return (data, True)

--- a/poetry.lock
+++ b/poetry.lock
@@ -2572,7 +2572,7 @@ requests = ">=2.0.0"
 
 [[package]]
 name = "notifications-utils"
-version = "53.2.1"
+version = "53.2.2"
 description = "Shared python code for Notification - Provides logging utils etc."
 optional = false
 python-versions = "~3.12.7"
@@ -2608,8 +2608,8 @@ werkzeug = "3.0.4"
 [package.source]
 type = "git"
 url = "https://github.com/cds-snc/notifier-utils.git"
-reference = "53.2.1"
-resolved_reference = "33c27a5c99c8da74fcedc310e40a4c82cd87e459"
+reference = "53.2.2"
+resolved_reference = "9b236b2b4a24b53d8696d74deb31570ed6804aab"
 
 [[package]]
 name = "ordered-set"
@@ -4552,4 +4552,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.12.7"
-content-hash = "cecc425be27521f0086303615fe1614a1cc006dc5e587b700297955dfdb9e990"
+content-hash = "f0a017ed297a6866f956ca1284d8e894ce4802749e046b72708a26fb7a23f90f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ more-itertools = "8.14.0"
 nanoid = "2.0.0"
 newrelic = "10.3.0"
 notifications-python-client = "6.4.1"
-notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", tag = "53.2.1" }
+notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", tag = "53.2.2" }
 pre-commit = "^3.7.1"
 psycopg2-binary = "2.9.9"
 pwnedpasswords = "2.0.0"

--- a/tests/app/celery/test_process_ses_receipts_tasks.py
+++ b/tests/app/celery/test_process_ses_receipts_tasks.py
@@ -446,7 +446,7 @@ class TestAnnualLimits:
     ):
         mocker.patch("app.annual_limit_client.increment_email_delivered")
         mocker.patch("app.annual_limit_client.increment_email_failed")
-        mocker.patch("app.annual_limit_client.was_seeded_today", return_value=True)
+        mocker.patch("app.celery.process_ses_receipts_tasks.get_annual_limit_notifications_v3", return_value=({}, False))
 
         # TODO FF_ANNUAL_LIMIT removal
         with set_config(notify_api, "FF_ANNUAL_LIMIT", True):
@@ -469,7 +469,7 @@ class TestAnnualLimits:
     ):
         mocker.patch("app.annual_limit_client.increment_email_failed")
         mocker.patch("app.annual_limit_client.increment_email_delivered")
-        mocker.patch("app.annual_limit_client.was_seeded_today", return_value=True)
+        mocker.patch("app.celery.process_ses_receipts_tasks.get_annual_limit_notifications_v3", return_value=({}, False))
 
         # TODO FF_ANNUAL_LIMIT removal
         with set_config(notify_api, "FF_ANNUAL_LIMIT", True):
@@ -527,7 +527,6 @@ class TestAnnualLimits:
     ):
         mocker.patch("app.annual_limit_client.increment_email_delivered")
         mocker.patch("app.annual_limit_client.increment_email_failed")
-        mocker.patch("app.annual_limit_client.was_seeded_today", return_value=False)
         mock_seed_annual_limit = mocker.patch("app.annual_limit_client.seed_annual_limit_notifications")
 
         notification = save_notification(
@@ -539,9 +538,7 @@ class TestAnnualLimits:
                 sent_by="ses",
             )
         )
-        # TODO FF_ANNUAL_LIMIT removal
-        with set_config(notify_api, "FF_ANNUAL_LIMIT", True), set_config(notify_api, "REDIS_ENABLED", True):
-            process_ses_results(callback(reference="ref"))
-            mock_seed_annual_limit.assert_called_once_with(notification.service_id, data)
-            annual_limit_client.increment_email_delivered.assert_not_called()
-            annual_limit_client.increment_email_failed.assert_not_called()
+        process_ses_results(callback(reference="ref"))
+        mock_seed_annual_limit.assert_called_once_with(notification.service_id, data)
+        annual_limit_client.increment_email_delivered.assert_not_called()
+        annual_limit_client.increment_email_failed.assert_not_called()


### PR DESCRIPTION
# Summary | Résumé

When testing the annual limits code, there are times when the seeded_at key for notifications_v2 is set, but the data for the other mappings is not set. We changed the function to check if the seeded_at exists, then the mappings MUST exist (even if they are zero) - else we reseed the data. 

# Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.