### PR TITLE
Fix SMS annual limit reached email not sent bug

### DIFF
--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -186,7 +186,12 @@ def check_email_annual_limit(service: Service, requested_emails=0):
             send_annual_limit_reached_email(service, "email", current_fiscal_year + 1)
 
         # Will this send put annual usage within 80% of the limit?
-        if is_near_annual_limit and not annual_limit_client.check_has_warning_been_sent(service.id, EMAIL_TYPE):
+        # Send the warning email if the current send does not also put them at their limit
+        if (
+            is_near_annual_limit
+            and not annual_limit_client.check_has_warning_been_sent(service.id, EMAIL_TYPE)
+            and not send_reaches_annual_limit
+        ):
             annual_limit_client.set_nearing_email_limit(service.id)
             current_app.logger.info(
                 f"Service {service.id} reached 80% of their annual email limit of {service.email_annual_limit} messages. Sending annual limit usage warning email."
@@ -243,8 +248,14 @@ def check_sms_annual_limit(service: Service, requested_sms=0):
             )
             send_annual_limit_reached_email(service, "sms", current_fiscal_year + 1)
 
-        # Will this send put annual usage within 80% of the limit?
-        if is_near_annual_limit and not annual_limit_client.check_has_warning_been_sent(service.id, SMS_TYPE):
+        # Will this send put annual usage within 80%?
+        # Send the warning email if the current send does not also put them at their limit
+        # Larger multi-part SMS could technically do this, but it is an unlikely edge case.
+        if (
+            is_near_annual_limit
+            and not annual_limit_client.check_has_warning_been_sent(service.id, SMS_TYPE)
+            and not send_reaches_annual_limit
+        ):
             annual_limit_client.set_nearing_sms_limit(service.id)
             current_app.logger.info(
                 f"Service {service.id} reached 80% of their annual SMS limit of {service.sms_annual_limit} messages. Sending annual limit usage warning email."

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -136,8 +136,8 @@ service_blueprint = Blueprint("service", __name__)
 
 register_errors(service_blueprint)
 
-ANNUAL_LIMIT_SMS_OVER_NEAR_STATUS_FIELDS = ["near_sms_limit", "near_email_limit"]
-ANNUAL_LIMIT_EMAIL_OVER_NEAR_STATUS_FIELDS = ["over_email_limit", "near_email_limit"]
+ANNUAL_LIMIT_SMS_OVER_NEAR_STATUS_FIELDS = ["near_sms_limit", "over_sms_limit"]
+ANNUAL_LIMIT_EMAIL_OVER_NEAR_STATUS_FIELDS = ["near_email_limit", "over_email_limit"]
 
 
 @service_blueprint.errorhandler(IntegrityError)
@@ -326,7 +326,10 @@ def update_service(service_id):
     if sms_annual_limit_changed:
         _warn_service_users_about_annual_limit_change(service, SMS_TYPE)
         # TODO: abstract this in the annual_limits_client
-        redis_store.delete_hash_fields(f"annual-limit:{service_id}:status", ANNUAL_LIMIT_SMS_OVER_NEAR_STATUS_FIELDS)
+        fields_to_clear = list(ANNUAL_LIMIT_SMS_OVER_NEAR_STATUS_FIELDS)
+        if current_app.config.get("FF_USE_BILLABLE_UNITS"):
+            fields_to_clear += ["near_sms_billable_units_limit", "over_sms_billable_units_limit"]
+        redis_store.delete_hash_fields(f"annual-limit:{service_id}:status", fields_to_clear)
     if email_annual_limit_changed:
         _warn_service_users_about_annual_limit_change(service, EMAIL_TYPE)
         # TODO: abstract this in the annual_limits_client

--- a/tests/app/notifications/test_validators.py
+++ b/tests/app/notifications/test_validators.py
@@ -798,6 +798,85 @@ class TestAnnualLimitValidators:
         check_sms_annual_limit(service, 4)
         mock_send_email.assert_not_called()
 
+    def test_check_sms_annual_limit_only_sends_reached_email_when_near_and_reached_in_same_send(
+        self,
+        notify_api,
+        notify_db,
+        notify_db_session,
+        mocker,
+    ):
+        """When a single send crosses both the 80% near-limit threshold and reaches the annual limit,
+        only the 'reached limit' email should be sent, not the 'near limit' warning.
+        e.g. service has limit of 5 SMS parts, sends 1 message that is 5 parts.
+        """
+        mocker.patch("app.redis_store.set_hash_value")
+        mocker.patch("app.redis_store.get", return_value=0)
+        mocker.patch(
+            "app.notifications.validators.get_annual_limit_notifications_v2",
+            return_value={
+                "total_sms_fiscal_year_to_yesterday": 0,
+                "total_sms_billable_units_fiscal_year_to_yesterday": 0,
+            },
+        )
+        mocker.patch("app.notifications.validators.fetch_todays_requested_sms_count", return_value=0)
+        mocker.patch("app.notifications.validators.fetch_todays_requested_sms_billable_units_count", return_value=0)
+        mocker.patch("app.annual_limit_client.check_has_over_limit_been_sent", return_value=False)
+        mocker.patch("app.annual_limit_client.check_has_warning_been_sent", return_value=False)
+        mock_set_over = mocker.patch("app.annual_limit_client.set_over_sms_limit")
+        mock_set_near = mocker.patch("app.annual_limit_client.set_nearing_sms_limit")
+        mock_send_reached = mocker.patch("app.notifications.validators.send_annual_limit_reached_email")
+        mock_send_near = mocker.patch("app.notifications.validators.send_near_annual_limit_warning_email")
+
+        service = create_sample_service(notify_db, notify_db_session, sms_annual_limit=5)
+
+        # Send 5 parts at once — crosses 80% AND reaches limit
+        check_sms_annual_limit(service, 5)
+
+        # Reached limit email should be sent
+        mock_set_over.assert_called_once_with(service.id)
+        mock_send_reached.assert_called_once()
+
+        # Near limit email should NOT be sent
+        mock_set_near.assert_not_called()
+        mock_send_near.assert_not_called()
+
+    def test_check_email_annual_limit_only_sends_reached_email_when_near_and_reached_in_same_send(
+        self,
+        notify_api,
+        notify_db,
+        notify_db_session,
+        mocker,
+    ):
+        """When a single send crosses both the 80% near-limit threshold and reaches the annual limit,
+        only the 'reached limit' email should be sent, not the 'near limit' warning.
+        """
+        mocker.patch("app.redis_store.set_hash_value")
+        mocker.patch("app.redis_store.get", return_value=0)
+        mocker.patch(
+            "app.notifications.validators.get_annual_limit_notifications_v2",
+            return_value={"total_email_fiscal_year_to_yesterday": 0},
+        )
+        mocker.patch("app.notifications.validators.fetch_todays_email_count", return_value=0)
+        mocker.patch("app.annual_limit_client.check_has_over_limit_been_sent", return_value=False)
+        mocker.patch("app.annual_limit_client.check_has_warning_been_sent", return_value=False)
+        mock_set_over = mocker.patch("app.annual_limit_client.set_over_email_limit")
+        mock_set_near = mocker.patch("app.annual_limit_client.set_nearing_email_limit")
+        mock_send_reached = mocker.patch("app.notifications.validators.send_annual_limit_reached_email")
+        mock_send_near = mocker.patch("app.notifications.validators.send_near_annual_limit_warning_email")
+
+        service = create_sample_service(notify_db, notify_db_session, email_annual_limit=5)
+
+        # Send 5 emails at once — crosses 80% AND reaches limit
+        check_email_annual_limit(service, 5)
+
+        # Reached limit email should be sent
+        mock_set_over.assert_called_once_with(service.id)
+        mock_send_reached.assert_called_once()
+
+        # Near limit email should NOT be sent
+        mock_set_near.assert_not_called()
+        mock_send_near.assert_not_called()
+
 
 # TODO: Remove feature flag checks after FF_USE_BILLABLE_UNITS go live
 class TestBillableUnitsInValidators:

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1042,11 +1042,11 @@ def test_update_service_annual_limits(
     )
     assert getattr(sample_service, limit_field) == limit_value
     if limit_field == "sms_annual_limit":
+        expected_fields = ["near_sms_limit", "over_sms_limit"]
+        if current_app.config.get("FF_USE_BILLABLE_UNITS"):
+            expected_fields += ["near_sms_billable_units_limit", "over_sms_billable_units_limit"]
         assert redis_delete.call_args_list == [
-            call(
-                f"annual-limit:{sample_service.id}:status",
-                ["near_sms_limit", "over_sms_limit", "near_sms_billable_units_limit", "over_sms_billable_units_limit"],
-            ),
+            call(f"annual-limit:{sample_service.id}:status", expected_fields),
         ]
     if limit_field == "email_annual_limit":
         assert redis_delete.call_args_list == [

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1043,7 +1043,10 @@ def test_update_service_annual_limits(
     assert getattr(sample_service, limit_field) == limit_value
     if limit_field == "sms_annual_limit":
         assert redis_delete.call_args_list == [
-            call(f"annual-limit:{sample_service.id}:status", ["near_sms_limit", "over_sms_limit"]),
+            call(
+                f"annual-limit:{sample_service.id}:status",
+                ["near_sms_limit", "over_sms_limit", "near_sms_billable_units_limit", "over_sms_billable_units_limit"],
+            ),
         ]
     if limit_field == "email_annual_limit":
         assert redis_delete.call_args_list == [

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -1043,11 +1043,11 @@ def test_update_service_annual_limits(
     assert getattr(sample_service, limit_field) == limit_value
     if limit_field == "sms_annual_limit":
         assert redis_delete.call_args_list == [
-            call(f"annual-limit:{sample_service.id}:status", ["near_sms_limit", "near_email_limit"]),
+            call(f"annual-limit:{sample_service.id}:status", ["near_sms_limit", "over_sms_limit"]),
         ]
     if limit_field == "email_annual_limit":
         assert redis_delete.call_args_list == [
-            call(f"annual-limit:{sample_service.id}:status", ["over_email_limit", "near_email_limit"]),
+            call(f"annual-limit:{sample_service.id}:status", ["near_email_limit", "over_email_limit"]),
         ]
 
 


### PR DESCRIPTION

# Summary | Résumé
This PR fixes a bug where the SMS annual limit reached email wasn't always being sent out. Originally it seemed like the issue was with sending via the API. [During testing](https://docs.google.com/document/d/17_hHvjjaF1EBYtteGKX-Qzcg_rqsnvpsRMLaaxybbVc/edit?tab=t.0#heading=h.4cxn7nr1idzw) it was observed that after sending via the API the service no longer received annual limit reached emails. 

However this was a red herring as, prior to sending via the API, the service's annual limit was increased. This should have resulted in `over_sms_limit` flag being reset but it was not.

## The actual bug
`ANNUAL_LIMIT_SMS_OVER_NEAR_STATUS_FIELDS` had `near_email_limit` in the list of values instead of `over_sms_limit`. This caused the `over_sms_limit` flag to never be cleared when a service's annual limit was increased, resulting in the email never being sent


## Related Issues | Cartes liées
* https://docs.google.com/document/d/17_hHvjjaF1EBYtteGKX-Qzcg_rqsnvpsRMLaaxybbVc/edit?tab=t.0#heading=h.4cxn7nr1idzw

# Test instructions | Instructions pour tester la modification
### Part 1
1. Create a fresh service
2. Set your SMS annual limit to 5
3. Send 5 SMS message parts
4. Note you received the annual limit reached email

### Part 2
1. Set your SMS annual limit to 10
2. Send 5 sms message parts **using the API**
3. Note that you received the annual limit reached email


### Part 3
1. Set your SMS annual limit to 15
2. Send 5 sms message parts **use a mixture of the API and UI**
3. Note that you received the annual limit reached email

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.