### PR TITLE
Add scripts to generate data

### DIFF
--- a/tests-simulate-prod-data/.env.example
+++ b/tests-simulate-prod-data/.env.example
@@ -24,11 +24,12 @@ SQLALCHEMY_DATABASE_URI=postgresql://postgres:postgres@localhost:5432/notificati
 # DATE_START=2025-04-01
 # DATE_END=2026-03-31
 
-# Notification volumes
+# Notification volumes (default: ~14M notifications)
 # NUM_EMAILS_TOTAL=5000000
 # NUM_EMAILS_FAILED=50000
 # NUM_SMS_TOTAL=9000000
 # NUM_SMS_FAILED=90000
+# NUM_LIVE_NOTIFICATIONS=1000000
 
 # Jobs
 # NUM_JOBS=200
@@ -39,3 +40,7 @@ SQLALCHEMY_DATABASE_URI=postgresql://postgres:postgres@localhost:5432/notificati
 
 # Organisation
 # ORGANISATION_NAME=test-simulate-prod-data-org
+
+# NOTE: For quick testing with ~100K notifications, use the --quick-100000 flag:
+#   python generate.py --quick-100000
+#   make generate-quick-100000

--- a/tests-simulate-prod-data/.env.example
+++ b/tests-simulate-prod-data/.env.example
@@ -31,6 +31,8 @@ SQLALCHEMY_DATABASE_URI=postgresql://postgres:postgres@localhost:5432/notificati
 # NUM_SMS_FAILED=90000
 # NUM_LIVE_NOTIFICATIONS=1000000
 
+# LINK_EXISTING_USER_EMAIL=notify-service-user@notification.alpha.canada.ca
+
 # Jobs
 # NUM_JOBS=200
 # JOB_NOTIFICATION_COUNT=10000

--- a/tests-simulate-prod-data/.env.example
+++ b/tests-simulate-prod-data/.env.example
@@ -1,0 +1,42 @@
+# Database connection
+SQLALCHEMY_DATABASE_URI=postgresql://postgres:postgres@localhost:5432/notification_api
+
+# Service settings
+# SERVICE_NAME=test-simulate-prod-data-service
+# SERVICE_EMAIL_FROM=test-simulate-prod-data@staging.local
+# SERVICE_SMS_ANNUAL_LIMIT=10000000
+# SERVICE_EMAIL_ANNUAL_LIMIT=25000000
+# SERVICE_MESSAGE_LIMIT=250000
+# SERVICE_SMS_DAILY_LIMIT=100000
+# SERVICE_RATE_LIMIT=3000
+
+# Users
+# NUM_USERS=5
+# USER_PASSWORD=test-simulate-prod-data-password-1!
+
+# Template folders
+# NUM_TEMPLATE_FOLDERS=5
+# HIGH_VOLUME_FOLDER_TEMPLATE_COUNT=2000
+# OTHER_FOLDER_TEMPLATE_COUNT=5
+# TEMPLATE_VARIABLES_MIN=3
+# TEMPLATE_VARIABLES_MAX=5
+
+# Notification date range (fiscal year)
+# DATE_START=2025-04-01
+# DATE_END=2026-03-31
+
+# Notification volumes
+# NUM_EMAILS_TOTAL=5000000
+# NUM_EMAILS_FAILED=50000
+# NUM_SMS_TOTAL=9000000
+# NUM_SMS_FAILED=90000
+
+# Jobs
+# NUM_JOBS=200
+# JOB_NOTIFICATION_COUNT=10000
+
+# Batch size for bulk inserts (tune for your DB)
+# BATCH_SIZE=10000
+
+# Organisation
+# ORGANISATION_NAME=test-simulate-prod-data-org

--- a/tests-simulate-prod-data/.env.example
+++ b/tests-simulate-prod-data/.env.example
@@ -12,7 +12,6 @@ SQLALCHEMY_DATABASE_URI=postgresql://postgres:postgres@localhost:5432/notificati
 
 # Users
 # NUM_USERS=5
-# USER_PASSWORD=test-simulate-prod-data-password-1!
 
 # Template folders
 # NUM_TEMPLATE_FOLDERS=5

--- a/tests-simulate-prod-data/Makefile
+++ b/tests-simulate-prod-data/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install setup generate generate-quick cleanup
+.PHONY: help install setup generate generate-quick generate-no-aggregates cleanup all
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'

--- a/tests-simulate-prod-data/Makefile
+++ b/tests-simulate-prod-data/Makefile
@@ -1,0 +1,29 @@
+.PHONY: help install setup generate generate-quick cleanup
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+install: ## Install Python dependencies
+	pip install -r requirements.txt
+
+setup: ## Copy .env.example to .env (if .env doesn't exist)
+	@if [ ! -f .env ]; then \
+		cp .env.example .env; \
+		echo ".env created from .env.example — edit SQLALCHEMY_DATABASE_URI before running."; \
+	else \
+		echo ".env already exists — skipping."; \
+	fi
+
+generate: install ## Generate all production-like data (full run: ~14M notifications)
+	python generate.py
+
+generate-quick: install ## Generate everything except notification_history (fast, for testing setup)
+	python generate.py --skip-notifications
+
+generate-no-aggregates: install ## Generate data but skip ft_notification_status and ft_billing
+	python generate.py --skip-aggregates
+
+cleanup: install ## Delete all test-simulate-prod-data entities from the database
+	python generate.py --cleanup-only
+
+all: install setup generate ## Full setup: install deps, create .env, generate data

