### PR TITLE
Disabling New Relic completely for the AWS lambda.

### DIFF
--- a/application.py
+++ b/application.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 
 import os
 
-import newrelic.agent  # See https://bit.ly/2xBVKBH
+# import newrelic.agent  # See https://bit.ly/2xBVKBH
 from apig_wsgi import make_lambda_handler
 from aws_xray_sdk.core import patch_all, xray_recorder
 from aws_xray_sdk.ext.flask.middleware import XRayMiddleware
@@ -44,6 +44,6 @@ if os.environ.get("USE_LOCAL_JINJA_TEMPLATES") == "True":
 
 
 def handler(event, context):
-    newrelic.agent.initialize(environment=app.config["NOTIFY_ENVIRONMENT"])  # noqa: E402
-    newrelic.agent.register_application(timeout=20.0)
+    # newrelic.agent.initialize(environment=app.config["NOTIFY_ENVIRONMENT"])  # noqa: E402
+    # newrelic.agent.register_application(timeout=20.0)
     return apig_wsgi_handler(event, context)

--- a/ci/Dockerfile.lambda
+++ b/ci/Dockerfile.lambda
@@ -43,10 +43,13 @@ COPY bin/sync_lambda_envs.sh /
 RUN chmod 755 /usr/bin/aws-lambda-rie /entry.sh /sync_lambda_envs.sh
 
 # New Relic lambda layer
-RUN unzip newrelic-layer.zip -d /opt && rm newrelic-layer.zip
+#RUN unzip newrelic-layer.zip -d /opt && rm newrelic-layer.zip
 
 ENTRYPOINT [ "/entry.sh" ]
 
 # Launch the New Relic lambda wrapper which will then launch the app
 # handler defined in the NEW_RELIC_LAMBDA_HANDLER environment variable
-CMD [ "newrelic_lambda_wrapper.handler" ]
+#CMD [ "newrelic_lambda_wrapper.handler" ]
+
+# Temporary: Disable New Relic completely and get directly to GCNotify lambda's handler.
+CMD [ "applicaton.handler" ]


### PR DESCRIPTION
# Summary | Résumé

Disable New Relic completely for the lambda:

* Disabled the New Relic lambda handler override.
* Target the lambda handler directly to GCNotify one.
* Disable New Relic initialization on application's startup. It should still activate in Kubernetes pods because these go through gunicorn..

## Related Issues | Cartes liées

Incident channel #incident-2025-08-21-500s-on-admin

# Test instructions | Instructions pour tester la modification

Deploy in staging first and make sure lambda runs properly without New Relic enabled.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.