### PR TITLE
Logging env vars in Entry.sh

### DIFF
--- a/bin/entry.sh
+++ b/bin/entry.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 if [ -z "${AWS_LAMBDA_RUNTIME_API}" ]; then
+    echo "ENTRY.SH: Running locally"
     exec /usr/bin/aws-lambda-rie $(which python) -m awslambdaric $1
 else
-    . /sync_lambda_envs.sh # Retrieve .env from parameter store and remove currently set environement variables
+    echo "ENTRY.SH: Running in AWS Lambda"
+    . /sync_lambda_envs.sh
+    echo "All environment variable names:"
+    env | cut -d '=' -f 1
     exec $(which python) -m awslambdaric $1
 fi


### PR DESCRIPTION
# Summary | Résumé

outputting some useful logging info for env variables to the entry.sh script

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/656

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.