### PR TITLE
[Security] - Experiment migrating to fido2 2.2.0

### DIFF
--- a/app/dao/fido2_key_dao.py
+++ b/app/dao/fido2_key_dao.py
@@ -3,8 +3,8 @@ import io
 import json
 import pickle
 
+from fido2.utils import websafe_encode
 from fido2.webauthn import AttestationObject, AttestedCredentialData, AuthenticatorData
-from fido2.webauthn import CollectedClientData as ClientData
 from sqlalchemy import and_
 
 from app import db
@@ -62,16 +62,15 @@ def _ensure_bytes(value):
 
 class _Fido2CredentialUnpickler(pickle.Unpickler):
     def find_class(self, module, name):
-        # Handle both old and new fido2 library module paths for backward compatibility
+        # Handle fido2 library module path changes across versions for backward compatibility.
         # In fido2 0.9.x, AttestedCredentialData was in fido2.ctap2
         # In fido2 1.x, it's in fido2.webauthn (and internally in fido2.ctap2.base)
-        if name == "AttestedCredentialData":
-            if module in ("fido2.ctap2", "fido2.ctap2.base", "fido2.webauthn"):
-                return AttestedCredentialData
-        # Handle AuthenticatorData for completeness
-        if name == "AuthenticatorData":
-            if module in ("fido2.ctap2", "fido2.ctap2.base", "fido2.webauthn"):
-                return AuthenticatorData
+        # In fido2 2.x, it remains in fido2.webauthn
+        _FIDO2_MODULES = ("fido2.ctap2", "fido2.ctap2.base", "fido2.webauthn")
+        if name == "AttestedCredentialData" and module in _FIDO2_MODULES:
+            return AttestedCredentialData
+        if name == "AuthenticatorData" and module in _FIDO2_MODULES:
+            return AuthenticatorData
         return super().find_class(module, name)
 
 
@@ -81,7 +80,29 @@ def deserialize_fido2_key(serialized_key):
 
 
 def decode_and_register(data, state):
-    client_data = ClientData(_ensure_bytes(data["clientDataJSON"]))
-    att_obj = AttestationObject(_ensure_bytes(data["attestationObject"]))
-    auth_data = Config.FIDO2_SERVER.register_complete(state, client_data, att_obj)
+    """Complete FIDO2 registration using the fido2 v2 API.
+
+    Accepts either:
+      - A standard WebAuthn RegistrationResponse JSON dict (fido2 v2 format)
+      - A legacy dict with top-level 'clientDataJSON' and 'attestationObject' keys
+    """
+    if "response" in data:
+        # Standard WebAuthn RegistrationResponse JSON – pass directly
+        response = data
+    else:
+        # Legacy format: build a RegistrationResponse-compatible dict.
+        # Extract the credential ID from the attestation object so we can
+        # populate the required 'rawId' field.
+        raw_att = _ensure_bytes(data["attestationObject"])
+        att_obj = AttestationObject(raw_att)
+        cred_id = att_obj.auth_data.credential_data.credential_id
+        response = {
+            "rawId": websafe_encode(cred_id),
+            "response": {
+                "clientDataJSON": websafe_encode(_ensure_bytes(data["clientDataJSON"])),
+                "attestationObject": websafe_encode(raw_att),
+            },
+            "type": "public-key",
+        }
+    auth_data = Config.FIDO2_SERVER.register_complete(state, response)
     return base64.b64encode(pickle.dumps(auth_data.credential_data)).decode("utf8")

--- a/app/dao/fido2_key_dao.py
+++ b/app/dao/fido2_key_dao.py
@@ -5,6 +5,7 @@ import pickle
 
 from fido2.utils import websafe_encode
 from fido2.webauthn import AttestationObject, AttestedCredentialData, AuthenticatorData
+from flask import current_app
 from sqlalchemy import and_
 
 from app import db
@@ -47,6 +48,22 @@ def get_fido2_session(user_id):
     return json.loads(session.session)
 
 
+def _base64url_decode(value):
+    """Decode a base64url-encoded string to bytes.
+
+    Handles missing padding and both base64url and standard base64.
+    """
+    if isinstance(value, bytes):
+        value = value.decode("utf-8")
+    # Add padding if needed
+    padding = 4 - len(value) % 4
+    if padding != 4:
+        value += "=" * padding
+    # Convert base64url to standard base64
+    value = value.replace("-", "+").replace("_", "/")
+    return base64.b64decode(value)
+
+
 def _ensure_bytes(value):
     """Convert various binary-like types to bytes for FIDO2 operations."""
     if isinstance(value, bytes):
@@ -75,8 +92,39 @@ class _Fido2CredentialUnpickler(pickle.Unpickler):
 
 
 def deserialize_fido2_key(serialized_key):
+    """Deserialize a pickled FIDO2 credential.
+
+    Returns AttestedCredentialData with credential_id attribute.
+    Raises ValueError if deserialization fails or credential is malformed.
+    """
     raw = base64.b64decode(serialized_key if isinstance(serialized_key, (bytes, bytearray)) else serialized_key.encode("utf-8"))
-    return _Fido2CredentialUnpickler(io.BytesIO(raw)).load()
+
+    # Log the pickle header to understand what version/class was stored
+    current_app.logger.info(f"Deserializing FIDO2 key, raw pickle size: {len(raw)} bytes")
+
+    credential = _Fido2CredentialUnpickler(io.BytesIO(raw)).load()
+
+    current_app.logger.info(f"Deserialized credential type: {type(credential).__module__}.{type(credential).__name__}")
+    current_app.logger.info(f"Credential attributes: {[a for a in dir(credential) if not a.startswith('_')]}")
+
+    # Verify the deserialized credential has the expected structure
+    if not hasattr(credential, "credential_id"):
+        current_app.logger.error(
+            f"Deserialized credential missing 'credential_id' attribute. Type: {type(credential)}, attrs: {dir(credential)}"
+        )
+        raise ValueError("Malformed FIDO2 credential: missing credential_id")
+
+    if credential.credential_id is None or len(credential.credential_id) == 0:
+        current_app.logger.error("Deserialized credential has empty credential_id")
+        raise ValueError("Malformed FIDO2 credential: empty credential_id")
+
+    from fido2.utils import websafe_encode
+
+    cred_id_b64 = websafe_encode(credential.credential_id)
+    current_app.logger.info(f"Credential ID (base64url): {cred_id_b64}")
+    current_app.logger.info(f"Credential ID length: {len(credential.credential_id)} bytes")
+
+    return credential
 
 
 def decode_and_register(data, state):
@@ -85,21 +133,27 @@ def decode_and_register(data, state):
     Accepts either:
       - A standard WebAuthn RegistrationResponse JSON dict (fido2 v2 format)
       - A legacy dict with top-level 'clientDataJSON' and 'attestationObject' keys
