### PR TITLE
Add a log containing both the document id and the notification id

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -266,6 +266,9 @@ def send_email_to_provider(notification: Notification):
             filename = personalisation_data[key]["document"].get("filename")
             mime_type = personalisation_data[key]["document"].get("mime_type")
             document_id = personalisation_data[key]["document"]["id"]
+            current_app.logger.info(
+                f"Calling document_download_client.check_scan_verdict() for document_id: {document_id} and notification_id: {notification.id}"
+            )
             scan_verdict_response = document_download_client.check_scan_verdict(service.id, document_id, sending_method)
             check_for_malware_errors(scan_verdict_response.status_code, notification)
             current_app.logger.info(f"scan_verdict for document_id {document_id} is {scan_verdict_response.json()}")


### PR DESCRIPTION
# Summary | Résumé

Add a log containing both the document id and the notification id.
We don't have an existing way of relating these two ids, if the document is sent in "attach" mode. Adding this log will help us investigate errors in the future, and relate logs on the document-download-api to a particular notification in our DB.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.