### PR TITLE
fix n+1 on service activation

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -410,13 +410,14 @@ def get_notifications_for_service(
         # this field is not used and it can contain a lot of data
         query = query.options(defer("_personalisation"))
 
-    if format_for_csv:
-        # do an explicit join on the template, job, and created_by tables so that we won't
-        # do a separate query for each notification to get the template, job, and created_by
-        # when the csv data is being generated
-        query = query.options(
-            joinedload(Notification.template), joinedload(Notification.job), joinedload(Notification.created_by)
-        )
+    # Eager-load all relationships accessed during serialization to avoid N+1 queries.
+    # This applies equally to CSV and non-CSV paths.
+    query = query.options(
+        joinedload(Notification.template),
+        joinedload(Notification.job),
+        joinedload(Notification.created_by),
+        joinedload(Notification.api_key),
+    )
 
     return query.order_by(desc(Notification.created_at)).paginate(page=page, per_page=page_size, count=count_pages)
 

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -98,7 +98,18 @@ def dao_fetch_live_services_data(filter_heartbeats=None):
         .subquery()
     )
 
-    this_year_ft_billing = FactBilling.query.subquery()
+    this_year_ft_billing = (
+        db.session.query(
+            FactBilling.service_id,
+            FactBilling.notification_type,
+            FactBilling.notifications_sent,
+        )
+        .filter(
+            FactBilling.bst_date >= year_start_date,
+            FactBilling.bst_date < year_end_date,
+        )
+        .subquery()
+    )
 
     data = (
         db.session.query(
@@ -114,32 +125,38 @@ def dao_fetch_live_services_data(filter_heartbeats=None):
             Service.volume_sms.label("sms_volume_intent"),
             Service.volume_email.label("email_volume_intent"),
             Service.volume_letter.label("letter_volume_intent"),
-            case(
-                [
-                    (
-                        this_year_ft_billing.c.notification_type == "email",
-                        func.sum(this_year_ft_billing.c.notifications_sent),
-                    )
-                ],
-                else_=0,
+            func.sum(
+                case(
+                    [
+                        (
+                            this_year_ft_billing.c.notification_type == "email",
+                            this_year_ft_billing.c.notifications_sent,
+                        )
+                    ],
+                    else_=0,
+                )
             ).label("email_totals"),
-            case(
-                [
-                    (
-                        this_year_ft_billing.c.notification_type == "sms",
-                        func.sum(this_year_ft_billing.c.notifications_sent),
-                    )
-                ],
-                else_=0,
+            func.sum(
+                case(
+                    [
+                        (
+                            this_year_ft_billing.c.notification_type == "sms",
+                            this_year_ft_billing.c.notifications_sent,
+                        )
+                    ],
+                    else_=0,
+                )
             ).label("sms_totals"),
-            case(
-                [
-                    (
-                        this_year_ft_billing.c.notification_type == "letter",
-                        func.sum(this_year_ft_billing.c.notifications_sent),
-                    )
-                ],
-                else_=0,
+            func.sum(
+                case(
+                    [
+                        (
+                            this_year_ft_billing.c.notification_type == "letter",
+                            this_year_ft_billing.c.notifications_sent,
+                        )
+                    ],
+                    else_=0,
+                )
             ).label("letter_totals"),
             AnnualBilling.free_sms_fragment_limit,
         )
@@ -174,7 +191,6 @@ def dao_fetch_live_services_data(filter_heartbeats=None):
             Service.volume_sms,
             Service.volume_email,
             Service.volume_letter,
-            this_year_ft_billing.c.notification_type,
             AnnualBilling.free_sms_fragment_limit,
         )
         .order_by(asc(Service.go_live_at))
@@ -182,18 +198,7 @@ def dao_fetch_live_services_data(filter_heartbeats=None):
 
     if filter_heartbeats:
         data = data.filter(Service.id != current_app.config["NOTIFY_SERVICE_ID"])
-    data = data.all()
-    results = []
-    for row in data:
-        existing_service = next((x for x in results if x["service_id"] == row.service_id), None)
-
-        if existing_service is not None:
-            existing_service["email_totals"] += row.email_totals
-            existing_service["sms_totals"] += row.sms_totals
-            existing_service["letter_totals"] += row.letter_totals
-        else:
-            results.append(row._asdict())
-    return results
+    return [row._asdict() for row in data.all()]
 
 
 def dao_fetch_service_by_id(service_id, only_active=False, use_cache=False) -> Service:

--- a/app/service/sender.py
+++ b/app/service/sender.py
@@ -17,9 +17,9 @@ def send_notification_to_service_users(service_id, template_id, personalisation=
     personalisation = personalisation or {}
     include_user_fields = include_user_fields or []
     template = dao_get_template_by_id(template_id)
-    service = dao_fetch_service_by_id(service_id)
-    active_users = dao_fetch_active_users_for_service(service.id)
+    active_users = dao_fetch_active_users_for_service(service_id)
     notify_service = dao_fetch_service_by_id(current_app.config["NOTIFY_SERVICE_ID"])
+    reply_to_text = notify_service.get_default_reply_to_email_address()
 
     for user in active_users:
         personalisation = _add_user_fields(user, personalisation, include_user_fields)
@@ -32,7 +32,7 @@ def send_notification_to_service_users(service_id, template_id, personalisation=
             notification_type=template.template_type,
             api_key_id=None,
             key_type=KEY_TYPE_NORMAL,
-            reply_to_text=notify_service.get_default_reply_to_email_address(),
+            reply_to_text=reply_to_text,
         )
         send_notification_to_queue(notification, False, queue=QueueNames.NOTIFY)
 

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -175,13 +175,13 @@ def test_get_live_services_data(sample_user, admin_request):
     template2 = create_template(service=service, template_type="email")
     dao_add_service_to_organisation(service=service, organisation_id=org.id)
     create_ft_billing(
-        utc_date="2019-04-20",
+        utc_date="2026-04-20",
         notification_type="sms",
         template=template,
         service=service,
     )
     create_ft_billing(
-        utc_date="2019-04-20",
+        utc_date="2026-04-20",
         notification_type="email",
         template=template2,
         service=service,


### PR DESCRIPTION
# Summary | Résumé

Service activation N+1 is causing 400+ select statements

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/784

# Test instructions | Instructions pour tester la modification

Verify activate service still functions

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.