### PR TITLE
Revert "Revert "Batch save ses receipts""

### DIFF
--- a/app/aws/mocks.py
+++ b/app/aws/mocks.py
@@ -197,6 +197,24 @@ def ses_complaint_callback():
     }
 
 
+def ses_complaint_account_suppression_list_callback_with_missing_complained_recipients():
+    return {
+        "Signature": "bb",
+        "SignatureVersion": "1",
+        "MessageAttributes": {},
+        "MessageId": "98c6e927-af5d-5f3b-9522-bab736f2cbde",
+        "UnsubscribeUrl": "https://sns.eu-west-1.amazonaws.com",
+        "TopicArn": "arn:ses_notifications",
+        "Type": "Notification",
+        "Timestamp": "2018-06-05T14:00:15.952Z",
+        "Subject": None,
+        "Messages": json.loads(
+            '[{"notificationType":"Complaint","complaint":{"complaintFeedbackType": "abuse", "complaintSubType": "OnAccountSuppressionList", "timestamp":"2018-06-05T13:59:58.000Z","feedbackId":"ses_feedback_id"},"mail":{"timestamp":"2018-06-05T14:00:15.950Z","source":"\\"Some Service\\" <someservicenotifications.service.gov.uk>","sourceArn":"arn:identity/notifications.service.gov.uk","sourceIp":"52.208.24.161","sendingAccountId":"888450439860","messageId":"ref1"}}]'
+        ),  # noqa
+        "SigningCertUrl": "https://sns.pem",
+    }
+
+
 def ses_complaint_callback_with_subtype(subtype):
     """
     https://docs.aws.amazon.com/ses/latest/DeveloperGuide/notification-contents.html#complaint-object

--- a/app/aws/mocks.py
+++ b/app/aws/mocks.py
@@ -12,6 +12,70 @@ def sns_s3_callback(filename, message_id="some-message-id"):
     )
 
 
+def generate_ses_notification_callbacks(references, with_complaints=False):
+    messages = []
+
+    for i, ref in enumerate(references):
+        ses_message_body = {
+            "delivery": {
+                "processingTimeMillis": 2003,
+                "recipients": ["success@simulator.amazonses.com"],
+                "remoteMtaIp": "123.123.123.123",
+                "reportingMTA": "a7-32.smtp-out.eu-west-1.amazonses.com",
+                "smtpResponse": "250 2.6.0 Message received",
+                "timestamp": "2017-11-17T12:14:03.646Z",
+            },
+            "mail": {
+                "commonHeaders": {
+                    "from": ["TEST <TEST@notify.works>"],
+                    "subject": "lambda test",
+                    "to": ["success@simulator.amazonses.com"],
+                },
+                "destination": ["success@simulator.amazonses.com"],
+                "headers": [
+                    {"name": "From", "value": "TEST <TEST@notify.works>"},
+                    {"name": "To", "value": "success@simulator.amazonses.com"},
+                    {"name": "Subject", "value": "lambda test"},
+                    {"name": "MIME-Version", "value": "1.0"},
+                    {
+                        "name": "Content-Type",
+                        "value": 'multipart/alternative; boundary="----=_Part_617203_1627511946.1510920841645"',
+                    },
+                ],
+                "headersTruncated": False,
+                "messageId": ref,
+                "sendingAccountId": "12341234",
+                "source": '"TEST" <TEST@notify.works>',
+                "sourceArn": "arn:aws:ses:eu-west-1:12341234:identity/notify.works",
+                "sourceIp": "0.0.0.1",
+                "timestamp": "2017-11-17T12:14:01.643Z",
+            },
+            "notificationType": "Delivery",
+        }
+        if with_complaints and i % 2 == 1:
+            ses_message_body["notificationType"] = "Complaint"
+            ses_message_body["complaint"] = {
+                "complaintFeedbackType": "abuse",
+                "complainedRecipients": [{"emailAddress": "recipient1@example.com"}],
+                "timestamp": "2018-06-05T13:59:58.000Z",
+                "feedbackId": "ses_feedback_id",
+            }
+        messages.append(ses_message_body)
+    return {
+        "Type": "Notification",
+        "MessageId": "8e83c020-1234-1234-1234-92a8ee9baa0a",
+        "TopicArn": "arn:aws:sns:eu-west-1:12341234:ses_notifications",
+        "Subject": None,
+        "Messages": json.loads(json.dumps(messages)),
+        "Timestamp": "2017-11-17T12:14:03.710Z",
+        "SignatureVersion": "1",
+        "Signature": "[REDACTED]",
+        "SigningCertUrl": "https://sns.eu-west-1.amazonaws.com/SimpleNotificationService-[REDACTED].pem",
+        "UnsubscribeUrl": "https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=[REACTED]",
+        "MessageAttributes": {},
+    }
+
+
 def ses_notification_callback(reference):
     ses_message_body = {
         "delivery": {
@@ -55,7 +119,7 @@ def ses_notification_callback(reference):
         "MessageId": "8e83c020-1234-1234-1234-92a8ee9baa0a",
         "TopicArn": "arn:aws:sns:eu-west-1:12341234:ses_notifications",
         "Subject": None,
-        "Message": json.dumps(ses_message_body),
+        "Messages": [ses_message_body],
         "Timestamp": "2017-11-17T12:14:03.710Z",
         "SignatureVersion": "1",
         "Signature": "[REDACTED]",
@@ -88,7 +152,7 @@ def ses_complaint_callback_malformed_message_id():
         "Type": "Notification",
         "Timestamp": "2018-06-05T14:00:15.952Z",
         "Subject": None,
-        "Message": '{"notificationType":"Complaint","complaint":{"complainedRecipients":[{"emailAddress":"recipient1@example.com"}],"timestamp":"2018-06-05T13:59:58.000Z","feedbackId":"ses_feedback_id"},"mail":{"timestamp":"2018-06-05T14:00:15.950Z","source":"\\"Some Service\\" <someservicenotifications.service.gov.uk>","sourceArn":"arn:identity/notifications.service.gov.uk","sourceIp":"52.208.24.161","sendingAccountId":"888450439860","badMessageId":"ref1","destination":["recipient1@example.com"]}}',  # noqa
+        "Messages": '{"notificationType":"Complaint","complaint":{"complainedRecipients":[{"emailAddress":"recipient1@example.com"}],"timestamp":"2018-06-05T13:59:58.000Z","feedbackId":"ses_feedback_id"},"mail":{"timestamp":"2018-06-05T14:00:15.950Z","source":"\\"Some Service\\" <someservicenotifications.service.gov.uk>","sourceArn":"arn:identity/notifications.service.gov.uk","sourceIp":"52.208.24.161","sendingAccountId":"888450439860","badMessageId":"ref1","destination":["recipient1@example.com"]}}',  # noqa
         "SigningCertUrl": "https://sns.pem",
     }
 
@@ -107,7 +171,7 @@ def ses_complaint_callback_with_missing_complaint_type():
         "Type": "Notification",
         "Timestamp": "2018-06-05T14:00:15.952Z",
         "Subject": None,
-        "Message": '{"notificationType":"Complaint","complaint":{"complainedRecipients":[{"emailAddress":"recipient1@example.com"}],"timestamp":"2018-06-05T13:59:58.000Z","feedbackId":"ses_feedback_id"},"mail":{"timestamp":"2018-06-05T14:00:15.950Z","source":"\\"Some Service\\" <someservicenotifications.service.gov.uk>","sourceArn":"arn:identity/notifications.service.gov.uk","sourceIp":"52.208.24.161","sendingAccountId":"888450439860","messageId":"ref1","destination":["recipient1@example.com"]}}',  # noqa
+        "Messages": '{"notificationType":"Complaint","complaint":{"complainedRecipients":[{"emailAddress":"recipient1@example.com"}],"timestamp":"2018-06-05T13:59:58.000Z","feedbackId":"ses_feedback_id"},"mail":{"timestamp":"2018-06-05T14:00:15.950Z","source":"\\"Some Service\\" <someservicenotifications.service.gov.uk>","sourceArn":"arn:identity/notifications.service.gov.uk","sourceIp":"52.208.24.161","sendingAccountId":"888450439860","messageId":"ref1","destination":["recipient1@example.com"]}}',  # noqa
         "SigningCertUrl": "https://sns.pem",
     }
 
@@ -126,7 +190,9 @@ def ses_complaint_callback():
         "Type": "Notification",
         "Timestamp": "2018-06-05T14:00:15.952Z",
         "Subject": None,
-        "Message": '{"notificationType":"Complaint","complaint":{"complaintFeedbackType": "abuse", "complainedRecipients":[{"emailAddress":"recipient1@example.com"}],"timestamp":"2018-06-05T13:59:58.000Z","feedbackId":"ses_feedback_id"},"mail":{"timestamp":"2018-06-05T14:00:15.950Z","source":"\\"Some Service\\" <someservicenotifications.service.gov.uk>","sourceArn":"arn:identity/notifications.service.gov.uk","sourceIp":"52.208.24.161","sendingAccountId":"888450439860","messageId":"ref1","destination":["recipient1@example.com"]}}',  # noqa
+        "Messages": json.loads(
+            '[{"notificationType":"Complaint","complaint":{"complaintFeedbackType": "abuse", "complainedRecipients":[{"emailAddress":"recipient1@example.com"}],"timestamp":"2018-06-05T13:59:58.000Z","feedbackId":"ses_feedback_id"},"mail":{"timestamp":"2018-06-05T14:00:15.950Z","source":"\\"Some Service\\" <someservicenotifications.service.gov.uk>","sourceArn":"arn:identity/notifications.service.gov.uk","sourceIp":"52.208.24.161","sendingAccountId":"888450439860","messageId":"ref1","destination":["recipient1@example.com"]}}]'
+        ),  # noqa
         "SigningCertUrl": "https://sns.pem",
     }
 
@@ -145,7 +211,7 @@ def ses_complaint_callback_with_subtype(subtype):
         "Type": "Notification",
         "Timestamp": "2018-06-05T14:00:15.952Z",
         "Subject": None,
-        "Message": '{"notificationType":"Complaint","complaint":{"complaintFeedbackType": "abuse", "complainedRecipients":[{"emailAddress":"recipient1@example.com"}],"timestamp":"2018-06-05T13:59:58.000Z","feedbackId":"ses_feedback_id", "complaintSubType":"'
+        "Messages": '{"notificationType":"Complaint","complaint":{"complaintFeedbackType": "abuse", "complainedRecipients":[{"emailAddress":"recipient1@example.com"}],"timestamp":"2018-06-05T13:59:58.000Z","feedbackId":"ses_feedback_id", "complaintSubType":"'
         + subtype
         + '"},"mail":{"timestamp":"2018-06-05T14:00:15.950Z","source":"\\"Some Service\\" <someservicenotifications.service.gov.uk>","sourceArn":"arn:identity/notifications.service.gov.uk","sourceIp":"52.208.24.161","sendingAccountId":"888450439860","messageId":"ref1","destination":["recipient1@example.com"]}}',  # noqa
         "SigningCertUrl": "https://sns.pem",
@@ -370,7 +436,7 @@ def _ses_bounce_callback(reference, bounce_type, bounce_subtype=None):
         "MessageId": "36e67c28-1234-1234-1234-2ea0172aa4a7",
         "TopicArn": "arn:aws:sns:eu-west-1:12341234:ses_notifications",
         "Subject": None,
-        "Message": json.dumps(ses_message_body),
+        "Messages": [ses_message_body],
         "Timestamp": "2017-11-17T12:14:05.149Z",
         "SignatureVersion": "1",
         "Signature": "[REDACTED]",  # noqa

--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -108,7 +108,7 @@ class SESReceipt(TypedDict, total=False):
     send: Optional[SESSend]
 
 
-def handle_complaints(receipts: List[SESReceipt]) -> List[SESReceipt]:
+def handle_complaints(receipts: List[Tuple[SESReceipt, Notification]]) -> List[SESReceipt]:
     """Processes the current batch of notification receipts. Handles complaints, removing them from the batch
        and returning the remaining messages for further processing.
 

