### PR TITLE
New Relic Variables and On/Off Switch Docker implementation (STAGING)

### DIFF
--- a/.github/workflows/lambda_staging.yml
+++ b/.github/workflows/lambda_staging.yml
@@ -54,6 +54,37 @@ jobs:
             --function-name ${{ matrix.image }} \
             --image-uri $REGISTRY/${{ matrix.image }}:${GITHUB_SHA::7} > /dev/null 2>&1
 
+      - name: Sync NEW_RELIC_* variables from ENVIRONMENT_VARIABLES SSM to Lambda environment
+        run: |
+          PARAMS=$(aws ssm get-parameter \
+            --name ENVIRONMENT_VARIABLES \
+            --with-decryption \
+            --query 'Parameter.Value' \
+            --output text)
+
+          # Extract all NEW_RELIC_* variables from the parameter store content
+          NEW_RELIC_VARS=$(echo "$PARAMS" | grep '^NEW_RELIC_' || true)
+
+          # Build a jq filter to add all NEW_RELIC_* vars
+          JQ_FILTER='.'
+          while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            key=$(echo "$line" | cut -d '=' -f 1)
+            value=$(echo "$line" | cut -d '=' -f 2-)
+            JQ_FILTER="$JQ_FILTER + {\"$key\": \"$value\"}"
+          done <<< "$NEW_RELIC_VARS"
+
+          EXISTING_VARS=$(aws lambda get-function-configuration \
+            --function-name ${{ matrix.image }} \
+            --query 'Environment.Variables' \
+            --output json)
+
+          echo "$EXISTING_VARS" | jq "$JQ_FILTER" > merged_env.json
+
+          aws lambda update-function-configuration \
+            --function-name ${{ matrix.image }} \
+            --environment "Variables=$(cat merged_env.json)"
+
       - name: Publish lambda version and update alias
         run: |
           aws lambda wait function-updated --function-name ${{ matrix.image }}

--- a/bin/entry.sh
+++ b/bin/entry.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
 if [ -z "${AWS_LAMBDA_RUNTIME_API}" ]; then
+    echo "ENTRY.SH: Running locally"
     exec /usr/bin/aws-lambda-rie $(which python) -m awslambdaric $1
 else
-    . /sync_lambda_envs.sh # Retrieve .env from parameter store and remove currently set environement variables
+    echo "ENTRY.SH: Running in AWS Lambda"
+    . /sync_lambda_envs.sh
+    env  # Optional: dump all environment variables
     exec $(which python) -m awslambdaric $1
 fi

--- a/ci/Dockerfile.lambda
+++ b/ci/Dockerfile.lambda
@@ -43,13 +43,8 @@ COPY bin/sync_lambda_envs.sh /
 RUN chmod 755 /usr/bin/aws-lambda-rie /entry.sh /sync_lambda_envs.sh
 
 # New Relic lambda layer
-#RUN unzip newrelic-layer.zip -d /opt && rm newrelic-layer.zip
+RUN unzip newrelic-layer.zip -d /opt && rm newrelic-layer.zip
 
 ENTRYPOINT [ "/entry.sh" ]
 
-# Launch the New Relic lambda wrapper which will then launch the app
-# handler defined in the NEW_RELIC_LAMBDA_HANDLER environment variable
-#CMD [ "newrelic_lambda_wrapper.handler" ]
-
-# Temporary: Disable New Relic completely and get directly to GCNotify lambda's handler.
-CMD [ "application.handler" ]
+CMD [ "sh", "-c", "if [ \"$ENABLE_NEW_RELIC\" = \"true\" ]; then exec newrelic_lambda_wrapper.handler; else exec application.handler; fi" ]

--- a/ci/Dockerfile.lambda
+++ b/ci/Dockerfile.lambda
@@ -47,4 +47,4 @@ RUN unzip newrelic-layer.zip -d /opt && rm newrelic-layer.zip
 
 ENTRYPOINT [ "/entry.sh" ]
 
-CMD [ "sh", "-c", "if [ \"$ENABLE_NEW_RELIC\" = \"true\" ]; then exec newrelic_lambda_wrapper.handler; else exec application.handler; fi" ]
+CMD [ "sh", "-c", "if [ \"$NEW_RELIC_ENABLED\" = \"true\" ]; then exec newrelic_lambda_wrapper.handler; else exec application.handler; fi" ]


### PR DESCRIPTION
# Summary | Résumé

updating docker file to choose handler based on NEW_RELIC_ENABLED var, adding all NEW_RELIC vars from param store to our actual Lambda configuration, outputting some useful logging info for the variable script

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/656

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.