### PR TITLE
Sort jobs by `created_at` column

### DIFF
--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -79,11 +79,7 @@ def dao_get_jobs_by_service_id(service_id, limit_days=None, page=1, page_size=50
 
     if statuses is not None and statuses != [""]:
         query_filter.append(Job.job_status.in_(statuses))
-    return (
-        Job.query.filter(*query_filter)
-        .order_by(Job.processing_started.desc().nulls_last(), Job.created_at.desc())
-        .paginate(page=page, per_page=page_size)
-    )
+    return Job.query.filter(*query_filter).order_by(Job.created_at.desc()).paginate(page=page, per_page=page_size)
 
 
 def dao_get_job_by_id(job_id) -> Job:

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -184,8 +184,8 @@ def test_get_jobs_for_service_in_processed_at_then_created_at_order(notify_db, n
     from_hour = partial(datetime, 2001, 1, 1)
 
     created_jobs = [
-        create_job(sample_template, created_at=from_hour(1), processing_started=from_hour(4)),
-        create_job(sample_template, created_at=from_hour(2), processing_started=from_hour(3)),
+        create_job(sample_template, created_at=from_hour(4), processing_started=from_hour(4)),
+        create_job(sample_template, created_at=from_hour(3), processing_started=from_hour(3)),
         create_job(sample_template, created_at=from_hour(2), processing_started=None),
         create_job(sample_template, created_at=from_hour(1), processing_started=None),
     ]

--- a/tests/app/job/test_rest.py
+++ b/tests/app/job/test_rest.py
@@ -948,21 +948,23 @@ def test_get_all_notifications_for_job_returns_csv_format(admin_request, sample_
 # This test assumes the local timezone is EST
 def test_get_jobs_should_retrieve_from_ft_notification_status_for_old_jobs(admin_request, sample_template):
     # it's the 10th today, so 3 days should include all of 7th, 8th, 9th, and some of 10th.
-    just_three_days_ago = datetime(2017, 6, 7, 3, 59, 59)
-    not_quite_three_days_ago = just_three_days_ago + timedelta(seconds=1)
+    just_three_days_ago_1 = datetime(2017, 6, 7, 3, 59, 59, 0)
+    just_three_days_ago_2 = datetime(2017, 6, 7, 3, 59, 59, 1)
+    just_three_days_ago_3 = datetime(2017, 6, 7, 3, 59, 59, 2)
+    not_quite_three_days_ago = just_three_days_ago_1 + timedelta(seconds=1)
 
     job_1 = create_job(
         sample_template,
-        created_at=just_three_days_ago,
-        processing_started=just_three_days_ago,
+        created_at=just_three_days_ago_1,
+        processing_started=just_three_days_ago_1,
     )
     job_2 = create_job(
         sample_template,
-        created_at=just_three_days_ago,
+        created_at=just_three_days_ago_2,
         processing_started=not_quite_three_days_ago,
     )
     # is old but hasn't started yet (probably a scheduled job). We don't have any stats for this job yet.
-    job_3 = create_job(sample_template, created_at=just_three_days_ago, processing_started=None)
+    job_3 = create_job(sample_template, created_at=just_three_days_ago_3, processing_started=None)
 
     # some notifications created more than three days ago, some created after the midnight cutoff
     create_ft_notification_status(date(2017, 6, 6), job=job_1, notification_status="delivered", count=2)
@@ -980,12 +982,12 @@ def test_get_jobs_should_retrieve_from_ft_notification_status_for_old_jobs(admin
 
     resp_json = admin_request.get("job.get_jobs_by_service", service_id=sample_template.service_id)
 
-    assert resp_json["data"][2]["id"] == str(job_3.id)
-    assert resp_json["data"][2]["statistics"] == []
-    assert resp_json["data"][0]["id"] == str(job_2.id)
-    assert resp_json["data"][0]["statistics"] == [{"status": "created", "count": 1}]
-    assert resp_json["data"][1]["id"] == str(job_1.id)
-    assert resp_json["data"][1]["statistics"] == [{"status": "delivered", "count": 6}]
+    assert resp_json["data"][0]["id"] == str(job_3.id)
+    assert resp_json["data"][0]["statistics"] == []
+    assert resp_json["data"][1]["id"] == str(job_2.id)
+    assert resp_json["data"][1]["statistics"] == [{"status": "created", "count": 1}]
+    assert resp_json["data"][2]["id"] == str(job_1.id)
+    assert resp_json["data"][2]["statistics"] == [{"status": "delivered", "count": 6}]
 
 
 def test_get_service_has_jobs_returns_true_when_jobs_exist(client, notify_db_session):


### PR DESCRIPTION
# Summary | Résumé

Sort jobs by the `created_at` column. This will prevent old jobs with `processing_started=null` from showing up at the top of the jobs page. But these jobs will still be visible when you page through the jobs - this change prevents them from being buried at the end of the list.

# Test instructions | Instructions pour tester la modification

- tests should pass

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.