### PR TITLE
Updating NR Zip Layer with Docker Layer Take #2

### DIFF
--- a/ci/Dockerfile.newrelic.lambda
+++ b/ci/Dockerfile.newrelic.lambda
@@ -1,3 +1,7 @@
+# Stage 1: Copy New Relic Lambda Layer for Python 3.12
+FROM public.ecr.aws/newrelic-lambda-layers-for-docker/newrelic-lambda-layers-python:312 AS layer
+
+# Stage 2: Build application
 FROM python:3.12-slim@sha256:31a416db24bd8ade7dac5fd5999ba6c234d7fa79d4add8781e95f41b187f4c9a
 
 ENV PYTHONPATH "${PYTHONPATH}:/opt/python/lib/python3.12/site-packages"
@@ -10,12 +14,12 @@ ENV POETRY_VIRTUALENVS_CREATE="false"
 ENV PATH="${APP_VENV}/bin:${POETRY_HOME}/bin:$PATH"
 
 RUN apt-get update
-RUN apt-get install -y bash git libtool  autoconf automake gcc  g++ make libffi-dev unzip
+RUN apt-get install -y bash git libtool autoconf automake gcc g++ make libffi-dev unzip
 
 RUN mkdir -p ${TASK_ROOT}
 WORKDIR ${TASK_ROOT}
 
-# Install poetry and isolate it in it's own venv
+# Install poetry and isolate it in its own venv
 RUN python -m venv ${POETRY_HOME} \
     && ${POETRY_HOME}/bin/pip3 install poetry==${POETRY_VERSION} virtualenv==20.30.0
 
@@ -24,12 +28,15 @@ COPY pyproject.toml poetry.lock ${TASK_ROOT}/
 RUN python -m venv ${APP_VENV} \
     && . ${APP_VENV}/bin/activate \
     && poetry install \
-    && poetry add awslambdaric newrelic-lambda wheel
+    && poetry add awslambdaric wheel
 
 COPY . ${TASK_ROOT}/
 
 RUN . ${APP_VENV}/bin/activate \
     && make generate-version-file
+
+# Copy New Relic Layer (agent + extension) from the pre-built image
+COPY --from=layer /opt/ /opt/
 
 ENV PORT=6011
 
@@ -42,11 +49,9 @@ COPY bin/entry.sh /
 COPY bin/sync_lambda_envs.sh /
 RUN chmod 755 /usr/bin/aws-lambda-rie /entry.sh /sync_lambda_envs.sh
 
-# New Relic lambda layer
-RUN unzip newrelic-layer.zip -d /opt && rm newrelic-layer.zip
-
 ENTRYPOINT [ "/entry.sh" ]
 
-# Launch the New Relic lambda wrapper which will then launch the app
-# handler defined in the NEW_RELIC_LAMBDA_HANDLER environment variable
+# Use New Relic wrapper for Lambda monitoring
+# Lambda data will appear in New Relic Serverless section (not APM)
+# K8s/ECS deployments will appear in APM section
 CMD [ "newrelic_lambda_wrapper.handler" ]


### PR DESCRIPTION
# Summary | Résumé

Replacing NR Zip with NR Docker Layer -- also removing a few lines of code that were in the app because it's handled by the included layer in the docker file now.

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/656

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [x] This PR does not significantly alter performance.
- [x] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.