### PR TITLE
Fix generated job report ordering

### DIFF
--- a/app/report/utils.py
+++ b/app/report/utils.py
@@ -107,7 +107,6 @@ def build_notifications_query(service_id, notification_type, language, notificat
         .outerjoin(j, j.id == n.job_id)
         .outerjoin(u, u.id == n.created_by_id)
         .filter(*query_filters)
-        .order_by(n.created_at.asc() if job_id else n.created_at.desc())
         .subquery()
     )
 
@@ -183,7 +182,8 @@ def build_notifications_query(service_id, notification_type, language, notificat
         ]
     )
 
-    return db.session.query(*query_columns)
+    # Add ordering to the outer query to guarantee CSV row order
+    return db.session.query(*query_columns).order_by(inner_query.c.created_at.asc())
 
 
 def compile_query_for_copy(query):

--- a/scripts/run_celery.ps1
+++ b/scripts/run_celery.ps1
@@ -1,3 +1,3 @@
 $ENV:FORKED_BY_MULTIPROCESSING=1
 
-celery --app run_celery worker --pidfile="$env:TEMP\celery.pid" --pool=solo --loglevel=DEBUG --concurrency=1 -Q "-priority-database-tasks.fifo,-normal-database-tasks,-bulk-database-tasks,job-tasks,notify-internal-tasks,periodic-tasks,priority-tasks,normal-tasks,bulk-tasks,reporting-tasks,research-mode-tasks,retry-tasks,send-sms-high,send-sms-medium,send-sms-low,service-callbacks,service-callbacks-retry,delivery-receipts"
+celery --app run_celery worker --pidfile="$env:TEMP\celery.pid" --pool=solo --loglevel=DEBUG --concurrency=1 -Q "-priority-database-tasks.fifo,-normal-database-tasks,-bulk-database-tasks,job-tasks,notify-internal-tasks,periodic-tasks,priority-tasks,normal-tasks,bulk-tasks,reporting-tasks,research-mode-tasks,retry-tasks,send-sms-high,send-sms-medium,send-sms-low,service-callbacks,service-callbacks-retry,delivery-receipts,generate_reports"

--- a/scripts/run_celery.sh
+++ b/scripts/run_celery.sh
@@ -6,4 +6,4 @@ set -e
 
 echo "Start celery, concurrency: ${CELERY_CONCURRENCY-4}"
 
-celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency="${CELERY_CONCURRENCY-4}" -Q -priority-database-tasks.fifo,-normal-database-tasks,-bulk-database-tasks,job-tasks,notify-internal-tasks,periodic-tasks,priority-tasks,normal-tasks,bulk-tasks,reporting-tasks,research-mode-tasks,retry-tasks,send-sms-high,send-sms-medium,send-sms-low,service-callbacks,service-callbacks-retry,delivery-receipts
+celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency="${CELERY_CONCURRENCY-4}" -Q -priority-database-tasks.fifo,-normal-database-tasks,-bulk-database-tasks,job-tasks,notify-internal-tasks,periodic-tasks,priority-tasks,normal-tasks,bulk-tasks,reporting-tasks,research-mode-tasks,retry-tasks,send-sms-high,send-sms-medium,send-sms-low,service-callbacks,service-callbacks-retry,delivery-receipts,generate_reports

--- a/tests/app/report/test_utils.py
+++ b/tests/app/report/test_utils.py
@@ -200,8 +200,8 @@ class TestNotificationReportIntegration:
         # Check the buffer content
         rows = list(csv.DictReader(csv_buffer.getvalue().splitlines()))
         assert len(rows) == 2
-        assert rows[0]["Recipient"] == "user1@example.com"
-        assert rows[1]["Recipient"] == "user2@example.com"
+        assert rows[0]["Recipient"] == "user2@example.com"
+        assert rows[1]["Recipient"] == "user1@example.com"
         assert set(r["Status"] for r in rows) == {"Delivered", "Failed"}
 
     def test_generate_csv_from_notifications_with_status_filter(self, notify_db, notify_db_session, sample_user):


### PR DESCRIPTION
# Summary | Résumé
This PR fixes an issue with generated reports where job reports were ordered desc instead of asc like the "last X days" reports making them inconsistent
- Applied ordering on the outer query instead of the inner query as [postgresql does not guarantee that the results of the outer query respect the ordering of inner queries](https://www.postgresql.org/docs/current/queries-order.html).

## Related Issues | Cartes liées

# Test instructions | Instructions pour tester la modification

#### Setup
1. Add `REPORTS_BUCKET_NAME=notification-canada-ca-staging-reports` to your local .env file
1. Check out this branch and run locally.
2. Run notification-admin locally as well
3. Send a few one off notifications from your service so that your report will not be empty
4. Send bulk notifications as well

#### Generate the "Notifications in last X days" report
6. Go to `http://localhost:6012/services/<your-service-id>/notifications/email`
7. Generate a report & wait for it to be ready

#### Generate the job report
1. Go to your dashboard, scroll down and click on the job you sent during setup
2. Generate a report and wait for it to be ready

#### Check the ordering on both reports
10. Log in to aws staging and locate the new reports s3 bucket by searching for "reports" in the s3 bucket list
11. Download the reports from the `notification-canada-ca-staging-reports/service-<your-serivice-id>` folder
12. Verify that the contents of the CSV's are ordered in `asc` fashion

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.