+        (these fields are base64url-encoded binary data)
     """
     if "response" in data:
         # Standard WebAuthn RegistrationResponse JSON – pass directly
         response = data
     else:
-        # Legacy format: build a RegistrationResponse-compatible dict.
+        # Legacy format: fields are base64url-encoded, need to decode first.
+        # Decode from base64url to get the actual binary data
+        raw_att = _base64url_decode(data["attestationObject"])
+        raw_client_data = _base64url_decode(data["clientDataJSON"])
+
         # Extract the credential ID from the attestation object so we can
         # populate the required 'rawId' field.
-        raw_att = _ensure_bytes(data["attestationObject"])
         att_obj = AttestationObject(raw_att)
         cred_id = att_obj.auth_data.credential_data.credential_id
+
+        # Build a RegistrationResponse-compatible dict with base64url-encoded values
         response = {
             "rawId": websafe_encode(cred_id),
             "response": {
-                "clientDataJSON": websafe_encode(_ensure_bytes(data["clientDataJSON"])),
+                "clientDataJSON": websafe_encode(raw_client_data),
                 "attestationObject": websafe_encode(raw_att),
             },
             "type": "public-key",

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -1,12 +1,8 @@
-import base64
 import json
 import uuid
 from datetime import datetime, timedelta
 
 import pwnedpasswords
-from fido2 import cbor
-from fido2.webauthn import AuthenticatorData
-from fido2.webauthn import CollectedClientData as ClientData
 from flask import Blueprint, abort, current_app, jsonify, request
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
@@ -16,7 +12,6 @@ from app.clients.freshdesk import Freshdesk
 from app.clients.salesforce.salesforce_engagement import ENGAGEMENT_STAGE_ACTIVATION
 from app.config import Config, QueueNames
 from app.dao.fido2_key_dao import (
-    _ensure_bytes,
     create_fido2_session,
     decode_and_register,
     delete_fido2_key,
@@ -797,12 +792,12 @@ def list_fido2_keys_user(user_id):
 def create_fido2_keys_user(user_id):
     user = get_user_and_accounts(user_id)
     data = request.get_json()
-    cbor_data = cbor.decode(base64.b64decode(data["payload"]))
     validate(data, fido2_key_schema)
 
     id = uuid.uuid4()
-    key = decode_and_register(cbor_data, get_fido2_session(user_id))
-    save_fido2_key(Fido2Key(id=id, user_id=user_id, name=cbor_data["name"], key=key))
+    # data["credential"] is the standard WebAuthn RegistrationResponse JSON
+    key = decode_and_register(data["credential"], get_fido2_session(user_id))
+    save_fido2_key(Fido2Key(id=id, user_id=user_id, name=data["name"], key=key))
     _update_alert(user, changes={"security_key_created": None})
     return jsonify({"id": id})
 
@@ -825,10 +820,8 @@ def fido2_keys_user_register(user_id):
     )
     create_fido2_session(user_id, state)
 
-    # In fido2 1.x, register_begin returns a PublicKeyCredentialCreationOptions object
-    # We can encode it directly as CBOR - the object itself is CBOR-serializable
-    registration_payload = base64.b64encode(cbor.encode(registration_data)).decode("utf8")
-    return jsonify({"data": registration_payload})
+    # fido2 v2: CredentialCreationOptions serializes to a JSON-compatible dict
+    return jsonify({"data": dict(registration_data)})
 
 
 @user_blueprint.route("/<uuid:user_id>/fido2_keys/authenticate", methods=["POST"])
@@ -848,18 +841,8 @@ def fido2_keys_user_authenticate(user_id):
         create_fido2_session(user_id, state)
         current_app.logger.info("FIDO2 session created successfully")
 
-        # In fido2 1.x, authenticate_begin returns a CredentialRequestOptions object
-        # We need to encode it directly as CBOR - the object itself is CBOR-serializable
-        current_app.logger.info(f"Authentication challenge type: {type(request_options)}")
-
-        # The request_options object can be CBOR encoded directly in fido2 1.x
-        cbor_encoded = cbor.encode(request_options)
-        current_app.logger.info(f"CBOR encoded length: {len(cbor_encoded)}")
-
-        # Base64 encode for transmission
-        auth_payload = base64.b64encode(cbor_encoded).decode("utf8")
-
-        return jsonify({"data": auth_payload})
+        # fido2 v2: CredentialRequestOptions serializes to a JSON-compatible dict
+        return jsonify({"data": dict(request_options)})
     except Exception as e:
         current_app.logger.exception(f"Error in FIDO2 authentication for user {user_id}: {str(e)}")
         return jsonify({"error": "An internal error has occurred"}), 500
@@ -873,20 +856,11 @@ def fido2_keys_user_validate(user_id):
         credentials = [deserialize_fido2_key(k.key) for k in keys]
 
         data = request.get_json()
-        cbor_data = cbor.decode(base64.b64decode(data["payload"]))
-
-        credential_id = _ensure_bytes(cbor_data["credentialId"])
-        client_data = ClientData(_ensure_bytes(cbor_data["clientDataJSON"]))
-        auth_data = AuthenticatorData(_ensure_bytes(cbor_data["authenticatorData"]))
-        signature = _ensure_bytes(cbor_data["signature"])
-
+        # data["credential"] is the standard WebAuthn AuthenticationResponse JSON
         Config.FIDO2_SERVER.authenticate_complete(
             get_fido2_session(user_id),
             credentials,
-            credential_id,
-            client_data,
-            auth_data,
-            signature,
+            data["credential"],
         )
 
         user_to_verify = get_user_by_id(user_id=user_id)

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -871,8 +871,25 @@ def fido2_keys_user_validate(user_id):
 
         current_app.logger.info(f"FIDO2 validation successful for user {user_id}")
         return jsonify({"status": "OK"})
+    except KeyError as e:
+        # Missing required field in request
+        current_app.logger.warning(f"FIDO2 validation failed for user {user_id}: missing field {e}")
+        return jsonify({"error": "Invalid request format"}), 400
+
+    except NoResultFound:
+        # Session expired or not found - could indicate replay attack or timeout
+        current_app.logger.warning(f"FIDO2 validation failed for user {user_id}: session not found")
+        return jsonify({"error": "Authentication session expired"}), 400
+
+    except ValueError as e:
+        # FIDO2 library validation failures (wrong challenge, signature, etc.)
+        # This is the expected error for invalid/forged credentials
+        current_app.logger.warning(f"FIDO2 validation failed for user {user_id}: {str(e)}")
+        return jsonify({"error": "Security key validation failed"}), 401
+
     except Exception as e:
-        current_app.logger.exception(f"Error in FIDO2 validation for user {user_id}: {str(e)}")
+        # Unexpected errors - these should be investigated
+        current_app.logger.exception(f"Unexpected error in FIDO2 validation for user {user_id}: {str(e)}")
         return jsonify({"error": "An internal error occurred"}), 500
 
 

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -837,12 +837,30 @@ def fido2_keys_user_authenticate(user_id):
 
         credentials = [deserialize_fido2_key(k.key) for k in keys]
 
+        # Log credential info at INFO level for debugging
+        from fido2.utils import websafe_encode
+
+        for i, cred in enumerate(credentials):
+            current_app.logger.info(f"Credential {i}: type={type(cred).__name__}")
+            if hasattr(cred, "credential_id"):
+                cred_id_b64 = websafe_encode(cred.credential_id)
+                current_app.logger.info(f"Credential {i} ID from DB: {cred_id_b64}")
+
         request_options, state = Config.FIDO2_SERVER.authenticate_begin(credentials)
         create_fido2_session(user_id, state)
         current_app.logger.info("FIDO2 session created successfully")
 
+        # Log the allowCredentials being sent to browser
+        response_dict = dict(request_options)
+        if "publicKey" in response_dict and "allowCredentials" in response_dict["publicKey"]:
+            allow_creds = response_dict["publicKey"]["allowCredentials"]
+            current_app.logger.info(f"Sending {len(allow_creds)} allowCredentials to browser")
+            for i, ac in enumerate(allow_creds):
+                cred_id = ac.get("id", "MISSING")
+                current_app.logger.info(f"allowCredentials[{i}] ID sent to browser: {cred_id}")
+
         # fido2 v2: CredentialRequestOptions serializes to a JSON-compatible dict
-        return jsonify({"data": dict(request_options)})
+        return jsonify({"data": response_dict})
     except Exception as e:
         current_app.logger.exception(f"Error in FIDO2 authentication for user {user_id}: {str(e)}")
         return jsonify({"error": "An internal error has occurred"}), 500

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -852,15 +852,29 @@ def fido2_keys_user_authenticate(user_id):
 def fido2_keys_user_validate(user_id):
     try:
         current_app.logger.info(f"Starting FIDO2 validation for user {user_id}")
+
+        # Validate request data BEFORE consuming the session
+        data = request.get_json()
+        if not isinstance(data, dict):
+            current_app.logger.warning(f"FIDO2 validation failed for user {user_id}: invalid or missing JSON body")
+            return jsonify({"error": "Invalid request format"}), 400
+
+        credential = data.get("credential")
+        if credential is None:
+            current_app.logger.warning(f"FIDO2 validation failed for user {user_id}: missing credential field")
+            return jsonify({"error": "Invalid request format"}), 400
+
         keys = list_fido2_keys(user_id)
         credentials = [deserialize_fido2_key(k.key) for k in keys]
 
-        data = request.get_json()
-        # data["credential"] is the standard WebAuthn AuthenticationResponse JSON
+        # Only fetch (and consume) the session after validating the request
+        session_state = get_fido2_session(user_id)
+
+        # credential is the standard WebAuthn AuthenticationResponse JSON
         Config.FIDO2_SERVER.authenticate_complete(
-            get_fido2_session(user_id),
+            session_state,
             credentials,
-            data["credential"],
+            credential,
         )
 
         user_to_verify = get_user_by_id(user_id=user_id)

--- a/app/user/users_schema.py
+++ b/app/user/users_schema.py
@@ -57,8 +57,9 @@ fido2_key_schema = {
     "description": "POST schema for adding a fido2 key",
     "type": "object",
     "properties": {
-        "payload": {"type": ["string", "null"]},
+        "name": {"type": "string"},
+        "credential": {"type": "object"},
     },
-    "required": ["payload"],
+    "required": ["name", "credential"],
     "additionalProperties": False,
 }

--- a/poetry.lock
+++ b/poetry.lock
@@ -1198,17 +1198,17 @@ testing = ["hatch", "pre-commit", "pytest", "tox"]
 
 [[package]]
 name = "fido2"
-version = "1.2.0"
+version = "2.2.0"
 description = "FIDO2/WebAuthn library for implementing clients and servers."
 optional = false
-python-versions = "<4.0,>=3.8"
+python-versions = "<4,>=3.10"
 files = [
-    {file = "fido2-1.2.0-py3-none-any.whl", hash = "sha256:f7c8ee62e359aa980a45773f9493965bb29ede1b237a9218169dbfe60c80e130"},
-    {file = "fido2-1.2.0.tar.gz", hash = "sha256:e39f95920122d64283fda5e5581d95a206e704fa42846bfa4662f86aa0d3333b"},
+    {file = "fido2-2.2.0-py3-none-any.whl", hash = "sha256:3587ccf0af7b71b5dd73f17e1dbec9f0fd157292f9163f02e7778f46d0d25fe5"},
+    {file = "fido2-2.2.0.tar.gz", hash = "sha256:0d8122e690096ad82afde42ac9d6433a4eeffda64084f36341ea02546b181dd1"},
 ]
 
 [package.dependencies]
-cryptography = ">=2.6,<35 || >35,<45"
+cryptography = ">=2.6,<35 || >35,<49"
 
 [package.extras]
 pcsc = ["pyscard (>=1.9,<3)"]
@@ -5053,4 +5053,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.12.7"
-content-hash = "26b11482c58d4eb693d13a7870a3985b0a61f21a8dff742d4325890441f4a8ec"
+content-hash = "cbffa1ea2f597103efb2e1b089ed3944b2836a92b32182cd04667fe07aaedc16"

--- a/poetry.lock
+++ b/poetry.lock
@@ -667,82 +667,99 @@ files = [
 
 [[package]]
 name = "cffi"
-version = "1.17.1"
+version = "2.0.0"
 description = "Foreign Function Interface for Python calling C code."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "cffi-1.17.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:df8b1c11f177bc2313ec4b2d46baec87a5f3e71fc8b45dab2ee7cae86d9aba14"},
-    {file = "cffi-1.17.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8f2cdc858323644ab277e9bb925ad72ae0e67f69e804f4898c070998d50b1a67"},
-    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:edae79245293e15384b51f88b00613ba9f7198016a5948b5dddf4917d4d26382"},
-    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:45398b671ac6d70e67da8e4224a065cec6a93541bb7aebe1b198a61b58c7b702"},
-    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ad9413ccdeda48c5afdae7e4fa2192157e991ff761e7ab8fdd8926f40b160cc3"},
-    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5da5719280082ac6bd9aa7becb3938dc9f9cbd57fac7d2871717b1feb0902ab6"},
-    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bb1a08b8008b281856e5971307cc386a8e9c5b625ac297e853d36da6efe9c17"},
-    {file = "cffi-1.17.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8"},
-    {file = "cffi-1.17.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:6883e737d7d9e4899a8a695e00ec36bd4e5e4f18fabe0aca0efe0a4b44cdb13e"},
-    {file = "cffi-1.17.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:6b8b4a92e1c65048ff98cfe1f735ef8f1ceb72e3d5f0c25fdb12087a23da22be"},
-    {file = "cffi-1.17.1-cp310-cp310-win32.whl", hash = "sha256:c9c3d058ebabb74db66e431095118094d06abf53284d9c81f27300d0e0d8bc7c"},
-    {file = "cffi-1.17.1-cp310-cp310-win_amd64.whl", hash = "sha256:0f048dcf80db46f0098ccac01132761580d28e28bc0f78ae0d58048063317e15"},
-    {file = "cffi-1.17.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a45e3c6913c5b87b3ff120dcdc03f6131fa0065027d0ed7ee6190736a74cd401"},
-    {file = "cffi-1.17.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:30c5e0cb5ae493c04c8b42916e52ca38079f1b235c2f8ae5f4527b963c401caf"},
-    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f75c7ab1f9e4aca5414ed4d8e5c0e303a34f4421f8a0d47a4d019ceff0ab6af4"},
-    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a1ed2dd2972641495a3ec98445e09766f077aee98a1c896dcb4ad0d303628e41"},
-    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:46bf43160c1a35f7ec506d254e5c890f3c03648a4dbac12d624e4490a7046cd1"},
-    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a24ed04c8ffd54b0729c07cee15a81d964e6fee0e3d4d342a27b020d22959dc6"},
-    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:610faea79c43e44c71e1ec53a554553fa22321b65fae24889706c0a84d4ad86d"},
-    {file = "cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a9b15d491f3ad5d692e11f6b71f7857e7835eb677955c00cc0aefcd0669adaf6"},
-    {file = "cffi-1.17.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:de2ea4b5833625383e464549fec1bc395c1bdeeb5f25c4a3a82b5a8c756ec22f"},
-    {file = "cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:fc48c783f9c87e60831201f2cce7f3b2e4846bf4d8728eabe54d60700b318a0b"},
-    {file = "cffi-1.17.1-cp311-cp311-win32.whl", hash = "sha256:85a950a4ac9c359340d5963966e3e0a94a676bd6245a4b55bc43949eee26a655"},
-    {file = "cffi-1.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:caaf0640ef5f5517f49bc275eca1406b0ffa6aa184892812030f04c2abf589a0"},
-    {file = "cffi-1.17.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:805b4371bf7197c329fcb3ead37e710d1bca9da5d583f5073b799d5c5bd1eee4"},
-    {file = "cffi-1.17.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:733e99bc2df47476e3848417c5a4540522f234dfd4ef3ab7fafdf555b082ec0c"},
-    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1257bdabf294dceb59f5e70c64a3e2f462c30c7ad68092d01bbbfb1c16b1ba36"},
-    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da95af8214998d77a98cc14e3a3bd00aa191526343078b530ceb0bd710fb48a5"},
-    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d63afe322132c194cf832bfec0dc69a99fb9bb6bbd550f161a49e9e855cc78ff"},
-    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f79fc4fc25f1c8698ff97788206bb3c2598949bfe0fef03d299eb1b5356ada99"},
-    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b62ce867176a75d03a665bad002af8e6d54644fad99a3c70905c543130e39d93"},
-    {file = "cffi-1.17.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:386c8bf53c502fff58903061338ce4f4950cbdcb23e2902d86c0f722b786bbe3"},
-    {file = "cffi-1.17.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4ceb10419a9adf4460ea14cfd6bc43d08701f0835e979bf821052f1805850fe8"},
-    {file = "cffi-1.17.1-cp312-cp312-win32.whl", hash = "sha256:a08d7e755f8ed21095a310a693525137cfe756ce62d066e53f502a83dc550f65"},
-    {file = "cffi-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:51392eae71afec0d0c8fb1a53b204dbb3bcabcb3c9b807eedf3e1e6ccf2de903"},
-    {file = "cffi-1.17.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f3a2b4222ce6b60e2e8b337bb9596923045681d71e5a082783484d845390938e"},
-    {file = "cffi-1.17.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0984a4925a435b1da406122d4d7968dd861c1385afe3b45ba82b750f229811e2"},
-    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d01b12eeeb4427d3110de311e1774046ad344f5b1a7403101878976ecd7a10f3"},
-    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:706510fe141c86a69c8ddc029c7910003a17353970cff3b904ff0686a5927683"},
-    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de55b766c7aa2e2a3092c51e0483d700341182f08e67c63630d5b6f200bb28e5"},
-    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c59d6e989d07460165cc5ad3c61f9fd8f1b4796eacbd81cee78957842b834af4"},
-    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd398dbc6773384a17fe0d3e7eeb8d1a21c2200473ee6806bb5e6a8e62bb73dd"},
-    {file = "cffi-1.17.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3edc8d958eb099c634dace3c7e16560ae474aa3803a5df240542b305d14e14ed"},
-    {file = "cffi-1.17.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:72e72408cad3d5419375fc87d289076ee319835bdfa2caad331e377589aebba9"},
-    {file = "cffi-1.17.1-cp313-cp313-win32.whl", hash = "sha256:e03eab0a8677fa80d646b5ddece1cbeaf556c313dcfac435ba11f107ba117b5d"},
-    {file = "cffi-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:f6a16c31041f09ead72d69f583767292f750d24913dadacf5756b966aacb3f1a"},
-    {file = "cffi-1.17.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:636062ea65bd0195bc012fea9321aca499c0504409f413dc88af450b57ffd03b"},
-    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c7eac2ef9b63c79431bc4b25f1cd649d7f061a28808cbc6c47b534bd789ef964"},
-    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e221cf152cff04059d011ee126477f0d9588303eb57e88923578ace7baad17f9"},
-    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:31000ec67d4221a71bd3f67df918b1f88f676f1c3b535a7eb473255fdc0b83fc"},
-    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6f17be4345073b0a7b8ea599688f692ac3ef23ce28e5df79c04de519dbc4912c"},
-    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e2b1fac190ae3ebfe37b979cc1ce69c81f4e4fe5746bb401dca63a9062cdaf1"},
-    {file = "cffi-1.17.1-cp38-cp38-win32.whl", hash = "sha256:7596d6620d3fa590f677e9ee430df2958d2d6d6de2feeae5b20e82c00b76fbf8"},
-    {file = "cffi-1.17.1-cp38-cp38-win_amd64.whl", hash = "sha256:78122be759c3f8a014ce010908ae03364d00a1f81ab5c7f4a7a5120607ea56e1"},
-    {file = "cffi-1.17.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b2ab587605f4ba0bf81dc0cb08a41bd1c0a5906bd59243d56bad7668a6fc6c16"},
-    {file = "cffi-1.17.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:28b16024becceed8c6dfbc75629e27788d8a3f9030691a1dbf9821a128b22c36"},
-    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1d599671f396c4723d016dbddb72fe8e0397082b0a77a4fab8028923bec050e8"},
-    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca74b8dbe6e8e8263c0ffd60277de77dcee6c837a3d0881d8c1ead7268c9e576"},
-    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f7f5baafcc48261359e14bcd6d9bff6d4b28d9103847c9e136694cb0501aef87"},
-    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:98e3969bcff97cae1b2def8ba499ea3d6f31ddfdb7635374834cf89a1a08ecf0"},
-    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cdf5ce3acdfd1661132f2a9c19cac174758dc2352bfe37d98aa7512c6b7178b3"},
-    {file = "cffi-1.17.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:9755e4345d1ec879e3849e62222a18c7174d65a6a92d5b346b1863912168b595"},
-    {file = "cffi-1.17.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:f1e22e8c4419538cb197e4dd60acc919d7696e5ef98ee4da4e01d3f8cfa4cc5a"},
-    {file = "cffi-1.17.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:c03e868a0b3bc35839ba98e74211ed2b05d2119be4e8a0f224fba9384f1fe02e"},
-    {file = "cffi-1.17.1-cp39-cp39-win32.whl", hash = "sha256:e31ae45bc2e29f6b2abd0de1cc3b9d5205aa847cafaecb8af1476a609a2f6eb7"},
-    {file = "cffi-1.17.1-cp39-cp39-win_amd64.whl", hash = "sha256:d016c76bdd850f3c626af19b0542c9677ba156e4ee4fccfdd7848803533ef662"},
-    {file = "cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824"},
+    {file = "cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44"},
+    {file = "cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453"},
+    {file = "cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495"},
+    {file = "cffi-2.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5"},
+    {file = "cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb"},
+    {file = "cffi-2.0.0-cp310-cp310-win32.whl", hash = "sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a"},
+    {file = "cffi-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739"},
+    {file = "cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe"},
+    {file = "cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26"},
+    {file = "cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9"},
+    {file = "cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414"},
+    {file = "cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743"},
+    {file = "cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5"},
+    {file = "cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5"},
+    {file = "cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d"},
+    {file = "cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d"},
+    {file = "cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba"},
+    {file = "cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94"},
+    {file = "cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187"},
+    {file = "cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18"},
+    {file = "cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5"},
+    {file = "cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6"},
+    {file = "cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb"},
+    {file = "cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26"},
+    {file = "cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c"},
+    {file = "cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b"},
+    {file = "cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27"},
+    {file = "cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75"},
+    {file = "cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91"},
+    {file = "cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5"},
+    {file = "cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775"},
+    {file = "cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205"},
+    {file = "cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1"},
+    {file = "cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f"},
+    {file = "cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25"},
+    {file = "cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad"},
+    {file = "cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9"},
+    {file = "cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592"},
+    {file = "cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512"},
+    {file = "cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4"},
+    {file = "cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e"},
+    {file = "cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6"},
+    {file = "cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9"},
+    {file = "cffi-2.0.0-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:fe562eb1a64e67dd297ccc4f5addea2501664954f2692b69a76449ec7913ecbf"},
+    {file = "cffi-2.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:de8dad4425a6ca6e4e5e297b27b5c824ecc7581910bf9aee86cb6835e6812aa7"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:4647afc2f90d1ddd33441e5b0e85b16b12ddec4fca55f0d9671fef036ecca27c"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3f4d46d8b35698056ec29bca21546e1551a205058ae1a181d871e278b0b28165"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e6e73b9e02893c764e7e8d5bb5ce277f1a009cd5243f8228f75f842bf937c534"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:cb527a79772e5ef98fb1d700678fe031e353e765d1ca2d409c92263c6d43e09f"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:61d028e90346df14fedc3d1e5441df818d095f3b87d286825dfcbd6459b7ef63"},
+    {file = "cffi-2.0.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:0f6084a0ea23d05d20c3edcda20c3d006f9b6f3fefeac38f59262e10cef47ee2"},
+    {file = "cffi-2.0.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:1cd13c99ce269b3ed80b417dcd591415d3372bcac067009b6e0f59c7d4015e65"},
+    {file = "cffi-2.0.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:89472c9762729b5ae1ad974b777416bfda4ac5642423fa93bd57a09204712322"},
+    {file = "cffi-2.0.0-cp39-cp39-win32.whl", hash = "sha256:2081580ebb843f759b9f617314a24ed5738c51d2aee65d31e02f6f7a2b97707a"},
+    {file = "cffi-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:b882b3df248017dba09d6b16defe9b5c407fe32fc7c65a9c69798e6175601be9"},
+    {file = "cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529"},
 ]
 
 [package.dependencies]
-pycparser = "*"
+pycparser = {version = "*", markers = "implementation_name != \"PyPy\""}
 
 [[package]]
 name = "cfgv"
@@ -1082,51 +1099,73 @@ yaml = ["PyYAML (>=3.10)"]
 
 [[package]]
 name = "cryptography"
-version = "43.0.3"
+version = "46.0.7"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
-python-versions = ">=3.7"
+python-versions = "!=3.9.0,!=3.9.1,>=3.8"
 files = [
-    {file = "cryptography-43.0.3-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:bf7a1932ac4176486eab36a19ed4c0492da5d97123f1406cf15e41b05e787d2e"},
-    {file = "cryptography-43.0.3-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:63efa177ff54aec6e1c0aefaa1a241232dcd37413835a9b674b6e3f0ae2bfd3e"},
-    {file = "cryptography-43.0.3-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e1ce50266f4f70bf41a2c6dc4358afadae90e2a1e5342d3c08883df1675374f"},
-    {file = "cryptography-43.0.3-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:443c4a81bb10daed9a8f334365fe52542771f25aedaf889fd323a853ce7377d6"},
-    {file = "cryptography-43.0.3-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:74f57f24754fe349223792466a709f8e0c093205ff0dca557af51072ff47ab18"},
-    {file = "cryptography-43.0.3-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9762ea51a8fc2a88b70cf2995e5675b38d93bf36bd67d91721c309df184f49bd"},
-    {file = "cryptography-43.0.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:81ef806b1fef6b06dcebad789f988d3b37ccaee225695cf3e07648eee0fc6b73"},
-    {file = "cryptography-43.0.3-cp37-abi3-win32.whl", hash = "sha256:cbeb489927bd7af4aa98d4b261af9a5bc025bd87f0e3547e11584be9e9427be2"},
-    {file = "cryptography-43.0.3-cp37-abi3-win_amd64.whl", hash = "sha256:f46304d6f0c6ab8e52770addfa2fc41e6629495548862279641972b6215451cd"},
-    {file = "cryptography-43.0.3-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:8ac43ae87929a5982f5948ceda07001ee5e83227fd69cf55b109144938d96984"},
-    {file = "cryptography-43.0.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:846da004a5804145a5f441b8530b4bf35afbf7da70f82409f151695b127213d5"},
-    {file = "cryptography-43.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f996e7268af62598f2fc1204afa98a3b5712313a55c4c9d434aef49cadc91d4"},
-    {file = "cryptography-43.0.3-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f7b178f11ed3664fd0e995a47ed2b5ff0a12d893e41dd0494f406d1cf555cab7"},
-    {file = "cryptography-43.0.3-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:c2e6fc39c4ab499049df3bdf567f768a723a5e8464816e8f009f121a5a9f4405"},
-    {file = "cryptography-43.0.3-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e1be4655c7ef6e1bbe6b5d0403526601323420bcf414598955968c9ef3eb7d16"},
-    {file = "cryptography-43.0.3-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:df6b6c6d742395dd77a23ea3728ab62f98379eff8fb61be2744d4679ab678f73"},
-    {file = "cryptography-43.0.3-cp39-abi3-win32.whl", hash = "sha256:d56e96520b1020449bbace2b78b603442e7e378a9b3bd68de65c782db1507995"},
-    {file = "cryptography-43.0.3-cp39-abi3-win_amd64.whl", hash = "sha256:0c580952eef9bf68c4747774cde7ec1d85a6e61de97281f2dba83c7d2c806362"},
-    {file = "cryptography-43.0.3-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:d03b5621a135bffecad2c73e9f4deb1a0f977b9a8ffe6f8e002bf6c9d07b918c"},
-    {file = "cryptography-43.0.3-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:a2a431ee15799d6db9fe80c82b055bae5a752bef645bba795e8e52687c69efe3"},
-    {file = "cryptography-43.0.3-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:281c945d0e28c92ca5e5930664c1cefd85efe80e5c0d2bc58dd63383fda29f83"},
-    {file = "cryptography-43.0.3-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:f18c716be16bc1fea8e95def49edf46b82fccaa88587a45f8dc0ff6ab5d8e0a7"},
-    {file = "cryptography-43.0.3-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:4a02ded6cd4f0a5562a8887df8b3bd14e822a90f97ac5e544c162899bc467664"},
-    {file = "cryptography-43.0.3-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:53a583b6637ab4c4e3591a15bc9db855b8d9dee9a669b550f311480acab6eb08"},
-    {file = "cryptography-43.0.3-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:1ec0bcf7e17c0c5669d881b1cd38c4972fade441b27bda1051665faaa89bdcaa"},
-    {file = "cryptography-43.0.3-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:2ce6fae5bdad59577b44e4dfed356944fbf1d925269114c28be377692643b4ff"},
-    {file = "cryptography-43.0.3.tar.gz", hash = "sha256:315b9001266a492a6ff443b61238f956b214dbec9910a081ba5b6646a055a805"},
+    {file = "cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b"},
+    {file = "cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85"},
+    {file = "cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e"},
+    {file = "cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457"},
+    {file = "cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b"},
+    {file = "cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2"},
+    {file = "cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e"},
+    {file = "cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee"},
+    {file = "cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298"},
+    {file = "cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb"},
+    {file = "cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0"},
+    {file = "cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85"},
+    {file = "cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e"},
+    {file = "cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246"},
+    {file = "cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc9ab8856ae6cf7c9358430e49b368f3108f050031442eaeb6b9d87e4dcf4e4f"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:d3b99c535a9de0adced13d159c5a9cf65c325601aa30f4be08afd680643e9c15"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:d02c738dacda7dc2a74d1b2b3177042009d5cab7c7079db74afc19e56ca1b455"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:04959522f938493042d595a736e7dbdff6eb6cc2339c11465b3ff89343b65f65"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:3986ac1dee6def53797289999eabe84798ad7817f3e97779b5061a95b0ee4968"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:258514877e15963bd43b558917bc9f54cf7cf866c38aa576ebf47a77ddbc43a4"},
+    {file = "cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5"},
 ]
 
 [package.dependencies]
-cffi = {version = ">=1.12", markers = "platform_python_implementation != \"PyPy\""}
+cffi = {version = ">=2.0.0", markers = "python_full_version >= \"3.9\" and platform_python_implementation != \"PyPy\""}
 
 [package.extras]
-docs = ["sphinx (>=5.3.0)", "sphinx-rtd-theme (>=1.1.1)"]
-docstest = ["pyenchant (>=1.6.11)", "readme-renderer", "sphinxcontrib-spelling (>=4.0.1)"]
-nox = ["nox"]
-pep8test = ["check-sdist", "click", "mypy", "ruff"]
-sdist = ["build"]
+docs = ["sphinx (>=5.3.0)", "sphinx-inline-tabs", "sphinx-rtd-theme (>=3.0.0)"]
+docstest = ["pyenchant (>=3)", "readme-renderer (>=30.0)", "sphinxcontrib-spelling (>=7.3.1)"]
+nox = ["nox[uv] (>=2024.4.15)"]
+pep8test = ["check-sdist", "click (>=8.0.1)", "mypy (>=1.14)", "ruff (>=0.11.11)"]
+sdist = ["build (>=1.0.0)"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["certifi", "cryptography-vectors (==43.0.3)", "pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-xdist"]
+test = ["certifi (>=2024)", "cryptography-vectors (==46.0.7)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
 test-randomorder = ["pytest-randomly"]
 
 [[package]]
@@ -2730,7 +2769,7 @@ requests = ">=2.0.0"
 
 [[package]]
 name = "notifications-utils"
-version = "53.2.21"
+version = "53.2.23"
 description = "Shared python code for Notification - Provides logging utils etc."
 optional = false
 python-versions = "~3.12.7"
@@ -2743,7 +2782,7 @@ bleach = "6.3.0"
 boto3 = "1.42.65"
 cachetools = "4.2.4"
 certifi = "^2024.0.0"
-cryptography = "^43.0.0"
+cryptography = "^46.0.5"
 Flask = "2.3.3"
 Flask-Redis = "0.4.0"
 itsdangerous = "2.2.0"
@@ -2766,8 +2805,8 @@ werkzeug = "3.0.6"
 [package.source]
 type = "git"
 url = "https://github.com/cds-snc/notifier-utils.git"
-reference = "53.2.21"
-resolved_reference = "27ef4ac659bef7a1d3fd09ea44f45d23d8b17e2b"
+reference = "renovate/pypi-cryptography-vulnerability"
+resolved_reference = "fa8736f8f35d9f52beee0d8aef9acf78eeba8d8e"
 
 [[package]]
 name = "opentelemetry-api"
@@ -5053,4 +5092,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.12.7"
-content-hash = "cbffa1ea2f597103efb2e1b089ed3944b2836a92b32182cd04667fe07aaedc16"
+content-hash = "5b4b942dbea4d584c87965c9a218ba4050543a8a8bdb2a05f4b27d2a0f672590"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ cffi = "1.17.1"
 click-datetime = "0.2"
 docopt = "0.6.2"
 environs = "9.5.0"       # pyup: <9.3.3 # marshmallow v3 throws errors"
-fido2 = "1.2.0"
+fido2 = "^2.2.0"
 #git+https://github.com/mitsuhiko/flask-sqlalchemy.git@500e732dd1b975a56ab06a46bd1a20a21e682262#egg=Flask-SQLAlchemy==2.3.2.dev20190108
 Flask = "2.3.3"
 Flask-Bcrypt = "1.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ celery = {extras = ["sqs"], version = "5.4.0"}
 
 # Pinned dependencies
 certifi = "^2024.0.0" # pinned for security reasons: https://github.com/cds-snc/notification-api/security/dependabot/119
-cffi = "1.17.1"
+cffi = "2.0.0"
 click-datetime = "0.2"
 docopt = "0.6.2"
 environs = "9.5.0"       # pyup: <9.3.3 # marshmallow v3 throws errors"
@@ -60,7 +60,7 @@ opentelemetry-instrumentation-celery = "0.55b1"
 opentelemetry-instrumentation-flask = "0.55b1"
 opentelemetry-instrumentation-redis = "0.55b1"
 opentelemetry-instrumentation-sqlalchemy = "0.55b1"
-notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", tag = "53.2.21"}
+notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", branch = "renovate/pypi-cryptography-vulnerability"}
 pre-commit = "^3.7.1"
 psycopg2-binary = "2.9.11"
 pwnedpasswords = "2.0.0"

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -1666,29 +1666,6 @@ def test_fido2_validate_returns_400_when_credential_missing(client, sample_servi
     mock_get_session.assert_not_called()
 
 
-def test_fido2_validate_returns_400_when_json_invalid(client, sample_service, mocker):
-    """Test that invalid JSON body returns 400 Bad Request without consuming session."""
-    sample_user = sample_service.users[0]
-    auth_header = create_authorization_header()
-
-    key = Fido2Key(name="sample key", key="abcd", user_id=sample_user.id)
-    save_fido2_key(key)
-
-    mock_get_session = mocker.patch("app.user.rest.get_fido2_session", return_value={"challenge": "test"})
-
-    # Send non-JSON content type (will make get_json() return None)
-    response = client.post(
-        url_for("user.fido2_keys_user_validate", user_id=sample_user.id),
-        data="not json",
-        headers=[("Content-Type", "text/plain"), auth_header],
-    )
-
-    assert response.status_code == 400
-    assert json.loads(response.get_data(as_text=True))["error"] == "Invalid request format"
-    # Session should NOT be consumed when request is malformed
-    mock_get_session.assert_not_called()
-
-
 def test_fido2_validate_returns_400_when_session_expired(client, sample_service, mocker):
     """Test that expired/missing session returns 400 Bad Request."""
     sample_user = sample_service.users[0]

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -1642,7 +1642,7 @@ def test_start_fido2_authentication(client, sample_service, mocker):
 
 
 def test_fido2_validate_returns_400_when_credential_missing(client, sample_service, mocker):
-    """Test that missing credential field returns 400 Bad Request."""
+    """Test that missing credential field returns 400 Bad Request without consuming session."""
     sample_user = sample_service.users[0]
     auth_header = create_authorization_header()
 
@@ -1651,7 +1651,7 @@ def test_fido2_validate_returns_400_when_credential_missing(client, sample_servi
 
     mock_cred = mocker.Mock()
     mocker.patch("app.user.rest.deserialize_fido2_key", return_value=mock_cred)
-    mocker.patch("app.user.rest.get_fido2_session", return_value={"challenge": "test"})
+    mock_get_session = mocker.patch("app.user.rest.get_fido2_session", return_value={"challenge": "test"})
 
     # Missing 'credential' key in request body
     response = client.post(
@@ -1662,6 +1662,31 @@ def test_fido2_validate_returns_400_when_credential_missing(client, sample_servi
 
     assert response.status_code == 400
     assert json.loads(response.get_data(as_text=True))["error"] == "Invalid request format"
+    # Session should NOT be consumed when request is malformed
+    mock_get_session.assert_not_called()
+
+
+def test_fido2_validate_returns_400_when_json_invalid(client, sample_service, mocker):
+    """Test that invalid JSON body returns 400 Bad Request without consuming session."""
+    sample_user = sample_service.users[0]
+    auth_header = create_authorization_header()
+
+    key = Fido2Key(name="sample key", key="abcd", user_id=sample_user.id)
+    save_fido2_key(key)
+
+    mock_get_session = mocker.patch("app.user.rest.get_fido2_session", return_value={"challenge": "test"})
+
+    # Send non-JSON content type (will make get_json() return None)
+    response = client.post(
+        url_for("user.fido2_keys_user_validate", user_id=sample_user.id),
+        data="not json",
+        headers=[("Content-Type", "text/plain"), auth_header],
+    )
+
+    assert response.status_code == 400
+    assert json.loads(response.get_data(as_text=True))["error"] == "Invalid request format"
+    # Session should NOT be consumed when request is malformed
+    mock_get_session.assert_not_called()
 
 
 def test_fido2_validate_returns_400_when_session_expired(client, sample_service, mocker):

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -1,11 +1,9 @@
-import base64
 import json
 from datetime import datetime
 from unittest import mock
 from uuid import UUID
 
 import pytest
-from fido2 import cbor
 from flask import current_app, url_for
 from freezegun import freeze_time
 
@@ -1544,9 +1542,18 @@ def test_create_fido2_keys_for_a_user(client, sample_service, mocker, account_ch
 
     create_fido2_session(sample_user.id, "ABCD")
 
-    data = {"name": "sample key one", "key": "abcd"}
-    data = cbor.encode(data)
-    data = {"payload": base64.b64encode(data).decode("utf-8")}
+    # Standard WebAuthn RegistrationResponse JSON format
+    data = {
+        "name": "sample key one",
+        "credential": {
+            "rawId": "dGVzdA",
+            "response": {
+                "clientDataJSON": "dGVzdA",
+                "attestationObject": "dGVzdA",
+            },
+            "type": "public-key",
+        },
+    }
 
     mocker.patch("app.user.rest.decode_and_register", return_value="abcd")
     mocker.patch("app.user.rest.persist_notification")
@@ -1599,10 +1606,10 @@ def test_start_fido2_registration(client, sample_service):
     )
     assert response.status_code == 200
     data = json.loads(response.get_data())
-    data = base64.b64decode(data["data"])
-    data = cbor.decode(data)
-    assert data["publicKey"]["rp"]["id"] == "localhost"
-    assert data["publicKey"]["user"]["id"] == sample_user.id.bytes
+    # fido2 v2: response is JSON with a nested publicKey object
+    public_key = data["data"]["publicKey"]
+    assert public_key["rp"]["id"] == "localhost"
+    assert public_key["user"]["id"]  # base64url-encoded user ID
 
 
 def test_start_fido2_authentication(client, sample_service, mocker):
@@ -1613,11 +1620,12 @@ def test_start_fido2_authentication(client, sample_service, mocker):
     mock_cred.credential_id = b"test_cred_id"
     mocker.patch("app.user.rest.deserialize_fido2_key", return_value=mock_cred)
 
-    # Mock the FIDO2 server to avoid internal errors and control the output
+    # Mock the FIDO2 server to return a dict-like object.
+    # In fido2 v2, authenticate_begin returns (CredentialRequestOptions, state)
+    # dict() on the options object produces a JSON-compatible dict.
     mock_server = mocker.patch("app.user.rest.Config.FIDO2_SERVER")
-    # Return a dict that mimics the options object.
-    # Note: The real code returns an object, but cbor.encode handles dicts too.
-    mock_server.authenticate_begin.return_value = ({"rpId": "localhost"}, "state")
+    mock_options = {"publicKey": {"rpId": "localhost"}}
+    mock_server.authenticate_begin.return_value = (mock_options, "state")
 
     key = Fido2Key(name="sample key", key="abcd", user_id=sample_user.id)
     save_fido2_key(key)
@@ -1628,9 +1636,8 @@ def test_start_fido2_authentication(client, sample_service, mocker):
     )
     assert response.status_code == 200
     data = json.loads(response.get_data())
-    data = base64.b64decode(data["data"])
-    data = cbor.decode(data)
-    assert data["rpId"] == "localhost"
+    # fido2 v2: response is JSON directly
+    assert data["data"]["publicKey"]["rpId"] == "localhost"
 
 
 def test_list_login_events_for_a_user(client, sample_service):

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -6,6 +6,7 @@ from uuid import UUID
 import pytest
 from flask import current_app, url_for
 from freezegun import freeze_time
+from sqlalchemy.orm.exc import NoResultFound
 
 from app import db
 from app.clients.salesforce.salesforce_engagement import ENGAGEMENT_STAGE_ACTIVATION
@@ -1638,6 +1639,101 @@ def test_start_fido2_authentication(client, sample_service, mocker):
     data = json.loads(response.get_data())
     # fido2 v2: response is JSON directly
     assert data["data"]["publicKey"]["rpId"] == "localhost"
+
+
+def test_fido2_validate_returns_400_when_credential_missing(client, sample_service, mocker):
+    """Test that missing credential field returns 400 Bad Request."""
+    sample_user = sample_service.users[0]
+    auth_header = create_authorization_header()
+
+    key = Fido2Key(name="sample key", key="abcd", user_id=sample_user.id)
+    save_fido2_key(key)
+
+    mock_cred = mocker.Mock()
+    mocker.patch("app.user.rest.deserialize_fido2_key", return_value=mock_cred)
+    mocker.patch("app.user.rest.get_fido2_session", return_value={"challenge": "test"})
+
+    # Missing 'credential' key in request body
+    response = client.post(
+        url_for("user.fido2_keys_user_validate", user_id=sample_user.id),
+        data=json.dumps({}),
+        headers=[("Content-Type", "application/json"), auth_header],
+    )
+
+    assert response.status_code == 400
+    assert json.loads(response.get_data(as_text=True))["error"] == "Invalid request format"
+
+
+def test_fido2_validate_returns_400_when_session_expired(client, sample_service, mocker):
+    """Test that expired/missing session returns 400 Bad Request."""
+    sample_user = sample_service.users[0]
+    auth_header = create_authorization_header()
+
+    key = Fido2Key(name="sample key", key="abcd", user_id=sample_user.id)
+    save_fido2_key(key)
+
+    mock_cred = mocker.Mock()
+    mocker.patch("app.user.rest.deserialize_fido2_key", return_value=mock_cred)
+    mocker.patch("app.user.rest.get_fido2_session", side_effect=NoResultFound())
+
+    response = client.post(
+        url_for("user.fido2_keys_user_validate", user_id=sample_user.id),
+        data=json.dumps({"credential": {"id": "test"}}),
+        headers=[("Content-Type", "application/json"), auth_header],
+    )
+
+    assert response.status_code == 400
+    assert json.loads(response.get_data(as_text=True))["error"] == "Authentication session expired"
+
+
+def test_fido2_validate_returns_401_when_validation_fails(client, sample_service, mocker):
+    """Test that FIDO2 validation failure returns 401 Unauthorized."""
+    sample_user = sample_service.users[0]
+    auth_header = create_authorization_header()
+
+    key = Fido2Key(name="sample key", key="abcd", user_id=sample_user.id)
+    save_fido2_key(key)
+
+    mock_cred = mocker.Mock()
+    mocker.patch("app.user.rest.deserialize_fido2_key", return_value=mock_cred)
+    mocker.patch("app.user.rest.get_fido2_session", return_value={"challenge": "test"})
+
+    mock_server = mocker.patch("app.user.rest.Config.FIDO2_SERVER")
+    mock_server.authenticate_complete.side_effect = ValueError("Wrong challenge in response.")
+
+    response = client.post(
+        url_for("user.fido2_keys_user_validate", user_id=sample_user.id),
+        data=json.dumps({"credential": {"id": "test"}}),
+        headers=[("Content-Type", "application/json"), auth_header],
+    )
+
+    assert response.status_code == 401
+    assert json.loads(response.get_data(as_text=True))["error"] == "Security key validation failed"
+
+
+def test_fido2_validate_returns_500_on_unexpected_error(client, sample_service, mocker):
+    """Test that unexpected errors return 500 Internal Server Error."""
+    sample_user = sample_service.users[0]
+    auth_header = create_authorization_header()
+
+    key = Fido2Key(name="sample key", key="abcd", user_id=sample_user.id)
+    save_fido2_key(key)
+
+    mock_cred = mocker.Mock()
+    mocker.patch("app.user.rest.deserialize_fido2_key", return_value=mock_cred)
+    mocker.patch("app.user.rest.get_fido2_session", return_value={"challenge": "test"})
+
+    mock_server = mocker.patch("app.user.rest.Config.FIDO2_SERVER")
+    mock_server.authenticate_complete.side_effect = RuntimeError("Unexpected database error")
+
+    response = client.post(
+        url_for("user.fido2_keys_user_validate", user_id=sample_user.id),
+        data=json.dumps({"credential": {"id": "test"}}),
+        headers=[("Content-Type", "application/json"), auth_header],
+    )
+
+    assert response.status_code == 500
+    assert json.loads(response.get_data(as_text=True))["error"] == "An internal error occurred"
 
 
 def test_list_login_events_for_a_user(client, sample_service):


### PR DESCRIPTION
# Summary | Résumé
We need to [bump `cryptography` in utils](https://github.com/cds-snc/notification-utils/pull/353) to patch a vulnerability. However, this also requires migrating to `fido2 >= 2.2.0`, as `fido2` transitively pulls in `cryptography` and `2.2.0` is the latest version that includes a patched `cryptography` version.

[The official Migration guide](https://developers.yubico.com/python-fido2/Migration_1-2.html) was followed in an attempt to integrate these changes into Notify
* `CBOR` transport encoding has been dropped in favour of `JSON`
    * Impacts the `register`, `create`, and `authenticate` endpoints
* `decode_and_register` now accepts both the `WebAuthn` module's new `RegistrationResponse` data object as well as the legacy `AuthenticatorAttestationResponse` format. If the legacy format is received, a compatible `RegistrationResponse` is built from it.


## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1
* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/1

# Test instructions | Instructions pour tester la modification
CI is passing
- [x] Test steps in [this admin PR](https://github.com/cds-snc/notification-admin/pull/2663) are complete

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.