### PR TITLE
Replacing NR Zip with NR Docker Layer

### DIFF
--- a/application.py
+++ b/application.py
@@ -20,10 +20,9 @@ patch_all()
 
 load_dotenv()
 
-# Initialize New Relic with custom environment parameter for K8s/ECS deployments
-# Note: In Lambda, the wrapper already calls newrelic.agent.initialize() during cold start,
-# but calling it again with the environment parameter is safe and ensures proper configuration.
-# The agent will only initialize once and subsequent calls are no-ops.
+# Initialize New Relic with custom environment parameter
+# In Lambda: wrapper calls initialize() first, this adds environment config
+# In K8s/ECS: reads from newrelic.ini via gunicorn_config.py
 if os.environ.get("NOTIFY_ENVIRONMENT"):
     newrelic.agent.initialize(environment=os.environ["NOTIFY_ENVIRONMENT"])
 

--- a/application.py
+++ b/application.py
@@ -3,7 +3,6 @@ from __future__ import print_function
 
 import os
 
-# newrelic.agent import removed - now handled by New Relic Lambda layer wrapper
 from apig_wsgi import make_lambda_handler
 from aws_xray_sdk.core import patch_all, xray_recorder
 from aws_xray_sdk.ext.flask.middleware import XRayMiddleware
@@ -44,7 +43,4 @@ if os.environ.get("USE_LOCAL_JINJA_TEMPLATES") == "True":
 
 
 def handler(event, context):
-    # New Relic initialization is now handled by the Lambda wrapper layer
-    # The wrapper automatically initializes the agent and wraps this handler
-    # Environment is set via NEW_RELIC_LAMBDA_HANDLER=application.handler
     return apig_wsgi_handler(event, context)

--- a/application.py
+++ b/application.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 
 import os
 
-import newrelic.agent  # See https://bit.ly/2xBVKBH
+# newrelic.agent import removed - now handled by New Relic Lambda layer wrapper
 from apig_wsgi import make_lambda_handler
 from aws_xray_sdk.core import patch_all, xray_recorder
 from aws_xray_sdk.ext.flask.middleware import XRayMiddleware
@@ -44,8 +44,7 @@ if os.environ.get("USE_LOCAL_JINJA_TEMPLATES") == "True":
 
 
 def handler(event, context):
-    # Initialize New Relic for Lambda
-    newrelic.agent.initialize(environment=app.config["NOTIFY_ENVIRONMENT"])  # noqa: E402
-    newrelic.agent.register_application(timeout=20.0)
-
+    # New Relic initialization is now handled by the Lambda wrapper layer
+    # The wrapper automatically initializes the agent and wraps this handler
+    # Environment is set via NEW_RELIC_LAMBDA_HANDLER=application.handler
     return apig_wsgi_handler(event, context)

--- a/ci/Dockerfile.newrelic.lambda
+++ b/ci/Dockerfile.newrelic.lambda
@@ -50,6 +50,7 @@ RUN chmod 755 /usr/bin/aws-lambda-rie /entry.sh /sync_lambda_envs.sh
 
 ENTRYPOINT [ "/entry.sh" ]
 
-# Launch the New Relic lambda wrapper which will then launch the app
-# handler defined in the NEW_RELIC_LAMBDA_HANDLER environment variable
+# Use New Relic wrapper for Lambda monitoring
+# Lambda data will appear in New Relic Serverless section (not APM)
+# K8s/ECS deployments will appear in APM section
 CMD [ "newrelic_lambda_wrapper.handler" ]

--- a/ci/Dockerfile.newrelic.lambda
+++ b/ci/Dockerfile.newrelic.lambda
@@ -1,6 +1,9 @@
+# Stage 1: Copy New Relic Lambda Layer for Python 3.12
+FROM public.ecr.aws/newrelic-lambda-layers-for-docker/newrelic-lambda-layers-python:312 AS layer
+
+# Stage 2: Build application
 FROM python:3.12-slim@sha256:31a416db24bd8ade7dac5fd5999ba6c234d7fa79d4add8781e95f41b187f4c9a
 
-ENV PYTHONPATH "${PYTHONPATH}:/opt/python/lib/python3.12/site-packages"
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV TASK_ROOT /app
 ENV APP_VENV="${TASK_ROOT}/.venv"
@@ -10,12 +13,12 @@ ENV POETRY_VIRTUALENVS_CREATE="false"
 ENV PATH="${APP_VENV}/bin:${POETRY_HOME}/bin:$PATH"
 
 RUN apt-get update
-RUN apt-get install -y bash git libtool  autoconf automake gcc  g++ make libffi-dev unzip
+RUN apt-get install -y bash git libtool autoconf automake gcc g++ make libffi-dev unzip
 
 RUN mkdir -p ${TASK_ROOT}
 WORKDIR ${TASK_ROOT}
 
-# Install poetry and isolate it in it's own venv
+# Install poetry and isolate it in its own venv
 RUN python -m venv ${POETRY_HOME} \
     && ${POETRY_HOME}/bin/pip3 install poetry==${POETRY_VERSION} virtualenv==20.30.0
 
@@ -24,12 +27,15 @@ COPY pyproject.toml poetry.lock ${TASK_ROOT}/
 RUN python -m venv ${APP_VENV} \
     && . ${APP_VENV}/bin/activate \
     && poetry install \
-    && poetry add awslambdaric newrelic-lambda wheel
+    && poetry add awslambdaric wheel
 
 COPY . ${TASK_ROOT}/
 
 RUN . ${APP_VENV}/bin/activate \
     && make generate-version-file
+
+# Copy New Relic Layer (agent + extension) from the pre-built image
+COPY --from=layer /opt/ /opt/
 
 ENV PORT=6011
 
@@ -41,9 +47,6 @@ ADD https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/latest
 COPY bin/entry.sh /
 COPY bin/sync_lambda_envs.sh /
 RUN chmod 755 /usr/bin/aws-lambda-rie /entry.sh /sync_lambda_envs.sh
-
-# New Relic lambda layer
-RUN unzip newrelic-layer.zip -d /opt && rm newrelic-layer.zip
 
 ENTRYPOINT [ "/entry.sh" ]
 


### PR DESCRIPTION
# Summary | Résumé

Replacing NR Zip with NR Docker Layer -- also removing a few lines of code that were in the app because it's handled by the included layer in the docker file now.

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/656

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.