--- a/tests-simulate-prod-data/Makefile
+++ b/tests-simulate-prod-data/Makefile
@@ -1,7 +1,7 @@
-.PHONY: help install setup generate generate-quick generate-no-aggregates cleanup all
+.PHONY: help install setup generate generate-quick generate-quick-100000 generate-no-aggregates generate-notifications-and-aggregates cleanup all
 
 help: ## Show this help
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z_0-9-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-40s\033[0m %s\n", $$1, $$2}'
 
 install: ## Install Python dependencies
 	pip install -r requirements.txt
@@ -20,8 +20,14 @@ generate: install ## Generate all production-like data (full run: ~14M notificat
 generate-quick: install ## Generate everything except notification_history (fast, for testing setup)
 	python generate.py --skip-notifications
 
+generate-quick-100000: install ## Generate all data with ~100K notifications (fast, for testing)
+	python generate.py --quick-100000
+
 generate-no-aggregates: install ## Generate data but skip ft_notification_status and ft_billing
 	python generate.py --skip-aggregates
+
+generate-notifications-and-aggregates: install ## Generate only notification_history, ft_notification_status, and ft_billing (requires existing setup)
+	python generate.py --only-notifications-and-aggregates
 
 cleanup: install ## Delete all test-simulate-prod-data entities from the database
 	python generate.py --cleanup-only

--- a/tests-simulate-prod-data/README.md
+++ b/tests-simulate-prod-data/README.md
@@ -8,14 +8,15 @@ Generate non-PII, production-like data in a staging database for performance tes
 |---|---|---|
 | Organisation | 1 | `test-simulate-prod-data-org` |
 | Service | 1 | `test-simulate-prod-data-service` with prod-like limits (10M SMS, 25M email annual) |
-| Users | 5 | `test-simulate-prod-data-user-{1..5}@staging-simulate.local`, blocked (no login), full permissions |
+| Users | 5 | `test-simulate-prod-data-user-{1..5}@staging-simulate.local`, blocked (no login), full permissions including folder access |
 | Reply-to address | 1 | Default reply-to for the service |
-| Template folders | 5 | 1 high-volume folder + 4 regular folders |
+| Template folders | 5 | 1 high-volume folder + 4 regular folders (all users have access to all folders) |
 | Templates | ~2,020 | 2,000 in the high-volume folder (mix of email/sms, with 3-5 `{{variables}}`), ~5 each in others |
 | Templates history | ~2,020 | Matching version 1 entries for all templates |
 | Jobs | 200 | Simulated bulk send jobs (status: finished) |
 | Notification history (email) | 5,000,000 | 4,950,000 delivered + 50,000 permanent-failure |
 | Notification history (SMS) | 9,000,000 | 8,910,000 delivered + 90,000 permanent-failure |
+| Live notifications | 1,000,000 | Recent notifications in the `notifications` table (last 7 days, mix of statuses) |
 | ft_notification_status | ~1,460 rows | Daily aggregates for the fiscal year |
 | ft_billing | ~730 rows | Daily billing aggregates for the fiscal year |
 
@@ -50,6 +51,7 @@ All other values have sensible defaults. See [.env.example](.env.example) for th
 | `NUM_EMAILS_FAILED` | `50000` | Email notifications with permanent-failure status |
 | `NUM_SMS_TOTAL` | `9000000` | Total SMS notifications to generate |
 | `NUM_SMS_FAILED` | `90000` | SMS notifications with permanent-failure status |
+| `NUM_LIVE_NOTIFICATIONS` | `1000000` | Recent notifications in the live `notifications` table |
 | `BATCH_SIZE` | `10000` | Rows per batch insert (tune for your DB) |
 
 ## Usage
@@ -67,8 +69,15 @@ make generate
 # Skip the 14M notification_history rows (fast — just creates service/users/templates/jobs)
 make generate-quick
 
+# Generate all data with ~185K notifications (fast, for testing the full flow)
+# Uses preset: 95.5K emails + 90K SMS + 10K live notifications
+make generate-quick-100000
+
 # Skip aggregate tables (ft_notification_status, ft_billing)
 make generate-no-aggregates
+
+# Generate only notifications and aggregates (requires existing setup objects from previous run)
+make generate-notifications-and-aggregates
 ```
 
 ### Cleanup (delete all generated data)

--- a/tests-simulate-prod-data/README.md
+++ b/tests-simulate-prod-data/README.md
@@ -1,0 +1,100 @@
+# tests-simulate-prod-data
+
+Generate non-PII, production-like data in a staging database for performance testing.
+
+## What it creates
+
+| Entity | Count | Details |
+|---|---|---|
+| Organisation | 1 | `test-simulate-prod-data-org` |
+| Service | 1 | `test-simulate-prod-data-service` with prod-like limits (10M SMS, 25M email annual) |
+| Users | 5 | `test-simulate-prod-data-user-{1..5}@staging-simulate.local`, all active with full permissions |
+| API Key | 1 | `normal` type key for the service |
+| Reply-to address | 1 | Default reply-to for the service |
+| Service callback | 1 | `delivery_status` callback |
+| Template folders | 5 | 1 high-volume folder + 4 regular folders |
+| Templates | ~2,020 | 2,000 in the high-volume folder (mix of email/sms, with 3-5 `{{variables}}`), ~5 each in others |
+| Templates history | ~2,020 | Matching version 1 entries for all templates |
+| Jobs | 200 | Simulated bulk send jobs (status: finished) |
+| Notification history (email) | 5,000,000 | 4,950,000 delivered + 50,000 permanent-failure |
+| Notification history (SMS) | 9,000,000 | 8,910,000 delivered + 90,000 permanent-failure |
+| ft_notification_status | ~1,460 rows | Daily aggregates for the fiscal year |
+| ft_billing | ~730 rows | Daily billing aggregates for the fiscal year |
+
+All data is spread across the configurable date range (default: fiscal year Apr 2025 – Mar 2026).
+
+## Prerequisites
+
+```bash
+pip install -r requirements.txt
+```
+
+## Configuration
+
+Copy the example env file and edit as needed:
+
+```bash
+cp .env.example .env
+```
+
+**Required:** `SQLALCHEMY_DATABASE_URI` — the PostgreSQL connection string for the target database.
+
+All other values have sensible defaults. See [.env.example](.env.example) for the full list.
+
+### Key configuration options
+
+| Variable | Default | Description |
+|---|---|---|
+| `SQLALCHEMY_DATABASE_URI` | _(required)_ | PostgreSQL connection string |
+| `DATE_START` | `2025-04-01` | Start of the notification date range |
+| `DATE_END` | `2026-03-31` | End of the notification date range |
+| `NUM_EMAILS_TOTAL` | `5000000` | Total email notifications to generate |
+| `NUM_EMAILS_FAILED` | `50000` | Email notifications with permanent-failure status |
+| `NUM_SMS_TOTAL` | `9000000` | Total SMS notifications to generate |
+| `NUM_SMS_FAILED` | `90000` | SMS notifications with permanent-failure status |
+| `BATCH_SIZE` | `10000` | Rows per batch insert (tune for your DB) |
+
+## Usage
+
+### Generate data
+
+```bash
+cd tests-simulate-prod-data
+python generate.py
+```
+
+#### Useful flags
+
+```bash
+# Skip the 14M notification_history rows (fast — just creates service/users/templates/jobs)
+python generate.py --skip-notifications
+
+# Skip aggregate tables (ft_notification_status, ft_billing)
+python generate.py --skip-aggregates
+```
+
+### Cleanup (delete all generated data)
+
+```bash
+python generate.py --cleanup-only
+```
+
+This finds all entities with the `test-simulate-prod-data` prefix and deletes them in the correct FK order.
+
+## How it works
+
+1. **No PII** — All email addresses use `@staging-simulate.local`, phone numbers use a test number (`+16135550199`). No real user data is created.
+2. **Direct SQL** — Uses SQLAlchemy Core with raw parameterised SQL for maximum insert speed. The 14M notification rows are inserted in configurable batches (default 10K).
+3. **Realistic distribution** — Notifications are randomly spread across the date range. ~70% of notifications are linked to job records. Templates contain 3-5 placeholder variables.
+4. **Idempotent cleanup** — The `--cleanup-only` flag removes everything by prefix, so you can re-run safely.
+
+## Performance notes
+
+- Inserting 14M rows takes significant time. Expect ~30-60 minutes depending on DB performance.
+- Increase `BATCH_SIZE` (e.g., 50000) on powerful staging DBs for faster inserts.
+- Use `--skip-notifications` to quickly test the setup logic before doing a full run.
+- Consider running inside a `screen` or `tmux` session for long runs.
+
+## Relationship to tests-perf
+
+This script populates the **database** with realistic data volumes. After running it, use the existing [tests-perf/](../tests-perf/) Locust scripts to run performance tests against the API with this data in place. The combination tests both API throughput and database query performance under realistic conditions.

--- a/tests-simulate-prod-data/README.md
+++ b/tests-simulate-prod-data/README.md
@@ -8,10 +8,8 @@ Generate non-PII, production-like data in a staging database for performance tes
 |---|---|---|
 | Organisation | 1 | `test-simulate-prod-data-org` |
 | Service | 1 | `test-simulate-prod-data-service` with prod-like limits (10M SMS, 25M email annual) |
-| Users | 5 | `test-simulate-prod-data-user-{1..5}@staging-simulate.local`, all active with full permissions |
-| API Key | 1 | `normal` type key for the service |
+| Users | 5 | `test-simulate-prod-data-user-{1..5}@staging-simulate.local`, blocked (no login), full permissions |
 | Reply-to address | 1 | Default reply-to for the service |
-| Service callback | 1 | `delivery_status` callback |
 | Template folders | 5 | 1 high-volume folder + 4 regular folders |
 | Templates | ~2,020 | 2,000 in the high-volume folder (mix of email/sms, with 3-5 `{{variables}}`), ~5 each in others |
 | Templates history | ~2,020 | Matching version 1 entries for all templates |
@@ -26,7 +24,7 @@ All data is spread across the configurable date range (default: fiscal year Apr 
 ## Prerequisites
 
 ```bash
-pip install -r requirements.txt
+make install
 ```
 
 ## Configuration
@@ -34,7 +32,7 @@ pip install -r requirements.txt
 Copy the example env file and edit as needed:
 
 ```bash
-cp .env.example .env
+make setup
 ```
 
 **Required:** `SQLALCHEMY_DATABASE_URI` — the PostgreSQL connection string for the target database.
@@ -60,23 +58,29 @@ All other values have sensible defaults. See [.env.example](.env.example) for th
 
 ```bash
 cd tests-simulate-prod-data
-python generate.py
+make generate
 ```
 
 #### Useful flags
 
 ```bash
 # Skip the 14M notification_history rows (fast — just creates service/users/templates/jobs)
-python generate.py --skip-notifications
+make generate-quick
 
 # Skip aggregate tables (ft_notification_status, ft_billing)
-python generate.py --skip-aggregates
+make generate-no-aggregates
 ```
 
 ### Cleanup (delete all generated data)
 
 ```bash
-python generate.py --cleanup-only
+make cleanup
+```
+
+### Full setup + generate (install, create .env, generate data)
+
+```bash
+make all
 ```
 
 This finds all entities with the `test-simulate-prod-data` prefix and deletes them in the correct FK order.

--- a/tests-simulate-prod-data/generate.py
+++ b/tests-simulate-prod-data/generate.py
@@ -8,6 +8,7 @@ Usage:
 Requires SQLALCHEMY_DATABASE_URI env var (or .env file).
 """
 
+import io
 import math
 import random
 import uuid
@@ -18,6 +19,12 @@ from dateutil import rrule
 from sim_config import PREFIX, Config
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import Session
+
+
+def _timestamp():
+    """Return current timestamp for logging."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -94,7 +101,45 @@ def _template_subject(num_vars, chosen_vars):
 
 def get_engine():
     Config.validate()
-    return create_engine(Config.SQLALCHEMY_DATABASE_URI, echo=False)
+    return create_engine(
+        Config.SQLALCHEMY_DATABASE_URI,
+        echo=False,
+    )
+
+
+def _copy_rows(session, table_name, columns, rows):
+    """Use PostgreSQL COPY FROM STDIN for fastest possible bulk insert.
+
+    COPY bypasses the SQL parser and streams data directly into the table,
+    making it 5-10x faster than even multi-row INSERT VALUES.
+    """
+    if not rows:
+        return
+
+    buf = io.StringIO()
+    for row in rows:
+        values = []
+        for col in columns:
+            val = row[col]
+            if val is None:
+                values.append("\\N")
+            elif isinstance(val, bool):
+                values.append("t" if val else "f")
+            elif isinstance(val, datetime):
+                values.append(val.isoformat())
+            else:
+                values.append(str(val))
+        buf.write("\t".join(values) + "\n")
+
+    buf.seek(0)
+
+    col_list = ", ".join(f'"{c}"' for c in columns)
+    copy_sql = f"COPY {table_name} ({col_list}) FROM STDIN"
+
+    raw_conn = session.connection().connection
+    cursor = raw_conn.cursor()
+    cursor.copy_expert(copy_sql, buf)
+    cursor.close()
 
 
 # ---------------------------------------------------------------------------
@@ -256,6 +301,20 @@ def grant_service_permissions(session, service_id):
         """),
             {"sid": str(service_id), "perm": perm, "now": datetime.now(timezone.utc)},
         )
+
+
+def grant_folder_permissions(session, users, service_id, folder_ids):
+    """Grant all users access to all template folders."""
+    print(f"  Granting folder permissions to {len(users)} users for {len(folder_ids)} folders...")
+    for u in users:
+        for fid in folder_ids:
+            session.execute(
+                text("""
+                INSERT INTO user_folder_permissions (user_id, template_folder_id, service_id)
+                VALUES (:uid, :fid, :sid)
+            """),
+                {"uid": str(u["id"]), "fid": str(fid), "sid": str(service_id)},
+            )
 
 
 def create_api_key(session, service_id, creator_id):
@@ -564,9 +623,28 @@ def _build_notification_batch(
 
 
 def insert_notification_history(session, service_id, email_template_ids, sms_template_ids, job_ids, api_key_id):
-    """Bulk-insert notification_history rows."""
+    """Bulk-insert notification_history rows using PostgreSQL COPY."""
     start_date = Config.date_start_parsed()
     end_date = Config.date_end_parsed()
+
+    nh_columns = [
+        "id",
+        "service_id",
+        "template_id",
+        "template_version",
+        "notification_type",
+        "created_at",
+        "sent_at",
+        "updated_at",
+        "notification_status",
+        "key_type",
+        "billable_units",
+        "international",
+        "api_key_id",
+        "job_id",
+        "job_row_number",
+        "client_reference",
+    ]
 
     for ntype, template_ids, total, failed_count in [
         (NOTIFICATION_TYPE_EMAIL, email_template_ids, Config.NUM_EMAILS_TOTAL, Config.NUM_EMAILS_FAILED),
@@ -578,7 +656,7 @@ def insert_notification_history(session, service_id, email_template_ids, sms_tem
 
         num_batches = math.ceil(total / Config.BATCH_SIZE)
         print(f"\n  Inserting {total:,} {ntype} notification_history rows ({failed_count:,} permanent-failure)...")
-        print(f"    Batches: {num_batches} x {Config.BATCH_SIZE:,}")
+        print(f"    Batches: {num_batches} x {Config.BATCH_SIZE:,} (using COPY)")
 
         remaining = total
         failed_remaining = failed_count
@@ -598,28 +676,122 @@ def insert_notification_history(session, service_id, email_template_ids, sms_tem
                 end_date,
             )
 
-            # Use raw SQL multi-row insert for maximum speed
             if rows:
-                session.execute(
-                    text("""
-                    INSERT INTO notification_history
-                        (id, service_id, template_id, template_version,
-                         notification_type, created_at, sent_at, updated_at, notification_status, key_type,
-                         billable_units, international, api_key_id, job_id, job_row_number,
-                         client_reference)
-                    VALUES
-                        (:id, :service_id, :template_id, :template_version,
-                         :notification_type, :created_at, :sent_at, :updated_at, :notification_status, :key_type,
-                         :billable_units, :international, :api_key_id, :job_id, :job_row_number,
-                         :client_reference)
-                """),
-                    rows,
-                )
+                _copy_rows(session, "notification_history", nh_columns, rows)
 
             if (batch_idx + 1) % 10 == 0 or batch_idx == num_batches - 1:
                 pct = ((batch_idx + 1) / num_batches) * 100
-                print(f"    ... batch {batch_idx+1}/{num_batches} ({pct:.1f}%)")
+                print(f"    ... batch {batch_idx+1}/{num_batches} ({pct:.1f}%) [{_timestamp()}]")
                 session.commit()
+
+
+def insert_live_notifications(session, service_id, email_template_ids, sms_template_ids, job_ids, api_key_id, total_count):
+    """Insert recent notifications into the live notifications table (last 7 days).
+
+    The notifications table holds recent/active notifications, while notification_history holds the archive.
+    """
+    start_date = datetime.now(timezone.utc) - timedelta(days=7)
+    end_date = datetime.now(timezone.utc)
+
+    # Distribute across email and SMS proportionally
+    total_emails = int(total_count * 0.4)  # 40% email
+    total_sms = total_count - total_emails  # 60% SMS
+
+    print(f"\n  Inserting {total_count:,} live notifications into 'notifications' table (last 7 days)...")
+    print(
+        f"    Split: {total_emails:,} email ({total_emails/total_count*100:.0f}%) + {total_sms:,} SMS ({total_sms/total_count*100:.0f}%)"
+    )
+    print("    Status distribution: ~2% created, ~3% sending, ~5% pending, ~85% delivered, ~5% permanent-failure")
+
+    notif_columns = [
+        "id",
+        "to",
+        "normalised_to",
+        "service_id",
+        "template_id",
+        "template_version",
+        "notification_type",
+        "created_at",
+        "sent_at",
+        "updated_at",
+        "notification_status",
+        "key_type",
+        "billable_units",
+        "international",
+        "api_key_id",
+        "job_id",
+        "job_row_number",
+        "client_reference",
+    ]
+
+    for ntype, template_ids, total in [
+        (NOTIFICATION_TYPE_EMAIL, email_template_ids, total_emails),
+        (NOTIFICATION_TYPE_SMS, sms_template_ids, total_sms),
+    ]:
+        if not template_ids or total == 0:
+            continue
+
+        type_jobs = [j for j in job_ids if j["type"] == ntype] if job_ids else []
+        rows = []
+
+        print(f"\n    Generating {total:,} {ntype} notifications... (using COPY)")
+
+        for i in range(total):
+            tmpl_id = random.choice(template_ids)
+            created = _random_date(start_date.date(), end_date.date())
+            job = random.choice(type_jobs) if type_jobs and random.random() < 0.7 else None
+
+            # Mix of statuses for live table (more realistic)
+            status_roll = random.random()
+            if status_roll < 0.02:
+                status = "created"
+            elif status_roll < 0.05:
+                status = "sending"
+            elif status_roll < 0.10:
+                status = "pending"
+            elif status_roll < 0.95:
+                status = "delivered"
+            else:
+                status = "permanent-failure"
+
+            to_address = f"test-{i}@{FAKE_EMAIL_DOMAIN}" if ntype == NOTIFICATION_TYPE_EMAIL else FAKE_PHONE
+
+            rows.append(
+                {
+                    "id": str(_uuid()),
+                    "to": to_address,
+                    "normalised_to": to_address.lower() if ntype == NOTIFICATION_TYPE_EMAIL else FAKE_PHONE,
+                    "service_id": str(service_id),
+                    "template_id": str(tmpl_id),
+                    "template_version": 1,
+                    "notification_type": ntype,
+                    "created_at": created,
+                    "sent_at": created + timedelta(seconds=random.randint(1, 30)) if status != "created" else None,
+                    "updated_at": created + timedelta(seconds=random.randint(31, 120)),
+                    "notification_status": status,
+                    "key_type": "normal",
+                    "billable_units": 1,
+                    "international": False,
+                    "api_key_id": str(api_key_id) if api_key_id else None,
+                    "job_id": str(job["id"]) if job else None,
+                    "job_row_number": random.randint(0, Config.JOB_NOTIFICATION_COUNT - 1) if job else None,
+                    "client_reference": PREFIX,
+                }
+            )
+
+            if len(rows) >= Config.BATCH_SIZE:
+                _copy_rows(session, "notifications", notif_columns, rows)
+                if (i + 1) % Config.BATCH_SIZE == 0 or i + 1 == total:
+                    pct = ((i + 1) / total) * 100
+                    print(f"      ... {i+1:,}/{total:,} ({pct:.1f}%) [{_timestamp()}]")
+                session.commit()
+                rows = []
+
+        if rows:
+            _copy_rows(session, "notifications", notif_columns, rows)
+            session.commit()
+
+    print(f"\n  ✓ Live notifications table populated ({total_count:,} rows).")
 
 
 def _distribute_over_days(total, num_days, day_index):
@@ -643,7 +815,20 @@ def populate_ft_notification_status(session, service_id, email_template_ids, sms
     num_days = len(dates)
     null_job_id = "00000000-0000-0000-0000-000000000000"
 
-    print(f"\n  Populating ft_notification_status over {num_days} days...")
+    ft_columns = [
+        "bst_date",
+        "template_id",
+        "service_id",
+        "job_id",
+        "notification_type",
+        "key_type",
+        "notification_status",
+        "notification_count",
+        "billable_units",
+        "created_at",
+    ]
+
+    print(f"\n  Populating ft_notification_status over {num_days} days... (using COPY)")
 
     rows = []
     for day_index, d in enumerate(dates):
@@ -690,32 +875,13 @@ def populate_ft_notification_status(session, service_id, email_template_ids, sms
                 )
 
         if len(rows) >= 5000:
-            session.execute(
-                text("""
-                INSERT INTO ft_notification_status
-                    (bst_date, template_id, service_id, job_id, notification_type, key_type,
-                     notification_status, notification_count, billable_units, created_at)
-                VALUES
-                    (:bst_date, :template_id, :service_id, :job_id, :notification_type, :key_type,
-                     :notification_status, :notification_count, :billable_units, :created_at)
-            """),
-                rows,
-            )
+            _copy_rows(session, "ft_notification_status", ft_columns, rows)
             rows = []
 
     if rows:
-        session.execute(
-            text("""
-            INSERT INTO ft_notification_status
-                (bst_date, template_id, service_id, job_id, notification_type, key_type,
-                 notification_status, notification_count, billable_units, created_at)
-            VALUES
-                (:bst_date, :template_id, :service_id, :job_id, :notification_type, :key_type,
-                 :notification_status, :notification_count, :billable_units, :created_at)
-        """),
-            rows,
-        )
+        _copy_rows(session, "ft_notification_status", ft_columns, rows)
 
+    session.commit()
     print("  ft_notification_status populated.")
 
 
@@ -726,7 +892,23 @@ def populate_ft_billing(session, service_id, email_template_ids, sms_template_id
     dates = list(rrule.rrule(freq=rrule.DAILY, dtstart=start_date, until=end_date))
     num_days = len(dates)
 
-    print(f"\n  Populating ft_billing over {num_days} days...")
+    billing_columns = [
+        "bst_date",
+        "template_id",
+        "service_id",
+        "notification_type",
+        "provider",
+        "rate_multiplier",
+        "international",
+        "rate",
+        "postage",
+        "sms_sending_vehicle",
+        "billable_units",
+        "notifications_sent",
+        "created_at",
+    ]
+
+    print(f"\n  Populating ft_billing over {num_days} days... (using COPY)")
 
     rows = []
     for day_index, d in enumerate(dates):
@@ -760,36 +942,13 @@ def populate_ft_billing(session, service_id, email_template_ids, sms_template_id
             )
 
         if len(rows) >= 5000:
-            session.execute(
-                text("""
-                INSERT INTO ft_billing
-                    (bst_date, template_id, service_id, notification_type, provider,
-                     rate_multiplier, international, rate, postage, sms_sending_vehicle,
-                     billable_units, notifications_sent, created_at)
-                VALUES
-                    (:bst_date, :template_id, :service_id, :notification_type, :provider,
-                     :rate_multiplier, :international, :rate, :postage, :sms_sending_vehicle,
-                     :billable_units, :notifications_sent, :created_at)
-            """),
-                rows,
-            )
+            _copy_rows(session, "ft_billing", billing_columns, rows)
             rows = []
 
     if rows:
-        session.execute(
-            text("""
-            INSERT INTO ft_billing
-                (bst_date, template_id, service_id, notification_type, provider,
-                 rate_multiplier, international, rate, postage, sms_sending_vehicle,
-                 billable_units, notifications_sent, created_at)
-            VALUES
-                (:bst_date, :template_id, :service_id, :notification_type, :provider,
-                 :rate_multiplier, :international, :rate, :postage, :sms_sending_vehicle,
-                 :billable_units, :notifications_sent, :created_at)
-        """),
-            rows,
-        )
+        _copy_rows(session, "ft_billing", billing_columns, rows)
 
+    session.commit()
     print("  ft_billing populated.")
 
 
@@ -801,7 +960,7 @@ def populate_ft_billing(session, service_id, email_template_ids, sms_template_id
 def cleanup(session):
     """Remove all test-simulate-prod-data entities."""
     print(f"\n{'='*60}")
-    print(f"CLEANUP: Removing all '{PREFIX}' data...")
+    print(f"CLEANUP: Removing all '{PREFIX}' data... [{_timestamp()}]")
     print(f"{'='*60}\n")
 
     # Build name patterns for services and orgs. Cleanup is limited to
@@ -872,6 +1031,17 @@ def cleanup(session):
             print("    Deleting templates...")
             session.execute(text("DELETE FROM templates WHERE service_id = :sid"), {"sid": sid})
 
+            # user_folder_permissions (before template_folder due to FK constraint)
+            print("    Deleting user_folder_permissions...")
+            session.execute(
+                text("""
+                DELETE FROM user_folder_permissions WHERE template_folder_id IN (
+                    SELECT id FROM template_folder WHERE service_id = :sid
+                )
+            """),
+                {"sid": sid},
+            )
+
             # template_folder
             print("    Deleting template_folder...")
             session.execute(text("DELETE FROM template_folder WHERE service_id = :sid"), {"sid": sid})
@@ -916,7 +1086,7 @@ def cleanup(session):
         session.execute(text("DELETE FROM organisation WHERE name LIKE :pattern"), {"pattern": org_name})
 
     session.commit()
-    print("\nCleanup complete.")
+    print(f"\nCleanup complete. [{_timestamp()}]")
 
 
 # ---------------------------------------------------------------------------
@@ -932,8 +1102,29 @@ def cleanup(session):
     "--skip-notifications", is_flag=True, default=False, help="Skip notification_history generation (for testing setup)"
 )
 @click.option("--skip-aggregates", is_flag=True, default=False, help="Skip ft_notification_status and ft_billing generation")
-def main(cleanup_only, skip_notifications, skip_aggregates):
+@click.option(
+    "--only-notifications-and-aggregates",
+    is_flag=True,
+    default=False,
+    help="Skip setup objects, only generate notification_history, ft_notification_status, and ft_billing",
+)
+@click.option(
+    "--quick-100000",
+    is_flag=True,
+    default=False,
+    help="Use quick 100K preset (~185K notifications total for fast testing)",
+)
+def main(cleanup_only, skip_notifications, skip_aggregates, only_notifications_and_aggregates, quick_100000):
     """Generate production-like data for staging performance testing."""
+
+    # Apply quick-100000 preset if requested
+    if quick_100000:
+        Config.NUM_EMAILS_TOTAL = Config.NUM_EMAILS_TOTAL_QUICK_100K
+        Config.NUM_EMAILS_FAILED = Config.NUM_EMAILS_FAILED_QUICK_100K
+        Config.NUM_SMS_TOTAL = Config.NUM_SMS_TOTAL_QUICK_100K
+        Config.NUM_SMS_FAILED = Config.NUM_SMS_FAILED_QUICK_100K
+        Config.NUM_LIVE_NOTIFICATIONS = Config.NUM_LIVE_NOTIFICATIONS_QUICK_100K
+
     engine = get_engine()
 
     with Session(engine) as session:
@@ -942,7 +1133,7 @@ def main(cleanup_only, skip_notifications, skip_aggregates):
             return
 
         print(f"\n{'='*60}")
-        print("GENERATE: Production-like data simulation")
+        print(f"GENERATE: Production-like data simulation [{_timestamp()}]")
         print(f"{'='*60}")
         print(f"  Prefix:       {PREFIX}")
         print(f"  Date range:   {Config.DATE_START} to {Config.DATE_END}")
@@ -956,12 +1147,97 @@ def main(cleanup_only, skip_notifications, skip_aggregates):
         print(f"{'='*60}\n")
 
         try:
+            if only_notifications_and_aggregates:
+                # Only generate notifications and aggregates for existing setup objects
+                print("\n" + "=" * 60)
+                print("MODE: Generating only notifications and aggregates")
+                print("=" * 60 + "\n")
+
+                # Find existing service
+                result = session.execute(text("SELECT id FROM services WHERE name = :name"), {"name": Config.SERVICE_NAME})
+                row = result.fetchone()
+                if not row:
+                    raise click.ClickException(
+                        f"Service '{Config.SERVICE_NAME}' not found. Run without --only-notifications-and-aggregates first to create setup objects."
+                    )
+                service_id = row[0]
+
+                # Find existing templates
+                result = session.execute(
+                    text("SELECT id, template_type FROM templates WHERE service_id = :sid ORDER BY created_at"),
+                    {"sid": str(service_id)},
+                )
+                all_template_ids = []
+                email_template_ids = []
+                sms_template_ids = []
+                for row in result:
+                    tid = row[0]
+                    ttype = row[1]
+                    all_template_ids.append(tid)
+                    if ttype == NOTIFICATION_TYPE_EMAIL:
+                        email_template_ids.append(tid)
+                    else:
+                        sms_template_ids.append(tid)
+
+                if not all_template_ids:
+                    raise click.ClickException(
+                        f"No templates found for service '{Config.SERVICE_NAME}'. Run without --only-notifications-and-aggregates first."
+                    )
+
+                print(f"  Found service: {service_id}")
+                print(
+                    f"  Found {len(all_template_ids)} templates (email: {len(email_template_ids)}, sms: {len(sms_template_ids)})"
+                )
+
+                # Find existing jobs
+                result = session.execute(
+                    text("SELECT id, template_id, created_at FROM jobs WHERE service_id = :sid ORDER BY created_at"),
+                    {"sid": str(service_id)},
+                )
+                job_ids = []
+                for row in result:
+                    # Determine type from template
+                    result2 = session.execute(text("SELECT template_type FROM templates WHERE id = :tid"), {"tid": str(row[1])})
+                    ttype_row = result2.fetchone()
+                    job_ids.append(
+                        {
+                            "id": row[0],
+                            "template_id": row[1],
+                            "type": ttype_row[0] if ttype_row else "email",
+                            "created_at": row[2],
+                        }
+                    )
+
+                print(f"  Found {len(job_ids)} jobs\\n")
+
+                # Generate notifications
+                print("Inserting notification_history...")
+                insert_notification_history(session, service_id, email_template_ids, sms_template_ids, job_ids, None)
+
+                print("\nInserting live notifications...")
+                insert_live_notifications(
+                    session, service_id, email_template_ids, sms_template_ids, job_ids, None, Config.NUM_LIVE_NOTIFICATIONS
+                )
+
+                # Generate aggregates
+                print("\\n[Bonus] Populating aggregate tables...")
+                populate_ft_notification_status(session, service_id, email_template_ids, sms_template_ids)
+                populate_ft_billing(session, service_id, email_template_ids, sms_template_ids)
+
+                print("\\nFinal commit...")
+                session.commit()
+                print("\\n" + "=" * 60)
+                print("SUCCESS: Notifications and aggregates generated.")
+                print(f"  Service ID: {service_id}")
+                print("=" * 60)
+                return
+
             # 1. Organisation
-            print("[1/12] Creating organisation...")
+            print(f"[1/12] Creating organisation... [{_timestamp()}]")
             org_id = create_organisation(session)
 
             # 2. Users
-            print("[2/12] Creating users...")
+            print(f"[2/12] Creating users... [{_timestamp()}]")
             users = create_users(session)
 
             # 3. Service
@@ -993,6 +1269,10 @@ def main(cleanup_only, skip_notifications, skip_aggregates):
             print("[9/12] Creating template folders...")
             folder_ids, folder_names = create_template_folders(session, service_id)
 
+            # 9b. Grant folder permissions
+            print("[9b/12] Granting folder permissions...")
+            grant_folder_permissions(session, users, service_id, folder_ids)
+
             # 10. Templates
             print("[10/12] Creating templates...")
             all_template_ids, email_template_ids, sms_template_ids = create_templates(
@@ -1012,26 +1292,38 @@ def main(cleanup_only, skip_notifications, skip_aggregates):
 
             # 12. Notifications
             if not skip_notifications:
-                print("[12/12] Inserting notification_history...")
+                print(f"[12/12] Inserting notification_history... [{_timestamp()}]")
                 insert_notification_history(session, service_id, email_template_ids, sms_template_ids, job_ids, api_key_id)
+                print(f"\n[12b/12] Inserting live notifications... [{_timestamp()}]")
+                insert_live_notifications(
+                    session, service_id, email_template_ids, sms_template_ids, job_ids, api_key_id, Config.NUM_LIVE_NOTIFICATIONS
+                )
             else:
                 print("[12/12] Skipping notification_history (--skip-notifications)")
 
             # Aggregate tables
             if not skip_aggregates:
-                print("\n[Bonus] Populating aggregate tables...")
+                print(f"\n[Bonus] Populating aggregate tables... [{_timestamp()}]")
                 populate_ft_notification_status(session, service_id, email_template_ids, sms_template_ids)
                 populate_ft_billing(session, service_id, email_template_ids, sms_template_ids)
             else:
                 print("\n[Bonus] Skipping aggregates (--skip-aggregates)")
 
-            print("\nFinal commit...")
+            print(f"\nFinal commit... [{_timestamp()}]")
             session.commit()
             print("\n" + "=" * 60)
-            print("SUCCESS: All data generated.")
+            print(f"SUCCESS: All data generated. [{_timestamp()}]")
             print(f"  Service ID: {service_id}")
             print(f"  Service Name: {Config.SERVICE_NAME}")
             print(f"  Organisation ID: {org_id}")
+            if not skip_notifications:
+                print("\n  Notification Summary:")
+                print(f"    notification_history: {Config.NUM_EMAILS_TOTAL + Config.NUM_SMS_TOTAL:,} rows")
+                print(f"      - Email: {Config.NUM_EMAILS_TOTAL:,} ({Config.NUM_EMAILS_FAILED:,} failed)")
+                print(f"      - SMS: {Config.NUM_SMS_TOTAL:,} ({Config.NUM_SMS_FAILED:,} failed)")
+                print(f"    notifications (live): {Config.NUM_LIVE_NOTIFICATIONS:,} rows (last 7 days)")
+                print(f"      - Email: {int(Config.NUM_LIVE_NOTIFICATIONS * 0.4):,} (40%)")
+                print(f"      - SMS: {int(Config.NUM_LIVE_NOTIFICATIONS * 0.6):,} (60%)")
             print("=" * 60)
 
         except Exception as e:

--- a/tests-simulate-prod-data/generate.py
+++ b/tests-simulate-prod-data/generate.py
@@ -352,6 +352,106 @@ def create_callback(session, service_id, creator_id):
     return None
 
 
+def create_annual_billing(session, service_id):
+    """Create annual_billing record for the current fiscal year."""
+    # Canadian fiscal year starts April 1
+    now = datetime.now(timezone.utc)
+    fiscal_year_start = now.year if now.month >= 4 else now.year - 1
+    billing_id = _uuid()
+    print(f"  Creating annual_billing for fiscal year {fiscal_year_start} ({billing_id})...")
+    session.execute(
+        text("""
+        INSERT INTO annual_billing (id, service_id, financial_year_start, free_sms_fragment_limit, created_at)
+        VALUES (:id, :sid, :year, :limit, :now)
+    """),
+        {
+            "id": str(billing_id),
+            "sid": str(service_id),
+            "year": fiscal_year_start,
+            "limit": Config.SERVICE_SMS_ANNUAL_LIMIT,
+            "now": datetime.now(timezone.utc),
+        },
+    )
+    return billing_id
+
+
+def create_sms_sender(session, service_id):
+    """Create a default SMS sender for the service."""
+    sender_id = _uuid()
+    print(f"  Creating default SMS sender ({sender_id})...")
+    session.execute(
+        text("""
+        INSERT INTO service_sms_senders (id, sms_sender, service_id, is_default, created_at)
+        VALUES (:id, :sender, :sid, true, :now)
+    """),
+        {
+            "id": str(sender_id),
+            "sid": str(service_id),
+            "sender": "NOTIFY",
+            "now": datetime.now(timezone.utc),
+        },
+    )
+    return sender_id
+
+
+def link_existing_user(session, service_id, folder_ids):
+    """Link an existing real user to the service so they can access it from the frontend."""
+    email = Config.LINK_EXISTING_USER_EMAIL
+    if not email:
+        return
+
+    result = session.execute(text("SELECT id FROM users WHERE email_address = :email"), {"email": email})
+    row = result.fetchone()
+    if not row:
+        print(f"  WARNING: User '{email}' not found in database — skipping link.")
+        return
+
+    user_id = str(row[0])
+    print(f"  Linking existing user '{email}' ({user_id}) to service...")
+
+    # user_to_service
+    session.execute(
+        text("INSERT INTO user_to_service (user_id, service_id) VALUES (:uid, :sid)"),
+        {"uid": user_id, "sid": str(service_id)},
+    )
+
+    # Grant permissions
+    permissions = [
+        "manage_users",
+        "manage_templates",
+        "manage_settings",
+        "send_texts",
+        "send_emails",
+        "send_letters",
+        "manage_api_keys",
+        "view_activity",
+    ]
+    for perm in permissions:
+        session.execute(
+            text("""
+            INSERT INTO permissions (id, service_id, user_id, permission, created_at)
+            VALUES (:id, :sid, :uid, :perm, :now)
+        """),
+            {
+                "id": str(_uuid()),
+                "sid": str(service_id),
+                "uid": user_id,
+                "perm": perm,
+                "now": datetime.now(timezone.utc),
+            },
+        )
+
+    # Grant folder permissions
+    for fid in folder_ids:
+        session.execute(
+            text("""
+            INSERT INTO user_folder_permissions (user_id, template_folder_id, service_id)
+            VALUES (:uid, :fid, :sid)
+        """),
+            {"uid": user_id, "fid": str(fid), "sid": str(service_id)},
+        )
+
+
 def create_template_folders(session, service_id):
     folder_ids = []
     folder_names = []
@@ -679,10 +779,9 @@ def insert_notification_history(session, service_id, email_template_ids, sms_tem
             if rows:
                 _copy_rows(session, "notification_history", nh_columns, rows)
 
-            if (batch_idx + 1) % 10 == 0 or batch_idx == num_batches - 1:
-                pct = ((batch_idx + 1) / num_batches) * 100
-                print(f"    ... batch {batch_idx+1}/{num_batches} ({pct:.1f}%) [{_timestamp()}]")
-                session.commit()
+            session.commit()
+            pct = ((batch_idx + 1) / num_batches) * 100
+            print(f"    ... batch {batch_idx+1}/{num_batches} ({pct:.1f}%) [{_timestamp()}]")
 
 
 def insert_live_notifications(session, service_id, email_template_ids, sms_template_ids, job_ids, api_key_id, total_count):
@@ -781,15 +880,15 @@ def insert_live_notifications(session, service_id, email_template_ids, sms_templ
 
             if len(rows) >= Config.BATCH_SIZE:
                 _copy_rows(session, "notifications", notif_columns, rows)
-                if (i + 1) % Config.BATCH_SIZE == 0 or i + 1 == total:
-                    pct = ((i + 1) / total) * 100
-                    print(f"      ... {i+1:,}/{total:,} ({pct:.1f}%) [{_timestamp()}]")
                 session.commit()
+                pct = ((i + 1) / total) * 100
+                print(f"      ... {i+1:,}/{total:,} ({pct:.1f}%) [{_timestamp()}]")
                 rows = []
 
         if rows:
             _copy_rows(session, "notifications", notif_columns, rows)
             session.commit()
+            print(f"      ... {total:,}/{total:,} (100.0%) [{_timestamp()}]")
 
     print(f"\n  ✓ Live notifications table populated ({total_count:,} rows).")
 
@@ -1054,6 +1153,14 @@ def cleanup(session):
             print("    Deleting service_email_reply_to...")
             session.execute(text("DELETE FROM service_email_reply_to WHERE service_id = :sid"), {"sid": sid})
 
+            # annual_billing
+            print("    Deleting annual_billing...")
+            session.execute(text("DELETE FROM annual_billing WHERE service_id = :sid"), {"sid": sid})
+
+            # service_sms_senders
+            print("    Deleting service_sms_senders...")
+            session.execute(text("DELETE FROM service_sms_senders WHERE service_id = :sid"), {"sid": sid})
+
             # api_keys
             print("    Deleting api_keys...")
             session.execute(text("DELETE FROM api_keys WHERE service_id = :sid"), {"sid": sid})
@@ -1265,6 +1372,10 @@ def main(cleanup_only, skip_notifications, skip_aggregates, only_notifications_a
             create_reply_to(session, service_id)
             create_callback(session, service_id, users[0]["id"])
 
+            # 8b. Annual billing and SMS sender
+            create_annual_billing(session, service_id)
+            create_sms_sender(session, service_id)
+
             # 9. Template folders
             print("[9/12] Creating template folders...")
             folder_ids, folder_names = create_template_folders(session, service_id)
@@ -1272,6 +1383,9 @@ def main(cleanup_only, skip_notifications, skip_aggregates, only_notifications_a
             # 9b. Grant folder permissions
             print("[9b/12] Granting folder permissions...")
             grant_folder_permissions(session, users, service_id, folder_ids)
+
+            # 9c. Link existing user (optional — set LINK_EXISTING_USER_EMAIL in .env)
+            link_existing_user(session, service_id, folder_ids)
 
             # 10. Templates
             print("[10/12] Creating templates...")

--- a/tests-simulate-prod-data/generate.py
+++ b/tests-simulate-prod-data/generate.py
@@ -259,23 +259,14 @@ def grant_service_permissions(session, service_id):
 
 
 def create_api_key(session, service_id, creator_id):
-    key_id = _uuid()
-    print(f"  Creating API key ({key_id})...")
-    session.execute(
-        text("""
-        INSERT INTO api_keys (id, name, secret, service_id, key_type, created_by_id, created_at, version)
-        VALUES (:id, :name, :secret, :sid, 'normal', :created_by, :now, 1)
-    """),
-        {
-            "id": str(key_id),
-            "name": f"{PREFIX}-api-key",
-            "secret": str(_uuid()),  # NOT a signed secret; API key record exists for FK integrity only
-            "sid": str(service_id),
-            "created_by": str(creator_id),
-            "now": datetime.now(timezone.utc),
-        },
-    )
-    return key_id
+    """Skip API key creation — the secret column requires app-level signing (SECRET_KEY).
+
+    Inserting a raw UUID would produce a record that can never authenticate and
+    would cause BadSignature errors if the app ever reads it.  Jobs and
+    notification_history allow NULL api_key_id, so we simply omit the record.
+    """
+    print("  Skipping API key creation (secret requires app signing config).")
+    return None
 
 
 def create_reply_to(session, service_id):
@@ -504,7 +495,7 @@ def create_jobs(session, service_id, email_template_ids, sms_template_ids, creat
                 "finished": created + timedelta(minutes=random.randint(5, 60)),
                 "created": created,
                 "created_by": str(creator_id),
-                "api_key": str(api_key_id),
+                "api_key": str(api_key_id) if api_key_id else None,
             },
         )
         job_ids.append({"id": jid, "template_id": tmpl_id, "type": ntype, "created_at": created})
@@ -562,7 +553,7 @@ def _build_notification_batch(
                 "key_type": "normal",
                 "billable_units": 1,
                 "international": False,
-                "api_key_id": str(api_key_id),
+                "api_key_id": str(api_key_id) if api_key_id else None,
                 "job_id": str(job["id"]) if job else None,
                 "job_row_number": random.randint(0, Config.JOB_NOTIFICATION_COUNT - 1) if job else None,
                 "client_reference": PREFIX,
@@ -828,6 +819,7 @@ def cleanup(session):
             raise click.ClickException(
                 f"Refusing cleanup: ORGANISATION_NAME '{Config.ORGANISATION_NAME}' does not start with required prefix '{PREFIX}'."
             )
+        org_names.add(Config.ORGANISATION_NAME)
 
     # Find the service(s)
     clauses = " OR ".join(f"name LIKE :p{i}" for i in range(len(service_names)))

--- a/tests-simulate-prod-data/generate.py
+++ b/tests-simulate-prod-data/generate.py
@@ -2,8 +2,8 @@
 test-simulate-prod-data: Generate non-PII production-like data in a staging database.
 
 Usage:
-    python generate.py          # populate data
-    python generate.py --cleanup  # remove all test-simulate-prod-data entities
+    python generate.py               # populate data
+    python generate.py --cleanup-only  # remove all test-simulate-prod-data entities
 
 Requires SQLALCHEMY_DATABASE_URI env var (or .env file).
 """
@@ -531,7 +531,6 @@ def create_jobs(session, service_id, email_template_ids, sms_template_ids, creat
 
 
 def _build_notification_batch(
-    batch_idx,
     batch_size,
     service_id,
     template_ids,
@@ -548,7 +547,13 @@ def _build_notification_batch(
     type_jobs = [j for j in job_ids if j["type"] == notification_type] if job_ids else []
 
     for _ in range(batch_size):
-        is_failed = num_failed_remaining > 0 and (random.random() < (num_failed_remaining / max(num_remaining, 1)))
+        # Force remaining failures into the last rows to guarantee exact totals
+        if num_failed_remaining >= num_remaining:
+            is_failed = True
+        elif num_failed_remaining > 0:
+            is_failed = random.random() < (num_failed_remaining / max(num_remaining, 1))
+        else:
+            is_failed = False
         status = "permanent-failure" if is_failed else "delivered"
         if is_failed:
             num_failed_remaining -= 1
@@ -605,13 +610,12 @@ def insert_notification_history(session, service_id, email_template_ids, sms_tem
         for batch_idx in range(num_batches):
             batch_size = min(Config.BATCH_SIZE, remaining)
             rows, failed_remaining, remaining = _build_notification_batch(
-                batch_idx,
                 batch_size,
                 service_id,
                 template_ids,
                 ntype,
                 failed_remaining,
-                remaining + batch_size,  # add back since we subtract in func
+                remaining,
                 job_ids,
                 api_key_id,
                 start_date,
@@ -636,18 +640,23 @@ def insert_notification_history(session, service_id, email_template_ids, sms_tem
                     rows,
                 )
 
-            remaining -= batch_size
-
             if (batch_idx + 1) % 10 == 0 or batch_idx == num_batches - 1:
                 pct = ((batch_idx + 1) / num_batches) * 100
                 print(f"    ... batch {batch_idx+1}/{num_batches} ({pct:.1f}%)")
-                session.flush()
+                session.commit()
+
+
+def _distribute_over_days(total, num_days, day_index):
+    """Distribute total evenly across days, spreading the remainder across the first days."""
+    base = total // num_days
+    remainder = total % num_days
+    return base + (1 if day_index < remainder else 0)
 
 
 def populate_ft_notification_status(session, service_id, email_template_ids, sms_template_ids):
     """Aggregate notification_history data into ft_notification_status for dashboards."""
-    start_date = Config.date_start_parsed()
-    end_date = Config.date_end_parsed()
+    start_date = datetime.combine(Config.date_start_parsed(), datetime.min.time())
+    end_date = datetime.combine(Config.date_end_parsed(), datetime.min.time())
     dates = list(rrule.rrule(freq=rrule.DAILY, dtstart=start_date, until=end_date))
 
     total_email_delivered = Config.NUM_EMAILS_TOTAL - Config.NUM_EMAILS_FAILED
@@ -661,7 +670,7 @@ def populate_ft_notification_status(session, service_id, email_template_ids, sms
     print(f"\n  Populating ft_notification_status over {num_days} days...")
 
     rows = []
-    for d in dates:
+    for day_index, d in enumerate(dates):
         bst_date = d.date()
         for ntype, template_ids, delivered_total, failed_total in [
             (NOTIFICATION_TYPE_EMAIL, email_template_ids, total_email_delivered, total_email_failed),
@@ -670,8 +679,8 @@ def populate_ft_notification_status(session, service_id, email_template_ids, sms
             if not template_ids:
                 continue
             tmpl_id = random.choice(template_ids)
-            daily_delivered = max(1, delivered_total // num_days)
-            daily_failed = max(0, failed_total // num_days)
+            daily_delivered = _distribute_over_days(delivered_total, num_days, day_index)
+            daily_failed = _distribute_over_days(failed_total, num_days, day_index)
 
             if daily_delivered > 0:
                 rows.append(
@@ -736,15 +745,15 @@ def populate_ft_notification_status(session, service_id, email_template_ids, sms
 
 def populate_ft_billing(session, service_id, email_template_ids, sms_template_ids):
     """Populate ft_billing aggregate table."""
-    start_date = Config.date_start_parsed()
-    end_date = Config.date_end_parsed()
+    start_date = datetime.combine(Config.date_start_parsed(), datetime.min.time())
+    end_date = datetime.combine(Config.date_end_parsed(), datetime.min.time())
     dates = list(rrule.rrule(freq=rrule.DAILY, dtstart=start_date, until=end_date))
     num_days = len(dates)
 
     print(f"\n  Populating ft_billing over {num_days} days...")
 
     rows = []
-    for d in dates:
+    for day_index, d in enumerate(dates):
         bst_date = d.date()
         for ntype, template_ids, total, provider in [
             (NOTIFICATION_TYPE_EMAIL, email_template_ids, Config.NUM_EMAILS_TOTAL, "ses"),
@@ -753,7 +762,7 @@ def populate_ft_billing(session, service_id, email_template_ids, sms_template_id
             if not template_ids:
                 continue
             tmpl_id = random.choice(template_ids)
-            daily_sent = max(1, total // num_days)
+            daily_sent = _distribute_over_days(total, num_days, day_index)
             rate = 0.0 if ntype == NOTIFICATION_TYPE_EMAIL else 0.02
 
             rows.append(
@@ -819,8 +828,18 @@ def cleanup(session):
     print(f"CLEANUP: Removing all '{PREFIX}' data...")
     print(f"{'='*60}\n")
 
+    # Build name patterns for services and orgs (configured names may not include PREFIX)
+    service_names = {f"{PREFIX}%"}
+    org_names = {f"{PREFIX}%"}
+    if Config.SERVICE_NAME and not Config.SERVICE_NAME.startswith(PREFIX):
+        service_names.add(Config.SERVICE_NAME)
+    if Config.ORGANISATION_NAME and not Config.ORGANISATION_NAME.startswith(PREFIX):
+        org_names.add(Config.ORGANISATION_NAME)
+
     # Find the service(s)
-    result = session.execute(text("SELECT id FROM services WHERE name LIKE :pattern"), {"pattern": f"{PREFIX}%"})
+    clauses = " OR ".join(f"name LIKE :p{i}" for i in range(len(service_names)))
+    params = {f"p{i}": n for i, n in enumerate(service_names)}
+    result = session.execute(text(f"SELECT id FROM services WHERE {clauses}"), params)
     service_ids = [str(row[0]) for row in result]
 
     if not service_ids:
@@ -908,7 +927,8 @@ def cleanup(session):
 
     # Organisation
     print("  Deleting organisation...")
-    session.execute(text("DELETE FROM organisation WHERE name LIKE :pattern"), {"pattern": f"{PREFIX}%"})
+    for org_name in org_names:
+        session.execute(text("DELETE FROM organisation WHERE name LIKE :pattern"), {"pattern": org_name})
 
     session.commit()
     print("\nCleanup complete.")
@@ -995,13 +1015,15 @@ def main(cleanup_only, skip_notifications, skip_aggregates):
             )
 
             # Flush before notifications so FKs are available
-            session.flush()
+            session.commit()
+            print("\n  Setup objects committed.\n")
 
             # 11. Jobs
             print("[11/12] Creating jobs...")
             job_ids = create_jobs(session, service_id, email_template_ids, sms_template_ids, users[0]["id"], api_key_id)
 
-            session.flush()
+            session.commit()
+            print("  Jobs committed.\n")
 
             # 12. Notifications
             if not skip_notifications:
@@ -1018,7 +1040,7 @@ def main(cleanup_only, skip_notifications, skip_aggregates):
             else:
                 print("\n[Bonus] Skipping aggregates (--skip-aggregates)")
 
-            print("\nCommitting all data...")
+            print("\nFinal commit...")
             session.commit()
             print("\n" + "=" * 60)
             print("SUCCESS: All data generated.")

--- a/tests-simulate-prod-data/generate.py
+++ b/tests-simulate-prod-data/generate.py
@@ -1,0 +1,1038 @@
+"""
+test-simulate-prod-data: Generate non-PII production-like data in a staging database.
+
+Usage:
+    python generate.py          # populate data
+    python generate.py --cleanup  # remove all test-simulate-prod-data entities
+
+Requires SQLALCHEMY_DATABASE_URI env var (or .env file).
+"""
+
+import math
+import random
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import click
+from dateutil import rrule
+from sim_config import PREFIX, Config
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import Session
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+FAKE_EMAIL_DOMAIN = "staging-simulate.local"
+FAKE_PHONE = "+16135550199"
+
+VARIABLE_NAMES = [
+    "first_name",
+    "last_name",
+    "reference_number",
+    "date",
+    "amount",
+    "service_name",
+    "address",
+    "account_id",
+    "status",
+    "link",
+    "confirmation_code",
+    "expiry_date",
+    "case_number",
+    "department",
+    "action_required",
+]
+
+EMAIL_PROVIDERS = ["ses"]
+SMS_PROVIDERS = ["sns"]
+
+NOTIFICATION_TYPE_EMAIL = "email"
+NOTIFICATION_TYPE_SMS = "sms"
+
+
+def _uuid():
+    return uuid.uuid4()
+
+
+def _random_date(start_date, end_date):
+    """Return a random datetime between start_date and end_date."""
+    delta = end_date - start_date
+    random_days = random.randint(0, delta.days)
+    random_seconds = random.randint(0, 86399)
+    return datetime.combine(start_date, datetime.min.time()) + timedelta(days=random_days, seconds=random_seconds)
+
+
+def _template_content(num_vars, template_type):
+    """Generate template content with {{placeholder}} variables."""
+    chosen = random.sample(VARIABLE_NAMES, min(num_vars, len(VARIABLE_NAMES)))
+    if template_type == NOTIFICATION_TYPE_EMAIL:
+        lines = [f"Dear {{{{{chosen[0]}}}}}," if chosen else "Dear user,"]
+        lines.append("")
+        lines.append("This is a notification regarding your account.")
+        for var in chosen[1:]:
+            lines.append(f"Your {var.replace('_', ' ')}: {{{{{var}}}}}")
+        lines.append("")
+        lines.append("Thank you.")
+        return "\n".join(lines)
+    else:
+        parts = [f"{{{{{v}}}}}" for v in chosen]
+        return f"Notification: {' | '.join(parts)}"
+
+
+def _template_subject(num_vars, chosen_vars):
+    """Generate an email subject with a variable."""
+    if chosen_vars:
+        return f"Notification for {{{{{chosen_vars[0]}}}}}"
+    return "Notification"
+
+
+# ---------------------------------------------------------------------------
+# Database setup using raw SQLAlchemy (no Flask app context needed)
+# ---------------------------------------------------------------------------
+
+
+def get_engine():
+    Config.validate()
+    return create_engine(Config.SQLALCHEMY_DATABASE_URI, echo=False)
+
+
+# ---------------------------------------------------------------------------
+# Data generation functions
+# ---------------------------------------------------------------------------
+
+
+def create_organisation(session):
+    org_id = _uuid()
+    print(f"  Creating organisation '{Config.ORGANISATION_NAME}' ({org_id})...")
+    session.execute(
+        text("""
+        INSERT INTO organisation (id, name, active, created_at, default_branding_is_french, organisation_type)
+        VALUES (:id, :name, true, :now, false, 'central')
+    """),
+        {"id": str(org_id), "name": Config.ORGANISATION_NAME, "now": datetime.now(timezone.utc)},
+    )
+    return org_id
+
+
+def create_users(session):
+    users = []
+    for i in range(1, Config.NUM_USERS + 1):
+        user_id = _uuid()
+        email = f"{PREFIX}-user-{i}@{FAKE_EMAIL_DOMAIN}"
+        print(f"  Creating user {i}/{Config.NUM_USERS}: {email} ({user_id})...")
+        session.execute(
+            text("""
+            INSERT INTO users (id, name, email_address, _password, mobile_number,
+                               password_changed_at, state, auth_type, created_at, blocked,
+                               platform_admin, failed_login_count, password_expired)
+            VALUES (:id, :name, :email, :password, :mobile,
+                    :now, 'active', 'email_auth', :now, false,
+                    false, 0, false)
+        """),
+            {
+                "id": str(user_id),
+                "name": f"{PREFIX} User {i}",
+                "email": email,
+                "password": "simulated-no-login",  # not a real bcrypt hash — these users should never log in
+                "mobile": FAKE_PHONE,
+                "now": datetime.now(timezone.utc),
+            },
+        )
+        users.append({"id": user_id, "email": email, "index": i})
+    return users
+
+
+def create_service(session, users, org_id):
+    service_id = _uuid()
+    creator = users[0]
+    print(f"  Creating service '{Config.SERVICE_NAME}' ({service_id})...")
+    session.execute(
+        text("""
+        INSERT INTO services (id, name, created_by_id, created_at, active, restricted,
+                              message_limit, sms_daily_limit, sms_annual_limit, email_annual_limit,
+                              email_from, organisation_type, prefix_sms, rate_limit,
+                              count_as_live, research_mode, organisation_id, version,
+                              default_branding_is_french)
+        VALUES (:id, :name, :created_by, :now, true, false,
+                :message_limit, :sms_daily_limit, :sms_annual_limit, :email_annual_limit,
+                :email_from, 'central', true, :rate_limit,
+                true, false, :org_id, 1, false)
+    """),
+        {
+            "id": str(service_id),
+            "name": Config.SERVICE_NAME,
+            "created_by": str(creator["id"]),
+            "now": datetime.now(timezone.utc),
+            "message_limit": Config.SERVICE_MESSAGE_LIMIT,
+            "sms_daily_limit": Config.SERVICE_SMS_DAILY_LIMIT,
+            "sms_annual_limit": Config.SERVICE_SMS_ANNUAL_LIMIT,
+            "email_annual_limit": Config.SERVICE_EMAIL_ANNUAL_LIMIT,
+            "email_from": Config.SERVICE_EMAIL_FROM,
+            "rate_limit": Config.SERVICE_RATE_LIMIT,
+            "org_id": str(org_id),
+        },
+    )
+
+    # Also insert into services_history (Versioned pattern)
+    session.execute(
+        text("""
+        INSERT INTO services_history (id, name, created_by_id, created_at, active, restricted,
+                              message_limit, sms_daily_limit, sms_annual_limit, email_annual_limit,
+                              email_from, organisation_type, prefix_sms, rate_limit,
+                              count_as_live, research_mode, organisation_id, version,
+                              default_branding_is_french)
+        VALUES (:id, :name, :created_by, :now, true, false,
+                :message_limit, :sms_daily_limit, :sms_annual_limit, :email_annual_limit,
+                :email_from, 'central', true, :rate_limit,
+                true, false, :org_id, 1, false)
+    """),
+        {
+            "id": str(service_id),
+            "name": Config.SERVICE_NAME,
+            "created_by": str(creator["id"]),
+            "now": datetime.now(timezone.utc),
+            "message_limit": Config.SERVICE_MESSAGE_LIMIT,
+            "sms_daily_limit": Config.SERVICE_SMS_DAILY_LIMIT,
+            "sms_annual_limit": Config.SERVICE_SMS_ANNUAL_LIMIT,
+            "email_annual_limit": Config.SERVICE_EMAIL_ANNUAL_LIMIT,
+            "email_from": Config.SERVICE_EMAIL_FROM,
+            "rate_limit": Config.SERVICE_RATE_LIMIT,
+            "org_id": str(org_id),
+        },
+    )
+    return service_id
+
+
+def link_users_to_service(session, users, service_id):
+    print(f"  Linking {len(users)} users to service...")
+    for u in users:
+        session.execute(
+            text("""
+            INSERT INTO user_to_service (user_id, service_id)
+            VALUES (:uid, :sid)
+        """),
+            {"uid": str(u["id"]), "sid": str(service_id)},
+        )
+
+
+def grant_user_permissions(session, users, service_id):
+    permissions = [
+        "manage_users",
+        "manage_templates",
+        "manage_settings",
+        "send_texts",
+        "send_emails",
+        "send_letters",
+        "manage_api_keys",
+        "view_activity",
+    ]
+    print(f"  Granting permissions to {len(users)} users...")
+    for u in users:
+        for perm in permissions:
+            session.execute(
+                text("""
+                INSERT INTO permissions (id, service_id, user_id, permission, created_at)
+                VALUES (:id, :sid, :uid, :perm, :now)
+            """),
+                {
+                    "id": str(_uuid()),
+                    "sid": str(service_id),
+                    "uid": str(u["id"]),
+                    "perm": perm,
+                    "now": datetime.now(timezone.utc),
+                },
+            )
+
+
+def grant_service_permissions(session, service_id):
+    svc_permissions = ["email", "sms", "international_sms", "schedule_notifications"]
+    print(f"  Granting service permissions: {svc_permissions}...")
+    for perm in svc_permissions:
+        session.execute(
+            text("""
+            INSERT INTO service_permissions (service_id, permission, created_at)
+            VALUES (:sid, :perm, :now)
+        """),
+            {"sid": str(service_id), "perm": perm, "now": datetime.now(timezone.utc)},
+        )
+
+
+def create_api_key(session, service_id, creator_id):
+    key_id = _uuid()
+    print(f"  Creating API key ({key_id})...")
+    session.execute(
+        text("""
+        INSERT INTO api_keys (id, name, secret, service_id, key_type, created_by_id, created_at, version)
+        VALUES (:id, :name, :secret, :sid, 'normal', :created_by, :now, 1)
+    """),
+        {
+            "id": str(key_id),
+            "name": f"{PREFIX}-api-key",
+            "secret": str(_uuid()),  # not a real signed secret; for data volume simulation only
+            "sid": str(service_id),
+            "created_by": str(creator_id),
+            "now": datetime.now(timezone.utc),
+        },
+    )
+    return key_id
+
+
+def create_reply_to(session, service_id):
+    reply_id = _uuid()
+    print(f"  Creating reply-to address ({reply_id})...")
+    session.execute(
+        text("""
+        INSERT INTO service_email_reply_to (id, service_id, email_address, is_default, archived, created_at)
+        VALUES (:id, :sid, :email, true, false, :now)
+    """),
+        {
+            "id": str(reply_id),
+            "sid": str(service_id),
+            "email": f"reply-{PREFIX}@{FAKE_EMAIL_DOMAIN}",
+            "now": datetime.now(timezone.utc),
+        },
+    )
+    return reply_id
+
+
+def create_callback(session, service_id, creator_id):
+    cb_id = _uuid()
+    print(f"  Creating service callback ({cb_id})...")
+    session.execute(
+        text("""
+        INSERT INTO service_callback_api (id, service_id, url, callback_type, bearer_token,
+                                          created_at, updated_by_id, version)
+        VALUES (:id, :sid, :url, 'delivery_status', :bearer, :now, :updated_by, 1)
+    """),
+        {
+            "id": str(cb_id),
+            "sid": str(service_id),
+            "url": f"https://{PREFIX}.example.com/callback",
+            "bearer": "simulated-bearer-token",
+            "now": datetime.now(timezone.utc),
+            "updated_by": str(creator_id),
+        },
+    )
+    return cb_id
+
+
+def create_template_folders(session, service_id):
+    folder_ids = []
+    folder_names = []
+    for i in range(1, Config.NUM_TEMPLATE_FOLDERS + 1):
+        fid = _uuid()
+        name = f"{PREFIX}-folder-{i}" if i > 1 else f"{PREFIX}-folder-high-volume"
+        print(f"  Creating template folder '{name}' ({fid})...")
+        session.execute(
+            text("""
+            INSERT INTO template_folder (id, service_id, name)
+            VALUES (:id, :sid, :name)
+        """),
+            {"id": str(fid), "sid": str(service_id), "name": name},
+        )
+        folder_ids.append(fid)
+        folder_names.append(name)
+    return folder_ids, folder_names
+
+
+def create_templates(session, service_id, creator_id, folder_ids):
+    """Create templates across folders. Folder 0 (high-volume) gets the bulk."""
+    all_template_ids = []
+    email_template_ids = []
+    sms_template_ids = []
+
+    # Folder 0: high-volume folder
+    hv_count = Config.HIGH_VOLUME_FOLDER_TEMPLATE_COUNT
+    print(f"  Creating {hv_count} templates in high-volume folder...")
+    for i in range(hv_count):
+        tid = _uuid()
+        num_vars = random.randint(Config.TEMPLATE_VARIABLES_MIN, Config.TEMPLATE_VARIABLES_MAX)
+        # Alternate between email and sms
+        ttype = NOTIFICATION_TYPE_EMAIL if i % 3 != 0 else NOTIFICATION_TYPE_SMS
+        content = _template_content(num_vars, ttype)
+        chosen_vars = random.sample(VARIABLE_NAMES, min(num_vars, len(VARIABLE_NAMES)))
+        subject = _template_subject(num_vars, chosen_vars) if ttype == NOTIFICATION_TYPE_EMAIL else None
+
+        session.execute(
+            text("""
+            INSERT INTO templates (id, name, template_type, created_at, content, subject,
+                                   archived, hidden, service_id, created_by_id, version, process_type)
+            VALUES (:id, :name, :ttype, :now, :content, :subject,
+                    false, false, :sid, :cid, 1, 'normal')
+        """),
+            {
+                "id": str(tid),
+                "name": f"{PREFIX}-template-{i+1}",
+                "ttype": ttype,
+                "now": datetime.now(timezone.utc),
+                "content": content,
+                "subject": subject,
+                "sid": str(service_id),
+                "cid": str(creator_id),
+            },
+        )
+
+        # templates_history row (version 1)
+        session.execute(
+            text("""
+            INSERT INTO templates_history (id, name, template_type, created_at, content, subject,
+                                           archived, hidden, service_id, created_by_id, version, process_type)
+            VALUES (:id, :name, :ttype, :now, :content, :subject,
+                    false, false, :sid, :cid, 1, 'normal')
+        """),
+            {
+                "id": str(tid),
+                "name": f"{PREFIX}-template-{i+1}",
+                "ttype": ttype,
+                "now": datetime.now(timezone.utc),
+                "content": content,
+                "subject": subject,
+                "sid": str(service_id),
+                "cid": str(creator_id),
+            },
+        )
+
+        # template_folder_map association
+        session.execute(
+            text("""
+            INSERT INTO template_folder_map (template_id, template_folder_id)
+            VALUES (:tid, :fid)
+        """),
+            {"tid": str(tid), "fid": str(folder_ids[0])},
+        )
+
+        all_template_ids.append(tid)
+        if ttype == NOTIFICATION_TYPE_EMAIL:
+            email_template_ids.append(tid)
+        else:
+            sms_template_ids.append(tid)
+
+        if (i + 1) % 500 == 0:
+            print(f"    ... {i+1}/{hv_count} templates created")
+            session.flush()
+
+    # Other folders: small number of templates each
+    for fi, fid in enumerate(folder_ids[1:], start=2):
+        count = Config.OTHER_FOLDER_TEMPLATE_COUNT
+        print(f"  Creating {count} templates in folder {fi}...")
+        for j in range(count):
+            tid = _uuid()
+            num_vars = random.randint(Config.TEMPLATE_VARIABLES_MIN, Config.TEMPLATE_VARIABLES_MAX)
+            ttype = NOTIFICATION_TYPE_EMAIL if j % 2 == 0 else NOTIFICATION_TYPE_SMS
+            content = _template_content(num_vars, ttype)
+            chosen_vars = random.sample(VARIABLE_NAMES, min(num_vars, len(VARIABLE_NAMES)))
+            subject = _template_subject(num_vars, chosen_vars) if ttype == NOTIFICATION_TYPE_EMAIL else None
+
+            session.execute(
+                text("""
+                INSERT INTO templates (id, name, template_type, created_at, content, subject,
+                                       archived, hidden, service_id, created_by_id, version, process_type)
+                VALUES (:id, :name, :ttype, :now, :content, :subject,
+                        false, false, :sid, :cid, 1, 'normal')
+            """),
+                {
+                    "id": str(tid),
+                    "name": f"{PREFIX}-folder{fi}-template-{j+1}",
+                    "ttype": ttype,
+                    "now": datetime.now(timezone.utc),
+                    "content": content,
+                    "subject": subject,
+                    "sid": str(service_id),
+                    "cid": str(creator_id),
+                },
+            )
+
+            session.execute(
+                text("""
+                INSERT INTO templates_history (id, name, template_type, created_at, content, subject,
+                                               archived, hidden, service_id, created_by_id, version, process_type)
+                VALUES (:id, :name, :ttype, :now, :content, :subject,
+                        false, false, :sid, :cid, 1, 'normal')
+            """),
+                {
+                    "id": str(tid),
+                    "name": f"{PREFIX}-folder{fi}-template-{j+1}",
+                    "ttype": ttype,
+                    "now": datetime.now(timezone.utc),
+                    "content": content,
+                    "subject": subject,
+                    "sid": str(service_id),
+                    "cid": str(creator_id),
+                },
+            )
+
+            session.execute(
+                text("""
+                INSERT INTO template_folder_map (template_id, template_folder_id)
+                VALUES (:tid, :fid)
+            """),
+                {"tid": str(tid), "fid": str(fid)},
+            )
+
+            all_template_ids.append(tid)
+            if ttype == NOTIFICATION_TYPE_EMAIL:
+                email_template_ids.append(tid)
+            else:
+                sms_template_ids.append(tid)
+
+    print(f"  Total templates: {len(all_template_ids)} (email: {len(email_template_ids)}, sms: {len(sms_template_ids)})")
+    return all_template_ids, email_template_ids, sms_template_ids
+
+
+def create_jobs(session, service_id, email_template_ids, sms_template_ids, creator_id, api_key_id):
+    """Create job records to simulate bulk sends."""
+    job_ids = []
+    all_templates = [(t, NOTIFICATION_TYPE_EMAIL) for t in email_template_ids[:10]] + [
+        (t, NOTIFICATION_TYPE_SMS) for t in sms_template_ids[:10]
+    ]
+    if not all_templates:
+        print("  WARNING: No templates available — skipping jobs.")
+        return job_ids
+
+    print(f"  Creating {Config.NUM_JOBS} jobs...")
+    start = Config.date_start_parsed()
+    end = Config.date_end_parsed()
+    for i in range(Config.NUM_JOBS):
+        jid = _uuid()
+        tmpl_id, ntype = random.choice(all_templates)
+        created = _random_date(start, end)
+        session.execute(
+            text("""
+            INSERT INTO jobs (id, original_file_name, service_id, template_id, template_version,
+                              notification_count, notifications_sent, notifications_delivered,
+                              notifications_failed, processing_started, processing_finished,
+                              created_at, created_by_id, api_key_id, job_status, archived)
+            VALUES (:id, :fname, :sid, :tid, 1,
+                    :count, :count, :delivered, :failed, :started, :finished,
+                    :created, :created_by, :api_key, 'finished', false)
+        """),
+            {
+                "id": str(jid),
+                "fname": f"{PREFIX}-job-{i+1}.csv",
+                "sid": str(service_id),
+                "tid": str(tmpl_id),
+                "count": Config.JOB_NOTIFICATION_COUNT,
+                "delivered": int(Config.JOB_NOTIFICATION_COUNT * 0.97),
+                "failed": int(Config.JOB_NOTIFICATION_COUNT * 0.03),
+                "started": created,
+                "finished": created + timedelta(minutes=random.randint(5, 60)),
+                "created": created,
+                "created_by": str(creator_id),
+                "api_key": str(api_key_id),
+            },
+        )
+        job_ids.append({"id": jid, "template_id": tmpl_id, "type": ntype, "created_at": created})
+
+        if (i + 1) % 50 == 0:
+            print(f"    ... {i+1}/{Config.NUM_JOBS} jobs created")
+
+    return job_ids
+
+
+def _build_notification_batch(
+    batch_idx,
+    batch_size,
+    service_id,
+    template_ids,
+    notification_type,
+    num_failed_remaining,
+    num_remaining,
+    job_ids,
+    api_key_id,
+    start_date,
+    end_date,
+):
+    """Build a list of parameter dicts for a batch of notification_history inserts."""
+    rows = []
+    type_jobs = [j for j in job_ids if j["type"] == notification_type] if job_ids else []
+
+    for _ in range(batch_size):
+        is_failed = num_failed_remaining > 0 and (random.random() < (num_failed_remaining / max(num_remaining, 1)))
+        status = "permanent-failure" if is_failed else "delivered"
+        if is_failed:
+            num_failed_remaining -= 1
+        num_remaining -= 1
+
+        tmpl_id = random.choice(template_ids)
+        created = _random_date(start_date, end_date)
+        job = random.choice(type_jobs) if type_jobs and random.random() < 0.7 else None
+
+        rows.append(
+            {
+                "id": str(_uuid()),
+                "service_id": str(service_id),
+                "template_id": str(tmpl_id),
+                "template_version": 1,
+                "notification_type": notification_type,
+                "created_at": created,
+                "sent_at": created + timedelta(seconds=random.randint(1, 30)),
+                "updated_at": created + timedelta(seconds=random.randint(31, 120)),
+                "notification_status": status,
+                "key_type": "normal",
+                "billable_units": 1,
+                "international": False,
+                "api_key_id": str(api_key_id),
+                "job_id": str(job["id"]) if job else None,
+                "job_row_number": random.randint(0, Config.JOB_NOTIFICATION_COUNT - 1) if job else None,
+                "client_reference": PREFIX,
+            }
+        )
+
+    return rows, num_failed_remaining, num_remaining
+
+
+def insert_notification_history(session, service_id, email_template_ids, sms_template_ids, job_ids, api_key_id):
+    """Bulk-insert notification_history rows."""
+    start_date = Config.date_start_parsed()
+    end_date = Config.date_end_parsed()
+
+    for ntype, template_ids, total, failed_count in [
+        (NOTIFICATION_TYPE_EMAIL, email_template_ids, Config.NUM_EMAILS_TOTAL, Config.NUM_EMAILS_FAILED),
+        (NOTIFICATION_TYPE_SMS, sms_template_ids, Config.NUM_SMS_TOTAL, Config.NUM_SMS_FAILED),
+    ]:
+        if not template_ids:
+            print(f"  WARNING: No {ntype} templates — skipping {ntype} notifications.")
+            continue
+
+        num_batches = math.ceil(total / Config.BATCH_SIZE)
+        print(f"\n  Inserting {total:,} {ntype} notification_history rows ({failed_count:,} permanent-failure)...")
+        print(f"    Batches: {num_batches} x {Config.BATCH_SIZE:,}")
+
+        remaining = total
+        failed_remaining = failed_count
+
+        for batch_idx in range(num_batches):
+            batch_size = min(Config.BATCH_SIZE, remaining)
+            rows, failed_remaining, remaining = _build_notification_batch(
+                batch_idx,
+                batch_size,
+                service_id,
+                template_ids,
+                ntype,
+                failed_remaining,
+                remaining + batch_size,  # add back since we subtract in func
+                job_ids,
+                api_key_id,
+                start_date,
+                end_date,
+            )
+
+            # Use raw SQL multi-row insert for maximum speed
+            if rows:
+                session.execute(
+                    text("""
+                    INSERT INTO notification_history
+                        (id, service_id, template_id, template_version,
+                         notification_type, created_at, sent_at, updated_at, notification_status, key_type,
+                         billable_units, international, api_key_id, job_id, job_row_number,
+                         client_reference)
+                    VALUES
+                        (:id, :service_id, :template_id, :template_version,
+                         :notification_type, :created_at, :sent_at, :updated_at, :notification_status, :key_type,
+                         :billable_units, :international, :api_key_id, :job_id, :job_row_number,
+                         :client_reference)
+                """),
+                    rows,
+                )
+
+            remaining -= batch_size
+
+            if (batch_idx + 1) % 10 == 0 or batch_idx == num_batches - 1:
+                pct = ((batch_idx + 1) / num_batches) * 100
+                print(f"    ... batch {batch_idx+1}/{num_batches} ({pct:.1f}%)")
+                session.flush()
+
+
+def populate_ft_notification_status(session, service_id, email_template_ids, sms_template_ids):
+    """Aggregate notification_history data into ft_notification_status for dashboards."""
+    start_date = Config.date_start_parsed()
+    end_date = Config.date_end_parsed()
+    dates = list(rrule.rrule(freq=rrule.DAILY, dtstart=start_date, until=end_date))
+
+    total_email_delivered = Config.NUM_EMAILS_TOTAL - Config.NUM_EMAILS_FAILED
+    total_email_failed = Config.NUM_EMAILS_FAILED
+    total_sms_delivered = Config.NUM_SMS_TOTAL - Config.NUM_SMS_FAILED
+    total_sms_failed = Config.NUM_SMS_FAILED
+
+    num_days = len(dates)
+    null_job_id = "00000000-0000-0000-0000-000000000000"
+
+    print(f"\n  Populating ft_notification_status over {num_days} days...")
+
+    rows = []
+    for d in dates:
+        bst_date = d.date()
+        for ntype, template_ids, delivered_total, failed_total in [
+            (NOTIFICATION_TYPE_EMAIL, email_template_ids, total_email_delivered, total_email_failed),
+            (NOTIFICATION_TYPE_SMS, sms_template_ids, total_sms_delivered, total_sms_failed),
+        ]:
+            if not template_ids:
+                continue
+            tmpl_id = random.choice(template_ids)
+            daily_delivered = max(1, delivered_total // num_days)
+            daily_failed = max(0, failed_total // num_days)
+
+            if daily_delivered > 0:
+                rows.append(
+                    {
+                        "bst_date": bst_date,
+                        "template_id": str(tmpl_id),
+                        "service_id": str(service_id),
+                        "job_id": null_job_id,
+                        "notification_type": ntype,
+                        "key_type": "normal",
+                        "notification_status": "delivered",
+                        "notification_count": daily_delivered,
+                        "billable_units": daily_delivered,
+                        "created_at": datetime.now(timezone.utc),
+                    }
+                )
+            if daily_failed > 0:
+                rows.append(
+                    {
+                        "bst_date": bst_date,
+                        "template_id": str(tmpl_id),
+                        "service_id": str(service_id),
+                        "job_id": null_job_id,
+                        "notification_type": ntype,
+                        "key_type": "normal",
+                        "notification_status": "permanent-failure",
+                        "notification_count": daily_failed,
+                        "billable_units": daily_failed,
+                        "created_at": datetime.now(timezone.utc),
+                    }
+                )
+
+        if len(rows) >= 5000:
+            session.execute(
+                text("""
+                INSERT INTO ft_notification_status
+                    (bst_date, template_id, service_id, job_id, notification_type, key_type,
+                     notification_status, notification_count, billable_units, created_at)
+                VALUES
+                    (:bst_date, :template_id, :service_id, :job_id, :notification_type, :key_type,
+                     :notification_status, :notification_count, :billable_units, :created_at)
+            """),
+                rows,
+            )
+            rows = []
+
+    if rows:
+        session.execute(
+            text("""
+            INSERT INTO ft_notification_status
+                (bst_date, template_id, service_id, job_id, notification_type, key_type,
+                 notification_status, notification_count, billable_units, created_at)
+            VALUES
+                (:bst_date, :template_id, :service_id, :job_id, :notification_type, :key_type,
+                 :notification_status, :notification_count, :billable_units, :created_at)
+        """),
+            rows,
+        )
+
+    print("  ft_notification_status populated.")
+
+
+def populate_ft_billing(session, service_id, email_template_ids, sms_template_ids):
+    """Populate ft_billing aggregate table."""
+    start_date = Config.date_start_parsed()
+    end_date = Config.date_end_parsed()
+    dates = list(rrule.rrule(freq=rrule.DAILY, dtstart=start_date, until=end_date))
+    num_days = len(dates)
+
+    print(f"\n  Populating ft_billing over {num_days} days...")
+
+    rows = []
+    for d in dates:
+        bst_date = d.date()
+        for ntype, template_ids, total, provider in [
+            (NOTIFICATION_TYPE_EMAIL, email_template_ids, Config.NUM_EMAILS_TOTAL, "ses"),
+            (NOTIFICATION_TYPE_SMS, sms_template_ids, Config.NUM_SMS_TOTAL, "sns"),
+        ]:
+            if not template_ids:
+                continue
+            tmpl_id = random.choice(template_ids)
+            daily_sent = max(1, total // num_days)
+            rate = 0.0 if ntype == NOTIFICATION_TYPE_EMAIL else 0.02
+
+            rows.append(
+                {
+                    "bst_date": bst_date,
+                    "template_id": str(tmpl_id),
+                    "service_id": str(service_id),
+                    "notification_type": ntype,
+                    "provider": provider,
+                    "rate_multiplier": 1,
+                    "international": False,
+                    "rate": rate,
+                    "postage": "none",
+                    "sms_sending_vehicle": "long_code",
+                    "billable_units": daily_sent,
+                    "notifications_sent": daily_sent,
+                    "created_at": datetime.now(timezone.utc),
+                }
+            )
+
+        if len(rows) >= 5000:
+            session.execute(
+                text("""
+                INSERT INTO ft_billing
+                    (bst_date, template_id, service_id, notification_type, provider,
+                     rate_multiplier, international, rate, postage, sms_sending_vehicle,
+                     billable_units, notifications_sent, created_at)
+                VALUES
+                    (:bst_date, :template_id, :service_id, :notification_type, :provider,
+                     :rate_multiplier, :international, :rate, :postage, :sms_sending_vehicle,
+                     :billable_units, :notifications_sent, :created_at)
+            """),
+                rows,
+            )
+            rows = []
+
+    if rows:
+        session.execute(
+            text("""
+            INSERT INTO ft_billing
+                (bst_date, template_id, service_id, notification_type, provider,
+                 rate_multiplier, international, rate, postage, sms_sending_vehicle,
+                 billable_units, notifications_sent, created_at)
+            VALUES
+                (:bst_date, :template_id, :service_id, :notification_type, :provider,
+                 :rate_multiplier, :international, :rate, :postage, :sms_sending_vehicle,
+                 :billable_units, :notifications_sent, :created_at)
+        """),
+            rows,
+        )
+
+    print("  ft_billing populated.")
+
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+
+
+def cleanup(session):
+    """Remove all test-simulate-prod-data entities."""
+    print(f"\n{'='*60}")
+    print(f"CLEANUP: Removing all '{PREFIX}' data...")
+    print(f"{'='*60}\n")
+
+    # Find the service(s)
+    result = session.execute(text("SELECT id FROM services WHERE name LIKE :pattern"), {"pattern": f"{PREFIX}%"})
+    service_ids = [str(row[0]) for row in result]
+
+    if not service_ids:
+        print("No services found with prefix. Checking for orphaned users...")
+    else:
+        for sid in service_ids:
+            print(f"\n  Cleaning service {sid}...")
+
+            # notification_history
+            print("    Deleting notification_history...")
+            session.execute(text("DELETE FROM notification_history WHERE service_id = :sid"), {"sid": sid})
+
+            # notifications (live table)
+            print("    Deleting notifications...")
+            session.execute(text("DELETE FROM notifications WHERE service_id = :sid"), {"sid": sid})
+
+            # ft_notification_status
+            print("    Deleting ft_notification_status...")
+            session.execute(text("DELETE FROM ft_notification_status WHERE service_id = :sid"), {"sid": sid})
+
+            # ft_billing
+            print("    Deleting ft_billing...")
+            session.execute(text("DELETE FROM ft_billing WHERE service_id = :sid"), {"sid": sid})
+
+            # jobs
+            print("    Deleting jobs...")
+            session.execute(text("DELETE FROM jobs WHERE service_id = :sid"), {"sid": sid})
+
+            # template_folder_map (via templates)
+            print("    Deleting template_folder_map...")
+            session.execute(
+                text("""
+                DELETE FROM template_folder_map WHERE template_id IN (
+                    SELECT id FROM templates WHERE service_id = :sid
+                )
+            """),
+                {"sid": sid},
+            )
+
+            # templates_history
+            print("    Deleting templates_history...")
+            session.execute(text("DELETE FROM templates_history WHERE service_id = :sid"), {"sid": sid})
+
+            # templates
+            print("    Deleting templates...")
+            session.execute(text("DELETE FROM templates WHERE service_id = :sid"), {"sid": sid})
+
+            # template_folder
+            print("    Deleting template_folder...")
+            session.execute(text("DELETE FROM template_folder WHERE service_id = :sid"), {"sid": sid})
+
+            # service_callback_api
+            print("    Deleting service_callback_api...")
+            session.execute(text("DELETE FROM service_callback_api WHERE service_id = :sid"), {"sid": sid})
+
+            # service_email_reply_to
+            print("    Deleting service_email_reply_to...")
+            session.execute(text("DELETE FROM service_email_reply_to WHERE service_id = :sid"), {"sid": sid})
+
+            # api_keys
+            print("    Deleting api_keys...")
+            session.execute(text("DELETE FROM api_keys WHERE service_id = :sid"), {"sid": sid})
+
+            # permissions
+            print("    Deleting permissions...")
+            session.execute(text("DELETE FROM permissions WHERE service_id = :sid"), {"sid": sid})
+
+            # service_permissions
+            print("    Deleting service_permissions...")
+            session.execute(text("DELETE FROM service_permissions WHERE service_id = :sid"), {"sid": sid})
+
+            # user_to_service
+            print("    Deleting user_to_service...")
+            session.execute(text("DELETE FROM user_to_service WHERE service_id = :sid"), {"sid": sid})
+
+            # service
+            print("    Deleting services_history...")
+            session.execute(text("DELETE FROM services_history WHERE id = :sid"), {"sid": sid})
+            print("    Deleting service...")
+            session.execute(text("DELETE FROM services WHERE id = :sid"), {"sid": sid})
+
+    # Users
+    print("\n  Deleting users...")
+    session.execute(text("DELETE FROM users WHERE email_address LIKE :pattern"), {"pattern": f"{PREFIX}%"})
+
+    # Organisation
+    print("  Deleting organisation...")
+    session.execute(text("DELETE FROM organisation WHERE name LIKE :pattern"), {"pattern": f"{PREFIX}%"})
+
+    session.commit()
+    print("\nCleanup complete.")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+@click.command()
+@click.option(
+    "--cleanup-only", is_flag=True, default=False, help="Only run cleanup (delete all test-simulate-prod-data entities)"
+)
+@click.option(
+    "--skip-notifications", is_flag=True, default=False, help="Skip notification_history generation (for testing setup)"
+)
+@click.option("--skip-aggregates", is_flag=True, default=False, help="Skip ft_notification_status and ft_billing generation")
+def main(cleanup_only, skip_notifications, skip_aggregates):
+    """Generate production-like data for staging performance testing."""
+    engine = get_engine()
+
+    with Session(engine) as session:
+        if cleanup_only:
+            cleanup(session)
+            return
+
+        print(f"\n{'='*60}")
+        print("GENERATE: Production-like data simulation")
+        print(f"{'='*60}")
+        print(f"  Prefix:       {PREFIX}")
+        print(f"  Date range:   {Config.DATE_START} to {Config.DATE_END}")
+        print(f"  Emails:       {Config.NUM_EMAILS_TOTAL:,} ({Config.NUM_EMAILS_FAILED:,} failed)")
+        print(f"  SMS:          {Config.NUM_SMS_TOTAL:,} ({Config.NUM_SMS_FAILED:,} failed)")
+        print(
+            f"  Templates:    {Config.HIGH_VOLUME_FOLDER_TEMPLATE_COUNT + Config.OTHER_FOLDER_TEMPLATE_COUNT * (Config.NUM_TEMPLATE_FOLDERS - 1)}"
+        )
+        print(f"  Users:        {Config.NUM_USERS}")
+        print(f"  Jobs:         {Config.NUM_JOBS}")
+        print(f"{'='*60}\n")
+
+        try:
+            # 1. Organisation
+            print("[1/12] Creating organisation...")
+            org_id = create_organisation(session)
+
+            # 2. Users
+            print("[2/12] Creating users...")
+            users = create_users(session)
+
+            # 3. Service
+            print("[3/12] Creating service...")
+            service_id = create_service(session, users, org_id)
+
+            # 4. Link users
+            print("[4/12] Linking users to service...")
+            link_users_to_service(session, users, service_id)
+
+            # 5. User permissions
+            print("[5/12] Granting user permissions...")
+            grant_user_permissions(session, users, service_id)
+
+            # 6. Service permissions
+            print("[6/12] Granting service permissions...")
+            grant_service_permissions(session, service_id)
+
+            # 7. API key
+            print("[7/12] Creating API key...")
+            api_key_id = create_api_key(session, service_id, users[0]["id"])
+
+            # 8. Reply-to and callback
+            print("[8/12] Creating reply-to and callback...")
+            create_reply_to(session, service_id)
+            create_callback(session, service_id, users[0]["id"])
+
+            # 9. Template folders
+            print("[9/12] Creating template folders...")
+            folder_ids, folder_names = create_template_folders(session, service_id)
+
+            # 10. Templates
+            print("[10/12] Creating templates...")
+            all_template_ids, email_template_ids, sms_template_ids = create_templates(
+                session, service_id, users[0]["id"], folder_ids
+            )
+
+            # Flush before notifications so FKs are available
+            session.flush()
+
+            # 11. Jobs
+            print("[11/12] Creating jobs...")
+            job_ids = create_jobs(session, service_id, email_template_ids, sms_template_ids, users[0]["id"], api_key_id)
+
+            session.flush()
+
+            # 12. Notifications
+            if not skip_notifications:
+                print("[12/12] Inserting notification_history...")
+                insert_notification_history(session, service_id, email_template_ids, sms_template_ids, job_ids, api_key_id)
+            else:
+                print("[12/12] Skipping notification_history (--skip-notifications)")
+
+            # Aggregate tables
+            if not skip_aggregates:
+                print("\n[Bonus] Populating aggregate tables...")
+                populate_ft_notification_status(session, service_id, email_template_ids, sms_template_ids)
+                populate_ft_billing(session, service_id, email_template_ids, sms_template_ids)
+            else:
+                print("\n[Bonus] Skipping aggregates (--skip-aggregates)")
+
+            print("\nCommitting all data...")
+            session.commit()
+            print("\n" + "=" * 60)
+            print("SUCCESS: All data generated.")
+            print(f"  Service ID: {service_id}")
+            print(f"  Service Name: {Config.SERVICE_NAME}")
+            print(f"  Organisation ID: {org_id}")
+            print("=" * 60)
+
+        except Exception as e:
+            print(f"\nERROR: {e}")
+            print("Rolling back...")
+            session.rollback()
+            raise
+
+
+if __name__ == "__main__":
+    main()

--- a/tests-simulate-prod-data/generate.py
+++ b/tests-simulate-prod-data/generate.py
@@ -127,7 +127,7 @@ def create_users(session):
                                password_changed_at, state, auth_type, created_at, blocked,
                                platform_admin, failed_login_count, password_expired)
             VALUES (:id, :name, :email, :password, :mobile,
-                    :now, 'active', 'email_auth', :now, false,
+                    :now, 'active', 'email_auth', :now, true,
                     false, 0, false)
         """),
             {
@@ -269,7 +269,7 @@ def create_api_key(session, service_id, creator_id):
         {
             "id": str(key_id),
             "name": f"{PREFIX}-api-key",
-            "secret": str(_uuid()),  # not a real signed secret; for data volume simulation only
+            "secret": str(_uuid()),  # NOT a signed secret; API key record exists for FK integrity only
             "sid": str(service_id),
             "created_by": str(creator_id),
             "now": datetime.now(timezone.utc),
@@ -297,24 +297,9 @@ def create_reply_to(session, service_id):
 
 
 def create_callback(session, service_id, creator_id):
-    cb_id = _uuid()
-    print(f"  Creating service callback ({cb_id})...")
-    session.execute(
-        text("""
-        INSERT INTO service_callback_api (id, service_id, url, callback_type, bearer_token,
-                                          created_at, updated_by_id, version)
-        VALUES (:id, :sid, :url, 'delivery_status', :bearer, :now, :updated_by, 1)
-    """),
-        {
-            "id": str(cb_id),
-            "sid": str(service_id),
-            "url": f"https://{PREFIX}.example.com/callback",
-            "bearer": "simulated-bearer-token",
-            "now": datetime.now(timezone.utc),
-            "updated_by": str(creator_id),
-        },
-    )
-    return cb_id
+    """Skip callback creation — bearer_token requires app-level signing (SECRET_KEY)."""
+    print("  Skipping service callback (bearer_token requires app signing config).")
+    return None
 
 
 def create_template_folders(session, service_id):
@@ -828,13 +813,21 @@ def cleanup(session):
     print(f"CLEANUP: Removing all '{PREFIX}' data...")
     print(f"{'='*60}\n")
 
-    # Build name patterns for services and orgs (configured names may not include PREFIX)
+    # Build name patterns for services and orgs. Cleanup is limited to
+    # namespaced test data — configured names must start with the test prefix.
     service_names = {f"{PREFIX}%"}
     org_names = {f"{PREFIX}%"}
-    if Config.SERVICE_NAME and not Config.SERVICE_NAME.startswith(PREFIX):
+    if Config.SERVICE_NAME:
+        if not Config.SERVICE_NAME.startswith(PREFIX):
+            raise click.ClickException(
+                f"Refusing cleanup: SERVICE_NAME '{Config.SERVICE_NAME}' does not start with required prefix '{PREFIX}'."
+            )
         service_names.add(Config.SERVICE_NAME)
-    if Config.ORGANISATION_NAME and not Config.ORGANISATION_NAME.startswith(PREFIX):
-        org_names.add(Config.ORGANISATION_NAME)
+    if Config.ORGANISATION_NAME:
+        if not Config.ORGANISATION_NAME.startswith(PREFIX):
+            raise click.ClickException(
+                f"Refusing cleanup: ORGANISATION_NAME '{Config.ORGANISATION_NAME}' does not start with required prefix '{PREFIX}'."
+            )
 
     # Find the service(s)
     clauses = " OR ".join(f"name LIKE :p{i}" for i in range(len(service_names)))

--- a/tests-simulate-prod-data/requirements.txt
+++ b/tests-simulate-prod-data/requirements.txt
@@ -1,5 +1,5 @@
-click
-python-dateutil
-python-dotenv
-sqlalchemy
-psycopg2-binary
+click==8.3.1
+python-dateutil==2.9.0.post0
+python-dotenv==1.0.1
+sqlalchemy==1.4.54
+psycopg2-binary==2.9.11

--- a/tests-simulate-prod-data/requirements.txt
+++ b/tests-simulate-prod-data/requirements.txt
@@ -1,0 +1,5 @@
+click
+python-dateutil
+python-dotenv
+sqlalchemy
+psycopg2-binary

--- a/tests-simulate-prod-data/sim_config.py
+++ b/tests-simulate-prod-data/sim_config.py
@@ -28,7 +28,6 @@ class Config:
 
     # Users
     NUM_USERS = int(os.environ.get("NUM_USERS", "5"))
-    USER_PASSWORD = os.environ.get("USER_PASSWORD", f"{PREFIX}-password-1!")
 
     # Template folders
     NUM_TEMPLATE_FOLDERS = int(os.environ.get("NUM_TEMPLATE_FOLDERS", "5"))
@@ -94,6 +93,12 @@ class Config:
             errors.append("NUM_TEMPLATE_FOLDERS must be at least 1.")
         if cls.BATCH_SIZE < 1:
             errors.append("BATCH_SIZE must be at least 1.")
+        if cls.NUM_EMAILS_FAILED > cls.NUM_EMAILS_TOTAL:
+            errors.append(
+                f"NUM_EMAILS_FAILED ({cls.NUM_EMAILS_FAILED:,}) must be <= NUM_EMAILS_TOTAL ({cls.NUM_EMAILS_TOTAL:,})."
+            )
+        if cls.NUM_SMS_FAILED > cls.NUM_SMS_TOTAL:
+            errors.append(f"NUM_SMS_FAILED ({cls.NUM_SMS_FAILED:,}) must be <= NUM_SMS_TOTAL ({cls.NUM_SMS_TOTAL:,}).")
 
         if errors:
             print("\n" + "=" * 60)

--- a/tests-simulate-prod-data/sim_config.py
+++ b/tests-simulate-prod-data/sim_config.py
@@ -3,7 +3,7 @@ from datetime import date
 
 from dotenv import load_dotenv
 
-load_dotenv()
+load_dotenv(override=True)
 
 PREFIX = "test-simulate-prod-data"
 
@@ -47,6 +47,16 @@ class Config:
     # Notifications — SMS
     NUM_SMS_TOTAL = int(os.environ.get("NUM_SMS_TOTAL", "9000000"))
     NUM_SMS_FAILED = int(os.environ.get("NUM_SMS_FAILED", "90000"))
+
+    # Live notifications (recent notifications in the notifications table, last 7 days)
+    NUM_LIVE_NOTIFICATIONS = int(os.environ.get("NUM_LIVE_NOTIFICATIONS", "1000000"))
+
+    # Quick 100K preset (smaller volumes for fast testing)
+    NUM_EMAILS_TOTAL_QUICK_100K = 95500
+    NUM_EMAILS_FAILED_QUICK_100K = 500
+    NUM_SMS_TOTAL_QUICK_100K = 90000
+    NUM_SMS_FAILED_QUICK_100K = 10000
+    NUM_LIVE_NOTIFICATIONS_QUICK_100K = 10000
 
     # Jobs
     NUM_JOBS = int(os.environ.get("NUM_JOBS", "200"))
@@ -138,6 +148,7 @@ class Config:
         print(f"  NUM_EMAILS_FAILED       : {cls.NUM_EMAILS_FAILED:,}")
         print(f"  NUM_SMS_TOTAL           : {cls.NUM_SMS_TOTAL:,}")
         print(f"  NUM_SMS_FAILED          : {cls.NUM_SMS_FAILED:,}")
+        print(f"  NUM_LIVE_NOTIFICATIONS  : {cls.NUM_LIVE_NOTIFICATIONS:,}")
         print(f"  NUM_JOBS                : {cls.NUM_JOBS}")
         print(f"  BATCH_SIZE              : {cls.BATCH_SIZE:,}")
         print(f"  ORGANISATION_NAME       : {cls.ORGANISATION_NAME}")

--- a/tests-simulate-prod-data/sim_config.py
+++ b/tests-simulate-prod-data/sim_config.py
@@ -99,6 +99,14 @@ class Config:
             )
         if cls.NUM_SMS_FAILED > cls.NUM_SMS_TOTAL:
             errors.append(f"NUM_SMS_FAILED ({cls.NUM_SMS_FAILED:,}) must be <= NUM_SMS_TOTAL ({cls.NUM_SMS_TOTAL:,}).")
+        if cls.SERVICE_NAME and not cls.SERVICE_NAME.startswith(PREFIX):
+            errors.append(
+                f"SERVICE_NAME ('{cls.SERVICE_NAME}') must start with prefix '{PREFIX}' to prevent accidental deletion of real data."
+            )
+        if cls.ORGANISATION_NAME and not cls.ORGANISATION_NAME.startswith(PREFIX):
+            errors.append(
+                f"ORGANISATION_NAME ('{cls.ORGANISATION_NAME}') must start with prefix '{PREFIX}' to prevent accidental deletion of real data."
+            )
 
         if errors:
             print("\n" + "=" * 60)

--- a/tests-simulate-prod-data/sim_config.py
+++ b/tests-simulate-prod-data/sim_config.py
@@ -68,6 +68,9 @@ class Config:
     # Organisation
     ORGANISATION_NAME = os.environ.get("ORGANISATION_NAME", f"{PREFIX}-org")
 
+    # Link an existing real user (by email) to the generated service for frontend access
+    LINK_EXISTING_USER_EMAIL = os.environ.get("LINK_EXISTING_USER_EMAIL", "")
+
     @classmethod
     def date_start_parsed(cls):
         return date.fromisoformat(cls.DATE_START)
@@ -152,4 +155,5 @@ class Config:
         print(f"  NUM_JOBS                : {cls.NUM_JOBS}")
         print(f"  BATCH_SIZE              : {cls.BATCH_SIZE:,}")
         print(f"  ORGANISATION_NAME       : {cls.ORGANISATION_NAME}")
+        print(f"  LINK_EXISTING_USER_EMAIL: {cls.LINK_EXISTING_USER_EMAIL or '(not set)'}")
         print("-" * 60 + "\n")

--- a/tests-simulate-prod-data/sim_config.py
+++ b/tests-simulate-prod-data/sim_config.py
@@ -1,0 +1,131 @@
+import os
+from datetime import date
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+PREFIX = "test-simulate-prod-data"
+
+
+class Config:
+    """Configuration for the production data simulation script.
+
+    All values can be overridden via environment variables.
+    """
+
+    # Database
+    SQLALCHEMY_DATABASE_URI = os.environ.get("SQLALCHEMY_DATABASE_URI", "")
+
+    # Service settings
+    SERVICE_NAME = os.environ.get("SERVICE_NAME", f"{PREFIX}-service")
+    SERVICE_EMAIL_FROM = os.environ.get("SERVICE_EMAIL_FROM", f"{PREFIX}@staging.local")
+    SERVICE_SMS_ANNUAL_LIMIT = int(os.environ.get("SERVICE_SMS_ANNUAL_LIMIT", "10000000"))
+    SERVICE_EMAIL_ANNUAL_LIMIT = int(os.environ.get("SERVICE_EMAIL_ANNUAL_LIMIT", "25000000"))
+    SERVICE_MESSAGE_LIMIT = int(os.environ.get("SERVICE_MESSAGE_LIMIT", "250000"))
+    SERVICE_SMS_DAILY_LIMIT = int(os.environ.get("SERVICE_SMS_DAILY_LIMIT", "100000"))
+    SERVICE_RATE_LIMIT = int(os.environ.get("SERVICE_RATE_LIMIT", "3000"))
+
+    # Users
+    NUM_USERS = int(os.environ.get("NUM_USERS", "5"))
+    USER_PASSWORD = os.environ.get("USER_PASSWORD", f"{PREFIX}-password-1!")
+
+    # Template folders
+    NUM_TEMPLATE_FOLDERS = int(os.environ.get("NUM_TEMPLATE_FOLDERS", "5"))
+    HIGH_VOLUME_FOLDER_TEMPLATE_COUNT = int(os.environ.get("HIGH_VOLUME_FOLDER_TEMPLATE_COUNT", "2000"))
+    OTHER_FOLDER_TEMPLATE_COUNT = int(os.environ.get("OTHER_FOLDER_TEMPLATE_COUNT", "5"))
+    TEMPLATE_VARIABLES_MIN = int(os.environ.get("TEMPLATE_VARIABLES_MIN", "3"))
+    TEMPLATE_VARIABLES_MAX = int(os.environ.get("TEMPLATE_VARIABLES_MAX", "5"))
+
+    # Notifications — date range
+    DATE_START = os.environ.get("DATE_START", "2025-04-01")
+    DATE_END = os.environ.get("DATE_END", "2026-03-31")
+
+    # Notifications — email
+    NUM_EMAILS_TOTAL = int(os.environ.get("NUM_EMAILS_TOTAL", "5000000"))
+    NUM_EMAILS_FAILED = int(os.environ.get("NUM_EMAILS_FAILED", "50000"))
+
+    # Notifications — SMS
+    NUM_SMS_TOTAL = int(os.environ.get("NUM_SMS_TOTAL", "9000000"))
+    NUM_SMS_FAILED = int(os.environ.get("NUM_SMS_FAILED", "90000"))
+
+    # Jobs
+    NUM_JOBS = int(os.environ.get("NUM_JOBS", "200"))
+    JOB_NOTIFICATION_COUNT = int(os.environ.get("JOB_NOTIFICATION_COUNT", "10000"))
+
+    # Batch size for bulk inserts
+    BATCH_SIZE = int(os.environ.get("BATCH_SIZE", "10000"))
+
+    # Organisation
+    ORGANISATION_NAME = os.environ.get("ORGANISATION_NAME", f"{PREFIX}-org")
+
+    @classmethod
+    def date_start_parsed(cls):
+        return date.fromisoformat(cls.DATE_START)
+
+    @classmethod
+    def date_end_parsed(cls):
+        return date.fromisoformat(cls.DATE_END)
+
+    @classmethod
+    def validate(cls):
+        errors = []
+
+        if not cls.SQLALCHEMY_DATABASE_URI:
+            errors.append("SQLALCHEMY_DATABASE_URI is required. Set it in .env or as an environment variable.")
+
+        if not cls.DATE_START:
+            errors.append("DATE_START is required (format: YYYY-MM-DD).")
+        if not cls.DATE_END:
+            errors.append("DATE_END is required (format: YYYY-MM-DD).")
+
+        if cls.DATE_START and cls.DATE_END:
+            try:
+                start = cls.date_start_parsed()
+                end = cls.date_end_parsed()
+                if start >= end:
+                    errors.append(f"DATE_START ({cls.DATE_START}) must be before DATE_END ({cls.DATE_END}).")
+            except ValueError as e:
+                errors.append(f"Invalid date format: {e}. Use YYYY-MM-DD.")
+
+        if cls.NUM_USERS < 1:
+            errors.append("NUM_USERS must be at least 1.")
+        if cls.NUM_TEMPLATE_FOLDERS < 1:
+            errors.append("NUM_TEMPLATE_FOLDERS must be at least 1.")
+        if cls.BATCH_SIZE < 1:
+            errors.append("BATCH_SIZE must be at least 1.")
+
+        if errors:
+            print("\n" + "=" * 60)
+            print("CONFIGURATION ERRORS")
+            print("=" * 60)
+            for i, err in enumerate(errors, 1):
+                print(f"  [{i}] {err}")
+            print()
+            print("Fix the above in your .env file or environment variables.")
+            print("See .env.example for reference.")
+            print("=" * 60 + "\n")
+            raise SystemExit(1)
+
+        # Log resolved config for visibility
+        print("\n" + "-" * 60)
+        print("Resolved configuration:")
+        print("-" * 60)
+        print(f"  SQLALCHEMY_DATABASE_URI : {'*' * 20} (set)")
+        print(f"  SERVICE_NAME            : {cls.SERVICE_NAME}")
+        print(f"  SERVICE_EMAIL_FROM      : {cls.SERVICE_EMAIL_FROM}")
+        print(f"  SERVICE_SMS_ANNUAL_LIMIT: {cls.SERVICE_SMS_ANNUAL_LIMIT:,}")
+        print(f"  SERVICE_EMAIL_ANNUAL_LIMIT: {cls.SERVICE_EMAIL_ANNUAL_LIMIT:,}")
+        print(f"  NUM_USERS               : {cls.NUM_USERS}")
+        print(f"  NUM_TEMPLATE_FOLDERS    : {cls.NUM_TEMPLATE_FOLDERS}")
+        print(f"  HIGH_VOLUME_FOLDER_TEMPLATE_COUNT: {cls.HIGH_VOLUME_FOLDER_TEMPLATE_COUNT:,}")
+        print(f"  DATE_START              : {cls.DATE_START}")
+        print(f"  DATE_END                : {cls.DATE_END}")
+        print(f"  NUM_EMAILS_TOTAL        : {cls.NUM_EMAILS_TOTAL:,}")
+        print(f"  NUM_EMAILS_FAILED       : {cls.NUM_EMAILS_FAILED:,}")
+        print(f"  NUM_SMS_TOTAL           : {cls.NUM_SMS_TOTAL:,}")
+        print(f"  NUM_SMS_FAILED          : {cls.NUM_SMS_FAILED:,}")
+        print(f"  NUM_JOBS                : {cls.NUM_JOBS}")
+        print(f"  BATCH_SIZE              : {cls.BATCH_SIZE:,}")
+        print(f"  ORGANISATION_NAME       : {cls.ORGANISATION_NAME}")
+        print("-" * 60 + "\n")


### PR DESCRIPTION
# Summary | Résumé

Add a standalone script (`tests-simulate-prod-data/`) that generates non-PII, production-like data volumes in a staging database for performance testing. The script creates a full service setup (org, 5 users, 2020 templates, 200 jobs, reply-to, callback) and can bulk-insert millions of `notification_history` rows with matching `ft_notification_status` and `ft_billing` aggregates spread over a configurable date range.

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/2876

# Test instructions | Instructions pour tester la modification

All commands from `tests-simulate-prod-data/`:

```bash
cd tests-simulate-prod-data
cp .env.example .env
# Edit .env — set SQLALCHEMY_DATABASE_URI to your DB connection string

1. Run make generate-quick-100000
1. Go to the frontend and see the notifications in the test service
1. Run make cleanup (to delete the data)

Goal: To run this script in staging for 14M notifications