### PR TITLE
Added Celery broker options override in DEV environment to encrypt SQS queues

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -706,15 +706,6 @@ class Development(Config):
     API_HOST_NAME = "http://localhost:6011"
     API_RATE_LIMIT_ENABLED = True
 
-    # AWS SQS settings override for development
-    BROKER_TRANSPORT_OPTIONS = {
-        "region": AWS_REGION,
-        "polling_interval": 1,  # 1 second
-        "visibility_timeout": 310,
-        "queue_name_prefix": NOTIFICATION_QUEUE_PREFIX,
-        "is_secure": True, # Use secure connection for SQS in development
-    }
-
 
 class Test(Development):
     NOTIFY_EMAIL_DOMAIN = os.getenv("NOTIFY_EMAIL_DOMAIN", "notification.canada.ca")
@@ -781,6 +772,14 @@ class Scratch(Production):
 class Dev(Production):
     FRESH_DESK_ENABLED = env.bool("FRESH_DESK_ENABLED", False)
     NOTIFY_ENVIRONMENT = "dev"
+    # AWS SQS settings override for development
+    BROKER_TRANSPORT_OPTIONS = {
+        "region": AWS_REGION,
+        "polling_interval": 1,  # 1 second
+        "visibility_timeout": 310,
+        "queue_name_prefix": NOTIFICATION_QUEUE_PREFIX,
+        "is_secure": True,  # Use secure connection for SQS in development
+    }
 
 
 configs = {

--- a/app/config.py
+++ b/app/config.py
@@ -706,6 +706,15 @@ class Development(Config):
     API_HOST_NAME = "http://localhost:6011"
     API_RATE_LIMIT_ENABLED = True
 
+    # AWS SQS settings override for development
+    BROKER_TRANSPORT_OPTIONS = {
+        "region": AWS_REGION,
+        "polling_interval": 1,  # 1 second
+        "visibility_timeout": 310,
+        "queue_name_prefix": NOTIFICATION_QUEUE_PREFIX,
+        "is_secure": True, # Use secure connection for SQS in development
+    }
+
 
 class Test(Development):
     NOTIFY_EMAIL_DOMAIN = os.getenv("NOTIFY_EMAIL_DOMAIN", "notification.canada.ca")


### PR DESCRIPTION
# Summary | Résumé

We are testing the SQS security encryption and targeting the dev environment first. We will destroy all SQS queues managed by Celery and watch what happens when the `is_secure` option is defined in the broker options.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/628

# Test instructions | Instructions pour tester la modification

1. Either destroy existing SQS queues in the development environment or optionally change the `NOTIFICATION_QUEUE_PREFIX` environment variable to something different where it can live side by side with the previously existing SQS queues.
2. Deploy the API image containing this change into the development change.
3. Cross fingers and verify if the newly created SQS queues have encryption enabled.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.