### PR TITLE
Testing if the NR layer can work without triggering lambda timeout issue

### DIFF
--- a/ci/Dockerfile.lambda
+++ b/ci/Dockerfile.lambda
@@ -24,7 +24,7 @@ COPY pyproject.toml poetry.lock ${TASK_ROOT}/
 RUN python -m venv ${APP_VENV} \
     && . ${APP_VENV}/bin/activate \
     && poetry install \
-    && poetry add awslambdaric wheel
+    && poetry add awslambdaric newrelic-lambda wheel
 
 COPY . ${TASK_ROOT}/
 
@@ -43,13 +43,10 @@ COPY bin/sync_lambda_envs.sh /
 RUN chmod 755 /usr/bin/aws-lambda-rie /entry.sh /sync_lambda_envs.sh
 
 # New Relic lambda layer
-#RUN unzip newrelic-layer.zip -d /opt && rm newrelic-layer.zip
+RUN unzip newrelic-layer.zip -d /opt && rm newrelic-layer.zip
 
 ENTRYPOINT [ "/entry.sh" ]
 
 # Launch the New Relic lambda wrapper which will then launch the app
 # handler defined in the NEW_RELIC_LAMBDA_HANDLER environment variable
-#CMD [ "newrelic_lambda_wrapper.handler" ]
-
-# Temporary: Disable New Relic completely and get directly to GCNotify lambda's handler.
-CMD [ "application.handler" ]
+CMD [ "newrelic_lambda_wrapper.handler" ]


### PR DESCRIPTION
# Summary | Résumé

Testing if the NR layer can work without triggering lambda timeout issue. We fixed the issue in production but we want to pinpoint the actual fix and how we can work out a better code maintenance strategy.

## Related Issues | Cartes liées

Incident #incident-2025-08-21-500s-on-admin

# Test instructions | Instructions pour tester la modification

Deploy in staging environment and look if lambda timeout issue triggers again.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.