### PR TITLE
Add 2 new indexes to the `jobs` table

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1517,7 +1517,7 @@ class Job(BaseModel):
     template_version = db.Column(db.Integer, nullable=False)
     created_at = db.Column(
         db.DateTime,
-        index=False,
+        index=True,
         unique=False,
         nullable=False,
         default=datetime.datetime.utcnow,
@@ -1534,7 +1534,7 @@ class Job(BaseModel):
     notifications_delivered = db.Column(db.Integer, nullable=False, default=0)
     notifications_failed = db.Column(db.Integer, nullable=False, default=0)
 
-    processing_started = db.Column(db.DateTime, index=False, unique=False, nullable=True)
+    processing_started = db.Column(db.DateTime, index=True, unique=False, nullable=True)
     processing_finished = db.Column(db.DateTime, index=False, unique=False, nullable=True)
     created_by = db.relationship("User")
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), index=True, nullable=True)

--- a/migrations/versions/0483_index_jobs.py
+++ b/migrations/versions/0483_index_jobs.py
@@ -1,0 +1,33 @@
+"""
+
+Revision ID: 0483_index_jobs
+Revises: 0482_index_facts
+Create Date: 2025-06-09 20:01:02.943393
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0483_index_jobs'
+down_revision = '0482_index_facts'
+
+def index_exists(name):
+    connection = op.get_bind()
+    result = connection.execute(
+        "SELECT exists(SELECT 1 from pg_indexes where indexname = '{}') as ix_exists;".format(name)
+    ).first()
+    return result.ix_exists
+
+def upgrade():
+    if not index_exists("ix_jobs_created_at"):
+        op.create_index(op.f('ix_jobs_created_at'), 'jobs', ['created_at'], unique=False)
+    if not index_exists("ix_jobs_processing_started"):
+        op.create_index(op.f('ix_jobs_processing_started'), 'jobs', ['processing_started'], unique=False)
+
+
+def downgrade():
+    if index_exists("ix_jobs_processing_started"):
+        op.drop_index(op.f('ix_jobs_processing_started'), table_name='jobs')
+    if index_exists("ix_jobs_created_at"):
+        op.drop_index(op.f('ix_jobs_created_at'), table_name='jobs')

--- a/migrations/versions/0483_index_jobs.py
+++ b/migrations/versions/0483_index_jobs.py
@@ -6,7 +6,6 @@ Create Date: 2025-06-09 20:01:02.943393
 
 """
 from alembic import op
-from sqlalchemy.dialects import postgresql
 
 revision = '0483_index_jobs'
 down_revision = '0482_index_facts'

--- a/migrations/versions/0483_index_jobs.py
+++ b/migrations/versions/0483_index_jobs.py
@@ -6,7 +6,6 @@ Create Date: 2025-06-09 20:01:02.943393
 
 """
 from alembic import op
-import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 revision = '0483_index_jobs'


### PR DESCRIPTION
# Summary | Résumé

Every time we call `dao_get_jobs_by_service_id` (which the dashboard does at every load) we are doing a full table scan on the jobs table. This is because we are filtering on `created_at` which is not indexed. Adding an index for this and `processing_started` (which we are ordering by) should improve the dashboard load time for services with a lot of jobs.
 
## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1953

# Test instructions | Instructions pour tester la modification

1. check out branch
2. run `flask db upgrade`
3. verify that you are on the new alembic version and that the new indexes have been added to the jobs table

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.