### PR TITLE
Disabling New Relic via the newrelic.ini file

### DIFF
--- a/newrelic.ini
+++ b/newrelic.ini
@@ -39,7 +39,7 @@
 # application and reports this data to the New Relic UI at
 # newrelic.com. This global switch is normally overridden for
 # each environment below.
-# monitor_mode = true
+monitor_mode = false
 
 # Sets the name of a file to log agent messages to. Useful for
 # debugging any issues with the agent. This is not set by


### PR DESCRIPTION
# Summary | Résumé

Disabling New Relic via the newrelic.ini file

We need a PR to trigger an API lambda deployment, so here it is.

## Related Issues | Cartes liées

None

# Test instructions | Instructions pour tester la modification

Make sure in New Relic that no new data consumption is present. Also check the lambdas environment variables.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.