### PR TITLE
Task/fix broken test

### DIFF
--- a/tests/app/celery/test_int_annual_limit_seeding.py
+++ b/tests/app/celery/test_int_annual_limit_seeding.py
@@ -1,7 +1,11 @@
 import uuid
 from datetime import datetime
+from os import getenv
+from urllib.parse import urlparse
 
+import pytest
 from freezegun import freeze_time
+from pytest_mock_resources import RedisConfig, create_redis_fixture
 from tests.app.db import (
     create_notification,
     create_service,
@@ -17,7 +21,16 @@ from app.celery.process_sns_receipts_tasks import process_sns_results
 from app.celery.reporting_tasks import create_nightly_notification_status_for_day
 
 
-def test_int_annual_limit_seeding_and_incrementation_flows_in_celery(sample_template, notify_api, mocker):
+@pytest.fixture(scope="session")
+def pmr_redis_config():
+    parsed_uri = urlparse(getenv("REDIS_URL"))
+    return RedisConfig(image="redis:6.2", host=parsed_uri.hostname, port="6380", ci_port="6380")
+
+
+redis = create_redis_fixture(scope="function")
+
+
+def test_int_annual_limit_seeding_and_incrementation_flows_in_celery(redis, sample_template, notify_api, mocker):
     """
     This integration-style test verifies the annual limit seeding and notification counting flows across multiple days, testing the flow
     between the process_sns_receipts task, which is responsible for seeded and incrementing notification counts in Redis, and the

--- a/tests/app/celery/test_int_annual_limit_seeding.py
+++ b/tests/app/celery/test_int_annual_limit_seeding.py
@@ -1,11 +1,7 @@
 import uuid
 from datetime import datetime
-from os import getenv
-from urllib.parse import urlparse
 
-import pytest
 from freezegun import freeze_time
-from pytest_mock_resources import RedisConfig, create_redis_fixture
 from tests.app.db import (
     create_notification,
     create_service,
@@ -21,16 +17,7 @@ from app.celery.process_sns_receipts_tasks import process_sns_results
 from app.celery.reporting_tasks import create_nightly_notification_status_for_day
 
 
-@pytest.fixture(scope="session")
-def pmr_redis_config():
-    parsed_uri = urlparse(getenv("REDIS_URL"))
-    return RedisConfig(image="redis:6.2", host=parsed_uri.hostname, port="6380", ci_port="6380")
-
-
-redis = create_redis_fixture(scope="function")
-
-
-def test_int_annual_limit_seeding_and_incrementation_flows_in_celery(redis, sample_template, notify_api, mocker):
+def test_int_annual_limit_seeding_and_incrementation_flows_in_celery(sample_template, notify_api, mocker):
     """
     This integration-style test verifies the annual limit seeding and notification counting flows across multiple days, testing the flow
     between the process_sns_receipts task, which is responsible for seeded and incrementing notification counts in Redis, and the

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -3,11 +3,14 @@ import random
 import string
 import uuid
 from datetime import datetime, timedelta
+from os import getenv
+from urllib.parse import urlparse
 
 import pytest
 import pytz
 import requests_mock
 from flask import current_app, url_for
+from pytest_mock_resources import RedisConfig
 from sqlalchemy import asc
 from sqlalchemy.orm.session import make_transient
 
@@ -78,6 +81,12 @@ from tests.app.db import (
 def rmock():
     with requests_mock.mock() as rmock:
         yield rmock
+
+
+@pytest.fixture(scope="session")
+def pmr_redis_config():
+    parsed_uri = urlparse(getenv("REDIS_URL"))
+    return RedisConfig(image="redis:6.2", host=parsed_uri.hostname, port="6380", ci_port="6380")
 
 
 @pytest.fixture(scope="function")

--- a/tests/app/test_queue.py
+++ b/tests/app/test_queue.py
@@ -1,24 +1,15 @@
 import time
 from contextlib import contextmanager
-from os import getenv
 from unittest import mock
-from urllib.parse import urlparse
 from uuid import uuid4
 
 import pytest
 from flask import Flask
-from pytest_mock_resources import RedisConfig, create_redis_fixture
+from pytest_mock_resources import create_redis_fixture
 
 from app import create_app, flask_redis, metrics_logger
 from app.config import Config, Test
 from app.queue import Buffer, MockQueue, RedisQueue, generate_element
-
-
-@pytest.fixture(scope="session")
-def pmr_redis_config():
-    parsed_uri = urlparse(getenv("REDIS_URL"))
-    return RedisConfig(image="redis:6.2", host=parsed_uri.hostname, port="6380", ci_port="6380")
-
 
 redis = create_redis_fixture(scope="function")
 REDIS_ELEMENTS_COUNT = 123


### PR DESCRIPTION
# Summary | Résumé

Fixes a broken integration test in `tests/app/celery/test_int_annual_limit_seeding.py` by adding a Redis fixture using `pytest_mock_resources`. The test now receives a dedicated function-scoped Redis fixture to ensure the Redis service is available during the test run.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1
* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/1

# Test instructions | Instructions pour tester la modification

Run the integration test to verify it passes:

```
pytest tests/app/celery/test_int_annual_limit_seeding.py
```

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.