### PR TITLE
fix

### DIFF
--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -276,8 +276,10 @@ def handle_retries(self, receipts_with_no_notification: List[SESReceipt]) -> Non
         self.retry(queue=QueueNames.RETRY, args=[{"Messages": receipts_with_no_notification}])
     except self.MaxRetriesExceededError:
         config_env = current_app.config["NOTIFY_ENVIRONMENT"]
-        if config_env != "development":
+        if config_env in ("production", "staging"):
             current_app.logger.error(f"notifications not found for SES references: {retry_ids}. Giving up. Env: {config_env}")
+        else:
+            current_app.logger.info(f"notifications not found for SES references: {retry_ids}. Giving up. Env: {config_env}")
 
 
 @notify_celery.task(

--- a/tests/app/celery/test_process_ses_receipts_tasks.py
+++ b/tests/app/celery/test_process_ses_receipts_tasks.py
@@ -214,10 +214,10 @@ def test_ses_callback_should_give_up_after_max_tries(notify_db, mocker):
         "app.celery.process_ses_receipts_tasks.process_ses_results.retry",
         side_effect=MaxRetriesExceededError,
     )
-    mock_logger = mocker.patch("app.celery.process_ses_receipts_tasks.current_app.logger.error")
+    mock_logger = mocker.patch("app.celery.process_ses_receipts_tasks.current_app.logger.info")
 
     assert process_ses_results(generate_ses_notification_callbacks(references=["ref"])) is None
-    mock_logger.assert_called_with("notifications not found for SES references: ref. Giving up.")
+    mock_logger.assert_called_with("notifications not found for SES references: ref. Giving up. Env: test")
 
 
 def test_ses_callback_does_not_call_send_delivery_status_if_no_db_entry(


### PR DESCRIPTION
# Summary | Résumé

We don't have receipts locally, so we don't want to log if the receipts is from a local env

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.