### PR TITLE
Add support for the one-click unsubscribe header

### DIFF
--- a/app/clients/email/aws_ses.py
+++ b/app/clients/email/aws_ses.py
@@ -40,6 +40,7 @@ class AwsSesClient(EmailClient):
         html_body="",
         reply_to_address=None,
         attachments=None,
+        extra_headers=None,
     ):
         def create_mime_base(attachments, html):
             msg_type = "mixed" if attachments or (not attachments and not html) else "alternative"
@@ -52,6 +53,8 @@ class AwsSesClient(EmailClient):
                     "reply-to",
                     ",".join([punycode_encode_email(addr) for addr in reply_to_addresses]),
                 )
+            for header_name, header_value in (extra_headers or {}).items():
+                ret[header_name] = header_value
             return ret
 
         def attach_html(m, content):

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -344,11 +344,15 @@ def send_email_to_provider(notification: Notification):
             contains_pii(notification, str(plain_text_email))
 
         # Service-managed one-click unsubscribe: if the template has use_custom_unsubscribe_url
-        # enabled and the personalisation contains ((unsubscribe_url)) or ((unsub_url)), use that
-        # URL for the RFC 8058 List-Unsubscribe header only (no Notify-hosted page or body link).
+        # enabled and the personalisation contains ((unsubscribe_url)), ((unsub_url)), or ((unsub_link)),
+        # use that URL for the RFC 8058 List-Unsubscribe header only (no Notify-hosted page or body link).
         unsubscribe_link_for_header = None
         if getattr(template_obj, "use_custom_unsubscribe_url", False) and personalisation_data:
