### PR TITLE
Fix for the sms annual limit warning email bug

### DIFF
--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -192,7 +192,7 @@ def check_email_annual_limit(service: Service, requested_emails=0):
                 f"Service {service.id} reached 80% of their annual email limit of {service.email_annual_limit} messages. Sending annual limit usage warning email."
             )
             send_near_annual_limit_warning_email(
-                service, "email", int(emails_sent_today + emails_sent_this_fiscal), current_fiscal_year + 1
+                service, "email", int(emails_sent_today + emails_sent_this_fiscal + requested_emails), current_fiscal_year + 1
             )
 
         return
@@ -250,7 +250,7 @@ def check_sms_annual_limit(service: Service, requested_sms=0):
                 f"Service {service.id} reached 80% of their annual SMS limit of {service.sms_annual_limit} messages. Sending annual limit usage warning email."
             )
             send_near_annual_limit_warning_email(
-                service, "sms", int(sms_sent_today + sms_sent_this_fiscal), current_fiscal_year + 1
+                service, "sms", int(sms_sent_today + sms_sent_this_fiscal + requested_sms), current_fiscal_year + 1
             )
 
         return

--- a/tests/app/celery/test_int_annual_limit_seeding.py
+++ b/tests/app/celery/test_int_annual_limit_seeding.py
@@ -2,6 +2,7 @@ import uuid
 from datetime import datetime
 
 from freezegun import freeze_time
+from pytest_mock_resources import create_redis_fixture
 from tests.app.db import (
     create_notification,
     create_service,
@@ -16,8 +17,10 @@ from app.aws.mocks import sns_success_callback
 from app.celery.process_sns_receipts_tasks import process_sns_results
 from app.celery.reporting_tasks import create_nightly_notification_status_for_day
 
+redis = create_redis_fixture(scope="function")
 
-def test_int_annual_limit_seeding_and_incrementation_flows_in_celery(sample_template, notify_api, mocker):
+
+def test_int_annual_limit_seeding_and_incrementation_flows_in_celery(redis, sample_template, notify_api, mocker):
     """
     This integration-style test verifies the annual limit seeding and notification counting flows across multiple days, testing the flow
     between the process_sns_receipts task, which is responsible for seeded and incrementing notification counts in Redis, and the


### PR DESCRIPTION
# Summary | Résumé

Previously, the warning email that you were close to reaching your annual sms limit contained the wrong number ("3 of 5 used" in the example below, when it should have been "4 of 5 used").

This PR fixes that.

This is an existing bug, not specific to `FF_USE_BILLABLE_UNITS = True`.

# Test instructions | Instructions pour tester la modification

1. on a service with 0 sms sent, set the annual sms limit to 5 text message parts, and the daily limit to 100 text message parts.
2. create an sms template that adds up to 1 text message part. 
3. send it to yourself  4 times
4. you should now get an email that says you have used "4 out of 5"  text message parts

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.