### PR TITLE
Add logging to see notification counts

### DIFF
--- a/app/celery/reporting_tasks.py
+++ b/app/celery/reporting_tasks.py
@@ -95,6 +95,15 @@ def create_nightly_notification_status_for_day(process_day):
     """
     process_day = datetime.strptime(process_day, "%Y-%m-%d").date()
     service_ids = [x.id for x in Service.query.all()]
+    if current_app.config["NOTIFY_ENVIRONMENT"] == "staging":
+        performance_test_service_id = "44c1a3f5-6a11-4952-b6f4-94dd46d009f2"
+        was_seeded_today = annual_limit_client.was_seeded_today(performance_test_service_id)
+        notifcation_counts = annual_limit_client.get_all_notification_counts(performance_test_service_id)
+        current_app.logger.info(
+            "Staging Performance Test data in redis START of task: was_seeded_today: {}, notification_counts: {}".format(
+                was_seeded_today, notifcation_counts
+            )
+        )
     chunk_size = 10
     iter_service_ids = iter(service_ids)
     current_app.logger.info("create-nightly-notification-status-for-day STARTED for day {} ".format(process_day))
@@ -134,6 +143,15 @@ def create_nightly_notification_status_for_day(process_day):
                     process_day, chunk, e
                 )
             )
+    if current_app.config["NOTIFY_ENVIRONMENT"] == "staging":
+        performance_test_service_id = "44c1a3f5-6a11-4952-b6f4-94dd46d009f2"
+        was_seeded_today = annual_limit_client.was_seeded_today(performance_test_service_id)
+        notifcation_counts = annual_limit_client.get_all_notification_counts(performance_test_service_id)
+        current_app.logger.info(
+            "Staging Performance Test data in redis START of task: was_seeded_today: {}, notification_counts: {}".format(
+                was_seeded_today, notifcation_counts
+            )
+        )
 
 
 @notify_celery.task(name="insert-quarter-data-for-annual-limits")


### PR DESCRIPTION
# Summary | Résumé

Just want to log data in staging for the performance test service, annual limit keys

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1
* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/1

# Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.