### PR TITLE
Added CODEOWNERS file with db changes stakeholders

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+*   @jimleroyer
+migrations/versions @jimleroyer @jzbahrai @patheard @willeybryan


### PR DESCRIPTION
# Summary | Résumé

Added CODEOWNERS file with db changes stakeholders, i.e. Pat, Bryan W. and Jumana B. This came up in a discussion within the team where we need to communicate the database changes so that our data consumers can react accordingly. We should notify via more traditional means (Slack, emails, in person?) but this should be a catch all so nothing should escape their attention. 

## Related Issues | Cartes liées

No specific task. Quick change for delivering quick notifications on database changes.

# Test instructions | Instructions pour tester la modification

Open new PR on database migration and users should get a notification from github with their preferred notif methods.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.