### PR TITLE
Remove localhost from allowed CORS origins

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -327,7 +327,6 @@ def init_app(app):
     @app.after_request
     def after_request(response):
         ALLOWED_ORIGINS = {
-            "http://localhost:8081",
             "https://documentation.notification.canada.ca",
             "https://documentation.staging.notification.cdssandbox.xyz",
             "https://documentation.dev.notification.cdssandbox.xyz",


### PR DESCRIPTION
# Summary | Résumé

Having localhost as an origin for CORS could be a potential security issue, so here it is removed.  The result is that we won't be able to use the "try it out" feature of Swagger locally.  We can still use it in the review environment, dev, staging, and prod, so this isn't really a big deal.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/1933

# Test instructions | Instructions pour tester la modification

- Ensure `localhost:8081` is not returned as a CORS origin when making an options request to the API at `/v2/notifications`

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.