### PR TITLE
Add a dedicated `/has_jobs` endpoint that is more efficient

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+*   @jimleroyer
+migrations/versions @jimleroyer @jzbahrai @patheard @willeybryan

--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -89,6 +89,14 @@ def dao_get_in_progress_jobs():
     return Job.query.filter(Job.job_status == JOB_STATUS_IN_PROGRESS).all()
 
 
+def dao_service_has_jobs(service_id):
+    """
+    Efficient check to see if a service has any jobs in the database.
+    Returns True if the service has at least one job, False otherwise.
+    """
+    return db.session.query(db.session.query(Job).filter(Job.service_id == service_id).exists()).scalar()
+
+
 def dao_set_scheduled_jobs_to_pending():
     """
     Sets all past scheduled jobs to pending, and then returns them for further processing.

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -231,7 +231,7 @@ def create_job(service_id):
 def get_service_has_jobs(service_id):
     """Check if a service has any jobs in the database."""
     has_jobs = dao_service_has_jobs(service_id)
-    return jsonify(has_jobs=has_jobs), 200
+    return jsonify(data={"has_jobs": has_jobs}), 200
 
 
 def get_paginated_jobs(service_id, limit_days, statuses, page):

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -17,6 +17,7 @@ from app.dao.jobs_dao import (
     dao_get_job_by_service_id_and_job_id,
     dao_get_jobs_by_service_id,
     dao_get_notification_outcomes_for_job,
+    dao_service_has_jobs,
     dao_update_job,
 )
 from app.dao.notifications_dao import get_notifications_for_job
@@ -224,6 +225,13 @@ def create_job(service_id):
     job_json["statistics"] = []
 
     return jsonify(data=job_json), 201
+
+
+@job_blueprint.route("/has_jobs", methods=["GET"])
+def get_service_has_jobs(service_id):
+    """Check if a service has any jobs in the database."""
+    has_jobs = dao_service_has_jobs(service_id)
+    return jsonify(has_jobs=has_jobs), 200
 
 
 def get_paginated_jobs(service_id, limit_days, statuses, page):

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -14,6 +14,7 @@ from app.dao.jobs_dao import (
     dao_get_jobs_by_service_id,
     dao_get_jobs_older_than_data_retention,
     dao_get_notification_outcomes_for_job,
+    dao_service_has_jobs,
     dao_set_scheduled_jobs_to_pending,
     dao_update_job,
 )
@@ -479,3 +480,15 @@ def test_can_letter_job_be_cancelled_returns_false_and_error_message_if_notifica
     result, errors = can_letter_job_be_cancelled(job)
     assert not result
     assert errors == "We are still processing these letters, please try again in a minute."
+
+
+def test_dao_service_has_jobs_returns_true_when_service_has_jobs(sample_template):
+    create_job(sample_template)
+    result = dao_service_has_jobs(sample_template.service_id)
+    assert result is True
+
+
+def test_dao_service_has_jobs_returns_false_when_service_has_no_jobs():
+    service_with_no_jobs = create_service(service_name="service-with-no-jobs")
+    result = dao_service_has_jobs(service_with_no_jobs.id)
+    assert result is False


### PR DESCRIPTION
# Summary | Résumé

Add a new dedicated `/has_jobs` endpoint that does an efficient query to check this. Admin was previous getting all the jobs data for a given service to make this check.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1919

# Test instructions | Instructions pour tester la modification

Same test as over here: https://github.com/cds-snc/notification-admin/pull/2187

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.