### PR TITLE
Fixed typo in lambda handler

### DIFF
--- a/ci/Dockerfile.lambda
+++ b/ci/Dockerfile.lambda
@@ -52,4 +52,4 @@ ENTRYPOINT [ "/entry.sh" ]
 #CMD [ "newrelic_lambda_wrapper.handler" ]
 
 # Temporary: Disable New Relic completely and get directly to GCNotify lambda's handler.
-CMD [ "applicaton.handler" ]
+CMD [ "application.handler" ]


### PR DESCRIPTION
# Summary | Résumé

Fixed the typo with the lambda handler, which tried to refer to the GCNotify lambda handler instead of the New Relic wrapper.

## Related Issues | Cartes liées

Incident #incident-2025-08-21-500s-on-admin

# Test instructions | Instructions pour tester la modification

Try it in staging, make sure lambda boots good in Lambda AWS console and check for errors in the lambda log group!

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.