### PR TITLE
Fix annual limit seeding in pinpoint and sns receipt tasks

### DIFF
--- a/app/annual_limit_utils.py
+++ b/app/annual_limit_utils.py
@@ -79,7 +79,7 @@ def get_annual_limit_notifications_v3(service_id: UUID) -> Tuple[dict, bool]:
         )
 
         current_app.logger.info(f"[alimit-debug] service_id: {service_id} email_fiscal: {email_fiscal}")
-        if email_fiscal is not None and sms_fiscal is not None:
+        if email_fiscal is not None or sms_fiscal is not None:
             current_app.logger.info(f"[alimit-debug] service {service_id} was seeded. annual_data: {annual_data}")
             return (annual_data, False)
         else:

--- a/app/annual_limit_utils.py
+++ b/app/annual_limit_utils.py
@@ -6,6 +6,7 @@ from flask import current_app
 from notifications_utils.clients.redis.annual_limit import (
     TOTAL_EMAIL_FISCAL_YEAR_TO_YESTERDAY,
     TOTAL_SMS_FISCAL_YEAR_TO_YESTERDAY,
+    annual_limit_notifications_v2_key,
 )
 from notifications_utils.decorators import requires_feature
 
@@ -71,10 +72,10 @@ def get_annual_limit_notifications_v3(service_id: UUID) -> Tuple[dict, bool]:
     else:
         annual_data = annual_limit_client.get_all_notification_counts(service_id)
         email_fiscal = annual_limit_client._redis_client.get_hash_field(
-            annual_limit_client.annual_limit_notifications_v2_key(service_id), TOTAL_EMAIL_FISCAL_YEAR_TO_YESTERDAY
+            annual_limit_notifications_v2_key(service_id), TOTAL_EMAIL_FISCAL_YEAR_TO_YESTERDAY
         )
         sms_fiscal = annual_limit_client._redis_client.get_hash_field(
-            annual_limit_client.annual_limit_notifications_v2_key(service_id), TOTAL_SMS_FISCAL_YEAR_TO_YESTERDAY
+            annual_limit_notifications_v2_key(service_id), TOTAL_SMS_FISCAL_YEAR_TO_YESTERDAY
         )
 
         current_app.logger.info(f"[alimit-debug] service_id: {service_id} email_fiscal: {email_fiscal}")

--- a/app/celery/process_pinpoint_receipts_tasks.py
+++ b/app/celery/process_pinpoint_receipts_tasks.py
@@ -6,7 +6,7 @@ from notifications_utils.statsd_decorators import statsd
 from sqlalchemy.orm.exc import NoResultFound
 
 from app import annual_limit_client, notify_celery, statsd_client
