### PR TITLE
Migration for 2fa template changes

### DIFF
--- a/migrations/versions/0488_update_2fa_templates.py
+++ b/migrations/versions/0488_update_2fa_templates.py
@@ -16,7 +16,7 @@ down_revision = "0487_update_user_auth_constraint"
 
 templates = [
     {
-        "id": "5b39e16a-9ff8-487c-9bfb-9e06bdb70f36",
+        "id": current_app.config["ACCOUNT_CHANGE_TEMPLATE_ID"],
         "template_type": "email",
         "subject": "Account information changed | Renseignements de compte modifiés",
         "content": """[[fr]]
@@ -40,10 +40,9 @@ Vous avez effectué une ou plusieurs modifications dans votre profil [Notificati
 
 **Si vous n'avez pas effectué ces modifications**, veuillez [nous joindre](https://notification.canada.ca/contact?lang=fr) immédiatement.
 [[/fr]]""",
-        "process_type": "priority",
     },
     {
-        "id": "6e97fd09-6da0-4cc8-829d-33cf5b818103",
+        "id": current_app.config["EMAIL_MAGIC_LINK_TEMPLATE_ID"],
         "template_type": "email",
         "subject": "Sign in | Connectez-vous",
         "content": """[[fr]]
@@ -69,10 +68,9 @@ Connectez-vous à Notification GC à l'aide du lien magique :
 
 L'équipe Notification GC
 [[/fr]]""",
-        "process_type": "priority",
     },
     {
-        "id": "ece42649-22a8-4d06-b87f-d52d5d3f0a27",
+        "id": current_app.config["NEW_USER_EMAIL_VERIFICATION_TEMPLATE_ID"],
         "template_type": "email",
         "subject": "Confirm your registration | Confirmer votre inscription",
         "content": """[[fr]]
@@ -98,10 +96,9 @@ Pour terminer votre inscription à Notification GC, utilisez le lien suivant :
 
 L'équipe Notification GC
 [[/fr]]""",
-        "process_type": "priority",
     },
     {
-        "id": "299726d2-dba6-42b8-8209-30e1d66ea164",
+        "id": current_app.config["EMAIL_2FA_TEMPLATE_ID"],
         "template_type": "email",
         "subject": "Sign in | Connectez-vous",
         "content": """[[fr]]
@@ -129,17 +126,15 @@ Terminez votre connexion à Notification GC en saisissant le code de sécurité 
 
 L'équipe Notification GC
 [[/fr]]""",
-        "process_type": "priority",
     },
     {
-        "id": "36fb0730-6259-4da1-8a80-c8de22ad4246",
+        "id": current_app.config["SMS_CODE_TEMPLATE_ID"],
         "template_type": "sms",
         "subject": None,
         "content": "((verify_code)) is your GC Notify authentication code | ((verify_code)) est votre code d'authentification de Notification GC",
-        "process_type": "priority",
     },
     {
-        "id": "eb4d9930-87ab-4aef-9bce-786762687884",
+        "id": current_app.config["CHANGE_EMAIL_CONFIRMATION_TEMPLATE_ID"],
         "template_type": "email",
         "subject": "Confirm new email address | Confirmer votre nouvelle adresse courriel",
         "content": """[[fr]]
@@ -167,7 +162,6 @@ Confirmez votre nouvelle adresse courriel pour Notification GC à l'aide du lien
 
 L'équipe Notification GC
 [[/fr]]""",
-        "process_type": "priority",
     },
 ]
 
@@ -178,8 +172,10 @@ def upgrade():
     for template in templates:
         current_version = conn.execute("select version from templates where id='{}'".format(template["id"])).fetchone()
         name = conn.execute("select name from templates where id='{}'".format(template["id"])).fetchone()
+        process_type = conn.execute("select process_type from templates where id='{}'".format(template["id"])).fetchone()
         template["version"] = current_version[0] + 1
         template["name"] = name[0]
