### PR TITLE
Fix bug where sent in the last week email totals were always 0

### DIFF
--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -398,7 +398,6 @@ def _stats_for_days_facts_with_billable_units(service_id, start_time, by_templat
             FactNotificationStatus.service_id == service_id,
             FactNotificationStatus.bst_date >= start_time,
             FactNotificationStatus.key_type != KEY_TYPE_TEST,
-            FactNotificationStatus.notification_type == SMS_TYPE,
         )
         .group_by(
             FactNotificationStatus.notification_type,
@@ -417,13 +416,12 @@ def _stats_for_today_with_billable_units(service_id, start_time, by_template=Fal
             Notification.status,
             *([Notification.template_id] if by_template else []),
             *([func.count().label("count")]),
-            *([func.sum(Notification.billable_units).label("billable_units")]),
+            *([func.coalesce(func.sum(Notification.billable_units), 0).label("billable_units")]),
         )
         .filter(
             Notification.created_at >= start_time,
             Notification.service_id == service_id,
             Notification.key_type != KEY_TYPE_TEST,
-            Notification.notification_type == SMS_TYPE,
         )
         .group_by(
             Notification.notification_type,


### PR DESCRIPTION
# Summary | Résumé

This PR:
- Removes `notification_type == SMS_TYPE` from both billable-units DAO functions so email data is now included
- Adds `coalesce(..., 0)` around `sum(Notification.billable_units)` in `_stats_for_today_with_billable_units` since `Notification.billable_units` is nullable for emails

## Related Issues | Cartes liées

https://docs.google.com/document/d/17_hHvjjaF1EBYtteGKX-Qzcg_rqsnvpsRMLaaxybbVc/edit?tab=t.0

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.