### PR TITLE
Exclude application/yaml from binary content types

### DIFF
--- a/app/v2/api_spec/get_api_spec.py
+++ b/app/v2/api_spec/get_api_spec.py
@@ -1,6 +1,7 @@
 import os
 
-from flask import Blueprint, current_app, send_file
+import yaml
+from flask import Blueprint, Response, current_app
 
 v2_api_spec_blueprint = Blueprint("v2_api_spec", __name__, url_prefix="/v2")
 
@@ -13,7 +14,12 @@ def get_v2_api_spec_en():
     spec_path = os.path.join(current_app.root_path, "openapi/v2-notifications-api-en.yaml")
     spec_path = os.path.abspath(spec_path)
 
-    return send_file(spec_path, mimetype="application/yaml", as_attachment=False, download_name="v2-notifications-api.yaml")
+    with open(spec_path, "r") as f:
+        yaml_data = yaml.safe_load(f)
+
+    yaml_string = yaml.dump(yaml_data, default_flow_style=False)
+    response = Response(yaml_string, mimetype="application/yaml")
+    return response
 
 
 @v2_api_spec_blueprint.route("/openapi-fr", methods=["GET"])
@@ -24,4 +30,8 @@ def get_v2_api_spec_fr():
     spec_path = os.path.join(current_app.root_path, "openapi/v2-notifications-api-fr.yaml")
     spec_path = os.path.abspath(spec_path)
 
-    return send_file(spec_path, mimetype="application/yaml", as_attachment=False, download_name="v2-notifications-api.yaml")
+    with open(spec_path, "r") as f:
+        yaml_data = f.read()
+
+    response = Response(yaml_data, mimetype="application/yaml")
+    return response

--- a/app/v2/api_spec/get_api_spec.py
+++ b/app/v2/api_spec/get_api_spec.py
@@ -1,6 +1,6 @@
 import os
 
-import yaml
+import yaml  # type: ignore
 from flask import Blueprint, Response, current_app
 
 v2_api_spec_blueprint = Blueprint("v2_api_spec", __name__, url_prefix="/v2")

--- a/application.py
+++ b/application.py
@@ -28,7 +28,7 @@ app = create_app(application)
 xray_recorder.configure(service="Notify-API", context=NotifyContext())
 XRayMiddleware(app, xray_recorder)
 
-apig_wsgi_handler = make_lambda_handler(app, binary_support=True)
+apig_wsgi_handler = make_lambda_handler(app, binary_support=True, non_binary_content_type_prefixes=["application/yaml"])
 
 if os.environ.get("USE_LOCAL_JINJA_TEMPLATES") == "True":
     print("")


### PR DESCRIPTION
# Summary | Résumé

This PR corrects an issue where the `wsgi` lambda handler was assuming and treating the `application/yaml` content type as binary content and applying base64 encoding on the response body. 

# Test instructions | Instructions pour tester la modification

1. Run this curl command `curl --location 'https://api.dev.notification.cdssandbox.xyz/v2/openapi-en'` to fetch the spec from dev where this code is currently running
2. Note that the spec is properly returned as yaml instead of a base64 encoded string

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.