### PR TITLE
Configuration to explicitly turn on SQS Queue Encryption

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -363,6 +363,7 @@ class Config(object):
         "polling_interval": 1,  # 1 second
         "visibility_timeout": 310,
         "queue_name_prefix": NOTIFICATION_QUEUE_PREFIX,
+        "is_secure": True,  # Use HTTPS for SQS
     }
     CELERY_ENABLE_UTC = True
     CELERY_TIMEZONE = os.getenv("TIMEZONE", "UTC")


### PR DESCRIPTION
# Summary | Résumé

Turning on a configuration to explicitly enable SQS Queue encyption using an AWS managed key whenever celery creates said queues

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/628

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.