### PR TITLE
Remove newrelic from lambda

### DIFF
--- a/ci/Dockerfile.lambda
+++ b/ci/Dockerfile.lambda
@@ -24,7 +24,7 @@ COPY pyproject.toml poetry.lock ${TASK_ROOT}/
 RUN python -m venv ${APP_VENV} \
     && . ${APP_VENV}/bin/activate \
     && poetry install \
-    && poetry add awslambdaric newrelic-lambda wheel
+    && poetry add awslambdaric wheel
 
 COPY . ${TASK_ROOT}/
 


### PR DESCRIPTION
# Summary | Résumé

Remove new relic from the build to help with incident where we are executing too many lambdas

#incident-2025-08-21-500s-on-admin