-from app.annual_limit_utils import get_annual_limit_notifications_v2
+from app.annual_limit_utils import get_annual_limit_notifications_v3
 from app.config import QueueNames
 from app.dao import notifications_dao
 from app.models import (
@@ -110,11 +110,7 @@ def process_pinpoint_results(self, response):
         service_id = notification.service_id
         # Flags if seeding has occurred. Since we seed after updating the notification status in the DB then the current notification
         # is included in the fetch_notification_status_for_service_for_day call below, thus we don't need to increment the count.
-        notifications_to_seed = None
-
-        if current_app.config["FF_ANNUAL_LIMIT"]:
-            if not annual_limit_client.was_seeded_today(service_id):
-                notifications_to_seed = get_annual_limit_notifications_v2(service_id)
+        _, did_we_seed = get_annual_limit_notifications_v3(service_id)
 
         if notification_status != NOTIFICATION_DELIVERED:
             current_app.logger.info(
@@ -126,7 +122,7 @@ def process_pinpoint_results(self, response):
             # TODO FF_ANNUAL_LIMIT removal
             if current_app.config["FF_ANNUAL_LIMIT"]:
                 # Only increment if we didn't just seed.
-                if notifications_to_seed is None:
+                if not did_we_seed:
                     annual_limit_client.increment_sms_failed(service_id)
                 current_app.logger.info(
                     f"Incremented sms_delivered count in Redis. Service: {service_id} Notification: {notification.id} Current counts: {annual_limit_client.get_all_notification_counts(service_id)}"
@@ -139,7 +135,7 @@ def process_pinpoint_results(self, response):
             # TODO FF_ANNUAL_LIMIT removal
             if current_app.config["FF_ANNUAL_LIMIT"]:
                 # Only increment if we didn't just seed.
-                if notifications_to_seed is None:
+                if not did_we_seed:
                     annual_limit_client.increment_sms_delivered(service_id)
                 current_app.logger.info(
                     f"Incremented sms_delivered count in Redis. Service: {service_id} Notification: {notification.id} Current counts: {annual_limit_client.get_all_notification_counts(service_id)}"

--- a/app/celery/process_sns_receipts_tasks.py
+++ b/app/celery/process_sns_receipts_tasks.py
@@ -5,7 +5,7 @@ from notifications_utils.statsd_decorators import statsd
 from sqlalchemy.orm.exc import NoResultFound
 
 from app import annual_limit_client, notify_celery, statsd_client
-from app.annual_limit_utils import get_annual_limit_notifications_v2
+from app.annual_limit_utils import get_annual_limit_notifications_v3
 from app.config import QueueNames
 from app.dao import notifications_dao
 from app.models import (
@@ -68,10 +68,7 @@ def process_sns_results(self, response):
         service_id = notification.service_id
         # Flags if seeding has occurred. Since we seed after updating the notification status in the DB then the current notification
         # is included in the fetch_notification_status_for_service_for_day call below, thus we don't need to increment the count.
-        notifications_to_seed = None
-        if current_app.config["FF_ANNUAL_LIMIT"]:
-            if not annual_limit_client.was_seeded_today(service_id):
-                notifications_to_seed = get_annual_limit_notifications_v2(service_id)
+        _, did_we_seed = get_annual_limit_notifications_v3(service_id)
 
         if notification_status != NOTIFICATION_DELIVERED:
             current_app.logger.info(
@@ -83,7 +80,7 @@ def process_sns_results(self, response):
             # TODO FF_ANNUAL_LIMIT removal
             if current_app.config["FF_ANNUAL_LIMIT"]:
                 # Only increment if we didn't just seed.
-                if notifications_to_seed is None:
+                if not did_we_seed:
                     annual_limit_client.increment_sms_failed(notification.service_id)
                 current_app.logger.info(
                     f"Incremented sms_failed count in Redis. Service: {notification.service_id} Notification: {notification.id} Current counts: {annual_limit_client.get_all_notification_counts(notification.service_id)}"
@@ -93,7 +90,7 @@ def process_sns_results(self, response):
             # TODO FF_ANNUAL_LIMIT removal
             if current_app.config["FF_ANNUAL_LIMIT"]:
                 # Only increment if we didn't just seed.
-                if notifications_to_seed is None:
+                if not did_we_seed:
                     annual_limit_client.increment_sms_delivered(notification.service_id)
                 current_app.logger.info(
                     f"Incremented sms_delivered count in Redis. Service: {notification.service_id} Notification: {notification.id} Current counts: {annual_limit_client.get_all_notification_counts(notification.service_id)}"

--- a/tests/app/celery/test_process_pinpoint_receipts_tasks.py
+++ b/tests/app/celery/test_process_pinpoint_receipts_tasks.py
@@ -445,8 +445,11 @@ class TestAnnualLimits:
                 sent_by="pinpoint",
             )
         )
-        process_pinpoint_results(callback(provider_response, reference="ref") if provider_response else callback(reference="ref"))
+        with set_config(notify_api, "REDIS_ENABLED", True):
+            process_pinpoint_results(
+                callback(provider_response, reference="ref") if provider_response else callback(reference="ref")
+            )
 
-        mock_seed_annual_limit.assert_called_once_with(notification.service_id, data)
-        annual_limit_client.increment_sms_delivered.assert_not_called()
-        annual_limit_client.increment_sms_failed.assert_not_called()
+            mock_seed_annual_limit.assert_called_once_with(notification.service_id, data)
+            annual_limit_client.increment_sms_delivered.assert_not_called()
+            annual_limit_client.increment_sms_failed.assert_not_called()

--- a/tests/app/celery/test_process_ses_receipts_tasks.py
+++ b/tests/app/celery/test_process_ses_receipts_tasks.py
@@ -201,6 +201,7 @@ def test_ses_callback_should_give_up_after_max_tries(notify_db, mocker):
 def test_ses_callback_does_not_call_send_delivery_status_if_no_db_entry(
     notify_db, notify_db_session, sample_email_template, mocker
 ):
+    mocker.patch("app.celery.process_ses_receipts_tasks.get_annual_limit_notifications_v3", return_value=({}, False))
     with freeze_time("2001-01-01T12:00:00"):
         send_mock = mocker.patch("app.celery.service_callback_tasks.send_delivery_status_to_service.apply_async")
         notification = create_sample_notification(
@@ -308,6 +309,7 @@ def test_ses_callback_should_set_status_to_temporary_failure(
 def test_ses_callback_should_set_status_to_permanent_failure(
     notify_db, notify_db_session, sample_email_template, mocker, bounce_subtype, provider_response
 ):
+    mocker.patch("app.celery.process_ses_receipts_tasks.get_annual_limit_notifications_v3", return_value=({}, False))
     send_mock = mocker.patch("app.celery.service_callback_tasks.send_delivery_status_to_service.apply_async")
     notification = create_sample_notification(
         notify_db,

--- a/tests/app/celery/test_process_ses_receipts_tasks.py
+++ b/tests/app/celery/test_process_ses_receipts_tasks.py
@@ -541,7 +541,8 @@ class TestAnnualLimits:
                 sent_by="ses",
             )
         )
-        process_ses_results(callback(reference="ref"))
-        mock_seed_annual_limit.assert_called_once_with(notification.service_id, data)
-        annual_limit_client.increment_email_delivered.assert_not_called()
-        annual_limit_client.increment_email_failed.assert_not_called()
+        with set_config(notify_api, "REDIS_ENABLED", True):
+            process_ses_results(callback(reference="ref"))
+            mock_seed_annual_limit.assert_called_once_with(notification.service_id, data)
+            annual_limit_client.increment_email_delivered.assert_not_called()
+            annual_limit_client.increment_email_failed.assert_not_called()

--- a/tests/app/celery/test_process_sns_receipts_tasks.py
+++ b/tests/app/celery/test_process_sns_receipts_tasks.py
@@ -377,8 +377,10 @@ class TestAnnualLimit:
                 sent_by="sns",
             )
         )
-        process_sns_results(callback(provider_response, reference="ref") if provider_response else callback(reference="ref"))
 
-        mock_seed_annual_limit.assert_called_once_with(notification.service_id, data)
-        annual_limit_client.increment_sms_delivered.assert_not_called()
-        annual_limit_client.increment_sms_failed.assert_not_called()
+        with set_config(notify_api, "REDIS_ENABLED", True):
+            process_sns_results(callback(provider_response, reference="ref") if provider_response else callback(reference="ref"))
+
+            mock_seed_annual_limit.assert_called_once_with(notification.service_id, data)
+            annual_limit_client.increment_sms_delivered.assert_not_called()
+            annual_limit_client.increment_sms_failed.assert_not_called()

--- a/tests/app/celery/test_process_sns_receipts_tasks.py
+++ b/tests/app/celery/test_process_sns_receipts_tasks.py
@@ -84,6 +84,7 @@ def test_process_sns_results_failed(
     should_log_warning,
     should_save_provider_response,
 ):
+    mocker.patch("app.celery.process_sns_receipts_tasks.get_annual_limit_notifications_v3", return_value=({}, False))
     mock_logger = mocker.patch("app.celery.process_sns_receipts_tasks.current_app.logger.info")
     mock_warning_logger = mocker.patch("app.celery.process_sns_receipts_tasks.current_app.logger.warning")
 

--- a/tests/app/celery/test_process_sns_receipts_tasks.py
+++ b/tests/app/celery/test_process_sns_receipts_tasks.py
@@ -47,7 +47,7 @@ def test_process_sns_results_delivered(sample_template, notify_db, notify_db_ses
     assert get_notification_by_id(notification.id).status == NOTIFICATION_DELIVERED
     assert get_notification_by_id(notification.id).provider_response == "Message has been accepted by phone carrier"
 
-    mock_logger.assert_called_once_with(f"SNS callback return status of delivered for notification: {notification.id}")
+    mock_logger.assert_called_with(f"SNS callback return status of delivered for notification: {notification.id}")
 
 
 @pytest.mark.parametrize(
@@ -105,7 +105,7 @@ def test_process_sns_results_failed(
     else:
         assert get_notification_by_id(notification.id).provider_response is None
 
-    mock_logger.assert_called_once_with(
+    mock_logger.assert_called_with(
         (
             f"SNS delivery failed: notification id {notification.id} and reference ref has error found. "
             f"Provider response: {provider_response}"
@@ -206,7 +206,7 @@ class TestAnnualLimit:
     ):
         mocker.patch("app.annual_limit_client.increment_sms_delivered")
         mocker.patch("app.annual_limit_client.increment_sms_failed")
-        mocker.patch("app.annual_limit_client.was_seeded_today", return_value=True)
+        mocker.patch("app.celery.process_sns_receipts_tasks.get_annual_limit_notifications_v3", return_value=({}, False))
 
         notification = save_notification(
             create_notification(
@@ -272,7 +272,7 @@ class TestAnnualLimit:
     ):
         mocker.patch("app.annual_limit_client.increment_sms_delivered")
         mocker.patch("app.annual_limit_client.increment_sms_failed")
-        mocker.patch("app.annual_limit_client.was_seeded_today", return_value=True)
+        mocker.patch("app.celery.process_sns_receipts_tasks.get_annual_limit_notifications_v3", return_value=({}, False))
 
         notification = save_notification(
             create_notification(
@@ -366,7 +366,6 @@ class TestAnnualLimit:
     ):
         mocker.patch("app.annual_limit_client.increment_sms_delivered")
         mocker.patch("app.annual_limit_client.increment_sms_failed")
-        mocker.patch("app.annual_limit_client.was_seeded_today", return_value=False)
         mock_seed_annual_limit = mocker.patch("app.annual_limit_client.seed_annual_limit_notifications")
 
         notification = save_notification(
@@ -378,9 +377,8 @@ class TestAnnualLimit:
                 sent_by="sns",
             )
         )
-        # TODO FF_ANNUAL_LIMIT removal
-        with set_config(notify_api, "FF_ANNUAL_LIMIT", True), set_config(notify_api, "REDIS_ENABLED", True):
-            process_sns_results(callback(provider_response, reference="ref") if provider_response else callback(reference="ref"))
-            mock_seed_annual_limit.assert_called_once_with(notification.service_id, data)
-            annual_limit_client.increment_sms_delivered.assert_not_called()
-            annual_limit_client.increment_sms_failed.assert_not_called()
+        process_sns_results(callback(provider_response, reference="ref") if provider_response else callback(reference="ref"))
+
+        mock_seed_annual_limit.assert_called_once_with(notification.service_id, data)
+        annual_limit_client.increment_sms_delivered.assert_not_called()
+        annual_limit_client.increment_sms_failed.assert_not_called()


### PR DESCRIPTION
# Summary | Résumé

This PR applies the same [changes made to process_ses_receipts](https://github.com/cds-snc/notification-api/pull/2527) to fix annual limit seeding issue.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-api/pull/2527

# Test instructions | Instructions pour tester la modification

CI passes
Verify in staging tomorrow post-perf test that the seeding occurred correctly.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.