### PR TITLE
Allow  test accounts to login with any code

### DIFF
--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -273,11 +273,12 @@ def verify_user_code(user_id):
             increment_failed_login_count(user_to_verify)
             raise InvalidRequest("Code has already been used", status_code=400)
 
+    user_to_verify.current_session_id = str(uuid.uuid4())
+    user_to_verify.logged_in_at = datetime.utcnow()
+    user_to_verify.failed_login_count = 0
+    save_model_user(user_to_verify)
+
     if code:
-        user_to_verify.current_session_id = str(uuid.uuid4())
-        user_to_verify.logged_in_at = datetime.utcnow()
-        user_to_verify.failed_login_count = 0
-        save_model_user(user_to_verify)
         if code:  # Ensure code is not None before calling use_user_code
             use_user_code(code.id)
     return jsonify({}), 204

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -278,7 +278,8 @@ def verify_user_code(user_id):
         user_to_verify.logged_in_at = datetime.utcnow()
         user_to_verify.failed_login_count = 0
         save_model_user(user_to_verify)
-        use_user_code(code.id)
+        if code:  # Ensure code is not None before calling use_user_code
+            use_user_code(code.id)
     return jsonify({}), 204
 
 

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -246,31 +246,39 @@ def verify_user_code(user_id):
     validate(data, post_verify_code_schema)
 
     user_to_verify = get_user_by_id(user_id=user_id)
+    code = None
 
-    code = get_user_code(user_to_verify, data["code"], data["code_type"])
+    email_prefix = current_app.config.get("CYPRESS_EMAIL_PREFIX", "")
+    if not (
+        current_app.config["NOTIFY_ENVIRONMENT"] == "development"
+        and "notification.canada.ca" not in request.host
+        and user_to_verify.email_address.startswith(email_prefix)
+        and user_to_verify.email_address.endswith("@cds-snc.ca")
+    ):
+        code = get_user_code(user_to_verify, data["code"], data["code_type"])
 
-    if verify_within_time(user_to_verify) >= 2:
-        raise InvalidRequest("Code already sent", status_code=400)
+        if verify_within_time(user_to_verify) >= 2:
+            raise InvalidRequest("Code already sent", status_code=400)
 
-    if user_to_verify.failed_login_count >= current_app.config.get("MAX_VERIFY_CODE_COUNT"):
-        raise InvalidRequest("Code not found", status_code=404)
-    if not code:
-        increment_failed_login_count(user_to_verify)
-        raise InvalidRequest("Code not found", status_code=404)
-    if datetime.utcnow() > code.expiry_datetime:
-        # sms and email
-        increment_failed_login_count(user_to_verify)
-        raise InvalidRequest("Code has expired", status_code=400)
-    if code.code_used:
-        increment_failed_login_count(user_to_verify)
-        raise InvalidRequest("Code has already been used", status_code=400)
+        if user_to_verify.failed_login_count >= current_app.config.get("MAX_VERIFY_CODE_COUNT"):
+            raise InvalidRequest("Code not found", status_code=404)
+        if not code:
+            increment_failed_login_count(user_to_verify)
+            raise InvalidRequest("Code not found", status_code=404)
+        if datetime.utcnow() > code.expiry_datetime:
+            # sms and email
+            increment_failed_login_count(user_to_verify)
+            raise InvalidRequest("Code has expired", status_code=400)
+        if code.code_used:
+            increment_failed_login_count(user_to_verify)
+            raise InvalidRequest("Code has already been used", status_code=400)
 
-    user_to_verify.current_session_id = str(uuid.uuid4())
-    user_to_verify.logged_in_at = datetime.utcnow()
-    user_to_verify.failed_login_count = 0
-    save_model_user(user_to_verify)
-
-    use_user_code(code.id)
+    if code:
+        user_to_verify.current_session_id = str(uuid.uuid4())
+        user_to_verify.logged_in_at = datetime.utcnow()
+        user_to_verify.failed_login_count = 0
+        save_model_user(user_to_verify)
+        use_user_code(code.id)
     return jsonify({}), 204
 
 

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -279,8 +279,7 @@ def verify_user_code(user_id):
     save_model_user(user_to_verify)
 
     if code:
-        if code:  # Ensure code is not None before calling use_user_code
-            use_user_code(code.id)
+        use_user_code(code.id)
     return jsonify({}), 204
 
 

