### PR TITLE
Fix/handle unique violation

### DIFF
--- a/app/errors.py
+++ b/app/errors.py
@@ -50,6 +50,15 @@ class CannotRemoveUserError(InvalidRequest):
         self.fields = fields
 
 
+class UserAlreadyInServiceError(InvalidRequest):
+    message = "This user is already in the service"
+
+    def __init__(self, fields=[], message=None, status_code=409):
+        # Call parent class __init__ with message and status_code
+        super().__init__(message=message if message else self.message, status_code=status_code)
+        self.fields = fields
+
+
 class DuplicateEntityError(InvalidRequest):
     """Generic error for handling unique constraint errors. This error should be subclassed to provide more specific error messages depending on the entity
        and their unique fields.

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -11,6 +11,7 @@ from notifications_utils.clients.redis import (
     over_email_daily_limit_cache_key,
     over_sms_daily_limit_cache_key,
 )
+from psycopg2.errors import UniqueViolation
 from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
@@ -85,7 +86,7 @@ from app.dao.services_dao import (
 )
 from app.dao.templates_dao import dao_get_template_by_id
 from app.dao.users_dao import get_user_by_id
-from app.errors import CannotRemoveUserError, InvalidRequest, register_errors
+from app.errors import CannotRemoveUserError, InvalidRequest, UserAlreadyInServiceError, register_errors
 from app.models import (
     EMAIL_TYPE,
     KEY_TYPE_NORMAL,
@@ -466,8 +467,8 @@ def add_user_to_service(service_id, user_id):
     user = get_user_by_id(user_id=user_id)
 
     if user in service.users:
-        error = "User id: {} already part of service id: {}".format(user_id, service_id)
-        raise InvalidRequest(error, status_code=400)
+        current_app.logger.info("User id: {} already part of service id: {}".format(user_id, service_id))
+        raise UserAlreadyInServiceError(status_code=409)
 
     data = request.get_json()
     validate(data, post_set_permissions_schema)
@@ -475,9 +476,12 @@ def add_user_to_service(service_id, user_id):
     permissions = [Permission(service_id=service_id, user_id=user_id, permission=p["permission"]) for p in data["permissions"]]
     folder_permissions = data.get("folder_permissions", [])
 
-    # try:
-    dao_add_user_to_service(service, user, permissions, folder_permissions)
-    # except UniqueViolation:
+    try:
+        dao_add_user_to_service(service, user, permissions, folder_permissions)
+    except UniqueViolation:
+        current_app.logger.info(f"UniqueViolation: User id: {user_id} already part of service id: {service_id}")
+        raise UserAlreadyInServiceError(status_code=409)
+
     data = service_schema.dump(service)
 
     if current_app.config["FF_SALESFORCE_CONTACT"]:

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -475,7 +475,9 @@ def add_user_to_service(service_id, user_id):
     permissions = [Permission(service_id=service_id, user_id=user_id, permission=p["permission"]) for p in data["permissions"]]
     folder_permissions = data.get("folder_permissions", [])
 
+    # try:
     dao_add_user_to_service(service, user, permissions, folder_permissions)
+    # except UniqueViolation:
     data = service_schema.dump(service)
 
     if current_app.config["FF_SALESFORCE_CONTACT"]:


### PR DESCRIPTION
# Summary | Résumé

This PR:
- handles the `UniqueViolation` that we were seeing get raised from the dao fn
- Return a [409 error](https://stackoverflow.com/questions/3825990/http-response-code-for-post-when-resource-already-exists) when the user already belongs to the service. This is so we don't trigger our alarms
- tests coming soon

Related admin PR: https://github.com/cds-snc/notification-admin/pull/2181

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1914

# Test instructions | Instructions pour tester la modification

We can't reproduce the bug, so I'm not sure how to test this.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.