### PR TITLE
Task/fix after revert

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -16,6 +16,7 @@ from app.dao.date_util import get_current_financial_year, get_midnight
 from app.dao.email_branding_dao import dao_get_email_branding_by_name
 from app.dao.letter_branding_dao import dao_get_letter_branding_by_name
 from app.dao.organisation_dao import dao_get_organisation_by_email_address
+from app.dao.permissions_dao import permission_dao
 from app.dao.service_sms_sender_dao import insert_service_sms_sender
 from app.dao.service_user_dao import dao_get_service_user
 from app.dao.template_folder_dao import dao_get_valid_template_folders_by_id
@@ -296,8 +297,6 @@ def dao_create_service(
     else:
         organisation = dao_get_organisation_by_email_address(user.email_address)
 
-    from app.dao.permissions_dao import permission_dao
-
     service.users.append(user)
     permission_dao.add_default_service_permissions_for_user(user, service)
     service.id = service_id or uuid.uuid4()  # must be set now so version history model can use same id
@@ -346,8 +345,6 @@ def dao_add_user_to_service(service, user, permissions=None, folder_permissions=
     folder_permissions = folder_permissions or []
 
     try:
-        from app.dao.permissions_dao import permission_dao
-
         service.users.append(user)
         permission_dao.set_user_service_permission(user, service, permissions, _commit=False)
         db.session.add(service)

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -483,6 +483,16 @@ def add_user_to_service(service_id, user_id):
         message = f"UniqueViolation: User id: {user_id} already part of service id: {service_id}"
         current_app.logger.info(message)
         raise UserAlreadyInServiceError(status_code=409, message=message)
+    except IntegrityError as e:
+        if isinstance(e.orig, UniqueViolation):
+            message = f"UniqueViolation: User id: {user_id} already part of service id: {service_id}"
+            current_app.logger.info(message)
+            raise UserAlreadyInServiceError(status_code=409, message=message)
+        else:
+            raise
+    except Exception as e:
+        current_app.logger.exception(e)
+        raise InvalidRequest("An error occurred while adding user to service", status_code=500)
 
     data = service_schema.dump(service)
 


### PR DESCRIPTION
# Summary | Résumé

After we revert this: https://github.com/cds-snc/notification-api/pull/2543
We want to add further exception handling in the rest call

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1
* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/1

# Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.