### PR TITLE
Add code to test for an user being added to a service they are already in

### DIFF
--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -1,6 +1,7 @@
 import json
 import uuid
 from datetime import datetime, timedelta
+from unittest.mock import patch
 
 import pytest
 from freezegun import freeze_time
@@ -1550,3 +1551,65 @@ class TestSensitiveService:
     def test_non_sensitive_service(self, notify_db, notify_db_session):
         sensitive_service = dao_fetch_service_ids_of_sensitive_services()
         assert sensitive_service == []
+
+
+class TestAddingUsertoExistingService:
+    def test_dao_add_user_to_service_handles_integrity_error_by_getting_existing_user(
+        self, notify_db_session, sample_service, sample_user
+    ):
+        """
+        Test that when an IntegrityError occurs during user addition (due to race condition),
+        the function recovers by fetching the existing user and updating permissions.
+        """
+
+        # Create a new user to add to the service
+        user = User(
+            name="Test Integrity User",
+            email_address="integrity-test@example.gov.uk",
+            password="password",
+            mobile_number="+16502532223",
+        )
+        save_model_user(user)
+
+        # Check how many users are in the service before we start
+        service_users_before = len(sample_service.users)
+        print(f"Service users before adding new user: {service_users_before}")
+
+        # First create the service user directly to simulate an existing relationship
+        service_user = ServiceUser(user_id=user.id, service_id=sample_service.id)
+        db.session.add(service_user)
+        db.session.commit()
+
+        # Verify the service_user exists
+        service_user_check = ServiceUser.query.filter_by(user_id=user.id, service_id=sample_service.id).first()
+        assert service_user_check is not None, "ServiceUser record was not created manually"
+
+        # Mock the permission dao to avoid the 'str' has no attribute 'user' error
+        with patch("app.dao.permissions_dao.permission_dao.set_user_service_permission") as mock_set_permissions:
+            # Now test the integrity error handling by attempting to add the user again with different permissions
+            # This simulates a race condition where another request has already created the service_user
+            new_permissions = ["send_emails", "send_texts"]
+
+            # Test that dao_add_user_to_service handles the case where the user is already in the service
+            dao_add_user_to_service(sample_service, user, permissions=new_permissions)
+
+            # Verify the mock was called with the correct parameters
+            mock_set_permissions.assert_called_once_with(user, sample_service, new_permissions, _commit=False)
+
+        # Also mock the scenario where an IntegrityError is raised during the function execution
+        # Instead of mocking ServiceUser class, we'll mock the flush method to simulate the IntegrityError
+        with (
+            patch.object(db.session, "flush") as mock_flush,
+            patch("app.dao.permissions_dao.permission_dao.set_user_service_permission") as mock_set_permissions,
+        ):
+            # Configure the flush mock to raise IntegrityError
+            mock_flush.side_effect = IntegrityError("duplicate key value", params={}, orig=None)
+
+            # Try adding with different permissions - this should handle the error gracefully
+            newer_permissions = ["send_emails", "send_texts", "manage_service"]
+
+            # This should not raise an exception to the caller
+            dao_add_user_to_service(sample_service, user, permissions=newer_permissions)
+
+            # Verify the mock was called with the correct parameters
+            mock_set_permissions.assert_called_with(user, sample_service, newer_permissions, _commit=False)


### PR DESCRIPTION
# Summary | Résumé

We were getting this error in production where we are adding a user to a service, and the user has already been added to the service. Previously we caught the error in app/service/rest.py but between checking for the user in the service, and trying to add the user again - we believe there is a race condition (by another process accessing an adding a user to the same service).

Trying to formulate why this might happen:
Why the UniqueViolation Error Still Occurs
The error is still occurring because of a race condition in the database operations. Potential sequence:
1. The error happens because of how SQLAlchemy handles sessions and transactions:
1. You check if the user is in [service.users](which is a Python-side check)
1. If not, you proceed with [dao_add_user_to_service()]
1. But before your transaction commits, another request might have successfully added the same user
1. The specific issue is that the service-user relationship is tracked in the user_to_service table with a unique constraint on (user_id, service_id). When multiple requests try to add the same user to the same service concurrently, the database constraint catches what your application logic couldn't prevent.

# Solution:
SQLAlchemy's session has an "autoflush" behavior that automatically synchronizes the session's state with the database before executing certain operations:

When you execute a query (like [ServiceUser.query.filter_by()]
SQLAlchemy first checks if there are any pending changes in the current session
If there are, it automatically flushes them to the database to ensure query results are consistent

The Race Condition Problem
1. Two concurrent requests try to add the same user to the same service
1. Both check if the user is already in the service and don't find them (they both pass the [if user in service.users]( check in add_user_to_service)
1. Both proceed to call [dao_add_user_to_service]
1. The first request successfully adds the user
1. The second request tries to add the user but fails with UniqueViolation because the user-service relationship already exists

How [no_autoflush]Helps
The [no_autoflush] context manager prevents SQLAlchemy from automatically flushing pending changes when executing the query. This is important because:
If there are any pending inserts for the same user-service pair in the session without [no_autoflush], SQLAlchemy would try to flush those changes before executing the query
This could cause a unique constraint violation before you even get the chance to check if the user-service relationship exists

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1940

# Test instructions | Instructions pour tester la modification
can't replicate and test :(

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.