### PR TITLE
Role name updates OIDC

### DIFF
--- a/.github/workflows/build_and_push_performance_test.yml
+++ b/.github/workflows/build_and_push_performance_test.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Configure credentials to Notify using OIDC
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:
-          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-api-apply
+          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-api-build-push-performance-test
           role-session-name: NotifyApiApply
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 

--- a/.github/workflows/lambda_production.yml
+++ b/.github/workflows/lambda_production.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Configure credentials to Notify using OIDC
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:
-          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-api-apply
+          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-api-lambda-production
           role-session-name: NotifyApiApply
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 

--- a/.github/workflows/lambda_staging.yml
+++ b/.github/workflows/lambda_staging.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Configure credentials to Notify using OIDC
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:
-          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-api-apply
+          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-api-lambda-staging
           role-session-name: NotifyApiApply
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 


### PR DESCRIPTION
# Summary | Résumé

This pull request updates the AWS IAM roles assumed by GitHub Actions workflows to use more specific roles for different deployment jobs. This improves security and clarity by ensuring each workflow only has the permissions it needs for its environment.

Credential configuration updates by environment:

* Changed the IAM role for the performance test build and push workflow to `notification-api-build-push-performance-test` in `.github/workflows/build_and_push_performance_test.yml`.
* Changed the IAM role for the lambda production deployment workflow to `notification-api-lambda-production` in `.github/workflows/lambda_production.yml`.
* Changed the IAM role for the lambda staging deployment workflow to `notification-api-lambda-staging` in `.github/workflows/lambda_staging.yml`.

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/742

# Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.