### PR TITLE
Task/add verified

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -168,6 +168,7 @@ class User(BaseModel):
     blocked = db.Column(db.Boolean, nullable=False, default=False)
     additional_information = db.Column(JSONB(none_as_null=True), nullable=True, default={})
     password_expired = db.Column(db.Boolean, nullable=False, default=False)
+    verified_phonenumber = db.Column(db.Boolean, nullable=True, default=False)
 
     # either email auth or a mobile number must be provided
     CheckConstraint("auth_type = 'email_auth' or mobile_number is not null")
@@ -224,6 +225,7 @@ class User(BaseModel):
             "blocked": self.blocked,
             "additional_information": self.additional_information,
             "password_expired": self.password_expired,
+            "verified_phonenumber": self.verified_phonenumber,
         }
 
     def serialize_for_users_list(self) -> dict:
@@ -232,6 +234,7 @@ class User(BaseModel):
             "name": self.name,
             "email_address": self.email_address,
             "mobile_number": self.mobile_number,
+            "verified_phonenumber": self.verified_phonenumber,
         }
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -234,7 +234,6 @@ class User(BaseModel):
             "name": self.name,
             "email_address": self.email_address,
             "mobile_number": self.mobile_number,
-            "verified_phonenumber": self.verified_phonenumber,
         }
 
 

--- a/migrations/versions/0484_users_migrations.py
+++ b/migrations/versions/0484_users_migrations.py
@@ -13,7 +13,7 @@ down_revision = '0483_index_jobs'
 
 
 def upgrade():
-    op.add_column("users", sa.Column("verified_phonenumber", sa.Boolean, server_default='true', nullable=True))
+    op.add_column("users", sa.Column("verified_phonenumber", sa.Boolean, server_default='false', nullable=True))
     op.execute("UPDATE users SET verified_phonenumber = true")
     
 

--- a/migrations/versions/0484_users_migrations.py
+++ b/migrations/versions/0484_users_migrations.py
@@ -1,0 +1,21 @@
+"""
+
+Revision ID: 0484_users_migrations
+Revises: 0483_index_jobs
+Create Date: 2025-06-09 20:01:02.943393
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0484_users_migrations'
+down_revision = '0483_index_jobs'
+
+
+def upgrade():
+    op.add_column("users", sa.Column("verified_phonenumber", sa.Boolean, server_default='true', nullable=True))
+    op.execute("UPDATE users SET verified_phonenumber = true")
+    
+
+def downgrade():
+    op.drop_column("users", "verified_phonenumber")


### PR DESCRIPTION
# Summary | Résumé

Add a new column verified_phonenumber
``` 
verified_phonenumber   | boolean                     |           |          | false
Indexes:
```
The reason this is currently nullable=true, so that this won't block writes when we go live. We will change this when we go live for the v2 auth feature

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/2028

# Test instructions | Instructions pour tester la modification
run a flask db upgrade

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.