--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -1,6 +1,9 @@
+import json
+import time
 from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple, TypedDict, cast
 
-from flask import current_app, json
+from flask import current_app
 from notifications_utils.statsd_decorators import statsd
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -8,7 +11,7 @@ from app import annual_limit_client, bounce_rate_client, notify_celery, statsd_c
 from app.annual_limit_utils import get_annual_limit_notifications_v3
 from app.config import QueueNames
 from app.dao import notifications_dao
-from app.models import NOTIFICATION_DELIVERED, NOTIFICATION_PERMANENT_FAILURE
+from app.models import NOTIFICATION_DELIVERED, NOTIFICATION_PERMANENT_FAILURE, Notification
 from app.notifications.callbacks import _check_and_queue_callback_task
 from app.notifications.notifications_ses_callback import (
     _check_and_queue_complaint_callback_task,
@@ -18,11 +21,198 @@ from app.notifications.notifications_ses_callback import (
 from celery.exceptions import Retry
 
 
-# Celery rate limits are per worker instance and not a global rate limit.
-# https://docs.celeryproject.org/en/stable/userguide/tasks.html#Task.rate_limit
-# This queue is consumed by 6 Celery instances with 4 workers in production.
-# The maximum throughput is therefore 6 instances * 4 workers * 30 tasks = 720 tasks / minute
-# if we set rate_limit="30/m" on the Celery task
+class SESMail(TypedDict):
+    """Structure of the 'mail' field in SES notification receipts"""
+
+    timestamp: str
+    source: str
+    sourceArn: str
+    sourceIp: str
+    callerIdentity: str
+    sendingAccountId: str
+    messageId: str
+    destination: List[str]
+
+
+class SESDelivery(TypedDict, total=False):
+    """Structure of the 'delivery' field in SES delivery notification receipts"""
+
+    timestamp: str
+    processingTimeMillis: int
+    recipients: List[str]
+    smtpResponse: str
+    remoteMtaIp: str
+    reportingMTA: str
+
+
+class SESBounce(TypedDict, total=False):
+    """Structure of the 'bounce' field in SES bounce notification receipts"""
+
+    bounceType: str
+    bounceSubType: str
+    bouncedRecipients: List[Dict[str, str]]
+    timestamp: str
+    feedbackId: str
+
+
+class SESComplaint(TypedDict, total=False):
+    """Structure of the 'complaint' field in SES complaint notification receipts"""
+
+    complainedRecipients: List[Dict[str, str]]
+    timestamp: str
+    feedbackId: str
+    complaintSubType: str
+    complaintFeedbackType: str
+
+
+class SESReceipt(TypedDict):
+    """Structure of SES notification receipts"""
+
+    notificationType: str
+    mail: SESMail
+    delivery: Optional[SESDelivery]
+    bounce: Optional[SESBounce]
+    complaint: Optional[SESComplaint]
+
+
+def handle_complaints_and_extract_ref_ids(messages: List[SESReceipt]) -> Tuple[List[str], List[SESReceipt]]:
+    """Processes the current batch of notification receipts. Handles complaints, removing them from the batch
+       and returning the remaining messages for further processing.
+
+    Args:
+        messages (List[SESReceipt]): List of SES messages received from the SQS receipt buffer queue.
+
+    Returns:
+        Tuple[List[str], List[SESReceipt]]: A tuple containing a list of notification reference IDs and a reduced list of
+        SES messages not containing any complaint receipts.
+    """
+    ref_ids = []
+    complaint_free_messages = []
+    current_app.logger.info(f"[batch-celery] - Received: {len(messages)} receipts from Lambda.. beginning processing")
+    for message in messages:
+        notification_type = message["notificationType"]
+        if notification_type == "Complaint":
+            current_app.logger.info(f"[batch-celery] - Handling complaint: {message}")
+            _check_and_queue_complaint_callback_task(*handle_complaint(message))
+        else:
+            ref_ids.append(message["mail"]["messageId"])
+            complaint_free_messages.append(message)
+    current_app.logger.info(f"[batch-celery] - Complaints handled, processing: {len(complaint_free_messages)} remaining receipts")
+    return ref_ids, complaint_free_messages
+
+
+def fetch_notifications(ref_ids: List[str]) -> Optional[List[Notification]]:
+    """Fetch notifications by reference IDs."""
+    try:
+        return notifications_dao.dao_get_notifications_by_references(ref_ids)
+    except NoResultFound:
+        return None
+    except Exception as e:
+        raise e
+
+
+def categorize_receipts(
+    ses_messages: List[SESReceipt], notifications: List[Notification]
+) -> Tuple[List[Tuple[SESReceipt, Notification]], List[SESReceipt]]:
+    """Categorize SES messages into those with and without notifications."""
+    receipts_with_notification = []
+    receipts_with_no_notification = []
+    notification_map = {n.reference: n for n in notifications}
+
+    for message in ses_messages:
+        message_id = message["mail"]["messageId"]
+        notification = notification_map.get(message_id)
+        if notification:
+            receipts_with_notification.append((message, notification))
+        else:
+            receipts_with_no_notification.append(message)
+
+    return receipts_with_notification, receipts_with_no_notification
+
+
+def process_notifications(
+    receipts_with_notification: List[Tuple[SESReceipt, Notification]],
+) -> List[Tuple[SESReceipt, Notification, Dict[str, Any]]]:
+    """Process notifications and update their statuses."""
+    updates = []
+    receipts_with_notification_and_aws_response_dict = []
+    for message, notification in receipts_with_notification:
+        aws_response_dict = get_aws_responses(message)
+        new_status = aws_response_dict["notification_status"]
+
+        if not (notification.status == NOTIFICATION_PERMANENT_FAILURE and new_status == NOTIFICATION_DELIVERED):
+            updates.append(
+                {
+                    "notification": notification,
+                    "new_status": new_status,
+                    "provider_response": aws_response_dict.get("provider_response"),
+                    "bounce_response": aws_response_dict.get("bounce_response"),
+                }
+            )
+        receipts_with_notification_and_aws_response_dict.append((message, notification, aws_response_dict))
+        current_app.logger.info(f"[batch-celery] process_notifications - updates: {len(updates)}")
+    notifications_dao._update_notification_statuses(updates)
+    return receipts_with_notification_and_aws_response_dict
+
+
+def update_annual_limit_and_bounce_rate(
+    receipt: SESReceipt, notification: Notification, aws_response_dict: Dict[str, Any]
+) -> None:
+    new_status = aws_response_dict["notification_status"]
+    is_success = aws_response_dict["success"]
+    log_prefix = f"SES callback for notification {notification.id} reference {notification.reference} for service {notification.service_id}: "
+    # Check if we have already seeded the annual limit counts for today, if we have we do not need to increment later on.
+    # We seed AFTER updating the notification status, thus the current notification will already be counted.
+
+    _, did_we_seed = get_annual_limit_notifications_v3(notification.service_id)
+    current_app.logger.info(f"[alimit-debug] did_we_seed: {did_we_seed}, data: {_}")
+
+    if not is_success:
+        current_app.logger.info(f"{log_prefix} Delivery failed with error: {aws_response_dict["message"]}")
+
+        if not did_we_seed:
+            annual_limit_client.increment_email_failed(notification.service_id)
+            current_app.logger.info(
+                f"Incremented email_failed count in Redis. Service: {notification.service_id} Notification: {notification.id} Current counts: {annual_limit_client.get_all_notification_counts(notification.service_id)}"
+            )
+    else:
+        current_app.logger.info(
+            f"{log_prefix} Delivery status: {new_status}" "SES callback return status of {} for notification: {}".format(
+                new_status, notification.id
+            )
+        )
+
+        if not did_we_seed:
+            annual_limit_client.increment_email_delivered(notification.service_id)
+            current_app.logger.info(
+                f"Incremented email_delivered count in Redis. Service: {notification.service_id} Notification: {notification.id} current counts: {annual_limit_client.get_all_notification_counts(notification.service_id)}"
+            )
+
+    statsd_client.incr("callback.ses.{}".format(new_status))
+
+    if new_status == NOTIFICATION_PERMANENT_FAILURE:
+        bounce_rate_client.set_sliding_hard_bounce(notification.service_id, str(notification.id))
+        current_app.logger.info(
+            f"Setting total hard bounce notifications for service {notification.service_id} with notification {notification.id} in REDIS"
+        )
+
+    if notification.sent_at:
+        statsd_client.timing_with_dates("callback.ses.elapsed-time", datetime.utcnow(), notification.sent_at)
+
+
+def handle_retries(self, receipts_with_no_notification: List[SESReceipt]) -> None:
+    """Handle retries for receipts without notifications."""
+    retry_ids = ", ".join([msg["mail"]["messageId"] for msg in receipts_with_no_notification])
+    try:
+        current_app.logger.warning(
+            f"RETRY {self.request.retries}: notifications not found for SES references {retry_ids}. "
+            f"Callback may have arrived before notification was persisted to the DB. Adding task to retry queue"
+        )
+        self.retry(queue=QueueNames.RETRY, args=[{"Messages": receipts_with_no_notification}])
+    except self.MaxRetriesExceededError:
+        current_app.logger.warning(f"notifications not found for SES references: {retry_ids}. Giving up.")
+
+
 @notify_celery.task(
     bind=True,
     name="process-ses-result",
@@ -30,119 +220,39 @@ from celery.exceptions import Retry
     default_retry_delay=300,
 )
 @statsd(namespace="tasks")
-def process_ses_results(self, response):  # noqa: C901
-    # initialize these to None so error handling is simpler
-    notification = None
-    reference = None
-    notification_status = None
+def process_ses_results(self, response: Dict[str, Any]) -> Optional[bool]:
+    start_time = time.time()  # TODO : Remove after benchmarking
+    receipts = response["Messages"] if "Messages" in response else [json.loads(response["Message"])]
 
     try:
-        ses_message = json.loads(response["Message"])
-        notification_type = ses_message["notificationType"]
+        ref_ids, ses_messages = handle_complaints_and_extract_ref_ids(cast(List[SESReceipt], receipts))
+        if not ses_messages:
+            return True
 
-        try:
-            if notification_type == "Complaint":
-                _check_and_queue_complaint_callback_task(*handle_complaint(ses_message))
-                return True
+        notifications = fetch_notifications(ref_ids)
+        if notifications is None:
+            handle_retries(self, ses_messages)
+            return None
 
-            reference = ses_message["mail"]["messageId"]
-            notification = notifications_dao.dao_get_notification_by_reference(reference)
-        except NoResultFound:
-            try:
-                current_app.logger.warning(
-                    f"RETRY {self.request.retries}: notification not found for SES reference {reference}. "
-                    f"Callback may have arrived before notification was persisted to the DB. Adding task to retry queue"
-                )
-                self.retry(queue=QueueNames.RETRY)
-            except self.MaxRetriesExceededError:
-                current_app.logger.warning(f"notification not found for SES reference: {reference}. Giving up.")
-            return
-        except Exception as e:
-            try:
-                current_app.logger.warning(
-                    f"RETRY {self.request.retries}: notification not found for SES reference {reference}. "
-                    f"There was an Error: {e}. Adding task to retry queue"
-                )
-                self.retry(queue=QueueNames.RETRY)
-            except self.MaxRetriesExceededError:
-                current_app.logger.warning(
-                    f"notification not found for SES reference: {reference}. Error has persisted > number of retries. Giving up."
-                )
-            return
+        receipts_with_notification, receipts_with_no_notification = categorize_receipts(ses_messages, notifications)
+        receipts_with_notification_and_aws_response_dict = process_notifications(receipts_with_notification)
 
-        aws_response_dict = get_aws_responses(ses_message)
-        notification_status = aws_response_dict["notification_status"]
-        # Sometimes we get callback from the providers in the wrong order. If the notification has a
-        # permanent failure status, we don't want to overwrite it with a delivered status.
-        if notification.status == NOTIFICATION_PERMANENT_FAILURE and notification_status == NOTIFICATION_DELIVERED:
-            pass
-        else:
-            notifications_dao._update_notification_status(
-                notification=notification,
-                status=notification_status,
-                provider_response=aws_response_dict.get("provider_response", None),
-                bounce_response=aws_response_dict.get("bounce_response", None),
-            )
+        for message, notification, aws_response_dict in receipts_with_notification_and_aws_response_dict:
+            update_annual_limit_and_bounce_rate(message, notification, aws_response_dict)
+            _check_and_queue_callback_task(notification)
 
-        service_id = notification.service_id
-        # Flags if seeding has occurred. Since we seed after updating the notification status in the DB then the current notification
-        # is included in the fetch_notification_status_for_service_for_day call below, thus we don't need to increment the count.
+        if receipts_with_no_notification:
+            handle_retries(self, receipts_with_no_notification)
 
-        # Check if we have already seeded the annual limit counts for today
-        _, did_we_seed = get_annual_limit_notifications_v3(service_id)
-        current_app.logger.info(f"[alimit-debug] did_we_seed: {did_we_seed}, data: {_}")
-
-        if not aws_response_dict["success"]:
-            current_app.logger.info(
-                "SES delivery failed: notification id {} and reference {} has error found. Status {}".format(
-                    notification.id, reference, aws_response_dict["message"]
-                )
-            )
-            if current_app.config["FF_ANNUAL_LIMIT"]:
-                # Only increment if we didn't just seed.
-                if not did_we_seed:
-                    annual_limit_client.increment_email_failed(notification.service_id)
-                current_app.logger.info(
-                    f"Incremented email_failed count in Redis. Service: {notification.service_id} Notification: {notification.id} Current counts: {annual_limit_client.get_all_notification_counts(notification.service_id)}"
-                )
-        else:
-            current_app.logger.info(
-                "SES callback return status of {} for notification: {}".format(notification_status, notification.id)
-            )
-            if current_app.config["FF_ANNUAL_LIMIT"]:
-                # Only increment if we didn't just seed.
-                if not did_we_seed:
-                    annual_limit_client.increment_email_delivered(notification.service_id)
-                current_app.logger.info(
-                    f"Incremented email_delivered count in Redis. Service: {notification.service_id} Notification: {notification.id} current counts: {annual_limit_client.get_all_notification_counts(notification.service_id)}"
-                )
-
-        statsd_client.incr("callback.ses.{}".format(notification_status))
-
-        if notification_status == NOTIFICATION_PERMANENT_FAILURE:
-            bounce_rate_client.set_sliding_hard_bounce(notification.service_id, str(notification.id))
-            current_app.logger.info(
-                f"Setting total hard bounce notifications for service {notification.service.id} with notification {notification.id} in REDIS"
-            )
-
-        if notification.sent_at:
-            statsd_client.timing_with_dates("callback.ses.elapsed-time", datetime.utcnow(), notification.sent_at)
-
-        _check_and_queue_callback_task(notification)
-
+        end_time = time.time()
+        current_app.logger.info(f"[batch-celery] - process_ses_results took {end_time - start_time} seconds")
         return True
 
     except Retry:
+        end_time = time.time()
+        current_app.logger.info(f"[batch-celery] Retry - process_ses_results took {end_time - start_time} seconds")
         raise
-
-    except Exception as e:
-        notifcation_msg = "Notification ID: {}".format(notification.id) if notification else "No notification"
-        notification_status_msg = (
-            "Notification status: {}".format(notification_status) if notification_status else "No notification status"
-        )
-        ref_msg = "Reference ID: {}".format(reference) if reference else "No reference"
-
-        current_app.logger.exception(
-            "Error processing SES results: {} [{}, {}, {}]".format(type(e), notifcation_msg, notification_status_msg, ref_msg)
-        )
-        self.retry(queue=QueueNames.RETRY)
+    except Exception:
+        current_app.logger.exception(f"Error processing SES results for receipt batch: {response['Messages']}")
+        self.retry(queue=QueueNames.RETRY, args=[{"Messages": receipts}])
+        return None

--- a/app/notifications/notifications_ses_callback.py
+++ b/app/notifications/notifications_ses_callback.py
@@ -197,6 +197,10 @@ def remove_emails_from_bounce(bounce_dict):
 
 def remove_emails_from_complaint(complaint_dict):
     remove_mail_headers(complaint_dict)
+    # If the complaint is because the email address is on the suppression list, there will be no
+    # complainedRecipients in the SES message from which we can get the email address.
+    if complaint_dict["complaint"].get("complaintSubType") == "OnAccountSuppressionList":
+        return None
     complaint_dict["complaint"].pop("complainedRecipients")
     return complaint_dict["mail"].pop("destination")
 

--- a/app/notifications/notifications_ses_callback.py
+++ b/app/notifications/notifications_ses_callback.py
@@ -148,8 +148,8 @@ def handle_complaint(ses_message):
     current_app.logger.info("Complaint from SES: \n{}".format(json.dumps(ses_message).replace("{", "(").replace("}", ")")))
     try:
         reference = ses_message["mail"]["messageId"]
-    except KeyError as e:
-        current_app.logger.exception("Complaint from SES failed to get reference from message", e)
+    except KeyError:
+        current_app.logger.exception("Complaint from SES failed to get reference from message")
         return
     notification = dao_get_notification_history_by_reference(reference)
     ses_complaint = ses_message.get("complaint", None)

--- a/app/notifications/notifications_ses_callback.py
+++ b/app/notifications/notifications_ses_callback.py
@@ -144,7 +144,8 @@ def get_aws_responses(ses_message):
 
 
 def handle_complaint(ses_message):
-    recipient_email = remove_emails_from_complaint(ses_message)[0]
+    recipient_emails = remove_emails_from_complaint(ses_message)
+    recipient_email = recipient_emails[0] if recipient_emails else None
     current_app.logger.info("Complaint from SES: \n{}".format(json.dumps(ses_message).replace("{", "(").replace("}", ")")))
     try:
         reference = ses_message["mail"]["messageId"]

--- a/app/notifications/notifications_ses_callback.py
+++ b/app/notifications/notifications_ses_callback.py
@@ -151,7 +151,7 @@ def handle_complaint(ses_message, notification):
         ses_message["mail"]["messageId"]
     except KeyError as e:
         current_app.logger.exception("Complaint from SES failed to get reference from message", e)
-        return
+        return None
 
     ses_complaint = ses_message.get("complaint", None)
 

--- a/app/notifications/notifications_ses_callback.py
+++ b/app/notifications/notifications_ses_callback.py
@@ -5,7 +5,6 @@ from app.config import QueueNames
 from app.dao.complaint_dao import save_complaint
 from app.dao.notifications_dao import (
     _update_notification_status,
-    dao_get_notification_history_by_reference,
 )
 from app.dao.service_callback_api_dao import (
     get_service_complaint_callback_api_for_service,
@@ -143,16 +142,10 @@ def get_aws_responses(ses_message):
     return base
 
 
-def handle_complaint(ses_message):
+def handle_complaint(ses_message, notification):
     recipient_emails = remove_emails_from_complaint(ses_message)
     recipient_email = recipient_emails[0] if recipient_emails else None
     current_app.logger.info("Complaint from SES: \n{}".format(json.dumps(ses_message).replace("{", "(").replace("}", ")")))
-    try:
-        reference = ses_message["mail"]["messageId"]
-    except KeyError:
-        current_app.logger.exception("Complaint from SES failed to get reference from message")
-        return
-    notification = dao_get_notification_history_by_reference(reference)
     ses_complaint = ses_message.get("complaint", None)
 
     complaint = Complaint(

--- a/app/notifications/notifications_ses_callback.py
+++ b/app/notifications/notifications_ses_callback.py
@@ -146,6 +146,13 @@ def handle_complaint(ses_message, notification):
     recipient_emails = remove_emails_from_complaint(ses_message)
     recipient_email = recipient_emails[0] if recipient_emails else None
     current_app.logger.info("Complaint from SES: \n{}".format(json.dumps(ses_message).replace("{", "(").replace("}", ")")))
+
+    try:
+        ses_message["mail"]["messageId"]
+    except KeyError as e:
+        current_app.logger.exception("Complaint from SES failed to get reference from message", e)
+        return
+
     ses_complaint = ses_message.get("complaint", None)
 
     complaint = Complaint(

--- a/tests/app/celery/test_process_ses_receipts_tasks.py
+++ b/tests/app/celery/test_process_ses_receipts_tasks.py
@@ -150,6 +150,7 @@ def test_ses_callback_dont_change_hard_bounce_status(sample_template, mocker):
         mocker.patch("app.statsd_client.incr")
         mocker.patch("app.statsd_client.timing_with_dates")
         mocker.patch("app.celery.service_callback_tasks.send_delivery_status_to_service.apply_async")
+        mocker.patch("app.celery.process_ses_receipts_tasks.get_annual_limit_notifications_v3", return_value=({}, False))
         notification = save_notification(
             create_notification(
                 sample_template,
@@ -278,6 +279,7 @@ def test_ses_callback_should_update_multiple_notification_status_sent(
 def test_ses_callback_should_only_enqueue_failed_updates_for_retry(notify_db, notify_db_session, sample_email_template, mocker):
     mock_send = mocker.patch("app.celery.service_callback_tasks.send_delivery_status_to_service.apply_async")
     mock_retry: Mock = mocker.patch("app.celery.process_ses_receipts_tasks.process_ses_results.retry")
+    mocker.patch("app.celery.process_ses_receipts_tasks.get_annual_limit_notifications_v3", return_value=({}, False))
     callbacks = generate_ses_notification_callbacks(references=["ref1", "ref2", "ref3", "ref4", "ref5"])
     ids_to_retry = ["ref4", "ref5"]
     retry_args = [{"Messages": list(filter(lambda x: x["mail"]["messageId"] in ids_to_retry, callbacks["Messages"]))}]

--- a/tests/app/celery/test_process_ses_receipts_tasks.py
+++ b/tests/app/celery/test_process_ses_receipts_tasks.py
@@ -1,5 +1,6 @@
 import json
 from datetime import datetime
+from unittest.mock import Mock
 
 import pytest
 from freezegun import freeze_time
@@ -12,7 +13,7 @@ from tests.app.db import (
 from tests.conftest import set_config
 
 from app import annual_limit_client, bounce_rate_client, signer_complaint, statsd_client
-from app.aws.mocks import ses_complaint_callback, ses_unknown_bounce_callback
+from app.aws.mocks import generate_ses_notification_callbacks, ses_complaint_callback, ses_unknown_bounce_callback
 from app.celery.process_ses_receipts_tasks import process_ses_results
 from app.celery.research_mode_tasks import (
     ses_hard_bounce_callback,
@@ -47,16 +48,20 @@ from celery.exceptions import MaxRetriesExceededError
 
 def test_process_ses_results(sample_email_template, mocker):
     mocker.patch("app.celery.process_ses_receipts_tasks.get_annual_limit_notifications_v3", return_value=({}, False))
-    save_notification(
-        create_notification(
-            sample_email_template,
-            reference="ref1",
-            sent_at=datetime.utcnow(),
-            status="sending",
+    refs = []
+    for i in range(10):
+        ref = f"ref{i}"
+        save_notification(
+            create_notification(
+                sample_email_template,
+                reference=ref,
+                sent_at=datetime.utcnow(),
+                status="sending",
+            )
         )
-    )
+        refs.append(ref)
 
-    assert process_ses_results(response=ses_notification_callback(reference="ref1"))
+    assert process_ses_results(response=generate_ses_notification_callbacks(references=refs))
 
 
 def test_process_ses_results_retry_called(sample_email_template, notify_db, mocker):
@@ -70,7 +75,7 @@ def test_process_ses_results_retry_called(sample_email_template, notify_db, mock
     )
 
     mocker.patch(
-        "app.dao.notifications_dao._update_notification_status",
+        "app.dao.notifications_dao._update_notification_statuses",
         side_effect=Exception("EXPECTED"),
     )
     mocked = mocker.patch("app.celery.process_ses_receipts_tasks.process_ses_results.retry")
@@ -89,13 +94,13 @@ def test_process_ses_results_in_complaint(sample_email_template, mocker):
 
 
 def test_remove_emails_from_complaint():
-    test_json = json.loads(ses_complaint_callback()["Message"])
+    test_json = ses_complaint_callback()["Messages"][0]
     remove_emails_from_complaint(test_json)
     assert "recipient1@example.com" not in json.dumps(test_json)
 
 
 def test_remove_email_from_bounce():
-    test_json = json.loads(ses_hard_bounce_callback(reference="ref1")["Message"])
+    test_json = ses_hard_bounce_callback(reference="ref1")["Messages"][0]
     remove_emails_from_bounce(test_json)
     assert "bounce@simulator.amazonses.com" not in json.dumps(test_json)
 
@@ -116,7 +121,7 @@ def test_ses_callback_should_update_notification_status(notify_db, notify_db_ses
         callback_api = create_service_callback_api(service=sample_email_template.service, url="https://original_url.com")
         assert get_notification_by_id(notification.id).status == "sending"
 
-        assert process_ses_results(ses_notification_callback(reference="ref"))
+        assert process_ses_results(generate_ses_notification_callbacks(references=["ref"]))
         notification = get_notification_by_id(notification.id)
         assert notification.status == "delivered"
         assert notification.provider_response is None
@@ -143,7 +148,7 @@ def test_ses_callback_dont_change_hard_bounce_status(sample_template, mocker):
         )
         notification = get_notification_by_id(notification.id)
         assert notification.status == NOTIFICATION_PERMANENT_FAILURE
-        assert process_ses_results(ses_notification_callback(reference="ref"))
+        assert process_ses_results(generate_ses_notification_callbacks(references=["ref"]))
         notification = get_notification_by_id(notification.id)
         assert notification.status == NOTIFICATION_PERMANENT_FAILURE
 
@@ -194,8 +199,8 @@ def test_ses_callback_should_give_up_after_max_tries(notify_db, mocker):
     )
     mock_logger = mocker.patch("app.celery.process_ses_receipts_tasks.current_app.logger.warning")
 
-    assert process_ses_results(ses_notification_callback(reference="ref")) is None
-    mock_logger.assert_called_with("notification not found for SES reference: ref. Giving up.")
+    assert process_ses_results(generate_ses_notification_callbacks(references=["ref"])) is None
+    mock_logger.assert_called_with("notifications not found for SES references: ref. Giving up.")
 
 
 def test_ses_callback_does_not_call_send_delivery_status_if_no_db_entry(
@@ -215,7 +220,7 @@ def test_ses_callback_does_not_call_send_delivery_status_if_no_db_entry(
 
         assert get_notification_by_id(notification.id).status == "sending"
 
-        assert process_ses_results(ses_notification_callback(reference="ref"))
+        assert process_ses_results(generate_ses_notification_callbacks(references=["ref"]))
         notification = get_notification_by_id(notification.id)
         assert notification.status == "delivered"
         assert notification.provider_response is None
@@ -254,10 +259,49 @@ def test_ses_callback_should_update_multiple_notification_status_sent(
         status="sending",
     )
     create_service_callback_api(service=sample_email_template.service, url="https://original_url.com")
-    assert process_ses_results(ses_notification_callback(reference="ref1"))
-    assert process_ses_results(ses_notification_callback(reference="ref2"))
-    assert process_ses_results(ses_notification_callback(reference="ref3"))
+    assert process_ses_results(generate_ses_notification_callbacks(references=["ref1", "ref2", "ref3"]))
+
     assert send_mock.called
+
+
+def test_ses_callback_should_only_enqueue_failed_updates_for_retry(notify_db, notify_db_session, sample_email_template, mocker):
+    mock_send = mocker.patch("app.celery.service_callback_tasks.send_delivery_status_to_service.apply_async")
+    mock_retry: Mock = mocker.patch("app.celery.process_ses_receipts_tasks.process_ses_results.retry")
+    callbacks = generate_ses_notification_callbacks(references=["ref1", "ref2", "ref3", "ref4", "ref5"])
+    ids_to_retry = ["ref4", "ref5"]
+    retry_args = [{"Messages": list(filter(lambda x: x["mail"]["messageId"] in ids_to_retry, callbacks["Messages"]))}]
+
+    create_sample_notification(
+        notify_db,
+        notify_db_session,
+        template=sample_email_template,
+        reference="ref1",
+        sent_at=datetime.utcnow(),
+        status="sending",
+    )
+
+    create_sample_notification(
+        notify_db,
+        notify_db_session,
+        template=sample_email_template,
+        reference="ref2",
+        sent_at=datetime.utcnow(),
+        status="sending",
+    )
+
+    create_sample_notification(
+        notify_db,
+        notify_db_session,
+        template=sample_email_template,
+        reference="ref3",
+        sent_at=datetime.utcnow(),
+        status="sending",
+    )
+    create_service_callback_api(service=sample_email_template.service, url="https://original_url.com")
+    assert process_ses_results(callbacks)
+    assert mock_retry.call_args[1]["queue"] == "retry-tasks"
+    assert mock_retry.call_args[1]["args"] == retry_args
+    assert mock_send.call_count == 3
 
 
 @pytest.mark.parametrize(

--- a/tests/app/celery/test_process_sns_receipts_tasks.py
+++ b/tests/app/celery/test_process_sns_receipts_tasks.py
@@ -31,6 +31,7 @@ from celery.exceptions import MaxRetriesExceededError
 
 
 def test_process_sns_results_delivered(sample_template, notify_db, notify_db_session, mocker):
+    mocker.patch("app.celery.process_sns_receipts_tasks.get_annual_limit_notifications_v3", return_value=({}, False))
     mock_logger = mocker.patch("app.celery.process_sns_receipts_tasks.current_app.logger.info")
 
     notification = create_sample_notification(

--- a/tests/app/celery/test_process_sns_receipts_tasks.py
+++ b/tests/app/celery/test_process_sns_receipts_tasks.py
@@ -175,6 +175,7 @@ def test_process_sns_results_calls_service_callback(sample_template, notify_db_s
     with freeze_time("2021-01-01T12:00:00"):
         mocker.patch("app.statsd_client.incr")
         mocker.patch("app.statsd_client.timing_with_dates")
+        mocker.patch("app.celery.process_sns_receipts_tasks.get_annual_limit_notifications_v3", return_value=({}, False))
         send_mock = mocker.patch("app.celery.service_callback_tasks.send_delivery_status_to_service.apply_async")
         notification = create_sample_notification(
             notify_db,

--- a/tests/app/notifications/test_notifications_ses_callback.py
+++ b/tests/app/notifications/test_notifications_ses_callback.py
@@ -185,20 +185,21 @@ def test_ses_callback_should_not_set_status_once_status_is_delivered(
 
 def test_process_ses_results_in_complaint(sample_email_template):
     notification = save_notification(create_notification(template=sample_email_template, reference="ref1"))
-    handle_complaint(json.loads(ses_complaint_callback()["Message"]))
+    handle_complaint(ses_complaint_callback()["Messages"][0])
     complaints = Complaint.query.all()
     assert len(complaints) == 1
     assert complaints[0].notification_id == notification.id
 
 
 def test_handle_complaint_does_not_raise_exception_if_reference_is_missing(notify_api):
-    response = json.loads(ses_complaint_callback_malformed_message_id()["Message"])
+    response = json.loads(ses_complaint_callback_malformed_message_id()["Messages"])
     handle_complaint(response)
-    assert len(Complaint.query.all()) == 0
+    complaints = Complaint.query.all()
+    assert len(complaints) == 0
 
 
 def test_handle_complaint_does_raise_exception_if_notification_not_found(notify_api):
-    response = json.loads(ses_complaint_callback()["Message"])
+    response = ses_complaint_callback()["Messages"][0]
     with pytest.raises(expected_exception=SQLAlchemyError):
         handle_complaint(response)
 
@@ -207,7 +208,7 @@ def test_process_ses_results_in_complaint_if_notification_history_does_not_exist
     sample_email_template,
 ):
     notification = save_notification(create_notification(template=sample_email_template, reference="ref1"))
-    handle_complaint(json.loads(ses_complaint_callback()["Message"]))
+    handle_complaint(ses_complaint_callback()["Messages"][0])
     complaints = Complaint.query.all()
     assert len(complaints) == 1
     assert complaints[0].notification_id == notification.id
@@ -217,7 +218,7 @@ def test_process_ses_results_in_complaint_if_notification_does_not_exist(
     sample_email_template,
 ):
     notification = create_notification_history(template=sample_email_template, reference="ref1")
-    handle_complaint(json.loads(ses_complaint_callback()["Message"]))
+    handle_complaint(ses_complaint_callback()["Messages"][0])
     complaints = Complaint.query.all()
     assert len(complaints) == 1
     assert complaints[0].notification_id == notification.id
@@ -225,7 +226,7 @@ def test_process_ses_results_in_complaint_if_notification_does_not_exist(
 
 def test_process_ses_results_in_complaint_save_complaint_with_null_complaint_type(notify_api, sample_email_template):
     notification = save_notification(create_notification(template=sample_email_template, reference="ref1"))
-    msg = json.loads(ses_complaint_callback_with_missing_complaint_type()["Message"])
+    msg = json.loads(ses_complaint_callback_with_missing_complaint_type()["Messages"])
     handle_complaint(msg)
     complaints = Complaint.query.all()
     assert len(complaints) == 1
@@ -237,7 +238,7 @@ def test_account_suppression_list_complaint_updates_notification_status(sample_e
     notification = save_notification(create_notification(template=sample_email_template, reference="ref1"))
     assert get_notification_by_id(notification.id).status == "created"
 
-    handle_complaint(json.loads(ses_complaint_callback_with_subtype("OnAccountSuppressionList")["Message"]))
+    handle_complaint(json.loads(ses_complaint_callback_with_subtype("OnAccountSuppressionList")["Messages"]))
     complaints = Complaint.query.all()
 
     assert len(complaints) == 1
@@ -249,7 +250,7 @@ def test_regular_complaint_does_not_update_notification_status(sample_email_temp
     notification = save_notification(create_notification(template=sample_email_template, reference="ref1"))
     status = get_notification_by_id(notification.id).status
 
-    handle_complaint(json.loads(ses_complaint_callback_with_missing_complaint_type()["Message"]))
+    handle_complaint(json.loads(ses_complaint_callback_with_missing_complaint_type()["Messages"]))
     complaints = Complaint.query.all()
 
     assert len(complaints) == 1
@@ -365,9 +366,9 @@ class TestBounceRates:
     )
     def test_bounce_types(self, notify_api, bounceType, bounceSubType, expected_bounce_classification):
         if bounceType == "Permanent":
-            bounce_message = json.loads(ses_hard_bounce_callback(reference="ref", bounce_subtype=bounceSubType)["Message"])
+            bounce_message = ses_hard_bounce_callback(reference="ref", bounce_subtype=bounceSubType)["Messages"][0]
         elif bounceType == "Transient" or bounceType == "Undetermined":
-            bounce_message = json.loads(ses_soft_bounce_callback(reference="ref", bounce_subtype=bounceSubType)["Message"])
+            bounce_message = ses_soft_bounce_callback(reference="ref", bounce_subtype=bounceSubType)["Messages"][0]
             if bounceType == "Undetermined":
                 bounce_message["bounce"]["bounceType"] = "Undetermined"
 

--- a/tests/app/notifications/test_notifications_ses_callback.py
+++ b/tests/app/notifications/test_notifications_ses_callback.py
@@ -185,7 +185,7 @@ def test_ses_callback_should_not_set_status_once_status_is_delivered(
 
 def test_process_ses_results_in_complaint(sample_email_template):
     notification = save_notification(create_notification(template=sample_email_template, reference="ref1"))
-    handle_complaint(ses_complaint_callback()["Messages"][0])
+    handle_complaint(ses_complaint_callback()["Messages"][0], notification)
     complaints = Complaint.query.all()
     assert len(complaints) == 1
     assert complaints[0].notification_id == notification.id
@@ -218,7 +218,7 @@ def test_process_ses_results_in_complaint_if_notification_does_not_exist(
     sample_email_template,
 ):
     notification = create_notification_history(template=sample_email_template, reference="ref1")
-    handle_complaint(ses_complaint_callback()["Messages"][0])
+    handle_complaint(ses_complaint_callback()["Messages"][0], notification)
     complaints = Complaint.query.all()
     assert len(complaints) == 1
     assert complaints[0].notification_id == notification.id
@@ -238,7 +238,7 @@ def test_account_suppression_list_complaint_updates_notification_status(sample_e
     notification = save_notification(create_notification(template=sample_email_template, reference="ref1"))
     assert get_notification_by_id(notification.id).status == "created"
 
-    handle_complaint(json.loads(ses_complaint_callback_with_subtype("OnAccountSuppressionList")["Messages"]))
+    handle_complaint(json.loads(ses_complaint_callback_with_subtype("OnAccountSuppressionList")["Messages"]), notification)
     complaints = Complaint.query.all()
 
     assert len(complaints) == 1
@@ -250,7 +250,7 @@ def test_regular_complaint_does_not_update_notification_status(sample_email_temp
     notification = save_notification(create_notification(template=sample_email_template, reference="ref1"))
     status = get_notification_by_id(notification.id).status
 
-    handle_complaint(json.loads(ses_complaint_callback_with_missing_complaint_type()["Messages"]))
+    handle_complaint(json.loads(ses_complaint_callback_with_missing_complaint_type()["Messages"]), notification)
     complaints = Complaint.query.all()
 
     assert len(complaints) == 1


### PR DESCRIPTION
Reverts cds-snc/notification-api#2537

### New additions / bug fixes since the last revert:
- Added [missing receipt payload attributes](https://github.com/cds-snc/notification-api/pull/2538/commits/4757496fd069b82decbac3d793c3947c85eb547a) to our typed receipt classes, mitigating the potential for data loss when marshalling the raw receipt JSON into the typed data structures.
- Fixed a [typing issue](https://github.com/cds-snc/notification-api/pull/2538/commits/7f484f2bbd355863dd180fba4935158905b70403#diff-6da9ce98a04287a9303a293329834f04247e54bccb8ab2483969918bdc0b5ecbR147) that caused crashes during complaint receipt handling if the receipt did not contain a list of complainedRecipients
- [Refactored how we handle complaints when it's associated notification is not yet in the DB](https://github.com/cds-snc/notification-api/pull/2538/commits/875079ed324a41151619bec0770abd3924cbd9b5):
    - Eliminate redundant DB calls during processing. 
    - Only attempt to process complaints that have notifications in the DB. 
    - Those that do not yet have notifications in the DB are queued for retry.
- Left a TODO for the future re. potential to [further improve performance by parallelizing complaint processing](https://github.com/cds-snc/notification-api/pull/2538/commits/875079ed324a41151619bec0770abd3924cbd9b5#diff-c2b80d24dc75a580e7a46a64acf18189ffd7fb78462046b465c1e1e0795cb35fR287).
- Misc. test fixes, Code QL improvements
