### PR TITLE
Better JSON ENV Logging

### DIFF
--- a/bin/entry.sh
+++ b/bin/entry.sh
@@ -4,9 +4,13 @@ if [ -z "${AWS_LAMBDA_RUNTIME_API}" ]; then
     exec /usr/bin/aws-lambda-rie $(which python) -m awslambdaric $1
 else
     . /sync_lambda_envs.sh
-    VAR_NAMES=$(env | cut -d '=' -f 1 | sort)
-    echo "ENTRY.SH: Running in AWS Lambda (. /sync_lambda_envs.sh)
-All environment variable names (from AWS Parameter Store):
-${VAR_NAMES}"
+    # Collect environment variable names (sorted) into a JSON array for a single CloudWatch structured log line
+    VAR_NAMES_NL=$(env | cut -d '=' -f 1 | sort)
+    ENV_VAR_COUNT=$(printf '%s\n' "$VAR_NAMES_NL" | grep -c '^')
+    # Build JSON array manually (avoid requiring jq at runtime)
+    VAR_NAMES_JSON=$(printf '%s\n' "$VAR_NAMES_NL" | awk 'BEGIN { printf("["); first=1 } { gsub(/"/, "\\\""); if(!first) printf(","); printf("\"%s\"", $0); first=0 } END { printf("]") }')
+    TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u)
+    # Single structured JSON line
+    echo "{\"timestamp\":\"$TS\",\"source\":\"entry.sh\",\"mode\":\"lambda\",\"loader\":\"sync_lambda_envs.sh\",\"new_relic_enabled\":\"${NEW_RELIC_ENABLED:-unset}\",\"env_var_count\":$ENV_VAR_COUNT,\"env_var_names\":$VAR_NAMES_JSON}"
     exec $(which python) -m awslambdaric $1
 fi


### PR DESCRIPTION
# Summary | Résumé

outputting some better logging (as json) info for env variables to the entry.sh script.

The old way was still logging each name as a single line log entry :( 

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/656

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.