### PR TITLE
Drop fido2_key_id from users table

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -166,7 +166,6 @@ class User(BaseModel):
         nullable=False,
         default=EMAIL_AUTH_TYPE,
     )
-    fido2_key_id = db.Column(UUID(as_uuid=True), nullable=True)
     blocked = db.Column(db.Boolean, nullable=False, default=False)
     additional_information = db.Column(JSONB(none_as_null=True), nullable=True, default={})
     password_expired = db.Column(db.Boolean, nullable=False, default=False)
@@ -228,7 +227,6 @@ class User(BaseModel):
             "additional_information": self.additional_information,
             "password_expired": self.password_expired,
             "verified_phonenumber": self.verified_phonenumber,
-            "fido2_key_id": self.fido2_key_id,
         }
 
     def serialize_for_users_list(self) -> dict:

--- a/migrations/versions/0487_revert_security_key_auth.py
+++ b/migrations/versions/0487_revert_security_key_auth.py
@@ -1,0 +1,20 @@
+"""
+
+Revision ID: 0487_revert_security_key_auth
+Revises: 0486_user_security_key
+Create Date: 2025-07-21 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0487_revert_security_key_auth'
+down_revision = '0486_user_security_key'
+
+
+def upgrade():
+    op.drop_column('users', 'fido2_key_id')
+
+def downgrade():
+    op.add_column('users', sa.Column('fido2_key_id', postgresql.UUID(as_uuid=True), nullable=True))


### PR DESCRIPTION
# Summary | Résumé

Reverts changes from cds-snc/notification-api#2589

We decided against only allowing a specific key for login. Instead we will continue to allow you to log in using any of your currently existing security keys.

