### PR TITLE
New Relic Discrete Docker File

### DIFF
--- a/.github/workflows/lambda_staging.yml
+++ b/.github/workflows/lambda_staging.yml
@@ -41,12 +41,17 @@ jobs:
           # Fallback to false if not present
           NEW_RELIC_ENABLED=$(printf '%s' "$RAW" | grep -E '^NEW_RELIC_ENABLED=' | head -n1 | cut -d '=' -f2- || true)
           if [ -z "${NEW_RELIC_ENABLED}" ]; then NEW_RELIC_ENABLED=false; fi
-          echo "Building image (new_relic_enabled=$NEW_RELIC_ENABLED)" >&2
+          DOCKERFILE="ci/Dockerfile.lambda"
+          if [ "${NEW_RELIC_ENABLED}" = "true" ] || [ "${NEW_RELIC_ENABLED}" = "TRUE" ]; then
+            DOCKERFILE="ci/Dockerfile.newrelic.lambda"
+            echo "NEW_RELIC_ENABLED=$NEW_RELIC_ENABLED -> using ${DOCKERFILE}" >&2
+          else
+            echo "NEW_RELIC_ENABLED=$NEW_RELIC_ENABLED -> using plain ${DOCKERFILE}" >&2
+          fi
           docker build \
             --build-arg GIT_SHA=${GITHUB_SHA::7} \
-            --build-arg NEW_RELIC_ENABLED=$NEW_RELIC_ENABLED \
             -t $REGISTRY/${{ matrix.image }}:${GITHUB_SHA::7} \
-            -f ci/Dockerfile.lambda \
+            -f ${DOCKERFILE} \
             .
 
       - name: Login to ECR

--- a/ci/Dockerfile.newrelic.lambda
+++ b/ci/Dockerfile.newrelic.lambda
@@ -8,7 +8,7 @@ ENV POETRY_HOME="/opt/poetry"
 ENV POETRY_VERSION="1.7.1"
 ENV POETRY_VIRTUALENVS_CREATE="false"
 ENV PATH="${APP_VENV}/bin:${POETRY_HOME}/bin:$PATH"
-ENV APP_HANDLER=application.handler
+ENV NEW_RELIC_LAMBDA_HANDLER=application.handler
 
 RUN apt-get update \
  && apt-get install -y bash git libtool autoconf automake gcc g++ make libffi-dev unzip jo \
@@ -17,7 +17,7 @@ RUN apt-get update \
 RUN mkdir -p ${TASK_ROOT}
 WORKDIR ${TASK_ROOT}
 
-# Install poetry and isolate it in it's own venv
+# Install poetry and isolate it in its own venv
 RUN python -m venv ${POETRY_HOME} \
     && ${POETRY_HOME}/bin/pip3 install poetry==${POETRY_VERSION} virtualenv==20.30.0
 
@@ -38,11 +38,18 @@ ENV PORT=6011
 ARG GIT_SHA
 ENV GIT_SHA ${GIT_SHA}
 
-# (Optional) Add Lambda Runtime Interface Emulator and use a script in the ENTRYPOINT for simpler local runs
+# (Optional) Add Lambda Runtime Interface Emulator
 ADD https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/latest/download/aws-lambda-rie /usr/bin/aws-lambda-rie
 COPY bin/entry.sh /
 COPY bin/sync_lambda_envs.sh /
 RUN chmod 755 /usr/bin/aws-lambda-rie /entry.sh /sync_lambda_envs.sh
 
+# Extract New Relic layer (wrapper + libs); remove extension binary so we rely on wrapper only.
+# Expect a file newrelic-layer.zip in build context.
+RUN unzip newrelic-layer.zip -d /opt \
+ && rm -f /opt/extensions/newrelic* || true \
+ && rm -f newrelic-layer.zip
+
+# Use wrapper handler directly; wrapper will delegate to NEW_RELIC_LAMBDA_HANDLER.
 ENTRYPOINT [ "/entry.sh" ]
-CMD [ "application.handler" ]
+CMD [ "newrelic_lambda_wrapper.handler" ]


### PR DESCRIPTION
# Summary | Résumé

Creating separate docker file for NR that will build conditionally if it's enabled, and if not it builds the regular docker file for lambda

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/656

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.