### PR TITLE
Added an EN and FR string for verified_phonenumber

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -174,6 +174,7 @@ def update_dct_to_str(update_dct, lang):
             "auth_type": "second verification method changed",
             "security_key_created": "security key added",
             "security_key_deleted": "security key removed",
+            "verified_phonenumber": "phone number verification",
         },
         "FR": {
             "password": "Mot de passe modifié",
@@ -183,6 +184,7 @@ def update_dct_to_str(update_dct, lang):
             "auth_type": "Deuxième méthode de vérification modifiée",
             "security_key_created": "Clé de sécurité ajoutée",
             "security_key_deleted": "Clé de sécurité supprimée",
+            "verified_phonenumber": "Vérification du numéro de téléphone",
         },
     }
 


### PR DESCRIPTION
# Summary | Résumé

Adds human readable definition to `verified_phonenumber` account update type. 

## Related Issues | Cartes liées

Fixes https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/2197

# Test instructions | Instructions pour tester la modification

- [ ] In your profile
- [ ] Change or delete your phone number
- [ ] Get an email, it should have a nice label for "Phone number verification" in EN and FR
- [ ] Re-add, or re-verify your phone number
- [ ] Get an email, it should have a nice label for "Phone number verification" in EN and FR

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.