### PR TITLE
Task/optimize get jobs by service

### DIFF
--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -594,6 +594,25 @@ def fetch_notification_status_totals_for_all_services(start_date, end_date):
     return query.all()
 
 
+def fetch_notification_statuses_for_job_batch(service_id, job_ids):
+    """
+    Returns a list of (job_id, status, count) tuples for the given job_ids.
+    """
+    return (
+        db.session.query(
+            FactNotificationStatus.job_id,
+            FactNotificationStatus.notification_status.label("status"),
+            func.sum(FactNotificationStatus.notification_count).label("count"),
+        )
+        .filter(
+            FactNotificationStatus.service_id == service_id,
+            FactNotificationStatus.job_id.in_(job_ids),
+        )
+        .group_by(FactNotificationStatus.job_id, FactNotificationStatus.notification_status)
+        .all()
+    )
+
+
 def fetch_notification_statuses_for_job(job_id):
     return (
         db.session.query(

--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -31,6 +31,26 @@ from app.models import (
 
 
 @statsd(namespace="dao")
+def dao_get_notification_outcomes_for_job_batch(service_id, job_ids):
+    """
+    Returns a list of (job_id, status, count) tuples for the given job_ids.
+    """
+    return (
+        db.session.query(
+            Notification.job_id,
+            Notification.status,
+            func.count(Notification.id).label("count"),
+        )
+        .filter(
+            Notification.service_id == service_id,
+            Notification.job_id.in_(job_ids),
+        )
+        .group_by(Notification.job_id, Notification.status)
+        .all()
+    )
+
+
+@statsd(namespace="dao")
 def dao_get_notification_outcomes_for_job(service_id, job_id):
     notification = (
         db.session.query(func.count(Notification.status).label("count"), Notification.status)

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -1,3 +1,5 @@
+import time
+import uuid
 from datetime import datetime
 
 import dateutil
@@ -236,6 +238,7 @@ def get_service_has_jobs(service_id):
 
 
 def get_paginated_jobs(service_id, limit_days, statuses, page):
+    start_time = time.time()
     pagination = dao_get_jobs_by_service_id(
         service_id,
         limit_days=limit_days,
@@ -287,10 +290,13 @@ def get_paginated_jobs(service_id, limit_days, statuses, page):
             # We set this in the first loop so we can just skip it here
             continue
         elif start < cutoff:
-            job_data["statistics"] = old_stats.get(job_id, [])
+            job_data["statistics"] = old_stats.get(uuid.UUID(job_id), [])
         else:
-            job_data["statistics"] = recent_stats.get(job_id, [])
+            job_data["statistics"] = recent_stats.get(uuid.UUID(job_id), [])
         del job_data["_parsed_start"]  # Clean up that temporary field
+
+    end_time = time.time()
+    current_app.logger.info(f"[get_paginated_jobs] took {"{:.3f}".format(end_time - start_time)} seconds")
 
     return {
         "data": data,


### PR DESCRIPTION
# Summary | Résumé

This PR refactors `get_paginated_jobs`. Instead of looping through each job and calling the DB to fetch that job's status / status, it now does the following:

1. Categorize and add the jobs we're fetching stats for to two lists. One list for stats fetched from `notifcations`/`notification_history` tables and one list for stats fetched from `ft_notification_status`
2. Make only two DB calls to bulk fetch those stats from their respective sources instead of `DB calls = Page size | # of jobs to fetch stats for`

This is one part of the slow dashboard load times puzzle and is experimental. Initial testing locally with a service with 1 million jobs [showed some minor improvements](https://docs.google.com/spreadsheets/d/1rB5yH913YYyxSTZ_q1Erg-yL7oHdGvyfXU8H1rtBCrg/edit?gid=0#gid=0).

# Test instructions | Instructions pour tester la modification
1. Visit the dashboard of a service that normally takes a very long time to load
2. Use devtools to see if there are any reductions in the page load times for that dashboard

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.