+        template["process_type"] = process_type[0]
 
     template_update = """
         UPDATE templates SET content = '{}', subject = '{}', version = '{}', updated_at = '{}'

--- a/migrations/versions/0488_update_2fa_templates.py
+++ b/migrations/versions/0488_update_2fa_templates.py
@@ -1,0 +1,236 @@
+"""
+
+Revision ID: 0488_update_2fa_templates
+Revises: 0487_update_user_auth_constraint
+Create Date: 2025-08-12 00:00:00
+
+"""
+from datetime import datetime
+
+from alembic import op
+from flask import current_app
+
+revision = "0488_update_2fa_templates"
+down_revision = "0487_update_user_auth_constraint"
+
+
+templates = [
+    {
+        "id": "5b39e16a-9ff8-487c-9bfb-9e06bdb70f36",
+        "template_type": "email",
+        "subject": "Account information changed | Renseignements de compte modifiés",
+        "content": """[[fr]]
+*(la version française suit)*
+[[/fr]]
+
+[[en]]
+You just made one or more changes to your [GC Notify](((base_url))) account:
+
+((change_type_en))
+
+**If you did not make this change**, immediately [contact us](https://notification.canada.ca/contact?lang=en).
+[[/en]]
+
+___
+
+[[fr]]
+Vous avez effectué une ou plusieurs modifications dans votre profil [Notification GC](((base_url))) :
+
+((change_type_fr))
+
+**Si vous n'avez pas effectué ces modifications**, veuillez [nous joindre](https://notification.canada.ca/contact?lang=fr) immédiatement.
+[[/fr]]""",
+        "process_type": "priority",
+    },
+    {
+        "id": "6e97fd09-6da0-4cc8-829d-33cf5b818103",
+        "template_type": "email",
+        "subject": "Sign in | Connectez-vous",
+        "content": """[[fr]]
+*(la version française suit)*
+[[/fr]]
+
+[[en]]
+Hello ((name))
+
+Sign in to GC Notify with the following magic link: 
+
+^ [Sign in](((link_url_en)))
+
+The GC Notify Team
+[[/en]]
+---
+[[fr]]
+Bonjour ((name)),
+
+Connectez-vous à Notification GC à l'aide du lien magique :
+
+^ [Connectez-vous](((link_url_fr)))
+
+L'équipe Notification GC
+[[/fr]]""",
+        "process_type": "priority",
+    },
+    {
+        "id": "ece42649-22a8-4d06-b87f-d52d5d3f0a27",
+        "template_type": "email",
+        "subject": "Confirm your registration | Confirmer votre inscription",
+        "content": """[[fr]]
+*(la version française suit)*
+[[/fr]]
+
+[[en]]
+Hello ((name))
+
+Complete your registration for GC Notify by selecting the following link: 
+((url))
+
+The GC Notify Team
+[[/en]]
+
+---
+
+[[fr]]
+Bonjour ((name)),
+
+Pour terminer votre inscription à Notification GC, utilisez le lien suivant : 
+((url))
+
+L'équipe Notification GC
+[[/fr]]""",
+        "process_type": "priority",
+    },
+    {
+        "id": "299726d2-dba6-42b8-8209-30e1d66ea164",
+        "template_type": "email",
+        "subject": "Sign in | Connectez-vous",
+        "content": """[[fr]]
+*(la version française suit)*
+[[/fr]]
+
+[[en]]
+Hello ((name))
+
+Finish signing in to GC Notify by entering the following code:
+
+^ ((verify_code))
+
+The GC Notify Team
+[[/en]]
+
+---
+
+[[fr]]
+Bonjour ((name)),
+
+Terminez votre connexion à Notification GC en saisissant le code de sécurité suivant :
+
+^ ((verify_code))
+
+L'équipe Notification GC
+[[/fr]]""",
+        "process_type": "priority",
+    },
+    {
+        "id": "36fb0730-6259-4da1-8a80-c8de22ad4246",
+        "template_type": "sms",
+        "subject": None,
+        "content": "((verify_code)) is your GC Notify authentication code | ((verify_code)) est votre code d'authentification de Notification GC",
+        "process_type": "priority",
+    },
+    {
+        "id": "eb4d9930-87ab-4aef-9bce-786762687884",
+        "template_type": "email",
+        "subject": "Confirm new email address | Confirmer votre nouvelle adresse courriel",
+        "content": """[[fr]]
+*(la version française suit)*
+[[/fr]]
+
+[[en]]
+Hello ((name))
+
+Confirm your new email address with GC Notify by selecting the following link: ((url))
+        
+**If you did not change your email address**, [contact us](
+((feedback_url)) ""contact us"").
+
+The GC Notify Team
+[[/en]]
+---
+[[fr]]
+Bonjour ((name)),
+
+Confirmez votre nouvelle adresse courriel pour Notification GC à l'aide du lien suivant : 
+((url))
+        
+**Si vous n'avez pas effectué cette modification**, veuillez [nous joindre](((feedback_url)) ""communiquez avec nous"").
+
+L'équipe Notification GC
+[[/fr]]""",
+        "process_type": "priority",
+    },
+]
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    for template in templates:
+        current_version = conn.execute("select version from templates where id='{}'".format(template["id"])).fetchone()
+        name = conn.execute("select name from templates where id='{}'".format(template["id"])).fetchone()
+        template["version"] = current_version[0] + 1
+        template["name"] = name[0]
+
+    template_update = """
+        UPDATE templates SET content = '{}', subject = '{}', version = '{}', updated_at = '{}'
+        WHERE id = '{}'
+    """
+    template_update_no_subject = """
+        UPDATE templates SET content = '{}', version = '{}', updated_at = '{}'
+        WHERE id = '{}'
+    """
+    template_history_insert = """
+        INSERT INTO templates_history (id, name, template_type, created_at, content, archived, service_id, subject,
+        created_by_id, version, process_type, hidden)
+        VALUES ('{}', '{}', '{}', '{}', '{}', False, '{}', '{}', '{}', {}, '{}', false)
+    """
+
+    for template in templates:
+        if template["subject"] is not None:
+            op.execute(
+                template_update.format(
+                    template["content"],
+                    template["subject"],
+                    template["version"],
+                    datetime.utcnow(),
+                    template["id"],
+                )
+            )
+        else:
+            op.execute(
+                template_update_no_subject.format(
+                    template["content"],
+                    template["version"],
+                    datetime.utcnow(),
+                    template["id"],
+                )
+            )
+
+        op.execute(
+            template_history_insert.format(
+                template["id"],
+                template["name"],
+                template["template_type"],
+                datetime.utcnow(),
+                template["content"],
+                current_app.config["NOTIFY_SERVICE_ID"],
+                template["subject"] if template["subject"] is not None else "",
+                current_app.config["NOTIFY_USER_ID"],
+                template["version"],
+                template["process_type"],
+            )
+        )
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
# Summary | Résumé

These changes were already made manually in prod. We are also capturing them with a db migration so that they will be applied to local, dev, etc and be recoverable in a new environment.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/2196

# Test instructions | Instructions pour tester la modification

1. check out the branch and run locally
2. run `flask db upgrade`
3. ensure there are no errors
4. clear your template cache locally in the platform admin section of notification-admin
5. visit the preview pages for each of the following templates and verify that they match prod what is on prod:
```
5b39e16a-9ff8-487c-9bfb-9e06bdb70f36
6e97fd09-6da0-4cc8-829d-33cf5b818103
ece42649-22a8-4d06-b87f-d52d5d3f0a27
299726d2-dba6-42b8-8209-30e1d66ea164
36fb0730-6259-4da1-8a80-c8de22ad4246
eb4d9930-87ab-4aef-9bce-786762687884
```
So for example, compare
- http://localhost:6012/services/d6aa2c68-a2d9-4437-ab19-3ae8eb202553/templates/eb4d9930-87ab-4aef-9bce-786762687884, to
- https://notification.canada.ca/services/d6aa2c68-a2d9-4437-ab19-3ae8eb202553/templates/eb4d9930-87ab-4aef-9bce-786762687884


# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.