### PR TITLE
New Relic Cold Start Initialization/APM Variables and Handler

### DIFF
--- a/application.py
+++ b/application.py
@@ -32,10 +32,10 @@ apig_wsgi_handler = make_lambda_handler(
     app, binary_support=True, non_binary_content_type_prefixes=["application/yaml", "application/json"]
 )
 
-# Initialize New Relic at module load (cold start), not per invocation
-# This works for both Lambda (with wrapper) and K8s/ECS (via gunicorn_config.py)
-newrelic.agent.initialize(environment=app.config["NOTIFY_ENVIRONMENT"])  # noqa: E402
-newrelic.agent.register_application(timeout=20.0)
+# Initialize New Relic during Lambda cold starts. Kubernetes/ECS initialisation happens via gunicorn_config.py.
+if os.environ.get("AWS_LAMBDA_RUNTIME_API"):
+    newrelic.agent.initialize(environment=app.config["NOTIFY_ENVIRONMENT"])  # noqa: E402
+    newrelic.agent.register_application(timeout=20.0)
 
 if os.environ.get("USE_LOCAL_JINJA_TEMPLATES") == "True":
     print("")

--- a/application.py
+++ b/application.py
@@ -39,7 +39,7 @@ apig_wsgi_handler = make_lambda_handler(
 # Setting app_name for APM visibility (uses NEW_RELIC_APP_NAME env var)
 newrelic.agent.initialize(
     environment=app.config["NOTIFY_ENVIRONMENT"],
-    app_name=os.environ.get("NEW_RELIC_APP_NAME")
+    app_name=os.environ.get("NEW_RELIC_APP_NAME", "Notify-API-Default-Name")
 )  # noqa: E402
 newrelic.agent.register_application(timeout=20.0)
 

--- a/application.py
+++ b/application.py
@@ -39,7 +39,7 @@ apig_wsgi_handler = make_lambda_handler(
 # Setting app_name for APM visibility (uses NEW_RELIC_APP_NAME env var)
 newrelic.agent.initialize(
     environment=app.config["NOTIFY_ENVIRONMENT"],
-    app_name=os.environ.get("NEW_RELIC_APP_NAME", "Notify-API-Default-Name")
+    app_name=os.environ.get("NEW_RELIC_APP_NAME", "Notify-API-Default-Name"),
 )  # noqa: E402
 newrelic.agent.register_application(timeout=20.0)
 

--- a/application.py
+++ b/application.py
@@ -34,6 +34,7 @@ apig_wsgi_handler = make_lambda_handler(
 # Initialize New Relic during Lambda cold starts. Kubernetes/ECS initialisation happens via gunicorn_config.py.
 if os.environ.get("AWS_LAMBDA_RUNTIME_API"):
     import newrelic.agent  # See https://bit.ly/2xBVKBH
+
     newrelic.agent.initialize(environment=app.config["NOTIFY_ENVIRONMENT"])  # noqa: E402
     newrelic.agent.register_application(timeout=20.0)
 

--- a/application.py
+++ b/application.py
@@ -3,7 +3,6 @@ from __future__ import print_function
 
 import os
 
-import newrelic.agent  # See https://bit.ly/2xBVKBH
 from apig_wsgi import make_lambda_handler
 from aws_xray_sdk.core import patch_all, xray_recorder
 from aws_xray_sdk.ext.flask.middleware import XRayMiddleware
@@ -34,6 +33,7 @@ apig_wsgi_handler = make_lambda_handler(
 
 # Initialize New Relic during Lambda cold starts. Kubernetes/ECS initialisation happens via gunicorn_config.py.
 if os.environ.get("AWS_LAMBDA_RUNTIME_API"):
+    import newrelic.agent  # See https://bit.ly/2xBVKBH
     newrelic.agent.initialize(environment=app.config["NOTIFY_ENVIRONMENT"])  # noqa: E402
     newrelic.agent.register_application(timeout=20.0)
 

--- a/application.py
+++ b/application.py
@@ -34,9 +34,6 @@ apig_wsgi_handler = make_lambda_handler(
 
 # Initialize New Relic at module load (cold start), not per invocation
 # This works for both Lambda (with wrapper) and K8s/ECS (via gunicorn_config.py)
-# For Lambda: wrapper handles instrumentation, this adds environment context
-# For K8s/ECS: gunicorn_config.py reinitializes with proper settings
-# App name is set via NEW_RELIC_APP_NAME environment variable
 newrelic.agent.initialize(environment=app.config["NOTIFY_ENVIRONMENT"])  # noqa: E402
 newrelic.agent.register_application(timeout=20.0)
 

--- a/application.py
+++ b/application.py
@@ -36,11 +36,8 @@ apig_wsgi_handler = make_lambda_handler(
 # This works for both Lambda (with wrapper) and K8s/ECS (via gunicorn_config.py)
 # For Lambda: wrapper handles instrumentation, this adds environment context
 # For K8s/ECS: gunicorn_config.py reinitializes with proper settings
-# Setting app_name for APM visibility (uses NEW_RELIC_APP_NAME env var)
-newrelic.agent.initialize(
-    environment=app.config["NOTIFY_ENVIRONMENT"],
-    app_name=os.environ.get("NEW_RELIC_APP_NAME", "Notify-API-Default-Name"),
-)  # noqa: E402
+# App name is set via NEW_RELIC_APP_NAME environment variable
+newrelic.agent.initialize(environment=app.config["NOTIFY_ENVIRONMENT"])  # noqa: E402
 newrelic.agent.register_application(timeout=20.0)
 
 if os.environ.get("USE_LOCAL_JINJA_TEMPLATES") == "True":

--- a/application.py
+++ b/application.py
@@ -32,6 +32,17 @@ apig_wsgi_handler = make_lambda_handler(
     app, binary_support=True, non_binary_content_type_prefixes=["application/yaml", "application/json"]
 )
 
+# Initialize New Relic at module load (cold start), not per invocation
+# This works for both Lambda (with wrapper) and K8s/ECS (via gunicorn_config.py)
+# For Lambda: wrapper handles instrumentation, this adds environment context
+# For K8s/ECS: gunicorn_config.py reinitializes with proper settings
+# Setting app_name for APM visibility (uses NEW_RELIC_APP_NAME env var)
+newrelic.agent.initialize(
+    environment=app.config["NOTIFY_ENVIRONMENT"],
+    app_name=os.environ.get("NEW_RELIC_APP_NAME")
+)  # noqa: E402
+newrelic.agent.register_application(timeout=20.0)
+
 if os.environ.get("USE_LOCAL_JINJA_TEMPLATES") == "True":
     print("")
     print("========================================================")
@@ -44,8 +55,5 @@ if os.environ.get("USE_LOCAL_JINJA_TEMPLATES") == "True":
 
 
 def handler(event, context):
-    # Initialize New Relic for Lambda
-    newrelic.agent.initialize(environment=app.config["NOTIFY_ENVIRONMENT"])  # noqa: E402
-    newrelic.agent.register_application(timeout=20.0)
-
+    # Simple handler - New Relic already initialized at module level
     return apig_wsgi_handler(event, context)

--- a/bin/entry.sh
+++ b/bin/entry.sh
@@ -6,13 +6,13 @@ else
     RUNTIME_CMD="$(which python)"
 fi
 
+## IMPORTANT: NEW RELIC CONFIGURATION -- WE ALWAYS WANT TO USE APM MODE!
 # Force classic New Relic agent mode for Lambda so data flows to APM instead of the serverless extension
 unset NEW_RELIC_LAMBDA_EXTENSION_ENABLED
 unset NEW_RELIC_LAMBDA_HANDLER
 unset NEW_RELIC_EXTENSION_LOGS_ENABLED
 unset NEW_RELIC_EXTENSION_SEND_FUNCTION_LOGS
-
-export NEW_RELIC_SERVERLESS_MODE_ENABLED=${NEW_RELIC_SERVERLESS_MODE_ENABLED:-false}
+export NEW_RELIC_SERVERLESS_MODE_ENABLED=false
 export NEW_RELIC_CONFIG_FILE=${NEW_RELIC_CONFIG_FILE:-/app/newrelic.ini}
 
 exec ${RUNTIME_CMD} -m awslambdaric $1

--- a/bin/entry.sh
+++ b/bin/entry.sh
@@ -1,7 +1,18 @@
 #!/bin/sh
 if [ -z "${AWS_LAMBDA_RUNTIME_API}" ]; then
-    exec /usr/bin/aws-lambda-rie $(which python) -m awslambdaric $1
+    RUNTIME_CMD="/usr/bin/aws-lambda-rie $(which python)"
 else
     . /sync_lambda_envs.sh # Retrieve .env from parameter store and remove currently set environement variables
-    exec $(which python) -m awslambdaric $1
+    RUNTIME_CMD="$(which python)"
 fi
+
+# Force classic New Relic agent mode for Lambda so data flows to APM instead of the serverless extension
+unset NEW_RELIC_LAMBDA_EXTENSION_ENABLED
+unset NEW_RELIC_LAMBDA_HANDLER
+unset NEW_RELIC_EXTENSION_LOGS_ENABLED
+unset NEW_RELIC_EXTENSION_SEND_FUNCTION_LOGS
+
+export NEW_RELIC_SERVERLESS_MODE_ENABLED=${NEW_RELIC_SERVERLESS_MODE_ENABLED:-false}
+export NEW_RELIC_CONFIG_FILE=${NEW_RELIC_CONFIG_FILE:-/app/newrelic.ini}
+
+exec ${RUNTIME_CMD} -m awslambdaric $1

--- a/bin/get_newrelic_layer.sh
+++ b/bin/get_newrelic_layer.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# see https://layers.newrelic-external.com/
-
-aws lambda get-layer-version-by-arn \
---region ca-central-1 \
---arn arn:aws:lambda:ca-central-1:451483290750:layer:NewRelicPython312:22 \
-| jq -r '.Content.Location' \
-| xargs curl -o ../newrelic-layer.zip

--- a/ci/Dockerfile.lambda
+++ b/ci/Dockerfile.lambda
@@ -8,7 +8,6 @@ ENV POETRY_HOME="/opt/poetry"
 ENV POETRY_VERSION="1.7.1"
 ENV POETRY_VIRTUALENVS_CREATE="false"
 ENV PATH="${APP_VENV}/bin:${POETRY_HOME}/bin:$PATH"
-ENV APP_HANDLER=application.handler
 
 RUN apt-get update \
  && apt-get install -y bash git libtool autoconf automake gcc g++ make libffi-dev unzip jo \

--- a/ci/Dockerfile.newrelic.lambda
+++ b/ci/Dockerfile.newrelic.lambda
@@ -51,7 +51,5 @@ RUN chmod 755 /usr/bin/aws-lambda-rie /entry.sh /sync_lambda_envs.sh
 
 ENTRYPOINT [ "/entry.sh" ]
 
-# Use New Relic wrapper for Lambda monitoring
-# Lambda data will appear in New Relic Serverless section (not APM)
-# K8s/ECS deployments will appear in APM section
-CMD [ "newrelic_lambda_wrapper.handler" ]
+# Run the Flask application handler directly so the classic New Relic Python agent can report to APM
+CMD [ "application.handler" ]

--- a/ci/Dockerfile.newrelic.lambda
+++ b/ci/Dockerfile.newrelic.lambda
@@ -13,8 +13,9 @@ ENV POETRY_VERSION="1.7.1"
 ENV POETRY_VIRTUALENVS_CREATE="false"
 ENV PATH="${APP_VENV}/bin:${POETRY_HOME}/bin:$PATH"
 
-RUN apt-get update
-RUN apt-get install -y bash git libtool autoconf automake gcc g++ make libffi-dev unzip
+RUN apt-get update \
+ && apt-get install -y bash git libtool autoconf automake gcc g++ make libffi-dev unzip jo \
+ && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p ${TASK_ROOT}
 WORKDIR ${TASK_ROOT}

--- a/poetry.lock
+++ b/poetry.lock
@@ -2506,40 +2506,36 @@ test = ["codecov (>=2.1)", "pytest (>=7.2)", "pytest-cov (>=4.0)"]
 
 [[package]]
 name = "newrelic"
-version = "10.3.0"
+version = "11.0.0"
 description = "New Relic Python Agent"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "newrelic-10.3.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5cc803e30b72e2afe7b759a79fbadbed557aa5d51ef36f26d68e9d0aeb156a7f"},
-    {file = "newrelic-10.3.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c2fbdbbb4de1cb305b2c0155639fe74bf6925e54cc014a07176f46fba396cb03"},
-    {file = "newrelic-10.3.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:4a5f11d99621495c7edd121c96d8a71f9af4c0036de8546bc3aac94b6183a3f0"},
-    {file = "newrelic-10.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b1caebc9854614435acc28b95efa1b8b2a30eb9ac8778a96ff65ca619ce7e832"},
-    {file = "newrelic-10.3.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:667e91dc56a99358d08d93e9372f5889b3ba0650d0911718baef68ea607419d1"},
-    {file = "newrelic-10.3.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5dc21702764dffb8d55349fa75ad3d37a9ee53ab4ade3cc8cb347bdf0ba36268"},
-    {file = "newrelic-10.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:080e764b50be8522df204d5f8fb26bdfa64945da85fe2786bc3051318fa77188"},
-    {file = "newrelic-10.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e23dfbc55ba7baa3b65d4f2739ba328e15466a4d4767a85fe732082c423b88e0"},
-    {file = "newrelic-10.3.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30e272c8aa1d812bfe4609db48aa19d3322627263906f5a1cbba267625d0b40f"},
-    {file = "newrelic-10.3.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:31face7377b9083b0e889ea69d2a7d95a79dfdbfcf1bf92256e03d8863c92a68"},
-    {file = "newrelic-10.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9b459cdb67f3dc64ac16420a951f3c6c2e75b8f4bc68b2bfb3f395e83d611a61"},
-    {file = "newrelic-10.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a9085b07ec7e43c079137b515c007542b8f7ecda15504fc7e863fd235481bd87"},
-    {file = "newrelic-10.3.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:92c3da1480db8cd2c6f17e7b7bd09bfcb4a755caab823c9770185a97446f693d"},
-    {file = "newrelic-10.3.0-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f91ad51693f98be5dfd7d115588059e4f2371628aef7412ca830bfdb001d588"},
-    {file = "newrelic-10.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8847709eeda25ce9e577f2d593f0ca12e3de04d3e816e6fda29fa10a4e211900"},
-    {file = "newrelic-10.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0f587779f03b0dc1131e2067221042ce796551bbb73a361046f25102763d1718"},
-    {file = "newrelic-10.3.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb741158af8b84638187d12cce54263e4f14eb031778eea03a45cedb92b92678"},
-    {file = "newrelic-10.3.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5e8e60d72a8c9d31af96ada5bc20cecb9331079061c5cd0e63ebeed514526678"},
-    {file = "newrelic-10.3.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:7af34b3d833f15b4deccd8a0909231ba9adb3e86106630e1a1003d8fc57e0710"},
-    {file = "newrelic-10.3.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:bbd6f9f67fc17337719ef4a5abd5c988824e7b824b598dcfebe54d482cca3ab8"},
-    {file = "newrelic-10.3.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4315353409952f89c84f2cf99de50aadd793c18ee112701319e96f79e166feec"},
-    {file = "newrelic-10.3.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1fb7c6fcce05c2b7ed00801c10f6dc22efac68debe54ca0c2ff0b1b0e1ad81f8"},
-    {file = "newrelic-10.3.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:3c0a41f83a003d87a31a3e290f8c54d680b1590baa86a62ffb60f576ae4bf951"},
-    {file = "newrelic-10.3.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:17cbc679ec01bdd01092c159dc76a5c3abe91a5fd713dcf9429103162792cd5b"},
-    {file = "newrelic-10.3.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a7f9566282a6c0b1d733dc014b2123577c16a65be4814ea48af46d2c4de2a57"},
-    {file = "newrelic-10.3.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5aef5453250fd570af30be7a384b1c85fa5b92ad08a748f3266ea3540f1f06eb"},
-    {file = "newrelic-10.3.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:ee4ff34ab06f0df4ba823dd368fb79789bcdabe4ffa3c0b880a53a65f610f852"},
-    {file = "newrelic-10.3.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:a9453656125daf9b2ece9e49d6d99b064dbb9e85adc1ff6fadd4bdb89ab2f4cd"},
-    {file = "newrelic-10.3.0.tar.gz", hash = "sha256:26040d0b707c30dba2c93b3122e87b39d98cc4910bcbb518bf7ab7c8ab62a5b8"},
+    {file = "newrelic-11.0.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a8d2e4dd14a07c18976112ae06512d9c306cea29ed28a86a985f85ddeb2d531c"},
+    {file = "newrelic-11.0.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6a75441bc2d3a2462fb6e1bd249b161883b8f26bb89b0a4c85cce082013827f3"},
+    {file = "newrelic-11.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f527edd175b591d220d5c1f79ddaf45def2a0dc7c61d889d96a8c45655166968"},
+    {file = "newrelic-11.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c88af2362743da139d597253c0b2e7252c6693c804cf236163aa9879f09c938d"},
+    {file = "newrelic-11.0.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f8ff5e4304d7cf1f668b498bf84e8639ae7f55bb88cb83e3f0f950c02d401d46"},
+    {file = "newrelic-11.0.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:24d516aba469dccb410b0ba8585694be65e40b17383f4a14a834713a316cc77b"},
+    {file = "newrelic-11.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cd7ea98c575206062c45662a67dab9ab849cdbe1ec85af77a464a5c38e1ce345"},
+    {file = "newrelic-11.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a9da74aa99aaec48f73a0cf758e1fc14a39805fcca33057abddf0130f8d2b149"},
+    {file = "newrelic-11.0.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b42fe1c4c9e35a9fdf4c264faa1e92f6918d0014c31dad69fede2798bc4482bb"},
+    {file = "newrelic-11.0.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:927b150eefd9843a5abfc407a9eeac02f4119a842ea0597cd30e33c4b1d5bc61"},
+    {file = "newrelic-11.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a1ca9deba4f44e13eab9eb9866757135a88544b33d971e0929c6884821286bb5"},
+    {file = "newrelic-11.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ee444805ea0df9bcd3bb62873e16f8c5fe3848e0169fc90f8f74b611a51ae2d0"},
+    {file = "newrelic-11.0.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a060dd3918e19e629c9e0e5c16b8c97c4ea1989c7fc12e1845abec2b688e80f2"},
+    {file = "newrelic-11.0.0-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a5bbdc9c1062d8178dd47aaf26bda8c1ebc2700ed82927973ac005cdd1668a8"},
+    {file = "newrelic-11.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c27e089768c8883d4df35f5f1f406ec475ff5053f1463082e01115b25881e4a6"},
+    {file = "newrelic-11.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eb16e55ac25781812bfde1e7e4c181857f9578957919106e049e1a784b333942"},
+    {file = "newrelic-11.0.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f0499267e59934fe3df4de00335619d71344e9ac585c28a654a13e68d34a5c8c"},
+    {file = "newrelic-11.0.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:765ba1fb3fe139c3ece956a9ab6e69519b88b886b6a97cd637fb3d75bdb4c6d3"},
+    {file = "newrelic-11.0.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:94413632777d261a61aacabc5d3771b482155f58cf59524205bd2969daec888d"},
+    {file = "newrelic-11.0.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:577a8aa37c1f3ea2bc82298f27056fd5e32a917933748374de998e09a4baeb4d"},
+    {file = "newrelic-11.0.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:acf814050a7dc3d8631d9bde2a9af67c08a80f7e8fc6374e3488276f58ad1f12"},
+    {file = "newrelic-11.0.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17eb9301ef6761e2e541b57d1a36b8514cc44d5be26564942a8822b1d7bebb17"},
+    {file = "newrelic-11.0.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:e4c755d0e8a0e95c9e424fe3820c1e6720b71c3bfac763d826dbd70bf0cd29ac"},
+    {file = "newrelic-11.0.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:56794a746560a64fdcd49ca0ced7da941a13db6a60da33f971aa7a9ad488c2ef"},
+    {file = "newrelic-11.0.0.tar.gz", hash = "sha256:3419599597dfcb5c7dd78dd46d12097d20c72b19cc1c89218783804976d0931e"},
 ]
 
 [package.extras]
@@ -4565,4 +4561,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.12.7"
-content-hash = "ada58530ba08a6cafdb2146289dbef37a43911fc13052da71547c4407bf1f95d"
+content-hash = "5a603e9d74279275cf0cb812f52365684546f73238960242e3247863ddb5e2d7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ marshmallow = "3.22.0"
 marshmallow-sqlalchemy = "0.30.0"
 more-itertools = "8.14.0"
 nanoid = "2.0.0"
-newrelic = "10.3.0"
+newrelic = "11.0.0"
 notifications-python-client = "6.4.1"
 notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", tag = "53.2.8" }
 pre-commit = "^3.7.1"


### PR DESCRIPTION
# Summary | Résumé

Replacing NR Zip with NR Docker Layer -- also removing a few lines of code that were in the app because it's handled by the included layer in the docker file now.

Adjusting where NR gets initialized (moving to cold start) because we don't want the lambda to show up as piles and piles of lambda functions in NR

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/656

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [x] This PR does not significantly alter performance.
- [x] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.