--- a/tests/app/user/test_rest_verify.py
+++ b/tests/app/user/test_rest_verify.py
@@ -480,46 +480,80 @@ def test_user_verify_email_code_fails_if_code_already_used(admin_request, sample
     assert sample_user.current_session_id is None
 
 
-@pytest.mark.parametrize(
-    "env,host,email,should_accept",
-    [
-        ("development", "localhost:3000", "cypress-service-user@cds-snc.ca", True),
-        ("development", "dev.local", "cypress-service-user@cds-snc.ca", True),
-        ("production", "localhost:3000", "cypress-service-user@cds-snc.ca", False),
-        ("development", "notification.canada.ca", "cypress-service-user@cds-snc.ca", False),
-        ("development", "localhost:3000", "otheruser@cds-snc.ca", False),
-        ("development", "localhost:3000", "cypress_test@otherdomain.com", False),
-    ],
-)
-def test_verify_user_code_accepts_any_code_for_test_user(client, env, host, email, should_accept, mocker, cypress_user):
-    # Set the user email for this test case
-    cypress_user.email_address = email
-    # Patch get_user_by_id to return cypress_user
-    mocker.patch("app.service.rest.get_user_by_id", return_value=cypress_user)
-    # Patch save_model_user to avoid SQLAlchemy errors
-    mocker.patch("app.dao.users_dao.save_model_user", autospec=True)
-    with set_config_values(current_app, {"CYPRESS_EMAIL_PREFIX": "cypress-", "NOTIFY_ENVIRONMENT": env}):
-        data = {"code_type": "email", "code": "any-code"}
-        auth_header = create_authorization_header()
-        headers = [
-            ("Content-Type", "application/json"),
-            ("Host", host),
-            auth_header,
-        ]
-        resp = client.post(
-            url_for("user.verify_2fa_code", user_id=cypress_user.id),
-            data=json.dumps(data),
-            headers=headers,
-        )
-
-        if should_accept:
-            assert resp.status_code == 204
-        else:
-            assert resp.status_code == 404
-
-
 class TestE2EUserVerification:
-    pass
+    @pytest.mark.parametrize(
+        "env,host,email,should_accept",
+        [
+            ("development", "localhost:3000", "cypress-service-user@cds-snc.ca", True),
+            ("development", "dev.local", "cypress-service-user@cds-snc.ca", True),
+            ("production", "localhost:3000", "cypress-service-user@cds-snc.ca", False),
+            ("development", "notification.canada.ca", "cypress-service-user@cds-snc.ca", False),
+            ("development", "localhost:3000", "otheruser@cds-snc.ca", False),
+            ("development", "localhost:3000", "cypress_test@otherdomain.com", False),
+        ],
+    )
+    def test_verify_2fa_code_accepts_any_code_for_test_user(self, client, env, host, email, should_accept, mocker, cypress_user):
+        # Set the user email for this test case
+        cypress_user.email_address = email
+        # Patch get_user_by_id to return cypress_user
+        mocker.patch("app.service.rest.get_user_by_id", return_value=cypress_user)
+        # Patch save_model_user to avoid SQLAlchemy errors
+        mocker.patch("app.dao.users_dao.save_model_user", autospec=True)
+        with set_config_values(current_app, {"CYPRESS_EMAIL_PREFIX": "cypress-", "NOTIFY_ENVIRONMENT": env}):
+            data = {"code_type": "email", "code": "any-code"}
+            auth_header = create_authorization_header()
+            headers = [
+                ("Content-Type", "application/json"),
+                ("Host", host),
+                auth_header,
+            ]
+            resp = client.post(
+                url_for("user.verify_2fa_code", user_id=cypress_user.id),
+                data=json.dumps(data),
+                headers=headers,
+            )
+
+            if should_accept:
+                assert resp.status_code == 204
+            else:
+                assert resp.status_code == 404
+
+    @pytest.mark.parametrize(
+        "env,host,email,should_accept",
+        [
+            ("development", "localhost:3000", "cypress-service-user@cds-snc.ca", True),
+            ("development", "dev.local", "cypress-service-user@cds-snc.ca", True),
+            ("production", "localhost:3000", "cypress-service-user@cds-snc.ca", False),
+            ("development", "notification.canada.ca", "cypress-service-user@cds-snc.ca", False),
+            ("development", "localhost:3000", "otheruser@cds-snc.ca", False),
+            ("development", "localhost:3000", "cypress_test@otherdomain.com", False),
+        ],
+    )
+    def test_verify_user_code_accepts_any_code_for_test_user(self, client, env, host, email, should_accept, mocker, cypress_user):
+        # Set the user email for this test case
+        cypress_user.email_address = email
+        # Patch get_user_by_id to return cypress_user
+        mocker.patch("app.service.rest.get_user_by_id", return_value=cypress_user)
+        # Patch save_model_user to avoid SQLAlchemy errors
+        mocker.patch("app.dao.users_dao.save_model_user", autospec=True)
+        with set_config_values(current_app, {"CYPRESS_EMAIL_PREFIX": "cypress-", "NOTIFY_ENVIRONMENT": env}):
+            data = {"code_type": "email", "code": "any-code"}
+            auth_header = create_authorization_header()
+            headers = [
+                ("Content-Type", "application/json"),
+                ("Host", host),
+                auth_header,
+            ]
+            resp = client.post(
+                url_for("user.verify_user_code", user_id=cypress_user.id),
+                data=json.dumps(data),
+                headers=headers,
+            )
+
+            if should_accept:
+                assert resp.status_code == 204
+            else:
+                assert resp.status_code == 404
 
 
 class TestVerify2FACode:


### PR DESCRIPTION
# Summary | Résumé

This PR helps to simplify E2E testing by enabling the test account to authenticate with any verification code. 

See also, a similar PR that allowed verifying phone numbers for e2e tests: https://github.com/cds-snc/notification-api/pull/2585

## Security Considerations
✅ Production Safety: does not occur in production environments
✅ Domain Protection: Blocked on any notification.canada.ca domains
✅ Environment Isolation: Only active in development mode
✅ User checks: Only active for users with a specific email address pattern

## Testing
- Test cases covering all environment and host combinations
- Negative tests confirming shortcut not possible in production


# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.