### PR TITLE
Ensure testing templates don't get removed up during cleanup

### DIFF
--- a/app/cypress/rest.py
+++ b/app/cypress/rest.py
@@ -143,9 +143,27 @@ def _destroy_test_user(email_name):
         # cycle through all the services created by this user, remove associated entities
         services = Service.query.filter_by(created_by=user).filter(Service.id != current_app.config["CYPRESS_SERVICE_ID"])
         for service in services.all():
-            TemplateHistory.query.filter_by(service_id=service.id).delete()
+            # Delete template history except for smoke test templates
+            TemplateHistory.query.filter(
+                TemplateHistory.service_id == service.id,
+                ~TemplateHistory.id.in_(
+                    [
+                        current_app.config["CYPRESS_SMOKE_TEST_EMAIL_TEMPLATE_ID"],
+                        current_app.config["CYPRESS_SMOKE_TEST_SMS_TEMPLATE_ID"],
+                    ]
+                ),
+            ).delete()
 
-            Template.query.filter_by(service_id=service.id).delete()
+            # Delete templates except for smoke test templates
+            Template.query.filter(
+                Template.service_id == service.id,
+                ~Template.id.in_(
+                    [
+                        current_app.config["CYPRESS_SMOKE_TEST_EMAIL_TEMPLATE_ID"],
+                        current_app.config["CYPRESS_SMOKE_TEST_SMS_TEMPLATE_ID"],
+                    ]
+                ),
+            ).delete()
             AnnualBilling.query.filter_by(service_id=service.id).delete()
             ServicePermission.query.filter_by(service_id=service.id).delete()
             Permission.query.filter_by(service_id=service.id).delete()
@@ -154,8 +172,26 @@ def _destroy_test_user(email_name):
 
         # remove all entities related to the user itself
         TemplateRedacted.query.filter_by(updated_by=user).delete()
-        TemplateHistory.query.filter_by(created_by=user).delete()
-        Template.query.filter_by(created_by=user).delete()
+        # Delete template history except for smoke test templates
+        TemplateHistory.query.filter(
+            TemplateHistory.created_by == user,
+            ~TemplateHistory.id.in_(
+                [
+                    current_app.config["CYPRESS_SMOKE_TEST_EMAIL_TEMPLATE_ID"],
+                    current_app.config["CYPRESS_SMOKE_TEST_SMS_TEMPLATE_ID"],
+                ]
+            ),
+        ).delete()
+        # Delete templates except for smoke test templates
+        Template.query.filter(
+            Template.created_by == user,
+            ~Template.id.in_(
+                [
+                    current_app.config["CYPRESS_SMOKE_TEST_EMAIL_TEMPLATE_ID"],
+                    current_app.config["CYPRESS_SMOKE_TEST_SMS_TEMPLATE_ID"],
+                ]
+            ),
+        ).delete()
         Permission.query.filter_by(user=user).delete()
         LoginEvent.query.filter_by(user=user).delete()
         ServiceUser.query.filter_by(user_id=user.id).delete()


### PR DESCRIPTION
# Summary | Résumé

Update the cypress cleanup function to exclude the cypress templates explicitly.

# Test instructions | Instructions pour tester la modification

- After a few hours the scheduled test runs will fail if this didnt work

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.