### PR TITLE
Adjusting Lambda Sync Script to load ALL param store variables

### DIFF
--- a/bin/sync_lambda_envs.sh
+++ b/bin/sync_lambda_envs.sh
@@ -1,20 +1,10 @@
 #!/bin/sh
 
 # This script will retrieve notification environment variables from AWS parameter store
-# Since lambda & k8s environments have some variance, this script will remove any environment
-# variable that is already set when run within the lambda runtime environment
 
 TMP_ENV_FILE="/tmp/.env"
 
-var_expand() {
-  if [ -z "${1-}" ] || [ $# -ne 1 ]; then
-    printf 'var_expand: expected one argument\n' >&2;
-    return 1;
-  fi
-  eval printf '%s' "\"\${$1?}\"" 2> /dev/null # Variable double substitution to be able to check for variable
-}
-
-load_non_existing_envs() {
+load_all_envs() {
   local envFile=${1:-.env}
   local isComment='^[[:space:]]*#'
   local isBlank='^[[:space:]]*$'
@@ -28,9 +18,8 @@ load_non_existing_envs() {
     key=$(echo "$line" | cut -d '=' -f 1)
     value=$(echo "$line" | cut -d '=' -f 2-)
 
-    if [ -z $(var_expand $key) ]; then # Check if environment variable doesn't exist
-      export "${key}=${value}"
-    fi
+    # Always export (override any existing static value)
+    export "${key}=${value}"
     
   done < $TMP_ENV_FILE
 }
@@ -40,4 +29,4 @@ if [ ! -f "$TMP_ENV_FILE" ]; then # Only setup envs once per lambda lifecycle
   aws ssm get-parameters --region ca-central-1 --with-decryption --names ENVIRONMENT_VARIABLES --query 'Parameters[*].Value' --output text > "$TMP_ENV_FILE"
 fi
 
-load_non_existing_envs
+load_all_envs


### PR DESCRIPTION
# Summary | Résumé

Adjusting Lambda Sync Script to load ALL param store variables rather than just the ones that aren't already preloaded in the lambda static config.  

## Related Issues | Cartes liées
https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/656

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.