### PR TITLE
Add fido2_key_id column to users table

### DIFF
--- a/migrations/versions/0486_user_security_key.py
+++ b/migrations/versions/0486_user_security_key.py
@@ -1,0 +1,20 @@
+"""
+
+Revision ID: 0486_user_security_key
+Revises: 0485_security_key_auth
+Create Date: 2025-07-21 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0486_user_security_key'
+down_revision = '0485_security_key_auth'
+
+
+def upgrade():
+    op.add_column('users', sa.Column('fido2_key_id', postgresql.UUID(as_uuid=True), nullable=True))
+
+def downgrade():
+    op.drop_column('users', 'fido2_key_id')


### PR DESCRIPTION
# Summary | Résumé
This column will be used to determine which fido2 security key is currently in use for 2FA, and also to be able to display the key name in the user's profile in the new security section.

# Test instructions | Instructions pour tester la modification
1. `flask db upgrade` and `flask db downgrade` are working as expected.
2. CI is passing

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.