### PR TITLE
Update notification environment check to include staging

### DIFF
--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -250,7 +250,7 @@ def verify_user_code(user_id):
 
     email_prefix = current_app.config.get("CYPRESS_EMAIL_PREFIX", "")
     if not (
-        current_app.config["NOTIFY_ENVIRONMENT"] == "development"
+        current_app.config["NOTIFY_ENVIRONMENT"] in ("development", "staging")
         and "notification.canada.ca" not in request.host
         and user_to_verify.email_address.startswith(email_prefix)
         and user_to_verify.email_address.endswith("@cds-snc.ca")
@@ -308,7 +308,7 @@ def verify_2fa_code(user_id):
 
     email_prefix = current_app.config.get("CYPRESS_EMAIL_PREFIX", "")
     if not (
-        current_app.config["NOTIFY_ENVIRONMENT"] == "development"
+        current_app.config["NOTIFY_ENVIRONMENT"] in ("development", "staging")
         and "notification.canada.ca" not in request.host
         and user_to_verify.email_address.startswith(email_prefix)
         and user_to_verify.email_address.endswith("@cds-snc.ca")


### PR DESCRIPTION
# Summary | Résumé

Allow staging e2e tests to bypass code.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1
* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/1

# Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.