### PR TITLE
Modify auth type check constraint

### DIFF
--- a/migrations/versions/0487_update_user_auth_constraint.py
+++ b/migrations/versions/0487_update_user_auth_constraint.py
@@ -1,0 +1,26 @@
+"""
+Revision ID: 0488_update_user_auth_constraint
+Revises: 0487_revert_security_key_auth
+Create Date: 2025-07-22 00:00:00.000000
+"""
+
+from alembic import op
+
+revision = '0487_update_user_auth_constraint'
+down_revision = '0487_revert_security_key_auth'
+
+def upgrade():
+    op.drop_constraint('ck_users_mobile_or_email_auth', 'users', type_='check')
+    op.create_check_constraint(
+        'ck_users_mobile_or_email_auth',
+        'users',
+        "(auth_type IN ('email_auth', 'security_key_auth') OR mobile_number IS NOT NULL)"
+    )
+
+def downgrade():
+    op.drop_constraint('ck_users_mobile_or_email_auth', 'users', type_='check')
+    op.create_check_constraint(
+        'ck_users_mobile_or_email_auth',
+        'users',
+        "((auth_type = 'email_auth') OR (mobile_number IS NOT NULL))"
+    )


### PR DESCRIPTION
# Summary | Résumé
Previously if the user did not have a mobile number this check constraint would prevent the auth_type column from being changed to anything else but email_auth, preventing us from changing the auth_type to security_key_auth if the user did not have a phone number


# Test instructions | Instructions pour tester la modification
1. `flask db upgrade|downgrade` work
2. CI passes

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.