### PR TITLE
Update utils to latest

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2608,8 +2608,8 @@ werkzeug = "3.0.4"
 [package.source]
 type = "git"
 url = "https://github.com/cds-snc/notifier-utils.git"
-reference = "53.2.5"
-resolved_reference = "0a8ac9e3a2af5ad332cd3255ea445e74f7d06998"
+reference = "fix/nested-list-padding-2"
+resolved_reference = "e89a7dcc11f67bac0fb80668e21d7ab623300d5b"
 
 [[package]]
 name = "ordered-set"
@@ -4563,4 +4563,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.12.7"
-content-hash = "31166dc28f322031ea08a841fc4ac6c6cbbea0891977a725b9cfebe9f1f6810b"
+content-hash = "d51260376d7a5309f2316101973fc9208f143befb52bf108578ba5ad80931d5b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ more-itertools = "8.14.0"
 nanoid = "2.0.0"
 newrelic = "10.3.0"
 notifications-python-client = "6.4.1"
-notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", tag = "53.2.5" }
+notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", branch = "fix/nested-list-padding-2" }
 pre-commit = "^3.7.1"
 psycopg2-binary = "2.9.9"
 pwnedpasswords = "2.0.0"


### PR DESCRIPTION
# Summary | Résumé

I'll update this pr to use the version 53.2.6 once that is tagged. For now this points to a branch.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.