### PR TITLE
Add examples for /v2/bulk

### DIFF
--- a/openapi/v2-notifications-api-en.yaml
+++ b/openapi/v2-notifications-api-en.yaml
@@ -704,6 +704,49 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/PostBulkRequest'
+            examples:
+              basic_bulk_email_rows:
+                summary: Basic bulk email notification using rows
+                value:
+                  template_id: "12345678-1234-1234-1234-123456789012"
+                  name: "January Appointment Reminders"
+                  rows:
+                    - ["email address", "name"]
+                    - ["alice@example.com", "Alice"]
+                    - ["bob@example.com", "Bob"]
+              basic_bulk_email_csv:
+                summary: Basic bulk notification using csv
+                value:
+                  template_id: "12345678-1234-1234-1234-123456789012"
+                  name: "January Appointment Reminders"
+                  csv: "email address,name\nalice@example.com,Alice\nbob@example.com,Bob"
+              basic_bulk_sms_rows:
+                summary: Basic bulk email notification using rows
+                value:
+                  template_id: "12345678-1234-1234-1234-123456789012"
+                  name: "January Appointment Reminders"
+                  rows:
+                    - ["phone number", "name"]
+                    - ["123-456-7890", "Alice"]
+                    - ["+112345678901", "Bob"]
+              basic_bulk_sms_csv:
+                summary: Basic bulk notification using csv
+                value:
+                  template_id: "12345678-1234-1234-1234-123456789012"
+                  name: "January Appointment Reminders"
+                  csv: "phone number,name\n123-456-7890,Alice\n+112345678901,Bob"
+              scheduled_bulk_with_ref:
+                summary: Scheduled bulk notifications with a ref for tracking and reply to address
+                value:
+                  template_id: "12345678-1234-1234-1234-123456789012"
+                  name: "January Appointment Reminders"
+                  scheduled_for: "2025-06-25T15:15:00"
+                  reference: "january-reminders"
+                  reply_to_id: "12345678-1234-1234-1234-123456789012"
+                  rows:
+                    - ["email address", "name"]
+                    - ["alice@example.com", "Alice"]
+                    - ["bob@example.com", "Bob"]
       responses:
         '201':
           description: Bulk job created successfully
@@ -1375,7 +1418,7 @@ components:
       type: apiKey
       in: header
       name: Authorization
-      description: API Key with format 'Bearer {api_key}'
+      description: API Key with format 'ApiKey-v1 {api_key}'
 
 tags:
   - name: Notifications

--- a/openapi/v2-notifications-api-fr.yaml
+++ b/openapi/v2-notifications-api-fr.yaml
@@ -704,6 +704,49 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/PostBulkRequest'
+            examples:
+              basic_bulk_email_rows:
+                summary: Notification groupée par courriel de base utilisant des lignes
+                value:
+                  template_id: "12345678-1234-1234-1234-123456789012"
+                  name: "Rappels de rendez-vous de janvier"
+                  rows:
+                    - ["adresse courriel", "nom"]
+                    - ["alice@example.com", "Alice"]
+                    - ["bob@example.com", "Bob"]
+              basic_bulk_email_csv:
+                summary: Notification groupée de base utilisant un fichier CSV
+                value:
+                  template_id: "12345678-1234-1234-1234-123456789012"
+                  name: "Rappels de rendez-vous de janvier"
+                  csv: "adresse courriel,nom\nalice@example.com,Alice\nbob@example.com,Bob"
+              basic_bulk_sms_rows:
+                summary: Notification groupée par SMS de base utilisant des lignes
+                value:
+                  template_id: "12345678-1234-1234-1234-123456789012"
+                  name: "Rappels de rendez-vous de janvier"
+                  rows:
+                    - ["numéro de téléphone", "nom"]
+                    - ["123-456-7890", "Alice"]
+                    - ["+112345678901", "Bob"]
+              basic_bulk_sms_csv:
+                summary: Notification groupée de base par SMS utilisant un fichier CSV
+                value:
+                  template_id: "12345678-1234-1234-1234-123456789012"
+                  name: "Rappels de rendez-vous de janvier"
+                  csv: "numéro de téléphone,nom\n123-456-7890,Alice\n+112345678901,Bob"
+              scheduled_bulk_with_ref:
+                summary: Notifications groupées planifiées avec une référence pour le suivi et une adresse de réponse
+                value:
+                  template_id: "12345678-1234-1234-1234-123456789012"
+                  name: "Rappels de rendez-vous de janvier"
+                  scheduled_for: "2025-06-25T15:15:00"
+                  reference: "rappels-janvier"
+                  reply_to_id: "12345678-1234-1234-1234-123456789012"
+                  rows:
+                    - ["adresse courriel", "nom"]
+                    - ["alice@example.com", "Alice"]
+                    - ["bob@example.com", "Bob"]
       responses:
         '201':
           description: Tâche de notification en masse créée avec succès
@@ -1374,7 +1417,7 @@ components:
       type: apiKey
       in: header
       name: Authorization
-      description: Clé API au format 'Bearer {api_key}'
+      description: Clé API au format « ApiKey-v1 {api_key} »
 
 tags:
   - name: Notifications


### PR DESCRIPTION


# Summary | Résumé
This PR updates the open api spec  files with examples for the /v2/bulk endpoint as well as fixing the format example for the api key so it includes the `ApiKey-v1` prefix


# Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.