### PR TITLE
Pin Debian version to bookworm

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/python:3.12
+FROM mcr.microsoft.com/vscode/devcontainers/python:3.12-bookworm
 
 ARG KUBENS_VERSION="0.9.4"
 ENV POETRY_VERSION="1.7.1"


### PR DESCRIPTION
# Summary | Résumé

Because of the recent Debian `trixie` release from past August, the devcontainer image reference which had no pinned OS release automatically upgraded. Unfortunately, the requested packages in the Dockerfile needs proper care with upgrades. Hence I pinned to `bookworm` Debian release which was previously used with the current packages defined in the Dockerfile. This fixes the devcontainer setup issues that started to creep in. 

## Related Issues | Cartes liées

None

# Test instructions | Instructions pour tester la modification

None

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.