-            raw_url = personalisation_data.get("unsubscribe_url") or personalisation_data.get("unsub_url")
+            raw_url = (
+                personalisation_data.get("unsubscribe_url")
+                or personalisation_data.get("unsub_url")
+                or personalisation_data.get("unsub_link")
+            )
             unsubscribe_link_for_header = _validate_unsubscribe_url(raw_url, notification.id)
 
         current_app.logger.info(

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -246,6 +246,16 @@ def get_from_address(friendly_from: str, email_from: str, sending_domain: str) -
     return f'"{friendly_from_mime}" <{unidecode(email_from)}@{unidecode(sending_domain)}>'
 
 
+def _get_unsubscribe_headers(unsubscribe_link):
+    """Returns RFC 8058 one-click unsubscribe headers if a link is present."""
+    if unsubscribe_link:
+        return {
+            "List-Unsubscribe": f"<{unsubscribe_link}>",
+            "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+        }
+    return {}
+
+
 def send_email_to_provider(notification: Notification):
     current_app.logger.info(f"Sending email to provider for notification id {notification.id}")
     service = notification.service
@@ -321,6 +331,13 @@ def send_email_to_provider(notification: Notification):
         if current_app.config["SCAN_FOR_PII"]:
             contains_pii(notification, str(plain_text_email))
 
+        # Service-managed one-click unsubscribe: if the template has use_custom_unsubscribe_url
+        # enabled and the personalisation contains ((unsubscribe_url)) or ((unsub_url)), use that
+        # URL for the RFC 8058 List-Unsubscribe header only (no Notify-hosted page or body link).
+        unsubscribe_link_for_header = None
+        if getattr(template_obj, "use_custom_unsubscribe_url", False) and personalisation_data:
+            unsubscribe_link_for_header = personalisation_data.get("unsubscribe_url") or personalisation_data.get("unsub_url")
+
         current_app.logger.info(
             f"Trying to update notification id {notification.id} with service research {service.research_mode} or key type {notification.key_type}"
         )
@@ -350,6 +367,7 @@ def send_email_to_provider(notification: Notification):
                 html_body=str(html_email),
                 reply_to_address=validate_and_format_email_address(email_reply_to) if email_reply_to else None,
                 attachments=attachments,
+                extra_headers=_get_unsubscribe_headers(unsubscribe_link_for_header),
             )
             check_service_over_bounce_rate(service.id)
             bounce_rate_client.set_sliding_notifications(service.id, str(notification.id))

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -344,15 +344,11 @@ def send_email_to_provider(notification: Notification):
             contains_pii(notification, str(plain_text_email))
 
         # Service-managed one-click unsubscribe: if the template has use_custom_unsubscribe_url
-        # enabled and the personalisation contains ((unsubscribe_url)), ((unsub_url)), or ((unsub_link)),
-        # use that URL for the RFC 8058 List-Unsubscribe header only (no Notify-hosted page or body link).
+        # enabled and the personalisation contains ((unsubscribe_url)) or ((unsub_url)), use that
+        # URL for the RFC 8058 List-Unsubscribe header only (no Notify-hosted page or body link).
         unsubscribe_link_for_header = None
         if getattr(template_obj, "use_custom_unsubscribe_url", False) and personalisation_data:
-            raw_url = (
-                personalisation_data.get("unsubscribe_url")
-                or personalisation_data.get("unsub_url")
-                or personalisation_data.get("unsub_link")
-            )
+            raw_url = personalisation_data.get("unsubscribe_url") or personalisation_data.get("unsub_url")
             unsubscribe_link_for_header = _validate_unsubscribe_url(raw_url, notification.id)
 
         current_app.logger.info(

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -3,6 +3,7 @@ import os
 import re
 from datetime import datetime
 from typing import Any, Dict, Optional
+from urllib.parse import urlparse
 from uuid import UUID
 
 import phonenumbers
@@ -257,12 +258,23 @@ def _get_unsubscribe_headers(unsubscribe_link):
 
 
 def _validate_unsubscribe_url(url, notification_id):
-    """Validates that the unsubscribe URL uses http or https. Returns the URL if valid, None otherwise."""
+    """Validates that the unsubscribe URL is a well-formed https URL with a proper hostname.
+    Reuses the same criteria as the existing https_url JSON Schema definition in the project
+    (scheme must be https, host must look like a real domain with at least one dot).
+    Returns the URL if valid, None otherwise.
+    """
     if not url:
         return None
-    if not url.lower().startswith(("http://", "https://")):
+    try:
+        parsed = urlparse(url)
+        if parsed.scheme != "https":
+            raise ValueError("scheme must be https")
+        if not parsed.hostname or "." not in parsed.hostname:
+            raise ValueError("hostname must be a valid domain")
+    except Exception:
         current_app.logger.warning(
-            f"Notification {notification_id} has an invalid unsubscribe_url (not http/https): {url!r}. Header will not be added."
+            f"Notification {notification_id} has an invalid unsubscribe_url "
+            f"(must be a valid https URL with a proper domain): {url!r}. Header will not be added."
         )
         return None
     return url

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -256,6 +256,18 @@ def _get_unsubscribe_headers(unsubscribe_link):
     return {}
 
 
+def _validate_unsubscribe_url(url, notification_id):
+    """Validates that the unsubscribe URL uses http or https. Returns the URL if valid, None otherwise."""
+    if not url:
+        return None
+    if not url.lower().startswith(("http://", "https://")):
+        current_app.logger.warning(
+            f"Notification {notification_id} has an invalid unsubscribe_url (not http/https): {url!r}. Header will not be added."
+        )
+        return None
+    return url
+
+
 def send_email_to_provider(notification: Notification):
     current_app.logger.info(f"Sending email to provider for notification id {notification.id}")
     service = notification.service
@@ -336,7 +348,8 @@ def send_email_to_provider(notification: Notification):
         # URL for the RFC 8058 List-Unsubscribe header only (no Notify-hosted page or body link).
         unsubscribe_link_for_header = None
         if getattr(template_obj, "use_custom_unsubscribe_url", False) and personalisation_data:
-            unsubscribe_link_for_header = personalisation_data.get("unsubscribe_url") or personalisation_data.get("unsub_url")
+            raw_url = personalisation_data.get("unsubscribe_url") or personalisation_data.get("unsub_url")
+            unsubscribe_link_for_header = _validate_unsubscribe_url(raw_url, notification.id)
 
         current_app.logger.info(
             f"Trying to update notification id {notification.id} with service research {service.research_mode} or key type {notification.key_type}"

--- a/app/models.py
+++ b/app/models.py
@@ -1163,6 +1163,7 @@ class TemplateBase(BaseModel):
     subject = db.Column(db.Text)
     postage = db.Column(db.String, nullable=True)
     text_direction_rtl = db.Column(db.Boolean, nullable=False, default=False)
+    use_custom_unsubscribe_url = db.Column(db.Boolean, nullable=True, default=False)
     CheckConstraint(
         """
         CASE WHEN template_type = 'letter' THEN

--- a/app/models.py
+++ b/app/models.py
@@ -1163,7 +1163,7 @@ class TemplateBase(BaseModel):
     subject = db.Column(db.Text)
     postage = db.Column(db.String, nullable=True)
     text_direction_rtl = db.Column(db.Boolean, nullable=False, default=False)
-    use_custom_unsubscribe_url = db.Column(db.Boolean, nullable=True, default=False)
+    use_custom_unsubscribe_url = db.Column(db.Boolean, nullable=False, default=False)
     CheckConstraint(
         """
         CASE WHEN template_type = 'letter' THEN

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -419,6 +419,7 @@ class TemplateSchema(BaseTemplateSchema):
     created_at = FlexibleDateTime()
     updated_at = FlexibleDateTime()
     text_direction_rtl = field_for(models.Template, "text_direction_rtl")
+    use_custom_unsubscribe_url = field_for(models.Template, "use_custom_unsubscribe_url")
 
     def get_is_precompiled_letter(self, template):
         return template.is_precompiled_letter

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -287,6 +287,7 @@ def _template_has_not_changed(current_data, updated_template):
             "postage",
             "template_category_id",
             "text_direction_rtl",
+            "use_custom_unsubscribe_url",
         )
     )
 

--- a/migrations/versions/0509_use_custom_unsub_url.py
+++ b/migrations/versions/0509_use_custom_unsub_url.py
@@ -13,9 +13,9 @@ down_revision = "0508_update_daily_sms_limit"
 
 
 def upgrade():
-    op.add_column("templates", sa.Column("use_custom_unsubscribe_url", sa.Boolean(), nullable=True, server_default="false"))
+    op.add_column("templates", sa.Column("use_custom_unsubscribe_url", sa.Boolean(), nullable=False, server_default=sa.false()))
     op.add_column(
-        "templates_history", sa.Column("use_custom_unsubscribe_url", sa.Boolean(), nullable=True, server_default="false")
+        "templates_history", sa.Column("use_custom_unsubscribe_url", sa.Boolean(), nullable=False, server_default=sa.false())
     )
 
 

--- a/migrations/versions/0509_use_custom_unsub_url.py
+++ b/migrations/versions/0509_use_custom_unsub_url.py
@@ -1,0 +1,24 @@
+"""Add use_custom_unsubscribe_url to templates and templates_history.
+
+Revision ID: 0509_use_custom_unsub_url
+Revises: 0508_update_daily_sms_limit
+Create Date: 2026-04-20
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0509_use_custom_unsub_url"
+down_revision = "0508_update_daily_sms_limit"
+
+
+def upgrade():
+    op.add_column("templates", sa.Column("use_custom_unsubscribe_url", sa.Boolean(), nullable=True, server_default="false"))
+    op.add_column(
+        "templates_history", sa.Column("use_custom_unsubscribe_url", sa.Boolean(), nullable=True, server_default="false")
+    )
+
+
+def downgrade():
+    op.drop_column("templates_history", "use_custom_unsubscribe_url")
+    op.drop_column("templates", "use_custom_unsubscribe_url")

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -388,6 +388,8 @@ def test_send_email_does_not_add_unsubscribe_headers_when_use_custom_unsubscribe
         "javascript:alert(1)",
         "//example.com/unsub",
         "example.com/unsub",
+        "http://example.com/unsub",  # http is not allowed, only https
+        "https://hi",  # no dot in hostname
         "",
     ],
 )

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -317,7 +317,6 @@ def test_should_send_personalised_template_to_correct_email_provider_and_persist
     [
         ("unsubscribe_url", "https://example.com/unsubscribe/abc123"),
         ("unsub_url", "https://example.com/unsub/abc123"),
-        ("unsub_link", "https://example.com/unsub-link/abc123"),
     ],
 )
 def test_send_email_adds_one_click_unsubscribe_headers_when_use_custom_unsubscribe_url_enabled(

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -16,6 +16,7 @@ from app.dao import notifications_dao, provider_details_dao
 from app.dao.provider_details_dao import (
     dao_switch_sms_provider_to_provider_with_identifier,
 )
+from app.dao.templates_dao import dao_update_template
 from app.delivery import send_to_providers
 from app.exceptions import (
     DocumentDownloadException,
@@ -321,8 +322,6 @@ def test_should_send_personalised_template_to_correct_email_provider_and_persist
 def test_send_email_adds_one_click_unsubscribe_headers_when_use_custom_unsubscribe_url_enabled(
     sample_service, mocker, personalisation_key, unsubscribe_url
 ):
-    from app.dao.templates_dao import dao_update_template
-
     template = create_template(
         sample_service,
         template_type="email",
@@ -379,6 +378,49 @@ def test_send_email_does_not_add_unsubscribe_headers_when_use_custom_unsubscribe
 
     send_mock.assert_called_once()
     assert send_mock.call_args[1]["extra_headers"] == {}
+
+
+@pytest.mark.parametrize(
+    "bad_url",
+    [
+        "ftp://example.com/unsub",
+        "file:///etc/passwd",
+        "javascript:alert(1)",
+        "//example.com/unsub",
+        "example.com/unsub",
+        "",
+    ],
+)
+def test_send_email_does_not_add_unsubscribe_headers_for_invalid_url_scheme(sample_service, mocker, bad_url):
+    template = create_template(
+        sample_service,
+        template_type="email",
+        subject="Hello",
+        content="Body with ((unsubscribe_url))",
+    )
+    template.use_custom_unsubscribe_url = True
+    dao_update_template(template)
+
+    db_notification = save_notification(
+        create_notification(
+            template=template,
+            to_field="user@example.com",
+            personalisation={"unsubscribe_url": bad_url},
+        )
+    )
+
+    send_mock = mocker.patch("app.aws_ses_client.send_email", return_value="reference")
+    mocker.patch("app.delivery.send_to_providers.statsd_client")
+    mocker.patch("app.delivery.send_to_providers.bounce_rate_client")
+    logger_mock = mocker.patch("app.delivery.send_to_providers.current_app.logger.warning")
+
+    send_to_providers.send_email_to_provider(db_notification)
+
+    send_mock.assert_called_once()
+    assert send_mock.call_args[1]["extra_headers"] == {}
+    if bad_url:
+        logger_mock.assert_called_once()
+        assert "invalid unsubscribe_url" in logger_mock.call_args[0][0]
 
 
 @pytest.mark.skip(reason="the validator can throw a 500 causing us to fail all tests")

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -317,6 +317,7 @@ def test_should_send_personalised_template_to_correct_email_provider_and_persist
     [
         ("unsubscribe_url", "https://example.com/unsubscribe/abc123"),
         ("unsub_url", "https://example.com/unsub/abc123"),
+        ("unsub_link", "https://example.com/unsub-link/abc123"),
     ],
 )
 def test_send_email_adds_one_click_unsubscribe_headers_when_use_custom_unsubscribe_url_enabled(

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -311,6 +311,76 @@ def test_should_send_personalised_template_to_correct_email_provider_and_persist
     assert call(statsd_key) in statsd_mock.incr.call_args_list
 
 
+@pytest.mark.parametrize(
+    "personalisation_key, unsubscribe_url",
+    [
+        ("unsubscribe_url", "https://example.com/unsubscribe/abc123"),
+        ("unsub_url", "https://example.com/unsub/abc123"),
+    ],
+)
+def test_send_email_adds_one_click_unsubscribe_headers_when_use_custom_unsubscribe_url_enabled(
+    sample_service, mocker, personalisation_key, unsubscribe_url
+):
+    from app.dao.templates_dao import dao_update_template
+
+    template = create_template(
+        sample_service,
+        template_type="email",
+        subject="Hello",
+        content=f"Body with (({personalisation_key}))",
+    )
+    template.use_custom_unsubscribe_url = True
+    dao_update_template(template)
+
+    db_notification = save_notification(
+        create_notification(
+            template=template,
+            to_field="user@example.com",
+            personalisation={personalisation_key: unsubscribe_url},
+        )
+    )
+
+    send_mock = mocker.patch("app.aws_ses_client.send_email", return_value="reference")
+    mocker.patch("app.delivery.send_to_providers.statsd_client")
+    mocker.patch("app.delivery.send_to_providers.bounce_rate_client")
+
+    send_to_providers.send_email_to_provider(db_notification)
+
+    send_mock.assert_called_once()
+    call_kwargs = send_mock.call_args[1]
+    assert call_kwargs["extra_headers"] == {
+        "List-Unsubscribe": f"<{unsubscribe_url}>",
+        "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+    }
+
+
+def test_send_email_does_not_add_unsubscribe_headers_when_use_custom_unsubscribe_url_disabled(sample_service, mocker):
+    template = create_template(
+        sample_service,
+        template_type="email",
+        subject="Hello",
+        content="Body with ((unsubscribe_url))",
+    )
+    # use_custom_unsubscribe_url defaults to False — no DB update needed
+
+    db_notification = save_notification(
+        create_notification(
+            template=template,
+            to_field="user@example.com",
+            personalisation={"unsubscribe_url": "https://example.com/unsub"},
+        )
+    )
+
+    send_mock = mocker.patch("app.aws_ses_client.send_email", return_value="reference")
+    mocker.patch("app.delivery.send_to_providers.statsd_client")
+    mocker.patch("app.delivery.send_to_providers.bounce_rate_client")
+
+    send_to_providers.send_email_to_provider(db_notification)
+
+    send_mock.assert_called_once()
+    assert send_mock.call_args[1]["extra_headers"] == {}
+
+
 @pytest.mark.skip(reason="the validator can throw a 500 causing us to fail all tests")
 def test_should_send_personalised_template_with_html_enabled(sample_email_template_with_advanced_html, mocker, notify_api):
     db_notification = save_notification(

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -292,6 +292,7 @@ def test_should_send_personalised_template_to_correct_email_provider_and_persist
         html_body=ANY,
         reply_to_address=None,
         attachments=[],
+        extra_headers={},
     )
 
     assert "<!DOCTYPE html" in app.aws_ses_client.send_email.call_args[1]["html_body"]
@@ -338,6 +339,7 @@ def test_should_send_personalised_template_with_html_enabled(sample_email_templa
         html_body=ANY,
         reply_to_address=None,
         attachments=[],
+        extra_headers={},
     )
 
     assert "<!DOCTYPE html" in app.aws_ses_client.send_email.call_args[1]["html_body"]
@@ -383,6 +385,7 @@ def test_should_respect_custom_sending_domains(sample_service, mocker, sample_em
         html_body=ANY,
         reply_to_address=None,
         attachments=[],
+        extra_headers={},
     )
 
 
@@ -627,6 +630,7 @@ def test_send_email_should_use_service_reply_to_email(sample_service, sample_ema
         html_body=ANY,
         reply_to_address="foo@bar.com",
         attachments=[],
+        extra_headers={},
     )
 
 
@@ -651,6 +655,7 @@ def test_send_email_should_use_default_service_reply_to_email_when_two_are_set(s
         html_body=ANY,
         reply_to_address="foo@bar.com",
         attachments=[],
+        extra_headers={},
     )
 
 
@@ -675,6 +680,7 @@ def test_send_email_should_use_non_default_service_reply_to_email_when_it_is_set
         html_body=ANY,
         reply_to_address="foo_two@bar.com",
         attachments=[],
+        extra_headers={},
     )
 
 
@@ -958,6 +964,7 @@ def test_send_email_to_provider_uses_reply_to_from_notification(sample_email_tem
         html_body=ANY,
         reply_to_address="test@test.com",
         attachments=[],
+        extra_headers={},
     )
 
 
@@ -996,6 +1003,7 @@ def test_send_email_to_provider_should_format_reply_to_email_address(sample_emai
         html_body=ANY,
         reply_to_address="test@test.com",
         attachments=[],
+        extra_headers={},
     )
 
 
@@ -1025,6 +1033,7 @@ def test_send_email_to_provider_should_format_email_address(sample_email_notific
         html_body=ANY,
         reply_to_address=ANY,
         attachments=[],
+        extra_headers={},
     )
 
 
@@ -1198,6 +1207,7 @@ def test_notification_document_with_pdf_attachment(
         html_body=ANY,
         reply_to_address=ANY,
         attachments=attachments,
+        extra_headers=ANY,
     )
     if not filename_attribute_present:
         assert "http://foo.bar/url" in send_mock.call_args[1]["html_body"]


### PR DESCRIPTION
# Summary | Résumé

Add support for the one-click unsubscribe header.

Changes:

`app/clients/email/aws_ses.py`
Added `extra_headers=None` parameter to `send_email()`. These headers are injected into the MIME message before sending.

`app/delivery/send_to_providers.py`
- Added `_get_unsubscribe_headers(url)` — returns the RFC 8058 `List-Unsubscribe` and `List-Unsubscribe-Post` headers if a URL is provided.
- Before the `send_email()` call, checks if `template.use_custom_unsubscribe_url` is True and if unsubscribe_url (or unsub_url) is present in the personalisation. If so, passes it through extra_headers.

`app/models.py`
Added `use_custom_unsubscribe_url` boolean column to `TemplateBase`.

`app/schemas.py`
Exposed `use_custom_unsubscribe_url` in the template schema so it's readable/writable via the API.

`app/template/rest.py`
Added `use_custom_unsubscribe_url` to the `_template_has_not_changed` comparison.

`migrations/versions/0509_use_custom_unsub_url.py`
New migration adding the column to templates and templates_history


## Related Issues | Cartes liées

- https://github.com/cds-snc/notification-planning/issues/3096

# Test instructions | Instructions pour tester la modification

Follow the test instructions in this PR: https://github.com/cds-snc/notification-admin/pull/2671 

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.