### PR TITLE
Rate limiter on SMS sending / phase 1

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -57,7 +57,7 @@
                 "worker",
                 "--pidfile",
                 "/tmp/celery.pid",
-                "--concurrency=4",
+                "--concurrency=1",
                 "-l",
                 "DEBUG",
                 "-Q",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,7 +29,8 @@
             "module": "flask",
             "env": {
                 "FLASK_APP": "application.py",
-                "FLASK_ENV": "development"
+                "FLASK_ENV": "development",
+                "FF_SMS_RATELIMIT": "true"
             },
             "args": [
                 "run",
@@ -47,6 +48,9 @@
             "module": "celery",
             "console": "integratedTerminal",
             "justMyCode": false,
+            "env": {
+                "FF_SMS_RATELIMIT": "true"
+            },
             "args": [
                 "--app",
                 "run_celery",
@@ -57,7 +61,7 @@
                 "-l",
                 "DEBUG",
                 "-Q",
-                "database-tasks,-priority-database-tasks.fifo,-normal-database-tasks,-bulk-database-tasks,job-tasks,notify-internal-tasks,periodic-tasks,priority-tasks,normal-tasks,bulk-tasks,reporting-tasks,research-mode-tasks,retry-tasks,service-callbacks-retry,send-sms-tasks,send-sms-high,send-sms-medium,send-sms-low,send-throttled-sms-tasks,send-email-high,send-email-medium,send-email-low,send-email-tasks,service-callbacks,delivery-receipts",
+                "database-tasks,-priority-database-tasks.fifo,-normal-database-tasks,-bulk-database-tasks,job-tasks,notify-internal-tasks,periodic-tasks,priority-tasks,normal-tasks,bulk-tasks,reporting-tasks,research-mode-tasks,retry-tasks,service-callbacks-retry,send-sms-tasks,send-sms-high,send-sms-medium,send-sms-low,send-throttled-sms-tasks,send-sms-fair-tasks,send-email-high,send-email-medium,send-email-low,send-email-tasks,service-callbacks,delivery-receipts",
             ]
         },
         {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -62,6 +62,7 @@
                 "DEBUG",
                 "-Q",
                 "database-tasks,-priority-database-tasks.fifo,-normal-database-tasks,-bulk-database-tasks,job-tasks,notify-internal-tasks,periodic-tasks,priority-tasks,normal-tasks,bulk-tasks,reporting-tasks,research-mode-tasks,retry-tasks,service-callbacks-retry,send-sms-tasks,send-sms-high,send-sms-medium,send-sms-low,send-throttled-sms-tasks,send-sms-fair-tasks,send-email-high,send-email-medium,send-email-low,send-email-tasks,service-callbacks,delivery-receipts",
+                "--beat",
             ]
         },
         {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -57,7 +57,7 @@
                 "-l",
                 "DEBUG",
                 "-Q",
-                "database-tasks,-priority-database-tasks.fifo,-normal-database-tasks,-bulk-database-tasks,job-tasks,notify-internal-tasks,periodic-tasks,priority-tasks,normal-tasks,bulk-tasks,reporting-tasks,research-mode-tasks,retry-tasks,service-callbacks-retry,send-sms-tasks,send-sms-high,send-sms-medium,send-sms-low,send-throttled-sms-tasks,send-sms-fair-tasks,send-email-high,send-email-medium,send-email-low,send-email-tasks,service-callbacks,delivery-receipts",
+                "database-tasks,-priority-database-tasks.fifo,-normal-database-tasks,-bulk-database-tasks,job-tasks,notify-internal-tasks,periodic-tasks,priority-tasks,normal-tasks,bulk-tasks,reporting-tasks,research-mode-tasks,retry-tasks,service-callbacks-retry,send-sms-tasks,send-sms-high,send-sms-medium,send-sms-low,send-throttled-sms-tasks,send-sms-fair,send-email-high,send-email-medium,send-email-low,send-email-tasks,service-callbacks,delivery-receipts",
                 "--beat",
             ]
         },

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,8 +29,7 @@
             "module": "flask",
             "env": {
                 "FLASK_APP": "application.py",
-                "FLASK_ENV": "development",
-                "FF_SMS_RATELIMIT": "true"
+                "FLASK_ENV": "development"
             },
             "args": [
                 "run",
@@ -48,9 +47,6 @@
             "module": "celery",
             "console": "integratedTerminal",
             "justMyCode": false,
-            "env": {
-                "FF_SMS_RATELIMIT": "true"
-            },
             "args": [
                 "--app",
                 "run_celery",

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -38,6 +38,7 @@ from app.encryption import CryptoSigner
 from app.json_provider import NotifyJSONProvider
 from app.otel_request_metrics import init_otel_request_metrics
 from app.queue import RedisQueue
+from app.rate_limiter import initialize_rate_limiter
 
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 DATE_FORMAT = "%Y-%m-%d"
@@ -139,6 +140,9 @@ def create_app(application, config=None):
 
     if application.config["FF_SALESFORCE_CONTACT"]:
         salesforce_client.init_app(application)
+
+    # Initialize the global rate limiter instance with the configured rate limit for SMS delivery tasks.
+    initialize_rate_limiter(application.config["CELERY_DELIVER_SMS_RATE_LIMIT_PER_MINUTE"])
 
     flask_redis.init_app(application)
     flask_cache_ops.init_app(application)

--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -18,6 +18,10 @@ def make_task(app):
         abstract = True
         start = None
 
+        @property
+        def message_group_id(self):
+            return self.request.get("notify_message_group_id")
+
         def on_success(self, retval, task_id, args, kwargs):
             elapsed_time = time.time() - self.start
             app.logger.info("{task_name} took {time}s".format(task_name=self.name, time="{0:.4f}".format(elapsed_time)))
@@ -32,6 +36,13 @@ def make_task(app):
 
 
 class NotifyCelery(Celery):
+    def send_task(self, name, args=None, kwargs=None, **options):
+        options["headers"] = options.get("headers") or {}
+        message_group_id = options.get("MessageGroupId")
+        if message_group_id:
+            options["headers"]["notify_message_group_id"] = message_group_id
+        return super().send_task(name, args, kwargs, **options)
+
     def init_app(self, app):
         super().__init__(
             app.import_name,

--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -38,9 +38,10 @@ def make_task(app):
 class NotifyCelery(Celery):
     def send_task(self, name, args=None, kwargs=None, **options):
         options["headers"] = options.get("headers") or {}
-        message_group_id = options.get("MessageGroupId")
+        message_group_id = options.pop("MessageGroupId", None)
         if message_group_id:
-            options["headers"]["notify_message_group_id"] = message_group_id
+            # Convert UUID to string for SQS compatibility
+            options["headers"]["notify_message_group_id"] = str(message_group_id)
         return super().send_task(name, args, kwargs, **options)
 
     def init_app(self, app):

--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -40,8 +40,15 @@ class NotifyCelery(Celery):
         options["headers"] = options.get("headers") or {}
         message_group_id = options.pop("MessageGroupId", None)
         if message_group_id:
-            # Convert UUID to string for SQS compatibility
-            options["headers"]["notify_message_group_id"] = str(message_group_id)
+            message_group_id = str(message_group_id)
+            # Store in Celery task headers so tasks can read it via self.message_group_id
+            # (used by deliver_sms_rate_limited to re-queue with the same group).
+            options["headers"]["notify_message_group_id"] = message_group_id
+            # Also set as a kombu message property so the SQS transport includes
+            # MessageGroupId in the boto3 SendMessage call, enabling SQS fair queuing
+            # on both standard queues (noisy-neighbour protection) and FIFO queues.
+            options["properties"] = options.get("properties") or {}
+            options["properties"]["MessageGroupId"] = message_group_id
         return super().send_task(name, args, kwargs, **options)
 
     def init_app(self, app):

--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -41,14 +41,19 @@ class NotifyCelery(Celery):
         message_group_id = options.pop("MessageGroupId", None)
         if message_group_id:
             message_group_id = str(message_group_id)
-            # Store in Celery task headers so tasks can read it via self.message_group_id
+            # Always store in Celery task headers so tasks can read it via self.message_group_id
             # (used by deliver_sms_rate_limited to re-queue with the same group).
             options["headers"]["notify_message_group_id"] = message_group_id
-            # Also set as a kombu message property so the SQS transport includes
-            # MessageGroupId in the boto3 SendMessage call, enabling SQS fair queuing
-            # on both standard queues (noisy-neighbour protection) and FIFO queues.
-            options["properties"] = options.get("properties") or {}
-            options["properties"]["MessageGroupId"] = message_group_id
+            # Only forward to kombu as a message property (so SQS receives it) when the
+            # fair-queue feature flag is enabled. This prevents any SQS behaviour change
+            # in production until the flag is turned on.
+
+            # Also set as kombu message property so the SQS transport includes
+            # MessageGroupId in the message for FIFO queues. This is required
+            # for the fair-queue feature to work.
+            if current_app.config.get("FF_SMS_RATELIMIT"):
+                options["properties"] = options.get("properties") or {}
+                options["properties"]["MessageGroupId"] = message_group_id
         return super().send_task(name, args, kwargs, **options)
 
     def init_app(self, app):

--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -72,7 +72,7 @@ def deliver_sms(self, notification_id):
     default_retry_delay=300,
 )
 @statsd(namespace="tasks")
-def deliver_sms_rate_limited(self, notification_id: str, parts_count: int):
+def deliver_sms_rate_limited(self, notification_id: str, priority_queue: str, parts_count: int):
     acquired, seconds_to_wait = get_rate_limiter().acquire_lease(parts_count)
     if acquired:
         _deliver_sms(self, notification_id)
@@ -80,7 +80,7 @@ def deliver_sms_rate_limited(self, notification_id: str, parts_count: int):
         current_app.logger.warning(
             f"Rate limit hit for notification {notification_id} with {parts_count} parts. Retrying after {seconds_to_wait} seconds."
         )
-        deliver_sms_rate_limited.apply_async(queue=QueueNames.SEND_SMS_FAIR, args=[notification_id, parts_count], countdown=seconds_to_wait)
+        deliver_sms_rate_limited.apply_async(queue=priority_queue, args=[notification_id, priority_queue, parts_count], countdown=seconds_to_wait)
         raise Ignore()
 
 

--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -65,6 +65,7 @@ def deliver_throttled_sms(self, notification_id):
 def deliver_sms(self, notification_id):
     _deliver_sms(self, notification_id)
 
+
 @notify_celery.task(
     bind=True,
     name="deliver_sms_rate_limited",
@@ -80,7 +81,12 @@ def deliver_sms_rate_limited(self, notification_id: str, parts_count: int):
         current_app.logger.warning(
             f"Rate limit hit for notification {notification_id} with {parts_count} parts. Retrying after {seconds_to_wait} seconds."
         )
-        deliver_sms_rate_limited.apply_async(queue=QueueNames.SEND_SMS_FAIR, args=[notification_id, priority_queue, parts_count], countdown=seconds_to_wait, MessageGroupId=self.message_group_id)
+        deliver_sms_rate_limited.apply_async(
+            queue=QueueNames.SEND_SMS_FAIR,
+            args=[notification_id, parts_count],
+            countdown=seconds_to_wait,
+            MessageGroupId=self.message_group_id,
+        )
         raise Ignore()
 
 

--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -61,7 +61,14 @@ def deliver_throttled_sms(self, notification_id):
 )
 @statsd(namespace="tasks")
 def deliver_sms(self, notification_id):
-    _deliver_sms(self, notification_id)
+    # If the FF_SMS_RATELIMIT flag is on, the deliver_sms task will be called with a rate limit,
+    # and it will call a new task _deliver_sms_with_rate_limit which will not have a rate limit
+    # but will use an SQS message group id based on the priority of the message to ensure messages
+    # with the same priority are sent in order.
+    if Config.FF_SMS_RATELIMIT:
+        _deliver_sms_with_rate_limit(self, notification_id, None)
+    else:
+        _deliver_sms(self, notification_id)
 
 
 SCAN_RETRY_BACKOFF = 10
@@ -111,6 +118,42 @@ def _deliver_sms(self, notification_id):
         if not notification:
             raise NoResultFound()
         send_to_providers.send_sms_to_provider(notification)
+    except InvalidUrlException:
+        current_app.logger.error(f"Cannot send notification {notification_id}, got an invalid direct file url.")
+        update_notification_status_by_id(notification_id, NOTIFICATION_TECHNICAL_FAILURE)
+        _check_and_queue_callback_task(notification)
+    except (PinpointConflictException, PinpointValidationException) as e:
+        # As this is due to Pinpoint errors, we are NOT retrying the notification
+        # We are only warning on the error, and not logging an error
+        current_app.logger.warning("SMS delivery failed for notification_id {} Pinpoint error: {}".format(notification.id, e))
+        # PinpointConflictException reasons: https://botocore.amazonaws.com/v1/documentation/api/latest/reference/services/pinpoint-sms-voice-v2/client/exceptions/ConflictException.html
+        # PinpointValidationException reasons: https://botocore.amazonaws.com/v1/documentation/api/latest/reference/services/pinpoint-sms-voice-v2/client/exceptions/ValidationException.html
+        update_notification_status_by_id(
+            notification_id, NOTIFICATION_PROVIDER_FAILURE, feedback_reason=e.original_exception.response.get("Reason", "")
+        )
+        _check_and_queue_callback_task(notification)
+    except Exception:
+        try:
+            current_app.logger.exception("SMS notification delivery for id: {} failed".format(notification_id))
+            self.retry(**CeleryParams.retry(None if notification is None else notification.template.process_type))
+        except self.MaxRetriesExceededError:
+            message = (
+                "RETRY FAILED: Max retries reached. The task send_sms_to_provider failed for notification {}. "
+                "Notification has been updated to technical-failure".format(notification_id)
+            )
+            update_notification_status_by_id(notification_id, NOTIFICATION_TECHNICAL_FAILURE)
+            _check_and_queue_callback_task(notification)
+            raise NotificationTechnicalFailureException(message)
+
+
+def _deliver_sms_with_rate_limit(self, notification_id, priority):
+    try:
+        current_app.logger.info("Start sending SMS for notification id: {}".format(notification_id))
+        notification = notifications_dao.get_notification_by_id(notification_id)
+        if not notification:
+            raise NoResultFound()
+        # call a new sending celery task with the priority, which will be used for the message group id in SQS, 
+        # to ensure messages with the same priority are sent in order
     except InvalidUrlException:
         current_app.logger.error(f"Cannot send notification {notification_id}, got an invalid direct file url.")
         update_notification_status_by_id(notification_id, NOTIFICATION_TECHNICAL_FAILURE)

--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from celery.exceptions import Ignore
 from flask import current_app
 from notifications_utils.recipients import InvalidEmailError
 from notifications_utils.statsd_decorators import statsd
@@ -7,7 +8,7 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from app import notify_celery
 from app.celery.utils import CeleryParams
-from app.config import Config
+from app.config import Config, QueueNames
 from app.dao import notifications_dao
 from app.dao.notifications_dao import update_notification_status_by_id
 from app.delivery import send_to_providers
@@ -25,6 +26,7 @@ from app.models import (
     Notification,
 )
 from app.notifications.callbacks import _check_and_queue_callback_task
+from app.rate_limiter import get_rate_limiter
 from celery import Task
 
 
@@ -61,14 +63,26 @@ def deliver_throttled_sms(self, notification_id):
 )
 @statsd(namespace="tasks")
 def deliver_sms(self, notification_id):
-    # If the FF_SMS_RATELIMIT flag is on, the deliver_sms task will be called with a rate limit,
-    # and it will call a new task _deliver_sms_with_rate_limit which will not have a rate limit
-    # but will use an SQS message group id based on the priority of the message to ensure messages
-    # with the same priority are sent in order.
-    if Config.FF_SMS_RATELIMIT:
-        _deliver_sms_with_rate_limit(self, notification_id, None)
-    else:
+    _deliver_sms(self, notification_id)
+
+@notify_celery.task(
+    bind=True,
+    name="deliver_sms_rate_limited",
+    max_retries=48,
+    default_retry_delay=300,
+)
+@statsd(namespace="tasks")
+def deliver_sms_rate_limited(self, notification_id: str, parts_count: int):
+    acquired, seconds_to_wait = get_rate_limiter().acquire_lease(parts_count)
+    if acquired:
         _deliver_sms(self, notification_id)
+    else:
+        current_app.logger.warning(
+            f"Rate limit hit for notification {notification_id} with {parts_count} parts. Retrying after {seconds_to_wait} seconds."
+        )
+        # self.retry(countdown=seconds_to_wait, exc=Exception("Rate limit hit, retrying..."))
+        deliver_sms_rate_limited.apply_async(queue=QueueNames.SEND_SMS_FAIR, args=[notification_id, parts_count], countdown=seconds_to_wait)
+        raise Ignore()
 
 
 SCAN_RETRY_BACKOFF = 10
@@ -118,42 +132,6 @@ def _deliver_sms(self, notification_id):
         if not notification:
             raise NoResultFound()
         send_to_providers.send_sms_to_provider(notification)
-    except InvalidUrlException:
-        current_app.logger.error(f"Cannot send notification {notification_id}, got an invalid direct file url.")
-        update_notification_status_by_id(notification_id, NOTIFICATION_TECHNICAL_FAILURE)
-        _check_and_queue_callback_task(notification)
-    except (PinpointConflictException, PinpointValidationException) as e:
-        # As this is due to Pinpoint errors, we are NOT retrying the notification
-        # We are only warning on the error, and not logging an error
-        current_app.logger.warning("SMS delivery failed for notification_id {} Pinpoint error: {}".format(notification.id, e))
-        # PinpointConflictException reasons: https://botocore.amazonaws.com/v1/documentation/api/latest/reference/services/pinpoint-sms-voice-v2/client/exceptions/ConflictException.html
-        # PinpointValidationException reasons: https://botocore.amazonaws.com/v1/documentation/api/latest/reference/services/pinpoint-sms-voice-v2/client/exceptions/ValidationException.html
-        update_notification_status_by_id(
-            notification_id, NOTIFICATION_PROVIDER_FAILURE, feedback_reason=e.original_exception.response.get("Reason", "")
-        )
-        _check_and_queue_callback_task(notification)
-    except Exception:
-        try:
-            current_app.logger.exception("SMS notification delivery for id: {} failed".format(notification_id))
-            self.retry(**CeleryParams.retry(None if notification is None else notification.template.process_type))
-        except self.MaxRetriesExceededError:
-            message = (
-                "RETRY FAILED: Max retries reached. The task send_sms_to_provider failed for notification {}. "
-                "Notification has been updated to technical-failure".format(notification_id)
-            )
-            update_notification_status_by_id(notification_id, NOTIFICATION_TECHNICAL_FAILURE)
-            _check_and_queue_callback_task(notification)
-            raise NotificationTechnicalFailureException(message)
-
-
-def _deliver_sms_with_rate_limit(self, notification_id, priority):
-    try:
-        current_app.logger.info("Start sending SMS for notification id: {}".format(notification_id))
-        notification = notifications_dao.get_notification_by_id(notification_id)
-        if not notification:
-            raise NoResultFound()
-        # call a new sending celery task with the priority, which will be used for the message group id in SQS, 
-        # to ensure messages with the same priority are sent in order
     except InvalidUrlException:
         current_app.logger.error(f"Cannot send notification {notification_id}, got an invalid direct file url.")
         update_notification_status_by_id(notification_id, NOTIFICATION_TECHNICAL_FAILURE)

--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -80,7 +80,6 @@ def deliver_sms_rate_limited(self, notification_id: str, parts_count: int):
         current_app.logger.warning(
             f"Rate limit hit for notification {notification_id} with {parts_count} parts. Retrying after {seconds_to_wait} seconds."
         )
-        # self.retry(countdown=seconds_to_wait, exc=Exception("Rate limit hit, retrying..."))
         deliver_sms_rate_limited.apply_async(queue=QueueNames.SEND_SMS_FAIR, args=[notification_id, parts_count], countdown=seconds_to_wait)
         raise Ignore()
 

--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -1,6 +1,5 @@
 from typing import Optional
 
-from celery.exceptions import Ignore
 from flask import current_app
 from notifications_utils.recipients import InvalidEmailError
 from notifications_utils.statsd_decorators import statsd
@@ -28,6 +27,7 @@ from app.models import (
 from app.notifications.callbacks import _check_and_queue_callback_task
 from app.rate_limiter import get_rate_limiter
 from celery import Task
+from celery.exceptions import Ignore
 
 
 # Celery rate limits are per worker instance and not a global rate limit.
@@ -72,7 +72,7 @@ def deliver_sms(self, notification_id):
     default_retry_delay=300,
 )
 @statsd(namespace="tasks")
-def deliver_sms_rate_limited(self, notification_id: str, priority_queue: str, parts_count: int):
+def deliver_sms_rate_limited(self, notification_id: str, parts_count: int):
     acquired, seconds_to_wait = get_rate_limiter().acquire_lease(parts_count)
     if acquired:
         _deliver_sms(self, notification_id)
@@ -80,7 +80,7 @@ def deliver_sms_rate_limited(self, notification_id: str, priority_queue: str, pa
         current_app.logger.warning(
             f"Rate limit hit for notification {notification_id} with {parts_count} parts. Retrying after {seconds_to_wait} seconds."
         )
-        deliver_sms_rate_limited.apply_async(queue=priority_queue, args=[notification_id, priority_queue, parts_count], countdown=seconds_to_wait)
+        deliver_sms_rate_limited.apply_async(queue=QueueNames.SEND_SMS_FAIR, args=[notification_id, priority_queue, parts_count], countdown=seconds_to_wait, MessageGroupId=self.message_group_id)
         raise Ignore()
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -83,6 +83,10 @@ class QueueNames(object):
     # we have a limit to send per second and hence, needs to be throttled.
     SEND_THROTTLED_SMS = "send-throttled-sms-tasks"
 
+    # Fair queue for sending SMS, used to rate limit sending SMS from Notify to
+    # our SMS provider to avoid hitting downstream rate limits.
+    SEND_SMS_FAIR = "send-sms-fair-tasks"
+
     # Queues for sending all emails.
     SEND_EMAIL_HIGH = "send-email-high"
     SEND_EMAIL_MEDIUM = "send-email-medium"
@@ -139,6 +143,7 @@ class QueueNames(object):
             QueueNames.SEND_SMS_MEDIUM,
             QueueNames.SEND_SMS_LOW,
             QueueNames.SEND_THROTTLED_SMS,
+            QueueNames.SEND_SMS_FAIR,
             QueueNames.SEND_EMAIL_HIGH,
             QueueNames.SEND_EMAIL_MEDIUM,
             QueueNames.SEND_EMAIL_LOW,
@@ -580,6 +585,7 @@ class Config(object):
     }
     CELERY_QUEUES: List[Any] = []
     CELERY_DELIVER_SMS_RATE_LIMIT = os.getenv("CELERY_DELIVER_SMS_RATE_LIMIT", "1/s")
+    CELERY_DELIVER_SMS_RATE_LIMIT_PER_MINUTE = os.getenv("CELERY_DELIVER_SMS_RATE_LIMIT_PER_MINUTE", "1000/m")
     AWS_SEND_SMS_BOTO_CALL_LATENCY = os.getenv("AWS_SEND_SMS_BOTO_CALL_LATENCY", 0.06)  # average delay in production
 
     CONTACT_FORM_EMAIL_ADDRESS = os.getenv("CONTACT_FORM_EMAIL_ADDRESS", "helpdesk@cds-snc.ca")

--- a/app/config.py
+++ b/app/config.py
@@ -3,6 +3,7 @@ import os
 from datetime import timedelta
 from typing import Any, List
 
+from celery.schedules import crontab
 from dotenv import load_dotenv
 from environs import Env
 from fido2.server import Fido2Server
@@ -10,8 +11,6 @@ from fido2.webauthn import PublicKeyCredentialRpEntity
 from kombu import Exchange, Queue
 from notifications_utils import logging
 from sqlalchemy.pool import NullPool
-
-from celery.schedules import crontab
 
 env = Env()
 env.read_env()
@@ -588,7 +587,7 @@ class Config(object):
     }
     CELERY_QUEUES: List[Any] = []
     CELERY_DELIVER_SMS_RATE_LIMIT = os.getenv("CELERY_DELIVER_SMS_RATE_LIMIT", "1/s")
-    CELERY_DELIVER_SMS_RATE_LIMIT_PER_MINUTE = os.getenv("CELERY_DELIVER_SMS_RATE_LIMIT_PER_MINUTE", "1000/m")
+    CELERY_DELIVER_SMS_RATE_LIMIT_PER_MINUTE = env.int("CELERY_DELIVER_SMS_RATE_LIMIT_PER_MINUTE", 6_000)
     AWS_SEND_SMS_BOTO_CALL_LATENCY = os.getenv("AWS_SEND_SMS_BOTO_CALL_LATENCY", 0.06)  # average delay in production
 
     CONTACT_FORM_EMAIL_ADDRESS = os.getenv("CONTACT_FORM_EMAIL_ADDRESS", "helpdesk@cds-snc.ca")

--- a/app/config.py
+++ b/app/config.py
@@ -650,16 +650,18 @@ class Config(object):
     BR_CRITICAL_PERCENTAGE = 0.1
 
     # Feature flags for bounce rate
+    FF_ANNUAL_LIMIT = env.bool("FF_ANNUAL_LIMIT", False)
+    FF_BENCHMARK_ENDPOINT = env.bool("FF_BENCHMARK_ENDPOINT", False)
     # Timestamp in epoch milliseconds to seed the bounce rate. We will seed data for (24, the below config) included.
     FF_BOUNCE_RATE_SEED_EPOCH_MS = os.getenv("FF_BOUNCE_RATE_SEED_EPOCH_MS", False)
     # Feature flag to enable custom retry policies such as lowering retry period for certain priority lanes.
     FF_CELERY_CUSTOM_TASK_PARAMS = env.bool("FF_CELERY_CUSTOM_TASK_PARAMS", True)
     FF_CLOUDWATCH_METRICS_ENABLED = env.bool("FF_CLOUDWATCH_METRICS_ENABLED", False)
-    FF_SALESFORCE_CONTACT = env.bool("FF_SALESFORCE_CONTACT", False)
-    FF_ANNUAL_LIMIT = env.bool("FF_ANNUAL_LIMIT", False)
     FF_PT_SERVICE_SKIP_FRESHDESK = env.bool("FF_PT_SERVICE_SKIP_FRESHDESK", False)
+    FF_SALESFORCE_CONTACT = env.bool("FF_SALESFORCE_CONTACT", False)
+    FF_SMS_RATELIMIT = env.bool("FF_SMS_RATELIMIT", False)
     FF_USE_BILLABLE_UNITS = env.bool("FF_USE_BILLABLE_UNITS", False)
-    FF_BENCHMARK_ENDPOINT = env.bool("FF_BENCHMARK_ENDPOINT", False)
+
     WAF_SECRET = os.getenv("WAF_SECRET")
 
     # SRE Tools auth keys

--- a/app/config.py
+++ b/app/config.py
@@ -3,7 +3,6 @@ import os
 from datetime import timedelta
 from typing import Any, List
 
-from celery.schedules import crontab
 from dotenv import load_dotenv
 from environs import Env
 from fido2.server import Fido2Server
@@ -11,6 +10,8 @@ from fido2.webauthn import PublicKeyCredentialRpEntity
 from kombu import Exchange, Queue
 from notifications_utils import logging
 from sqlalchemy.pool import NullPool
+
+from celery.schedules import crontab
 
 env = Env()
 env.read_env()
@@ -588,6 +589,8 @@ class Config(object):
     CELERY_QUEUES: List[Any] = []
     CELERY_DELIVER_SMS_RATE_LIMIT = os.getenv("CELERY_DELIVER_SMS_RATE_LIMIT", "1/s")
     CELERY_DELIVER_SMS_RATE_LIMIT_PER_MINUTE = env.int("CELERY_DELIVER_SMS_RATE_LIMIT_PER_MINUTE", 6_000)
+    # SMS rate limiter backend: "memory" for in-process (Phase 1), "redis" for distributed (Phase 2, multi-worker)
+    SMS_RATE_LIMITER_BACKEND = os.getenv("SMS_RATE_LIMITER_BACKEND", "memory")
     AWS_SEND_SMS_BOTO_CALL_LATENCY = os.getenv("AWS_SEND_SMS_BOTO_CALL_LATENCY", 0.06)  # average delay in production
 
     CONTACT_FORM_EMAIL_ADDRESS = os.getenv("CONTACT_FORM_EMAIL_ADDRESS", "helpdesk@cds-snc.ca")

--- a/app/config.py
+++ b/app/config.py
@@ -85,7 +85,7 @@ class QueueNames(object):
 
     # Fair queue for sending SMS, used to rate limit sending SMS from Notify to
     # our SMS provider to avoid hitting downstream rate limits.
-    SEND_SMS_FAIR = "send-sms-fair-tasks"
+    SEND_SMS_FAIR = "send-sms-fair"
 
     # Queues for sending all emails.
     SEND_EMAIL_HIGH = "send-email-high"

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -257,118 +257,122 @@ def send_email_to_provider(notification: Notification):
         inactive_service_failure(notification=notification)
         return
 
-    # If the notification was not sent already, the status should be created.
-    if notification.status == "created":
-        provider = provider_to_use(EMAIL_TYPE, notification.id)
+    # Only process notifications with status 'created' to guarantee idempotency of this
+    # function. If the status is not 'created', it means the notification has already
+    # been processed and sent to a provider, so we should not attempt to send it again.
+    if notification.status != "created":
+        return
 
-        # Extract any file objects from the personalization
-        file_keys = [k for k, v in (notification.personalisation or {}).items() if isinstance(v, dict) and "document" in v]
-        attachments = []
+    provider = provider_to_use(EMAIL_TYPE, notification.id)
 
-        personalisation_data = notification.personalisation.copy()
+    # Extract any file objects from the personalization
+    file_keys = [k for k, v in (notification.personalisation or {}).items() if isinstance(v, dict) and "document" in v]
+    attachments = []
 
-        for key in file_keys:
-            check_file_url(personalisation_data[key]["document"], notification.id)
-            sending_method = personalisation_data[key]["document"].get("sending_method")
-            direct_file_url = personalisation_data[key]["document"]["direct_file_url"]
-            filename = personalisation_data[key]["document"].get("filename")
-            mime_type = personalisation_data[key]["document"].get("mime_type")
-            document_id = personalisation_data[key]["document"]["id"]
-            current_app.logger.info(
-                f"Calling document_download_client.check_scan_verdict() for document_id: {document_id} and notification_id: {notification.id}"
-            )
-            scan_verdict_response = document_download_client.check_scan_verdict(service.id, document_id, sending_method)
-            check_for_malware_errors(scan_verdict_response.status_code, notification)
-            current_app.logger.info(f"scan_verdict for document_id {document_id} is {scan_verdict_response.json()}")
-            if sending_method == "attach":
-                try:
-                    retries = Retry(total=5)
-                    http = PoolManager(retries=retries)
+    personalisation_data = notification.personalisation.copy()
 
-                    response = http.request("GET", url=direct_file_url)
-                    attachments.append(
-                        {
-                            "name": filename,
-                            "data": response.data,
-                            "mime_type": mime_type,
-                        }
-                    )
-                except Exception as e:
-                    current_app.logger.error(f"Could not download and attach {direct_file_url}\nException: {e}")
-                    del personalisation_data[key]
-
-            else:
-                personalisation_data[key] = personalisation_data[key]["document"]["url"]
-
-        template_obj = dao_get_template_by_id(notification.template_id, notification.template_version)
-        template_dict = template_obj.__dict__
-        template_dict["process_type"] = template_obj.process_type
-
-        # Local Jinja support - Add USE_LOCAL_JINJA_TEMPLATES=True to .env
-        # Add a folder to the project root called 'jinja_templates'
-        # with a copy of 'email_template.jinja2' from notification-utils repo
-        debug_template_path = (
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-            if os.environ.get("USE_LOCAL_JINJA_TEMPLATES") == "True"
-            else None
-        )
-        html_email = HTMLEmailTemplate(
-            template_dict,
-            values=personalisation_data,
-            jinja_path=debug_template_path,
-            allow_html=is_service_allowed_html(service),
-            **get_html_email_options(service),
-        )
-
-        plain_text_email = PlainTextEmailTemplate(template_dict, values=personalisation_data)
-
-        if current_app.config["SCAN_FOR_PII"]:
-            contains_pii(notification, str(plain_text_email))
-
+    for key in file_keys:
+        check_file_url(personalisation_data[key]["document"], notification.id)
+        sending_method = personalisation_data[key]["document"].get("sending_method")
+        direct_file_url = personalisation_data[key]["document"]["direct_file_url"]
+        filename = personalisation_data[key]["document"].get("filename")
+        mime_type = personalisation_data[key]["document"].get("mime_type")
+        document_id = personalisation_data[key]["document"]["id"]
         current_app.logger.info(
-            f"Trying to update notification id {notification.id} with service research {service.research_mode} or key type {notification.key_type}"
+            f"Calling document_download_client.check_scan_verdict() for document_id: {document_id} and notification_id: {notification.id}"
         )
-        if service.research_mode or notification.key_type == KEY_TYPE_TEST:
-            notification.reference = send_email_response(notification.to)
-            update_notification_to_sending(notification, provider)
-        elif notification.to == Config.INTERNAL_TEST_EMAIL_ADDRESS:
-            current_app.logger.info(f"notification {notification.id} sending to internal test email address. Not sending to AWS")
-            notification.reference = send_email_response(notification.to)
-            update_notification_to_sending(notification, provider)
+        scan_verdict_response = document_download_client.check_scan_verdict(service.id, document_id, sending_method)
+        check_for_malware_errors(scan_verdict_response.status_code, notification)
+        current_app.logger.info(f"scan_verdict for document_id {document_id} is {scan_verdict_response.json()}")
+        if sending_method == "attach":
+            try:
+                retries = Retry(total=5)
+                http = PoolManager(retries=retries)
+
+                response = http.request("GET", url=direct_file_url)
+                attachments.append(
+                    {
+                        "name": filename,
+                        "data": response.data,
+                        "mime_type": mime_type,
+                    }
+                )
+            except Exception as e:
+                current_app.logger.error(f"Could not download and attach {direct_file_url}\nException: {e}")
+                del personalisation_data[key]
+
         else:
-            if service.sending_domain is None or service.sending_domain.strip() == "":
-                sending_domain = current_app.config["NOTIFY_EMAIL_DOMAIN"]
-            else:
-                sending_domain = service.sending_domain
+            personalisation_data[key] = personalisation_data[key]["document"]["url"]
 
-            from_address = get_from_address(
-                friendly_from=service.name, email_from=service.email_from, sending_domain=sending_domain
-            )
-            email_reply_to = notification.reply_to_text
+    template_obj = dao_get_template_by_id(notification.template_id, notification.template_version)
+    template_dict = template_obj.__dict__
+    template_dict["process_type"] = template_obj.process_type
 
-            reference = provider.send_email(
-                from_address,
-                validate_and_format_email_address(notification.to),
-                plain_text_email.subject,
-                body=str(plain_text_email),
-                html_body=str(html_email),
-                reply_to_address=validate_and_format_email_address(email_reply_to) if email_reply_to else None,
-                attachments=attachments,
-            )
-            check_service_over_bounce_rate(service.id)
-            bounce_rate_client.set_sliding_notifications(service.id, str(notification.id))
-            current_app.logger.info(f"Setting total notifications for service {service.id} in REDIS")
-            current_app.logger.info(f"Notification id {notification.id} HAS BEEN SENT")
-            notification.reference = reference
-            update_notification_to_sending(notification, provider)
-        current_app.logger.info(f"Notification id {notification.id} status in sending")
+    # Local Jinja support - Add USE_LOCAL_JINJA_TEMPLATES=True to .env
+    # Add a folder to the project root called 'jinja_templates'
+    # with a copy of 'email_template.jinja2' from notification-utils repo
+    debug_template_path = (
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        if os.environ.get("USE_LOCAL_JINJA_TEMPLATES") == "True"
+        else None
+    )
+    html_email = HTMLEmailTemplate(
+        template_dict,
+        values=personalisation_data,
+        jinja_path=debug_template_path,
+        allow_html=is_service_allowed_html(service),
+        **get_html_email_options(service),
+    )
 
-        # Record StatsD stats to compute SLOs
-        statsd_client.timing_with_dates("email.total-time", notification.sent_at, notification.created_at)
-        attachments_category = "with-attachments" if attachments else "no-attachments"
-        statsd_key = f"email.{attachments_category}.process_type-{template_dict['process_type']}"
-        statsd_client.timing_with_dates(statsd_key, notification.sent_at, notification.created_at)
-        statsd_client.incr(statsd_key)
+    plain_text_email = PlainTextEmailTemplate(template_dict, values=personalisation_data)
+
+    if current_app.config["SCAN_FOR_PII"]:
+        contains_pii(notification, str(plain_text_email))
+
+    current_app.logger.info(
+        f"Trying to update notification id {notification.id} with service research {service.research_mode} or key type {notification.key_type}"
+    )
+    if service.research_mode or notification.key_type == KEY_TYPE_TEST:
+        notification.reference = send_email_response(notification.to)
+        update_notification_to_sending(notification, provider)
+    elif notification.to == Config.INTERNAL_TEST_EMAIL_ADDRESS:
+        current_app.logger.info(f"notification {notification.id} sending to internal test email address. Not sending to AWS")
+        notification.reference = send_email_response(notification.to)
+        update_notification_to_sending(notification, provider)
+    else:
+        if service.sending_domain is None or service.sending_domain.strip() == "":
+            sending_domain = current_app.config["NOTIFY_EMAIL_DOMAIN"]
+        else:
+            sending_domain = service.sending_domain
+
+        from_address = get_from_address(
+            friendly_from=service.name, email_from=service.email_from, sending_domain=sending_domain
+        )
+        email_reply_to = notification.reply_to_text
+
+        reference = provider.send_email(
+            from_address,
+            validate_and_format_email_address(notification.to),
+            plain_text_email.subject,
+            body=str(plain_text_email),
+            html_body=str(html_email),
+            reply_to_address=validate_and_format_email_address(email_reply_to) if email_reply_to else None,
+            attachments=attachments,
+        )
+        check_service_over_bounce_rate(service.id)
+        bounce_rate_client.set_sliding_notifications(service.id, str(notification.id))
+        current_app.logger.info(f"Setting total notifications for service {service.id} in REDIS")
+        current_app.logger.info(f"Notification id {notification.id} HAS BEEN SENT")
+        notification.reference = reference
+        update_notification_to_sending(notification, provider)
+    current_app.logger.info(f"Notification id {notification.id} status in sending")
+
+    # Record StatsD stats to compute SLOs
+    statsd_client.timing_with_dates("email.total-time", notification.sent_at, notification.created_at)
+    attachments_category = "with-attachments" if attachments else "no-attachments"
+    statsd_key = f"email.{attachments_category}.process_type-{template_dict['process_type']}"
+    statsd_client.timing_with_dates(statsd_key, notification.sent_at, notification.created_at)
+    statsd_client.incr(statsd_key)
 
 
 def update_notification_to_sending(notification, provider):

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -79,77 +79,81 @@ def send_sms_to_provider(notification):
     sending_to_internal_test_number = formatted_recipient == current_app.config["INTERNAL_TEST_NUMBER"]
     sending_to_dryrun_number = formatted_recipient == current_app.config["EXTERNAL_TEST_NUMBER"]
 
-    # If the notification was not sent already, the status should be created.
-    if notification.status == "created":
-        provider = provider_to_use(
-            SMS_TYPE,
-            notification.id,
-            notification.to,
-            notification.international,
-            notification.reply_to_text,
-            template_id=notification.template_id,
-        )
+    # Only process notifications with status 'created' to guarantee idempotency of this
+    # function. If the status is not 'created', it means the notification has already
+    # been processed and sent to a provider, so we should not attempt to send it again.
+    if notification.status != "created":
+        return
 
-        template_obj = dao_get_template_by_id(notification.template_id, notification.template_version)
-        template_dict = template_obj.__dict__
-        template_dict["process_type"] = template_obj.process_type
+    provider = provider_to_use(
+        SMS_TYPE,
+        notification.id,
+        notification.to,
+        notification.international,
+        notification.reply_to_text,
+        template_id=notification.template_id,
+    )
 
-        template = SMSMessageTemplate(
-            template_dict,
-            values=notification.personalisation,
-            prefix=service.name,
-            show_prefix=service.prefix_sms,
-        )
+    template_obj = dao_get_template_by_id(notification.template_id, notification.template_version)
+    template_dict = template_obj.__dict__
+    template_dict["process_type"] = template_obj.process_type
 
-        if is_blank(template):
-            empty_message_failure(notification=notification)
-            return
+    template = SMSMessageTemplate(
+        template_dict,
+        values=notification.personalisation,
+        prefix=service.name,
+        show_prefix=service.prefix_sms,
+    )
 
-        if service.research_mode or notification.key_type == KEY_TYPE_TEST or sending_to_internal_test_number:
-            current_app.logger.info(f"notification {notification.id} is sending to INTERNAL_TEST_NUMBER, no boto call to AWS.")
-            notification.reference = str(create_uuid())
-            update_notification_to_sending(notification, provider)
-            send_sms_response(provider.get_name(), notification.to, notification.reference)
-        else:
-            try:
-                template_category_id = template_dict.get("template_category_id")
-                if template_category_id is not None:
-                    sending_vehicle = SmsSendingVehicles(
-                        dao_get_template_category_by_id(template_category_id).sms_sending_vehicle
-                    )
-                else:
-                    sending_vehicle = None
-                reference = provider.send_sms(
-                    to=formatted_recipient,
-                    content=str(template),
-                    reference=str(notification.id),
-                    sender=notification.reply_to_text,
-                    template_id=notification.template_id,
-                    service_id=notification.service_id,
-                    sending_vehicle=sending_vehicle,
+    if is_blank(template):
+        empty_message_failure(notification=notification)
+        return
+
+    if service.research_mode or notification.key_type == KEY_TYPE_TEST or sending_to_internal_test_number:
+        current_app.logger.info(f"notification {notification.id} is sending to INTERNAL_TEST_NUMBER, no boto call to AWS.")
+        notification.reference = str(create_uuid())
+        update_notification_to_sending(notification, provider)
+        send_sms_response(provider.get_name(), notification.to, notification.reference)
+    else:
+        try:
+            template_category_id = template_dict.get("template_category_id")
+            if template_category_id is not None:
+                sending_vehicle = SmsSendingVehicles(
+                    dao_get_template_category_by_id(template_category_id).sms_sending_vehicle
                 )
-            except (PinpointConflictException, PinpointValidationException) as e:
-                raise e
-            except Exception as e:
-                notification.billable_units = template.fragment_count
-                dao_update_notification(notification)
-                dao_toggle_sms_provider(provider.name)
-                raise e
             else:
-                notification.reference = reference
-                notification.billable_units = template.fragment_count
-                if reference == "opted_out":
-                    update_notification_to_opted_out(notification, provider)
-                else:
-                    if sending_to_dryrun_number:
-                        send_sms_response(provider.get_name(), notification.to, reference)
-                    update_notification_to_sending(notification, provider)
+                sending_vehicle = None
+            reference = provider.send_sms(
+                to=formatted_recipient,
+                content=str(template),
+                reference=str(notification.id),
+                sender=notification.reply_to_text,
+                template_id=notification.template_id,
+                service_id=notification.service_id,
+                sending_vehicle=sending_vehicle,
+            )
+        except (PinpointConflictException, PinpointValidationException) as e:
+            raise e
+        except Exception as e:
+            notification.billable_units = template.fragment_count
+            dao_update_notification(notification)
+            dao_toggle_sms_provider(provider.name)
+            raise e
+        else:
+            notification.reference = reference
+            notification.billable_units = template.fragment_count
+            if reference == "opted_out":
+                update_notification_to_opted_out(notification, provider)
+            else:
+                if sending_to_dryrun_number:
+                    send_sms_response(provider.get_name(), notification.to, reference)
+                update_notification_to_sending(notification, provider)
 
-        # Record StatsD stats to compute SLOs
-        statsd_client.timing_with_dates("sms.total-time", notification.sent_at, notification.created_at)
-        statsd_key = f"sms.process_type-{template_dict['process_type']}"
-        statsd_client.timing_with_dates(statsd_key, notification.sent_at, notification.created_at)
-        statsd_client.incr(statsd_key)
+    # Record StatsD stats to compute SLOs
+    statsd_client.timing_with_dates("sms.total-time", notification.sent_at, notification.created_at)
+    statsd_key = f"sms.process_type-{template_dict['process_type']}"
+    statsd_client.timing_with_dates(statsd_key, notification.sent_at, notification.created_at)
+    statsd_client.incr(statsd_key)
 
 
 def is_service_allowed_html(service: Service) -> bool:

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -119,9 +119,7 @@ def send_sms_to_provider(notification):
         try:
             template_category_id = template_dict.get("template_category_id")
             if template_category_id is not None:
-                sending_vehicle = SmsSendingVehicles(
-                    dao_get_template_category_by_id(template_category_id).sms_sending_vehicle
-                )
+                sending_vehicle = SmsSendingVehicles(dao_get_template_category_by_id(template_category_id).sms_sending_vehicle)
             else:
                 sending_vehicle = None
             reference = provider.send_sms(
@@ -387,9 +385,7 @@ def send_email_to_provider(notification: Notification):
         else:
             sending_domain = service.sending_domain
 
-        from_address = get_from_address(
-            friendly_from=service.name, email_from=service.email_from, sending_domain=sending_domain
-        )
+        from_address = get_from_address(friendly_from=service.name, email_from=service.email_from, sending_domain=sending_domain)
         email_reply_to = notification.reply_to_text
 
         reference = provider.send_email(

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -304,7 +304,7 @@ def send_notification_to_queue(notification, research_mode, queue=None):
         queue = QueueNames.RESEARCH_MODE
 
     # Pioritize sending per services within the same queue by default.
-    message_group_id: str = notification.service_id
+    message_group_id: str = str(notification.service_id)
     celery_params: list = [str(notification.id)]
 
     # Final verification for the queue to send to and apply final stage overrides.

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import datetime
-from typing import List
+from typing import List, Optional
 
 from flask import current_app
 from notifications_utils.clients import redis
@@ -15,7 +15,7 @@ from notifications_utils.timezones import convert_local_timezone_to_utc
 from app import redis_store
 from app.celery import provider_tasks
 from app.celery.letters_pdf_tasks import create_letters_pdf
-from app.config import QueueNames
+from app.config import Priorities, QueueNames
 from app.dao.api_key_dao import update_last_used_api_key
 from app.dao.notifications_dao import (
     bulk_insert_notifications,
@@ -113,7 +113,7 @@ def persist_notification(
     )
     template = dao_get_template_by_id(template_id, template_version, use_cache=True)
     notification.queue_name = choose_queue(
-        notification=notification, research_mode=service.research_mode, queue=get_delivery_queue_for_template(template)
+        notification=notification, research_mode=service.research_mode, priority_queue=get_delivery_queue_for_template(template)
     )
 
     # Calculate billable_units if feature flag is enabled and not explicitly provided
@@ -210,18 +210,38 @@ def transform_notification(
 
 def db_save_and_send_notification(notification: Notification):
     dao_create_notification(notification)
+    current_app.logger.info(f"{notification.notification_type} {notification.id} created at {notification.created_at}")
+
     if notification.key_type != KEY_TYPE_TEST:
         service_id = notification.service_id
         if redis_store.get(redis.daily_limit_cache_key(service_id)):
             redis_store.incr(redis.daily_limit_cache_key(service_id))
 
-    current_app.logger.info(f"{notification.notification_type} {notification.id} created at {notification.created_at}")
+    # Pioritize sending per services within the same queue by default.
+    message_group_id: str = notification.service_id
+    queue: str = notification.queue_name
+    celery_params: list = [str(notification.id)]
+    if (
+        notification.notification_type == SMS_TYPE
+        # We don't want to send test notifications to the rate limited queue.
+        and notification.queue_name != QueueNames.RESEARCH_MODE
+        and current_app.config.get("FF_SMS_RATELIMIT")
+    ):
+        queue = QueueNames.SEND_SMS_FAIR
+        # Prioritize sending per the queue names derived from the template category.
+        message_group_id = get_delivery_queue_for_template(notification.template)
+        if current_app.config.get("FF_USE_BILLABLE_UNITS") and notification.billable_units:
+            celery_params.append(notification.billable_units)
+        else:
+            billable_units = number_of_sms_fragments(notification.template, notification.personalisation)
+            celery_params.append(billable_units)
 
     deliver_task = choose_deliver_task(notification)
     try:
         deliver_task.apply_async(
-            [str(notification.id)],
-            queue=notification.queue_name,
+            celery_params,
+            queue=queue,
+            MessageGroupId=message_group_id,
         )
     except Exception:
         dao_delete_notifications_by_id(notification.id)
@@ -231,23 +251,37 @@ def db_save_and_send_notification(notification: Notification):
     )
 
 
-def choose_queue(notification, research_mode, queue=None) -> QueueNames:
+def choose_queue(notification: Notification, research_mode: bool, priority_queue: Optional[str] = None) -> str:
+    """
+    Determine the appropriate Celery queue for a notification based on its attributes and the service's research mode.
+    Args:        notification (Notification): The notification for which to choose a queue.
+        research_mode (bool): Whether the service is in research mode.
+        priority_queue (QueueNames, optional): An optional pre-determined queue. If provided, this will be
+        used instead of determining the queue based on notification attributes.
+    Returns:
+        str: The appropriate Celery queue for the notification as a string.
+    """
     if research_mode or notification.key_type == KEY_TYPE_TEST:
-        queue = QueueNames.RESEARCH_MODE
+        return QueueNames.RESEARCH_MODE
 
+    override_queue: Optional[str] = priority_queue
     if notification.notification_type == SMS_TYPE:
         if notification.sends_with_custom_number():
-            queue = QueueNames.SEND_THROTTLED_SMS
-        if not queue:
-            queue = QueueNames.SEND_SMS_MEDIUM
-    if notification.notification_type == EMAIL_TYPE:
-        if not queue:
-            queue = QueueNames.SEND_EMAIL_MEDIUM
-    if notification.notification_type == LETTER_TYPE:
-        if not queue:
-            queue = QueueNames.CREATE_LETTERS_PDF
+            override_queue = QueueNames.SEND_THROTTLED_SMS
+        # Enable the SMS rate limit feature but without overriding throttled dedicated or research lanes.
+        elif not priority_queue and current_app.config.get("FF_SMS_RATELIMIT"):
+            override_queue = QueueNames.SEND_SMS_FAIR
+        elif not priority_queue:
+            override_queue = QueueNames.SEND_SMS_MEDIUM
+    elif notification.notification_type == EMAIL_TYPE:
+        if not priority_queue:
+            override_queue = QueueNames.SEND_EMAIL_MEDIUM
+    elif notification.notification_type == LETTER_TYPE:
+        if not priority_queue:
+            override_queue = QueueNames.CREATE_LETTERS_PDF
 
-    return queue
+    assert override_queue is not None, "Queue should have been determined based on notification type and priority queue"
+    return override_queue
 
 
 def choose_deliver_task(notification):
@@ -255,6 +289,8 @@ def choose_deliver_task(notification):
         deliver_task = provider_tasks.deliver_sms
         if notification.sends_with_custom_number():
             deliver_task = provider_tasks.deliver_throttled_sms
+        elif current_app.config.get("FF_SMS_RATELIMIT"):
+            deliver_task = provider_tasks.deliver_sms_rate_limited
     if notification.notification_type == EMAIL_TYPE:
         deliver_task = provider_tasks.deliver_email
     if notification.notification_type == LETTER_TYPE:
@@ -267,12 +303,28 @@ def send_notification_to_queue(notification, research_mode, queue=None):
     if research_mode or notification.key_type == KEY_TYPE_TEST:
         queue = QueueNames.RESEARCH_MODE
 
+    # Pioritize sending per services within the same queue by default.
+    message_group_id: str = notification.service_id
+    celery_params: list = [str(notification.id)]
+
+    # Final verification for the queue to send to and apply final stage overrides.
     if notification.notification_type == SMS_TYPE:
         deliver_task = provider_tasks.deliver_sms
         if notification.sends_with_custom_number():
             deliver_task = provider_tasks.deliver_throttled_sms
             queue = QueueNames.SEND_THROTTLED_SMS
-        if not queue or queue == QueueNames.NORMAL:
+        elif current_app.config.get("FF_SMS_RATELIMIT") and queue != QueueNames.RESEARCH_MODE:
+            deliver_task = provider_tasks.deliver_sms_rate_limited
+            # The previous queue parameter becomes the fair queue priority and
+            # the queue is overriden to be a fair queue.
+            message_group_id = queue or get_delivery_queue_for_template(notification.template)
+            queue = QueueNames.SEND_SMS_FAIR
+            if current_app.config.get("FF_USE_BILLABLE_UNITS") and notification.billable_units:
+                celery_params.append(notification.billable_units)
+            else:
+                billable_units = number_of_sms_fragments(notification.template, notification.personalisation)
+                celery_params.append(billable_units)
+        elif not queue or queue == QueueNames.NORMAL:
             queue = QueueNames.SEND_SMS_MEDIUM
     if notification.notification_type == EMAIL_TYPE:
         if not queue or queue == QueueNames.NORMAL:
@@ -284,7 +336,7 @@ def send_notification_to_queue(notification, research_mode, queue=None):
         deliver_task = create_letters_pdf
 
     try:
-        deliver_task.apply_async([str(notification.id)], queue=queue)
+        deliver_task.apply_async(celery_params, queue=queue, MessageGroupId=message_group_id)
     except Exception:
         dao_delete_notifications_by_id(notification.id)
         raise
@@ -338,7 +390,9 @@ def persist_notifications(notifications: List[VerifiedNotification]) -> List[Not
         template = dao_get_template_by_id(notification_obj.template_id, notification_obj.template_version, use_cache=True)
         service = dao_fetch_service_by_id(service_id, use_cache=True)
         notification_obj.queue_name = choose_queue(
-            notification=notification_obj, research_mode=service.research_mode, queue=get_delivery_queue_for_template(template)
+            notification=notification_obj,
+            research_mode=service.research_mode,
+            priority_queue=get_delivery_queue_for_template(template),
         )
 
         if notification.get("notification_type") == SMS_TYPE:

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -15,7 +15,7 @@ from notifications_utils.timezones import convert_local_timezone_to_utc
 from app import redis_store
 from app.celery import provider_tasks
 from app.celery.letters_pdf_tasks import create_letters_pdf
-from app.config import Priorities, QueueNames
+from app.config import QueueNames
 from app.dao.api_key_dao import update_last_used_api_key
 from app.dao.notifications_dao import (
     bulk_insert_notifications,

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -329,14 +329,16 @@ def send_notification_to_queue(notification, research_mode, queue=None):
                 celery_params.append(billable_units)
         elif not queue or queue == QueueNames.NORMAL:
             queue = QueueNames.SEND_SMS_MEDIUM
-    if notification.notification_type == EMAIL_TYPE:
+    elif notification.notification_type == EMAIL_TYPE:
         if not queue or queue == QueueNames.NORMAL:
             queue = QueueNames.SEND_EMAIL_MEDIUM
         deliver_task = provider_tasks.deliver_email
-    if notification.notification_type == LETTER_TYPE:
+    elif notification.notification_type == LETTER_TYPE:
         if not queue or queue == QueueNames.NORMAL:
             queue = QueueNames.CREATE_LETTERS_PDF
         deliver_task = create_letters_pdf
+    else:
+        raise ValueError(f"Unexpected notification type {notification.notification_type}")
 
     try:
         deliver_task.apply_async(celery_params, queue=queue, MessageGroupId=message_group_id)

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -223,6 +223,8 @@ def db_save_and_send_notification(notification: Notification):
     celery_params: list = [str(notification.id)]
     if (
         notification.notification_type == SMS_TYPE
+        # Custom/dedicated-number senders must stay on the throttled queue.
+        and not notification.sends_with_custom_number()
         # We don't want to send test notifications to the rate limited queue.
         and notification.queue_name != QueueNames.RESEARCH_MODE
         and current_app.config.get("FF_SMS_RATELIMIT")
@@ -261,13 +263,14 @@ def choose_queue(notification: Notification, research_mode: bool, priority_queue
     Returns:
         str: The appropriate Celery queue for the notification as a string.
     """
-    # Custom SMS senders (dedicated numbers) always route to the throttled queue,
-    # even in research mode — the dedicated number must be respected.
-    if notification.notification_type == SMS_TYPE and notification.sends_with_custom_number():
-        return QueueNames.SEND_THROTTLED_SMS
-
+    # Research mode and test keys always take priority — notifications are simulated
+    # and must not consume capacity on production workers.
     if research_mode or notification.key_type == KEY_TYPE_TEST:
         return QueueNames.RESEARCH_MODE
+
+    # Custom SMS senders (dedicated numbers) route to the throttled queue.
+    if notification.notification_type == SMS_TYPE and notification.sends_with_custom_number():
+        return QueueNames.SEND_THROTTLED_SMS
 
     override_queue: Optional[str] = priority_queue
     if notification.notification_type == SMS_TYPE:
@@ -290,7 +293,7 @@ def choose_queue(notification: Notification, research_mode: bool, priority_queue
 def choose_deliver_task(notification):
     if notification.notification_type == SMS_TYPE:
         deliver_task = provider_tasks.deliver_sms
-        if notification.sends_with_custom_number():
+        if notification.sends_with_custom_number() and notification.queue_name != QueueNames.RESEARCH_MODE:
             deliver_task = provider_tasks.deliver_throttled_sms
         elif current_app.config.get("FF_SMS_RATELIMIT") and notification.queue_name != QueueNames.RESEARCH_MODE:
             deliver_task = provider_tasks.deliver_sms_rate_limited
@@ -313,7 +316,7 @@ def send_notification_to_queue(notification, research_mode, queue=None):
     # Final verification for the queue to send to and apply final stage overrides.
     if notification.notification_type == SMS_TYPE:
         deliver_task = provider_tasks.deliver_sms
-        if notification.sends_with_custom_number():
+        if notification.sends_with_custom_number() and queue != QueueNames.RESEARCH_MODE:
             deliver_task = provider_tasks.deliver_throttled_sms
             queue = QueueNames.SEND_THROTTLED_SMS
         elif current_app.config.get("FF_SMS_RATELIMIT") and queue != QueueNames.RESEARCH_MODE:

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -286,7 +286,10 @@ def choose_queue(notification: Notification, research_mode: bool, priority_queue
         if not priority_queue:
             override_queue = QueueNames.CREATE_LETTERS_PDF
 
-    assert override_queue is not None, "Queue should have been determined based on notification type and priority queue"
+    if override_queue is None:
+        raise ValueError(
+            f"Could not determine queue for notification type {notification.notification_type!r}"
+        )
     return override_queue
 
 

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -217,7 +217,7 @@ def db_save_and_send_notification(notification: Notification):
         if redis_store.get(redis.daily_limit_cache_key(service_id)):
             redis_store.incr(redis.daily_limit_cache_key(service_id))
 
-    # Pioritize sending per services within the same queue by default.
+    # Prioritize sending per services within the same queue by default.
     message_group_id: str = notification.service_id
     queue: str = notification.queue_name
     celery_params: list = [str(notification.id)]

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -249,7 +249,7 @@ def db_save_and_send_notification(notification: Notification):
         dao_delete_notifications_by_id(notification.id)
         raise
     current_app.logger.info(
-        f"{notification.notification_type} {notification.id} sent to the {notification.queue_name} queue for delivery"
+        f"{notification.notification_type} {notification.id} sent to the {queue} queue for delivery"
     )
 
 

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -261,15 +261,18 @@ def choose_queue(notification: Notification, research_mode: bool, priority_queue
     Returns:
         str: The appropriate Celery queue for the notification as a string.
     """
+    # Custom SMS senders (dedicated numbers) always route to the throttled queue,
+    # even in research mode — the dedicated number must be respected.
+    if notification.notification_type == SMS_TYPE and notification.sends_with_custom_number():
+        return QueueNames.SEND_THROTTLED_SMS
+
     if research_mode or notification.key_type == KEY_TYPE_TEST:
         return QueueNames.RESEARCH_MODE
 
     override_queue: Optional[str] = priority_queue
     if notification.notification_type == SMS_TYPE:
-        if notification.sends_with_custom_number():
-            override_queue = QueueNames.SEND_THROTTLED_SMS
         # Enable the SMS rate limit feature but without overriding throttled dedicated or research lanes.
-        elif not priority_queue and current_app.config.get("FF_SMS_RATELIMIT"):
+        if not priority_queue and current_app.config.get("FF_SMS_RATELIMIT"):
             override_queue = QueueNames.SEND_SMS_FAIR
         elif not priority_queue:
             override_queue = QueueNames.SEND_SMS_MEDIUM
@@ -289,7 +292,7 @@ def choose_deliver_task(notification):
         deliver_task = provider_tasks.deliver_sms
         if notification.sends_with_custom_number():
             deliver_task = provider_tasks.deliver_throttled_sms
-        elif current_app.config.get("FF_SMS_RATELIMIT"):
+        elif current_app.config.get("FF_SMS_RATELIMIT") and notification.queue_name != QueueNames.RESEARCH_MODE:
             deliver_task = provider_tasks.deliver_sms_rate_limited
     if notification.notification_type == EMAIL_TYPE:
         deliver_task = provider_tasks.deliver_email

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -248,9 +248,7 @@ def db_save_and_send_notification(notification: Notification):
     except Exception:
         dao_delete_notifications_by_id(notification.id)
         raise
-    current_app.logger.info(
-        f"{notification.notification_type} {notification.id} sent to the {queue} queue for delivery"
-    )
+    current_app.logger.info(f"{notification.notification_type} {notification.id} sent to the {queue} queue for delivery")
 
 
 def choose_queue(notification: Notification, research_mode: bool, priority_queue: Optional[str] = None) -> str:
@@ -287,9 +285,7 @@ def choose_queue(notification: Notification, research_mode: bool, priority_queue
             override_queue = QueueNames.CREATE_LETTERS_PDF
 
     if override_queue is None:
-        raise ValueError(
-            f"Could not determine queue for notification type {notification.notification_type!r}"
-        )
+        raise ValueError(f"Could not determine queue for notification type {notification.notification_type!r}")
     return override_queue
 
 

--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -309,7 +309,7 @@ def send_notification_to_queue(notification, research_mode, queue=None):
     if research_mode or notification.key_type == KEY_TYPE_TEST:
         queue = QueueNames.RESEARCH_MODE
 
-    # Pioritize sending per services within the same queue by default.
+    # Prioritize sending per services within the same queue by default.
     message_group_id: str = str(notification.service_id)
     celery_params: list = [str(notification.id)]
 

--- a/app/rate_limiter.py
+++ b/app/rate_limiter.py
@@ -6,6 +6,7 @@ This module provides rate limiting for SMS parts delivery. It enforces a cap
 on the number of SMS parts (fragments) that can be sent per minute.
 """
 
+import math
 from abc import ABC, abstractmethod
 from collections import deque
 from time import time
@@ -25,7 +26,7 @@ class RateLimiter(ABC):
     @abstractmethod
     def acquire_lease(self, parts_count: int) -> Tuple[bool, int]:
         """
-        Attempt to acquire capacity for the given number of SMS parts.
+        Attempt to acquire a lease for the given number of SMS parts.
 
         Args:
             parts_count (int): Number of SMS parts (fragments) to send.
@@ -40,7 +41,7 @@ class RateLimiter(ABC):
     @abstractmethod
     def reset_limiter(self):
         """
-        Reset the rate limiter state.
+        Reset the rate limiter.
         """
         pass
 
@@ -50,7 +51,7 @@ class RateLimiter(ABC):
         Get the current parts count in the active window.
 
         Returns:
-            int: Number of parts consumed in the current window.
+            int: Number of parts used in the current window.
         """
         pass
 
@@ -64,10 +65,12 @@ class InMemoryRateLimiter(RateLimiter):
 
     Algorithm:
     - Maintains a deque of (timestamp, parts_count) tuples.
+    - Keeps a running total (current_usage) updated on append/popleft.
     - On each acquire_lease(), removes entries older than 60 seconds.
-    - Sums remaining parts and checks if adding new parts exceeds the cap.
-    - If capacity available, records the entry and returns (True, 0).
-    - If capacity exhausted, calculates seconds until oldest entry expires.
+    - Checks if current_usage + new_parts exceeds the cap.
+    - If capacity available, records the entry and updates running total.
+    - If capacity exhausted, calculates when enough entries will have expired
+      to accommodate the new request.
     """
 
     WINDOW_SIZE_SECONDS = 60
@@ -82,6 +85,7 @@ class InMemoryRateLimiter(RateLimiter):
         """
         self.cap_per_minute = cap_per_minute
         self.window: deque = deque()  # Stores (timestamp, parts_count) tuples
+        self.current_usage: int = 0  # Running total of parts in the current window
 
     def acquire_lease(self, parts_count: int) -> Tuple[bool, int]:
         """
@@ -94,63 +98,75 @@ class InMemoryRateLimiter(RateLimiter):
             Tuple[bool, int]:
                 - (True, 0) if parts can be sent immediately.
                 - (False, seconds_remaining) if rate limit exhausted;
-                  seconds_remaining is the time until the oldest window entry expires.
+                  seconds_remaining is the time until enough entries expire to
+                  accommodate the requested parts.
         """
         if parts_count <= 0:
             raise ValueError("parts_count must be positive")
 
         now = time()
-        cutoff_time = now - self.WINDOW_SIZE_SECONDS
+        window_start = now - self.WINDOW_SIZE_SECONDS
 
-        # Remove entries older than the 60-second window
-        while self.window and self.window[0][0] < cutoff_time:
-            self.window.popleft()
-
-        # Sum parts in the current window
-        current_usage = sum(parts for _, parts in self.window)
+        # Remove entries older than the 60-second window and update running total
+        while self.window and self.window[0][0] < window_start:
+            _, old_parts = self.window.popleft()
+            self.current_usage -= old_parts
 
         # Check if adding new parts exceeds the cap
-        if current_usage + parts_count <= self.cap_per_minute:
-            # Capacity available: record the entry
+        if self.current_usage + parts_count <= self.cap_per_minute:
+            # Enough parts available: record the entry and update running total
             self.window.append((now, parts_count))
+            self.current_usage += parts_count
             current_app.logger.info(
-                f"SMS rate limiter: acquired {parts_count} parts. "
-                f"Window usage: {current_usage + parts_count}/{self.cap_per_minute}"
+                f"SMS rate limiter: acquired {parts_count} parts. " f"Window usage: {self.current_usage}/{self.cap_per_minute}"
             )
             return True, 0
 
-        # Capacity exhausted: calculate retry delay
-        if self.window:
-            oldest_timestamp = self.window[0][0]
-            seconds_until_oldest_expires = self.WINDOW_SIZE_SECONDS - (now - oldest_timestamp)
-            # Ensure at least 1 second to avoid busy-loop retries
-            seconds_to_wait = max(1, int(seconds_until_oldest_expires) + 1)
+        # Not enough capacity: calculate when enough parts will be available for the new request
+        remaining_parts_needed = self.current_usage + parts_count - self.cap_per_minute
+        parts_freed = 0
+        last_timestamp_to_wait_for = None
+
+        # Iterate through window entries (oldest first) to find when we'll have enough space
+        for timestamp, parts in self.window:
+            parts_freed += parts
+            last_timestamp_to_wait_for = timestamp
+            if parts_freed >= remaining_parts_needed:
+                # This entry needs to expire to free enough space
+                break
+
+        # Calculate seconds to wait for the last entry to expire
+        if last_timestamp_to_wait_for is not None:
+            seconds_until_expires = self.WINDOW_SIZE_SECONDS - (now - last_timestamp_to_wait_for)
+            seconds_to_wait = max(1, math.ceil(seconds_until_expires))
         else:
-            # Edge case: window is empty but cap is exceeded (shouldn't happen)
+            # Fallback (shouldn't reach here)
             seconds_to_wait = 1
 
         current_app.logger.warning(
             f"SMS rate limiter: capacity exhausted. Requested {parts_count} parts "
-            f"but only {self.cap_per_minute - current_usage} available in current window. "
+            f"but only {self.cap_per_minute - self.current_usage} available in current window. "
             f"Will retry in {seconds_to_wait} seconds."
         )
         return False, seconds_to_wait
 
     def reset_limiter(self):
-        """Reset the rate limiter (clears all entries)."""
+        """Reset the rate limiter (clears all entries and running total)."""
         self.window.clear()
+        self.current_usage = 0
         current_app.logger.info("SMS rate limiter: reset (window cleared)")
 
     def get_current_usage(self) -> int:
         """Get the current parts count in the active 60-second window."""
         now = time()
-        cutoff_time = now - self.WINDOW_SIZE_SECONDS
+        window_start = now - self.WINDOW_SIZE_SECONDS
 
-        # Remove stale entries first
-        while self.window and self.window[0][0] < cutoff_time:
-            self.window.popleft()
+        # Remove expired entries and update running total
+        while self.window and self.window[0][0] < window_start:
+            _, old_parts = self.window.popleft()
+            self.current_usage -= old_parts
 
-        return sum(parts for _, parts in self.window)
+        return self.current_usage
 
 
 # ============================================================================

--- a/app/rate_limiter.py
+++ b/app/rate_limiter.py
@@ -1,0 +1,203 @@
+# app/rate_limiter.py
+"""
+Rate Limiting Module
+
+This module provides rate limiting for SMS parts delivery. It enforces a cap
+on the number of SMS parts (fragments) that can be sent per minute.
+"""
+
+from abc import ABC, abstractmethod
+from collections import deque
+from time import time
+from typing import Tuple
+
+from flask import current_app
+
+
+class RateLimiter(ABC):
+    """
+    Abstract base class defining the rate limiter interface.
+
+    Implementations should track parts capacity over time and enforce limits.
+    Phase 2 will provide a Redis-backed implementation.
+    """
+
+    @abstractmethod
+    def acquire_lease(self, parts_count: int) -> Tuple[bool, int]:
+        """
+        Attempt to acquire capacity for the given number of SMS parts.
+
+        Args:
+            parts_count (int): Number of SMS parts (fragments) to send.
+
+        Returns:
+            Tuple[bool, int]:
+                - bool: True if parts can be sent now, False if rate limit hit.
+                - int: If True, returns 0. If False, returns seconds to wait before retry.
+        """
+        pass
+
+    @abstractmethod
+    def reset_limiter(self):
+        """
+        Reset the rate limiter state.
+        """
+        pass
+
+    @abstractmethod
+    def get_current_usage(self) -> int:
+        """
+        Get the current parts count in the active window.
+
+        Returns:
+            int: Number of parts consumed in the current window.
+        """
+        pass
+
+
+class InMemoryRateLimiter(RateLimiter):
+    """
+    In-memory SMS parts rate limiter using a 60-second sliding window.
+
+    This implementation tracks parts sent in the current minute and enforces
+    the configured parts cap.
+
+    Algorithm:
+    - Maintains a deque of (timestamp, parts_count) tuples.
+    - On each acquire_lease(), removes entries older than 60 seconds.
+    - Sums remaining parts and checks if adding new parts exceeds the cap.
+    - If capacity available, records the entry and returns (True, 0).
+    - If capacity exhausted, calculates seconds until oldest entry expires.
+    """
+
+    WINDOW_SIZE_SECONDS = 60
+
+    def __init__(self, cap_per_minute: int):
+        """
+        Initialize the in-memory rate limiter.
+
+        Args:
+            cap_per_minute (int): Maximum SMS parts allowed per minute.
+                                  E.g., 1000 parts/minute.
+        """
+        self.cap_per_minute = cap_per_minute
+        self.window: deque = deque()  # Stores (timestamp, parts_count) tuples
+
+    def acquire_lease(self, parts_count: int) -> Tuple[bool, int]:
+        """
+        Attempt to acquire capacity for SMS parts.
+
+        Args:
+            parts_count (int): Number of parts to send.
+
+        Returns:
+            Tuple[bool, int]:
+                - (True, 0) if parts can be sent immediately.
+                - (False, seconds_remaining) if rate limit exhausted;
+                  seconds_remaining is the time until the oldest window entry expires.
+        """
+        if parts_count <= 0:
+            raise ValueError("parts_count must be positive")
+
+        now = time()
+        cutoff_time = now - self.WINDOW_SIZE_SECONDS
+
+        # Remove entries older than the 60-second window
+        while self.window and self.window[0][0] < cutoff_time:
+            self.window.popleft()
+
+        # Sum parts in the current window
+        current_usage = sum(parts for _, parts in self.window)
+
+        # Check if adding new parts exceeds the cap
+        if current_usage + parts_count <= self.cap_per_minute:
+            # Capacity available: record the entry
+            self.window.append((now, parts_count))
+            current_app.logger.info(
+                f"SMS rate limiter: acquired {parts_count} parts. "
+                f"Window usage: {current_usage + parts_count}/{self.cap_per_minute}"
+            )
+            return True, 0
+
+        # Capacity exhausted: calculate retry delay
+        if self.window:
+            oldest_timestamp = self.window[0][0]
+            seconds_until_oldest_expires = self.WINDOW_SIZE_SECONDS - (now - oldest_timestamp)
+            # Ensure at least 1 second to avoid busy-loop retries
+            seconds_to_wait = max(1, int(seconds_until_oldest_expires) + 1)
+        else:
+            # Edge case: window is empty but cap is exceeded (shouldn't happen)
+            seconds_to_wait = 1
+
+        current_app.logger.warning(
+            f"SMS rate limiter: capacity exhausted. Requested {parts_count} parts "
+            f"but only {self.cap_per_minute - current_usage} available in current window. "
+            f"Will retry in {seconds_to_wait} seconds."
+        )
+        return False, seconds_to_wait
+
+    def reset_limiter(self):
+        """Reset the rate limiter (clears all entries)."""
+        self.window.clear()
+        current_app.logger.info("SMS rate limiter: reset (window cleared)")
+
+    def get_current_usage(self) -> int:
+        """Get the current parts count in the active 60-second window."""
+        now = time()
+        cutoff_time = now - self.WINDOW_SIZE_SECONDS
+
+        # Remove stale entries first
+        while self.window and self.window[0][0] < cutoff_time:
+            self.window.popleft()
+
+        return sum(parts for _, parts in self.window)
+
+
+# ============================================================================
+# Module-level instance: Global rate limiter for the entire application
+# ============================================================================
+# This instance is created once per Flask app and shared across all Celery tasks.
+# It tracks parts sent across all services globally (not per-service).
+#
+# In Phase 2, this will be replaced with a Redis-backed instance via feature flag
+# or environment configuration, without changing any task code.
+# ============================================================================
+
+_rate_limiter_instance: RateLimiter | None = None
+
+
+def initialize_rate_limiter(cap_per_minute: int) -> RateLimiter:
+    """
+    Initialize the global rate limiter instance.
+
+    Called during app initialization (see app/__init__.py).
+
+    Args:
+        cap_per_minute (int): Maximum SMS parts per minute.
+
+    Returns:
+        RateLimiter: The initialized rate limiter instance.
+    """
+    global _rate_limiter_instance
+    _rate_limiter_instance = InMemoryRateLimiter(cap_per_minute)
+    return _rate_limiter_instance
+
+
+def get_rate_limiter() -> RateLimiter:
+    """
+    Get the global rate limiter instance.
+
+    Call this from tasks to access the rate limiter.
+    Raises RuntimeError if initialize_rate_limiter() hasn't been called.
+
+    Returns:
+        RateLimiter: The global rate limiter instance.
+
+    Raises:
+        RuntimeError: If the rate limiter hasn't been initialized.
+    """
+    if _rate_limiter_instance is None:
+        raise RuntimeError(
+            "SMS rate limiter not initialized. " "Call initialize_rate_limiter() during app startup (app/__init__.py)."
+        )
+    return _rate_limiter_instance

--- a/app/rate_limiter.py
+++ b/app/rate_limiter.py
@@ -39,13 +39,6 @@ class RateLimiter(ABC):
         pass
 
     @abstractmethod
-    def reset_limiter(self):
-        """
-        Reset the rate limiter.
-        """
-        pass
-
-    @abstractmethod
     def get_current_usage(self) -> int:
         """
         Get the current parts count in the active window.
@@ -103,6 +96,9 @@ class InMemoryRateLimiter(RateLimiter):
         """
         if parts_count <= 0:
             raise ValueError("parts_count must be positive")
+
+        if parts_count > self.cap_per_minute:
+            raise ValueError("parts_count must be smaller than or equal to the cap_per_minute")
 
         now = time()
         window_start = now - self.WINDOW_SIZE_SECONDS

--- a/app/rate_limiter.py
+++ b/app/rate_limiter.py
@@ -275,7 +275,7 @@ class RedisRateLimiter(RateLimiter):
         """
         self.cap_per_minute = cap_per_minute
         self.redis_client = redis_client
-        self._lua_scripts = {}
+        self._lua_scripts: dict[str, object] = {}
 
     @property
     def redis(self):

--- a/app/rate_limiter.py
+++ b/app/rate_limiter.py
@@ -432,7 +432,9 @@ class RedisRateLimiter(RateLimiter):
             try:
                 current_usage += int(parts_str)
             except ValueError:
-                pass
+                current_app.logger.warning(
+                    f"SMS rate limiter (Redis): skipping malformed usage entry member={member!r}, parts={parts_str!r}"
+                )
 
         return current_usage
 

--- a/app/rate_limiter.py
+++ b/app/rate_limiter.py
@@ -166,13 +166,17 @@ class InMemoryRateLimiter(RateLimiter):
 
 
 # ============================================================================
-# Module-level instance: Global rate limiter for the entire application
+# Module-level rate limiter instance
 # ============================================================================
-# This instance is created once per Flask app and shared across all Celery tasks.
-# It tracks parts sent across all services globally (not per-service).
+# For the in-memory backend, this instance is process-local: it is shared only
+# within the current Python process (for example, one Flask/Celery worker
+# process) and is not coordinated across multiple Celery worker processes,
+# pods, or hosts.
 #
-# In Phase 2, this will be replaced with a Redis-backed instance via feature flag
-# or environment configuration, without changing any task code.
+# As a result, the in-memory backend does not provide a true global cap unless
+# deployment is constrained so that only a single worker process/pod consumes
+# the relevant queue. Phase 2 should use a Redis-backed implementation to
+# enforce a global cross-process rate limit without changing task code.
 # ============================================================================
 
 _rate_limiter_instance: RateLimiter | None = None

--- a/app/rate_limiter.py
+++ b/app/rate_limiter.py
@@ -219,8 +219,12 @@ def initialize_rate_limiter(cap_per_minute: int, use_redis: bool = False) -> Rat
             config_backend = getattr(Config, "SMS_RATE_LIMITER_BACKEND", "memory")
             if config_backend.lower() == "redis":
                 backend = "redis"
-        except Exception:
-            pass
+        except (ImportError, AttributeError) as exc:
+            logger.warning(
+                "SMS rate limiter: failed to read backend from config; "
+                "falling back to in-memory backend. Error: %s",
+                exc,
+            )
 
     # Create the appropriate backend
     if backend == "redis":

--- a/app/rate_limiter.py
+++ b/app/rate_limiter.py
@@ -221,8 +221,7 @@ def initialize_rate_limiter(cap_per_minute: int, use_redis: bool = False) -> Rat
                 backend = "redis"
         except (ImportError, AttributeError) as exc:
             logger.warning(
-                "SMS rate limiter: failed to read backend from config; "
-                "falling back to in-memory backend. Error: %s",
+                "SMS rate limiter: failed to read backend from config; " "falling back to in-memory backend. Error: %s",
                 exc,
             )
 

--- a/app/rate_limiter.py
+++ b/app/rate_limiter.py
@@ -228,7 +228,7 @@ def initialize_rate_limiter(cap_per_minute: int, use_redis: bool = False) -> Rat
     # Create the appropriate backend
     if backend == "redis":
         logger.info("SMS rate limiter: initializing with Redis backend")
-        _rate_limiter_instance = RedisRateLimiter(cap_per_minute)
+        _rate_limiter_instance = RedisZSetRateLimiter(cap_per_minute)
     else:
         logger.info("SMS rate limiter: initializing with in-memory backend")
         _rate_limiter_instance = InMemoryRateLimiter(cap_per_minute)
@@ -256,7 +256,7 @@ def get_rate_limiter() -> RateLimiter:
     return _rate_limiter_instance
 
 
-class RedisRateLimiter(RateLimiter):
+class RedisZSetRateLimiter(RateLimiter):
     """
     Redis-backed SMS parts rate limiter using a 60-second sliding window.
 

--- a/app/rate_limiter.py
+++ b/app/rate_limiter.py
@@ -178,20 +178,54 @@ class InMemoryRateLimiter(RateLimiter):
 _rate_limiter_instance: RateLimiter | None = None
 
 
-def initialize_rate_limiter(cap_per_minute: int) -> RateLimiter:
+def initialize_rate_limiter(cap_per_minute: int, use_redis: bool = False) -> RateLimiter:
     """
     Initialize the global rate limiter instance.
 
     Called during app initialization (see app/__init__.py).
 
+    The backend is chosen based on:
+    1. use_redis parameter (if provided)
+    2. Config value from app.config.SMS_RATE_LIMITER_BACKEND (if set to 'redis')
+    3. Default: InMemoryRateLimiter
+
     Args:
         cap_per_minute (int): Maximum SMS parts per minute.
+        use_redis (bool, optional): Force Redis backend if True, in-memory if False.
 
     Returns:
         RateLimiter: The initialized rate limiter instance.
     """
+    import logging
+
     global _rate_limiter_instance
-    _rate_limiter_instance = InMemoryRateLimiter(cap_per_minute)
+
+    logger = logging.getLogger(__name__)
+
+    # Determine which backend to use
+    backend = "memory"  # default
+
+    if use_redis is not None:
+        backend = "redis" if use_redis else "memory"
+    else:
+        # Check config
+        try:
+            from app.config import Config
+
+            config_backend = getattr(Config, "SMS_RATE_LIMITER_BACKEND", "memory")
+            if config_backend.lower() == "redis":
+                backend = "redis"
+        except Exception:
+            pass
+
+    # Create the appropriate backend
+    if backend == "redis":
+        logger.info("SMS rate limiter: initializing with Redis backend")
+        _rate_limiter_instance = RedisRateLimiter(cap_per_minute)
+    else:
+        logger.info("SMS rate limiter: initializing with in-memory backend")
+        _rate_limiter_instance = InMemoryRateLimiter(cap_per_minute)
+
     return _rate_limiter_instance
 
 
@@ -213,3 +247,188 @@ def get_rate_limiter() -> RateLimiter:
             "SMS rate limiter not initialized. " "Call initialize_rate_limiter() during app startup (app/__init__.py)."
         )
     return _rate_limiter_instance
+
+
+class RedisRateLimiter(RateLimiter):
+    """
+    Redis-backed SMS parts rate limiter using a 60-second sliding window.
+
+    Key structure:
+    - `sms:rate_limit:entries` (sorted set)
+      - Score: timestamp of when entry was added
+      - Member: "entry_id:parts_count" (parts count is encoded in the member)
+
+    This approach avoids separate key tracking and usage cache inconsistency.
+    Parts counts are extracted via regex when needed.
+    """
+
+    WINDOW_SIZE_SECONDS = 60
+    REDIS_KEY_ENTRIES = "sms:rate_limit:entries"
+
+    def __init__(self, cap_per_minute: int, redis_client=None):
+        """
+        Initialize the Redis-backed rate limiter.
+
+        Args:
+            cap_per_minute (int): Maximum SMS parts allowed per minute.
+            redis_client: Redis client instance. If None, uses app's redis_store.
+        """
+        self.cap_per_minute = cap_per_minute
+        self.redis_client = redis_client
+        self._lua_scripts = {}
+
+    @property
+    def redis(self):
+        # Lazy-load Redis client to avoid circular imports at init time.
+        if self.redis_client is not None:
+            return self.redis_client
+        from app import redis_store
+
+        return redis_store
+
+    def _get_acquire_lua_script(self):
+        if "acquire" not in self._lua_scripts:
+            lua_code = """
+            local entries_key = KEYS[1]
+
+            local cap_per_minute = tonumber(ARGV[1])
+            local parts_count = tonumber(ARGV[2])
+            local now = tonumber(ARGV[3])
+            local entry_id = ARGV[4]
+            local window_size = tonumber(ARGV[5])
+
+            local window_start = now - window_size
+
+            -- 1. Remove expired entries
+            redis.call('ZREMRANGEBYSCORE', entries_key, '-inf', '(' .. window_start)
+
+            -- 2. Compute current usage by summing parts from members
+            local current_usage = 0
+            local entries = redis.call('ZRANGE', entries_key, 0, -1)
+
+            for i = 1, #entries do
+                local member = entries[i]
+                local sep = string.find(member, ":")
+                local parts = tonumber(string.sub(member, sep + 1)) or 0
+                current_usage = current_usage + parts
+            end
+
+            -- 3. Check capacity
+            if current_usage + parts_count <= cap_per_minute then
+                local member = entry_id .. ":" .. parts_count
+
+                redis.call('ZADD', entries_key, now, member)
+                redis.call('EXPIRE', entries_key, window_size + 10)
+
+                return {1, 0}
+            else
+                -- 4. Calculate wait time
+                local remaining_needed = current_usage + parts_count - cap_per_minute
+                local parts_freed = 0
+                local last_timestamp_to_wait = nil
+
+                local entries_with_scores = redis.call('ZRANGE', entries_key, 0, -1, 'WITHSCORES')
+
+                for i = 1, #entries_with_scores, 2 do
+                    local member = entries_with_scores[i]
+                    local timestamp = tonumber(entries_with_scores[i + 1])
+
+                    local sep = string.find(member, ":")
+                    local parts = tonumber(string.sub(member, sep + 1)) or 0
+                    parts_freed = parts_freed + parts
+                    last_timestamp_to_wait = timestamp
+
+                    if parts_freed >= remaining_needed then
+                        break
+                    end
+                end
+
+                local seconds_to_wait = 1
+                if last_timestamp_to_wait ~= nil then
+                    local seconds_until_expires = window_size - (now - last_timestamp_to_wait)
+                    seconds_to_wait = math.max(1, math.ceil(seconds_until_expires))
+                end
+
+                return {0, seconds_to_wait}
+            end
+            """
+            self._lua_scripts["acquire"] = self.redis.register_script(lua_code)
+
+        return self._lua_scripts["acquire"]
+
+    def acquire_lease(self, parts_count: int) -> Tuple[bool, int]:
+        """
+        Attempt to acquire capacity for SMS parts.
+
+        Args:
+            parts_count (int): Number of parts (fragments) to send.
+
+        Returns:
+            Tuple[bool, int]:
+                - (True, 0) if parts can be sent immediately.
+                - (False, seconds_remaining) if rate limit exhausted;
+                  seconds_remaining is the time until enough entries expire to
+                  accommodate the requested parts.
+        """
+        if parts_count <= 0:
+            raise ValueError("parts_count must be positive")
+
+        if parts_count > self.cap_per_minute:
+            raise ValueError("parts_count must be smaller than or equal to the cap_per_minute")
+
+        import uuid
+
+        now = time()
+        entry_id = str(uuid.uuid4())
+
+        script = self._get_acquire_lua_script()
+        result = script(
+            keys=[self.REDIS_KEY_ENTRIES],
+            args=[
+                self.cap_per_minute,
+                parts_count,
+                now,
+                entry_id,
+                self.WINDOW_SIZE_SECONDS,
+            ],
+        )
+
+        success, wait_seconds = result[0], result[1]
+
+        if success:
+            current_app.logger.info(f"SMS rate limiter (Redis): acquired {parts_count} parts. " f"Entry ID: {entry_id}")
+        else:
+            current_app.logger.warning(
+                f"SMS rate limiter (Redis): capacity exhausted. Requested {parts_count} parts. "
+                f"Will retry in {wait_seconds} seconds."
+            )
+
+        return bool(success), wait_seconds
+
+    def get_current_usage(self) -> int:
+        """Get the current parts count in the active 60-second window from Redis."""
+        now = time()
+        window_start = now - self.WINDOW_SIZE_SECONDS
+
+        # Remove expired entries
+        self.redis.zremrangebyscore(self.REDIS_KEY_ENTRIES, "-inf", f"({window_start}")
+
+        # Recalculate usage by summing parts from members (encoded as "entry_id:parts")
+        current_usage = 0
+        entries = self.redis.zrange(self.REDIS_KEY_ENTRIES, 0, -1)
+        for member in entries:
+            # Extract parts count from member string format "entry_id:parts_count"
+            if isinstance(member, bytes):
+                member = member.decode("utf-8")
+            parts_str = member.split(":")[-1] if ":" in member else "0"
+            try:
+                current_usage += int(parts_str)
+            except ValueError:
+                pass
+
+        return current_usage
+
+    def reset_limiter(self):
+        self.redis.delete(self.REDIS_KEY_ENTRIES)
+
+        current_app.logger.info("SMS rate limiter entries cleared")

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -502,7 +502,7 @@ def process_sms_or_email_notification(
             notification.queue_name = choose_queue(
                 notification=notification,
                 research_mode=service.research_mode,
-                queue=get_delivery_queue_for_template(template),
+                priority_queue=get_delivery_queue_for_template(template),
             )
             db_save_and_send_notification(notification)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -13,131 +13,131 @@ files = [
 
 [[package]]
 name = "aiohttp"
-version = "3.13.4"
+version = "3.13.5"
 description = "Async http client/server framework (asyncio)"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "aiohttp-3.13.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:6290fe12fe8cefa6ea3c1c5b969d32c010dfe191d4392ff9b599a3f473cbe722"},
-    {file = "aiohttp-3.13.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7520d92c0e8fbbe63f36f20a5762db349ff574ad38ad7bc7732558a650439845"},
-    {file = "aiohttp-3.13.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d2710ae1e1b81d0f187883b6e9d66cecf8794b50e91aa1e73fc78bfb5503b5d9"},
-    {file = "aiohttp-3.13.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:717d17347567ded1e273aa09918650dfd6fd06f461549204570c7973537d4123"},
-    {file = "aiohttp-3.13.4-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:383880f7b8de5ac208fa829c7038d08e66377283b2de9e791b71e06e803153c2"},
-    {file = "aiohttp-3.13.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1867087e2c1963db1216aedf001efe3b129835ed2b05d97d058176a6d08b5726"},
-    {file = "aiohttp-3.13.4-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6234bf416a38d687c3ab7f79934d7fb2a42117a5b9813aca07de0a5398489023"},
-    {file = "aiohttp-3.13.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3cdd3393130bf6588962441ffd5bde1d3ea2d63a64afa7119b3f3ba349cebbe7"},
-    {file = "aiohttp-3.13.4-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0d0dbc6c76befa76865373d6aa303e480bb8c3486e7763530f7f6e527b471118"},
-    {file = "aiohttp-3.13.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:10fb7b53262cf4144a083c9db0d2b4d22823d6708270a9970c4627b248c6064c"},
-    {file = "aiohttp-3.13.4-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:eb10ce8c03850e77f4d9518961c227be569e12f71525a7e90d17bca04299921d"},
-    {file = "aiohttp-3.13.4-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:7c65738ac5ae32b8feef699a4ed0dc91a0c8618b347781b7461458bbcaaac7eb"},
-    {file = "aiohttp-3.13.4-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:6b335919ffbaf98df8ff3c74f7a6decb8775882632952fd1810a017e38f15aee"},
-    {file = "aiohttp-3.13.4-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:ec75fc18cb9f4aca51c2cbace20cf6716e36850f44189644d2d69a875d5e0532"},
-    {file = "aiohttp-3.13.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:463fa18a95c5a635d2b8c09babe240f9d7dbf2a2010a6c0b35d8c4dff2a0e819"},
-    {file = "aiohttp-3.13.4-cp310-cp310-win32.whl", hash = "sha256:13168f5645d9045522c6cef818f54295376257ed8d02513a37c2ef3046fc7a97"},
-    {file = "aiohttp-3.13.4-cp310-cp310-win_amd64.whl", hash = "sha256:a7058af1f53209fdf07745579ced525d38d481650a989b7aa4a3b484b901cdab"},
-    {file = "aiohttp-3.13.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:8ea0c64d1bcbf201b285c2246c51a0c035ba3bbd306640007bc5844a3b4658c1"},
-    {file = "aiohttp-3.13.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6f742e1fa45c0ed522b00ede565e18f97e4cf8d1883a712ac42d0339dfb0cce7"},
-    {file = "aiohttp-3.13.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6dcfb50ee25b3b7a1222a9123be1f9f89e56e67636b561441f0b304e25aaef8f"},
-    {file = "aiohttp-3.13.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3262386c4ff370849863ea93b9ea60fd59c6cf56bf8f93beac625cf4d677c04d"},
-    {file = "aiohttp-3.13.4-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:473bb5aa4218dd254e9ae4834f20e31f5a0083064ac0136a01a62ddbae2eaa42"},
-    {file = "aiohttp-3.13.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e56423766399b4c77b965f6aaab6c9546617b8994a956821cc507d00b91d978c"},
-    {file = "aiohttp-3.13.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8af249343fafd5ad90366a16d230fc265cf1149f26075dc9fe93cfd7c7173942"},
-    {file = "aiohttp-3.13.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bc0a5cf4f10ef5a2c94fdde488734b582a3a7a000b131263e27c9295bd682d9"},
-    {file = "aiohttp-3.13.4-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5c7ff1028e3c9fc5123a865ce17df1cb6424d180c503b8517afbe89aa566e6be"},
-    {file = "aiohttp-3.13.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ba5cf98b5dcb9bddd857da6713a503fa6d341043258ca823f0f5ab7ab4a94ee8"},
-    {file = "aiohttp-3.13.4-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:d85965d3ba21ee4999e83e992fecb86c4614d6920e40705501c0a1f80a583c12"},
-    {file = "aiohttp-3.13.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:49f0b18a9b05d79f6f37ddd567695943fcefb834ef480f17a4211987302b2dc7"},
-    {file = "aiohttp-3.13.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7f78cb080c86fbf765920e5f1ef35af3f24ec4314d6675d0a21eaf41f6f2679c"},
-    {file = "aiohttp-3.13.4-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:67a3ec705534a614b68bbf1c70efa777a21c3da3895d1c44510a41f5a7ae0453"},
-    {file = "aiohttp-3.13.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d6630ec917e85c5356b2295744c8a97d40f007f96a1c76bf1928dc2e27465393"},
-    {file = "aiohttp-3.13.4-cp311-cp311-win32.whl", hash = "sha256:54049021bc626f53a5394c29e8c444f726ee5a14b6e89e0ad118315b1f90f5e3"},
-    {file = "aiohttp-3.13.4-cp311-cp311-win_amd64.whl", hash = "sha256:c033f2bc964156030772d31cbf7e5defea181238ce1f87b9455b786de7d30145"},
-    {file = "aiohttp-3.13.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ee62d4471ce86b108b19c3364db4b91180d13fe3510144872d6bad5401957360"},
-    {file = "aiohttp-3.13.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c0fd8f41b54b58636402eb493afd512c23580456f022c1ba2db0f810c959ed0d"},
-    {file = "aiohttp-3.13.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4baa48ce49efd82d6b1a0be12d6a36b35e5594d1dd42f8bfba96ea9f8678b88c"},
-    {file = "aiohttp-3.13.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d738ebab9f71ee652d9dbd0211057690022201b11197f9a7324fd4dba128aa97"},
-    {file = "aiohttp-3.13.4-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0ce692c3468fa831af7dceed52edf51ac348cebfc8d3feb935927b63bd3e8576"},
-    {file = "aiohttp-3.13.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8e08abcfe752a454d2cb89ff0c08f2d1ecd057ae3e8cc6d84638de853530ebab"},
-    {file = "aiohttp-3.13.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5977f701b3fff36367a11087f30ea73c212e686d41cd363c50c022d48b011d8d"},
-    {file = "aiohttp-3.13.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:54203e10405c06f8b6020bd1e076ae0fe6c194adcee12a5a78af3ffa3c57025e"},
-    {file = "aiohttp-3.13.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:358a6af0145bc4dda037f13167bef3cce54b132087acc4c295c739d05d16b1c3"},
-    {file = "aiohttp-3.13.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:898ea1850656d7d61832ef06aa9846ab3ddb1621b74f46de78fbc5e1a586ba83"},
-    {file = "aiohttp-3.13.4-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:7bc30cceb710cf6a44e9617e43eebb6e3e43ad855a34da7b4b6a73537d8a6763"},
-    {file = "aiohttp-3.13.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4a31c0c587a8a038f19a4c7e60654a6c899c9de9174593a13e7cc6e15ff271f9"},
-    {file = "aiohttp-3.13.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:2062f675f3fe6e06d6113eb74a157fb9df58953ffed0cdb4182554b116545758"},
-    {file = "aiohttp-3.13.4-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:3d1ba8afb847ff80626d5e408c1fdc99f942acc877d0702fe137015903a220a9"},
-    {file = "aiohttp-3.13.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b08149419994cdd4d5eecf7fd4bc5986b5a9380285bcd01ab4c0d6bfca47b79d"},
-    {file = "aiohttp-3.13.4-cp312-cp312-win32.whl", hash = "sha256:fc432f6a2c4f720180959bc19aa37259651c1a4ed8af8afc84dd41c60f15f791"},
-    {file = "aiohttp-3.13.4-cp312-cp312-win_amd64.whl", hash = "sha256:6148c9ae97a3e8bff9a1fc9c757fa164116f86c100468339730e717590a3fb77"},
-    {file = "aiohttp-3.13.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:63dd5e5b1e43b8fb1e91b79b7ceba1feba588b317d1edff385084fcc7a0a4538"},
-    {file = "aiohttp-3.13.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:746ac3cc00b5baea424dacddea3ec2c2702f9590de27d837aa67004db1eebc6e"},
-    {file = "aiohttp-3.13.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bda8f16ea99d6a6705e5946732e48487a448be874e54a4f73d514660ff7c05d3"},
-    {file = "aiohttp-3.13.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4b061e7b5f840391e3f64d0ddf672973e45c4cfff7a0feea425ea24e51530fc2"},
-    {file = "aiohttp-3.13.4-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b252e8d5cd66184b570d0d010de742736e8a4fab22c58299772b0c5a466d4b21"},
-    {file = "aiohttp-3.13.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:20af8aad61d1803ff11152a26146d8d81c266aa8c5aa9b4504432abb965c36a0"},
-    {file = "aiohttp-3.13.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:13a5cc924b59859ad2adb1478e31f410a7ed46e92a2a619d6d1dd1a63c1a855e"},
-    {file = "aiohttp-3.13.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:534913dfb0a644d537aebb4123e7d466d94e3be5549205e6a31f72368980a81a"},
-    {file = "aiohttp-3.13.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:320e40192a2dcc1cf4b5576936e9652981ab596bf81eb309535db7e2f5b5672f"},
-    {file = "aiohttp-3.13.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9e587fcfce2bcf06526a43cb705bdee21ac089096f2e271d75de9c339db3100c"},
-    {file = "aiohttp-3.13.4-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:9eb9c2eea7278206b5c6c1441fdd9dc420c278ead3f3b2cc87f9b693698cc500"},
-    {file = "aiohttp-3.13.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:29be00c51972b04bf9d5c8f2d7f7314f48f96070ca40a873a53056e652e805f7"},
-    {file = "aiohttp-3.13.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:90c06228a6c3a7c9f776fe4fc0b7ff647fffd3bed93779a6913c804ae00c1073"},
-    {file = "aiohttp-3.13.4-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:a533ec132f05fd9a1d959e7f34184cd7d5e8511584848dab85faefbaac573069"},
-    {file = "aiohttp-3.13.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1c946f10f413836f82ea4cfb90200d2a59578c549f00857e03111cf45ad01ca5"},
-    {file = "aiohttp-3.13.4-cp313-cp313-win32.whl", hash = "sha256:48708e2706106da6967eff5908c78ca3943f005ed6bcb75da2a7e4da94ef8c70"},
-    {file = "aiohttp-3.13.4-cp313-cp313-win_amd64.whl", hash = "sha256:74a2eb058da44fa3a877a49e2095b591d4913308bb424c418b77beb160c55ce3"},
-    {file = "aiohttp-3.13.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:e0a2c961fc92abeff61d6444f2ce6ad35bb982db9fc8ff8a47455beacf454a57"},
-    {file = "aiohttp-3.13.4-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:153274535985a0ff2bff1fb6c104ed547cec898a09213d21b0f791a44b14d933"},
-    {file = "aiohttp-3.13.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:351f3171e2458da3d731ce83f9e6b9619e325c45cbd534c7759750cabf453ad7"},
-    {file = "aiohttp-3.13.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f989ac8bc5595ff761a5ccd32bdb0768a117f36dd1504b1c2c074ed5d3f4df9c"},
-    {file = "aiohttp-3.13.4-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d36fc1709110ec1e87a229b201dd3ddc32aa01e98e7868083a794609b081c349"},
-    {file = "aiohttp-3.13.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:42adaeea83cbdf069ab94f5103ce0787c21fb1a0153270da76b59d5578302329"},
-    {file = "aiohttp-3.13.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:92deb95469928cc41fd4b42a95d8012fa6df93f6b1c0a83af0ffbc4a5e218cde"},
-    {file = "aiohttp-3.13.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0c0c7c07c4257ef3a1df355f840bc62d133bcdef5c1c5ba75add3c08553e2eed"},
-    {file = "aiohttp-3.13.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f062c45de8a1098cb137a1898819796a2491aec4e637a06b03f149315dff4d8f"},
-    {file = "aiohttp-3.13.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:76093107c531517001114f0ebdb4f46858ce818590363e3e99a4a2280334454a"},
-    {file = "aiohttp-3.13.4-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:6f6ec32162d293b82f8b63a16edc80769662fbd5ae6fbd4936d3206a2c2cc63b"},
-    {file = "aiohttp-3.13.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:5903e2db3d202a00ad9f0ec35a122c005e85d90c9836ab4cda628f01edf425e2"},
-    {file = "aiohttp-3.13.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2d5bea57be7aca98dbbac8da046d99b5557c5cf4e28538c4c786313078aca09e"},
-    {file = "aiohttp-3.13.4-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:bcf0c9902085976edc0232b75006ef38f89686901249ce14226b6877f88464fb"},
-    {file = "aiohttp-3.13.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c3295f98bfeed2e867cab588f2a146a9db37a85e3ae9062abf46ba062bd29165"},
-    {file = "aiohttp-3.13.4-cp314-cp314-win32.whl", hash = "sha256:a598a5c5767e1369d8f5b08695cab1d8160040f796c4416af76fd773d229b3c9"},
-    {file = "aiohttp-3.13.4-cp314-cp314-win_amd64.whl", hash = "sha256:c555db4bc7a264bead5a7d63d92d41a1122fcd39cc62a4db815f45ad46f9c2c8"},
-    {file = "aiohttp-3.13.4-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:45abbbf09a129825d13c18c7d3182fecd46d9da3cfc383756145394013604ac1"},
-    {file = "aiohttp-3.13.4-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:74c80b2bc2c2adb7b3d1941b2b60701ee2af8296fc8aad8b8bc48bc25767266c"},
-    {file = "aiohttp-3.13.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c97989ae40a9746650fa196894f317dafc12227c808c774929dda0ff873a5954"},
-    {file = "aiohttp-3.13.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dae86be9811493f9990ef44fff1685f5c1a3192e9061a71a109d527944eed551"},
-    {file = "aiohttp-3.13.4-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:1db491abe852ca2fa6cc48a3341985b0174b3741838e1341b82ac82c8bd9e871"},
-    {file = "aiohttp-3.13.4-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0e5d701c0aad02a7dce72eef6b93226cf3734330f1a31d69ebbf69f33b86666e"},
-    {file = "aiohttp-3.13.4-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8ac32a189081ae0a10ba18993f10f338ec94341f0d5df8fff348043962f3c6f8"},
-    {file = "aiohttp-3.13.4-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:98e968cdaba43e45c73c3f306fca418c8009a957733bac85937c9f9cf3f4de27"},
-    {file = "aiohttp-3.13.4-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ca114790c9144c335d538852612d3e43ea0f075288f4849cf4b05d6cd2238ce7"},
-    {file = "aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ea2e071661ba9cfe11eabbc81ac5376eaeb3061f6e72ec4cc86d7cdd1ffbdbbb"},
-    {file = "aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:34e89912b6c20e0fd80e07fa401fd218a410aa1ce9f1c2f1dad6db1bd0ce0927"},
-    {file = "aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0e217cf9f6a42908c52b46e42c568bd57adc39c9286ced31aaace614b6087965"},
-    {file = "aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:0c296f1221e21ba979f5ac1964c3b78cfde15c5c5f855ffd2caab337e9cd9182"},
-    {file = "aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:d99a9d168ebaffb74f36d011750e490085ac418f4db926cce3989c8fe6cb6b1b"},
-    {file = "aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cb19177205d93b881f3f89e6081593676043a6828f59c78c17a0fd6c1fbed2ba"},
-    {file = "aiohttp-3.13.4-cp314-cp314t-win32.whl", hash = "sha256:c606aa5656dab6552e52ca368e43869c916338346bfaf6304e15c58fb113ea30"},
-    {file = "aiohttp-3.13.4-cp314-cp314t-win_amd64.whl", hash = "sha256:014dcc10ec8ab8db681f0d68e939d1e9286a5aa2b993cbbdb0db130853e02144"},
-    {file = "aiohttp-3.13.4-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:b3f00bb9403728b08eb3951e982ca0a409c7a871d709684623daeab79465b181"},
-    {file = "aiohttp-3.13.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:cb15595eb52870f84248d7cc97013a76f52ab02ff74d394be093b1d9b8b82bc0"},
-    {file = "aiohttp-3.13.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:907ad36b6a65cff7d88d7aca0f77c650546ba850a4f92c92ecb83590d4613249"},
-    {file = "aiohttp-3.13.4-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5539ec0d6a3a5c6799b661b7e79166ad1b7ae71ccb59a92fcb6b4ef89295bc94"},
-    {file = "aiohttp-3.13.4-cp39-cp39-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3b4e07d8803a70dd886b5f38588e5b49f894995ca8e132b06c31a2583ae2ef6e"},
-    {file = "aiohttp-3.13.4-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ce7320a945aac4bf0bb8901600e4f9409eb602f25ce3ef4d275b48f6d704a862"},
-    {file = "aiohttp-3.13.4-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:26ed03f7d3d6453634729e2c7600d7255d65e879559c5a48fe1bb78355cde74b"},
-    {file = "aiohttp-3.13.4-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4c3f733916e85506b8000dddc071c6b82f8c68f56c99adb328d6550017db062d"},
-    {file = "aiohttp-3.13.4-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b3d525648fe7c8b4977e460c18098f9f81d7991d72edfdc2f13cf96068f279bc"},
-    {file = "aiohttp-3.13.4-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:4e2e68085730a03704beb2cff035fa8648f62c9f93758d7e6d70add7f7bb5b3b"},
-    {file = "aiohttp-3.13.4-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:797613182ffaaca0b9ad5f3b3d3ce5d21242c768f75e66c750b8292bd97c9de3"},
-    {file = "aiohttp-3.13.4-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:2d15e7e4f1099d9e4d863eaf77a8eee5dcb002b7d7188061b0fbee37f845899e"},
-    {file = "aiohttp-3.13.4-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:19f60011ad60e40a01d242238bb335399e3a4d8df958c63cbb835add8d5c3b5a"},
-    {file = "aiohttp-3.13.4-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:c344c47e85678e410b064fc2ace14db86bb69db7ed5520c234bf13aed603ec30"},
-    {file = "aiohttp-3.13.4-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:d904084985ca66459e93797e5e05985c048a9c0633655331144c089943e53d12"},
-    {file = "aiohttp-3.13.4-cp39-cp39-win32.whl", hash = "sha256:1746338dc2a33cf706cd7446575d13d451f28f9860bebc908c7632b22e71ae3f"},
-    {file = "aiohttp-3.13.4-cp39-cp39-win_amd64.whl", hash = "sha256:a5444dce2e6fba0a1dc2d58d026e674f25f21de178c6f844342629bcef019f2f"},
-    {file = "aiohttp-3.13.4.tar.gz", hash = "sha256:d97a6d09c66087890c2ab5d49069e1e570583f7ac0314ecf98294c1b6aaebd38"},
+    {file = "aiohttp-3.13.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:02222e7e233295f40e011c1b00e3b0bd451f22cf853a0304c3595633ee47da4b"},
+    {file = "aiohttp-3.13.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bace460460ed20614fa6bc8cb09966c0b8517b8c58ad8046828c6078d25333b5"},
+    {file = "aiohttp-3.13.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8f546a4dc1e6a5edbb9fd1fd6ad18134550e096a5a43f4ad74acfbd834fc6670"},
+    {file = "aiohttp-3.13.5-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c86969d012e51b8e415a8c6ce96f7857d6a87d6207303ab02d5d11ef0cad2274"},
+    {file = "aiohttp-3.13.5-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b6f6cd1560c5fa427e3b6074bb24d2c64e225afbb7165008903bd42e4e33e28a"},
+    {file = "aiohttp-3.13.5-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:636bc362f0c5bbc7372bc3ae49737f9e3030dbce469f0f422c8f38079780363d"},
+    {file = "aiohttp-3.13.5-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6a7cbeb06d1070f1d14895eeeed4dac5913b22d7b456f2eb969f11f4b3993796"},
+    {file = "aiohttp-3.13.5-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bca9ef7517fd7874a1a08970ae88f497bf5c984610caa0bf40bd7e8450852b95"},
+    {file = "aiohttp-3.13.5-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:019a67772e034a0e6b9b17c13d0a8fe56ad9fb150fc724b7f3ffd3724288d9e5"},
+    {file = "aiohttp-3.13.5-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f34ecee82858e41dd217734f0c41a532bd066bcaab636ad830f03a30b2a96f2a"},
+    {file = "aiohttp-3.13.5-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:4eac02d9af4813ee289cd63a361576da36dba57f5a1ab36377bc2600db0cbb73"},
+    {file = "aiohttp-3.13.5-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:4beac52e9fe46d6abf98b0176a88154b742e878fdf209d2248e99fcdf73cd297"},
+    {file = "aiohttp-3.13.5-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:c180f480207a9b2475f2b8d8bd7204e47aec952d084b2a2be58a782ffcf96074"},
+    {file = "aiohttp-3.13.5-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:2837fb92951564d6339cedae4a7231692aa9f73cbc4fb2e04263b96844e03b4e"},
+    {file = "aiohttp-3.13.5-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:d9010032a0b9710f58012a1e9c222528763d860ba2ee1422c03473eab47703e7"},
+    {file = "aiohttp-3.13.5-cp310-cp310-win32.whl", hash = "sha256:7c4b6668b2b2b9027f209ddf647f2a4407784b5d88b8be4efcc72036f365baf9"},
+    {file = "aiohttp-3.13.5-cp310-cp310-win_amd64.whl", hash = "sha256:cd3db5927bf9167d5a6157ddb2f036f6b6b0ad001ac82355d43e97a4bde76d76"},
+    {file = "aiohttp-3.13.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7ab7229b6f9b5c1ba4910d6c41a9eb11f543eadb3f384df1b4c293f4e73d44d6"},
+    {file = "aiohttp-3.13.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8f14c50708bb156b3a3ca7230b3d820199d56a48e3af76fa21c2d6087190fe3d"},
+    {file = "aiohttp-3.13.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e7d2f8616f0ff60bd332022279011776c3ac0faa0f1b463f7bb12326fbc97a1c"},
+    {file = "aiohttp-3.13.5-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2567b72e1ffc3ab25510db43f355b29eeada56c0a622e58dcdb19530eb0a3cb"},
+    {file = "aiohttp-3.13.5-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:fb0540c854ac9c0c5ad495908fdfd3e332d553ec731698c0e29b1877ba0d2ec6"},
+    {file = "aiohttp-3.13.5-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c9883051c6972f58bfc4ebb2116345ee2aa151178e99c3f2b2bbe2af712abd13"},
+    {file = "aiohttp-3.13.5-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2294172ce08a82fb7c7273485895de1fa1186cc8294cfeb6aef4af42ad261174"},
+    {file = "aiohttp-3.13.5-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3a807cabd5115fb55af198b98178997a5e0e57dead43eb74a93d9c07d6d4a7dc"},
+    {file = "aiohttp-3.13.5-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa6d0d932e0f39c02b80744273cd5c388a2d9bc07760a03164f229c8e02662f6"},
+    {file = "aiohttp-3.13.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:60869c7ac4aaabe7110f26499f3e6e5696eae98144735b12a9c3d9eae2b51a49"},
+    {file = "aiohttp-3.13.5-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:26d2f8546f1dfa75efa50c3488215a903c0168d253b75fba4210f57ab77a0fb8"},
+    {file = "aiohttp-3.13.5-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f1162a1492032c82f14271e831c8f4b49f2b6078f4f5fc74de2c912fa225d51d"},
+    {file = "aiohttp-3.13.5-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:8b14eb3262fad0dc2f89c1a43b13727e709504972186ff6a99a3ecaa77102b6c"},
+    {file = "aiohttp-3.13.5-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:ca9ac61ac6db4eb6c2a0cd1d0f7e1357647b638ccc92f7e9d8d133e71ed3c6ac"},
+    {file = "aiohttp-3.13.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:7996023b2ed59489ae4762256c8516df9820f751cf2c5da8ed2fb20ee50abab3"},
+    {file = "aiohttp-3.13.5-cp311-cp311-win32.whl", hash = "sha256:77dfa48c9f8013271011e51c00f8ada19851f013cde2c48fca1ba5e0caf5bb06"},
+    {file = "aiohttp-3.13.5-cp311-cp311-win_amd64.whl", hash = "sha256:d3a4834f221061624b8887090637db9ad4f61752001eae37d56c52fddade2dc8"},
+    {file = "aiohttp-3.13.5-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:023ecba036ddd840b0b19bf195bfae970083fd7024ce1ac22e9bba90464620e9"},
+    {file = "aiohttp-3.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15c933ad7920b7d9a20de151efcd05a6e38302cbf0e10c9b2acb9a42210a2416"},
+    {file = "aiohttp-3.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab2899f9fa2f9f741896ebb6fa07c4c883bfa5c7f2ddd8cf2aafa86fa981b2d2"},
+    {file = "aiohttp-3.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a60eaa2d440cd4707696b52e40ed3e2b0f73f65be07fd0ef23b6b539c9c0b0b4"},
+    {file = "aiohttp-3.13.5-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:55b3bdd3292283295774ab585160c4004f4f2f203946997f49aac032c84649e9"},
+    {file = "aiohttp-3.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2b2355dc094e5f7d45a7bb262fe7207aa0460b37a0d87027dcf21b5d890e7d5"},
+    {file = "aiohttp-3.13.5-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b38765950832f7d728297689ad78f5f2cf79ff82487131c4d26fe6ceecdc5f8e"},
+    {file = "aiohttp-3.13.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b18f31b80d5a33661e08c89e202edabf1986e9b49c42b4504371daeaa11b47c1"},
+    {file = "aiohttp-3.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:33add2463dde55c4f2d9635c6ab33ce154e5ecf322bd26d09af95c5f81cfa286"},
+    {file = "aiohttp-3.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:327cc432fdf1356fb4fbc6fe833ad4e9f6aacb71a8acaa5f1855e4b25910e4a9"},
+    {file = "aiohttp-3.13.5-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:7c35b0bf0b48a70b4cb4fc5d7bed9b932532728e124874355de1a0af8ec4bc88"},
+    {file = "aiohttp-3.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:df23d57718f24badef8656c49743e11a89fd6f5358fa8a7b96e728fda2abf7d3"},
+    {file = "aiohttp-3.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:02e048037a6501a5ec1f6fc9736135aec6eb8a004ce48838cb951c515f32c80b"},
+    {file = "aiohttp-3.13.5-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:31cebae8b26f8a615d2b546fee45d5ffb76852ae6450e2a03f42c9102260d6fe"},
+    {file = "aiohttp-3.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:888e78eb5ca55a615d285c3c09a7a91b42e9dd6fc699b166ebd5dee87c9ccf14"},
+    {file = "aiohttp-3.13.5-cp312-cp312-win32.whl", hash = "sha256:8bd3ec6376e68a41f9f95f5ed170e2fcf22d4eb27a1f8cb361d0508f6e0557f3"},
+    {file = "aiohttp-3.13.5-cp312-cp312-win_amd64.whl", hash = "sha256:110e448e02c729bcebb18c60b9214a87ba33bac4a9fa5e9a5f139938b56c6cb1"},
+    {file = "aiohttp-3.13.5-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a5029cc80718bbd545123cd8fe5d15025eccaaaace5d0eeec6bd556ad6163d61"},
+    {file = "aiohttp-3.13.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4bb6bf5811620003614076bdc807ef3b5e38244f9d25ca5fe888eaccea2a9832"},
+    {file = "aiohttp-3.13.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a84792f8631bf5a94e52d9cc881c0b824ab42717165a5579c760b830d9392ac9"},
+    {file = "aiohttp-3.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:57653eac22c6a4c13eb22ecf4d673d64a12f266e72785ab1c8b8e5940d0e8090"},
+    {file = "aiohttp-3.13.5-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e5e5f7debc7a57af53fdf5c5009f9391d9f4c12867049d509bf7bb164a6e295b"},
+    {file = "aiohttp-3.13.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c719f65bebcdf6716f10e9eff80d27567f7892d8988c06de12bbbd39307c6e3a"},
+    {file = "aiohttp-3.13.5-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d97f93fdae594d886c5a866636397e2bcab146fd7a132fd6bb9ce182224452f8"},
+    {file = "aiohttp-3.13.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3df334e39d4c2f899a914f1dba283c1aadc311790733f705182998c6f7cae665"},
+    {file = "aiohttp-3.13.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fe6970addfea9e5e081401bcbadf865d2b6da045472f58af08427e108d618540"},
+    {file = "aiohttp-3.13.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7becdf835feff2f4f335d7477f121af787e3504b48b449ff737afb35869ba7bb"},
+    {file = "aiohttp-3.13.5-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:676e5651705ad5d8a70aeb8eb6936c436d8ebbd56e63436cb7dd9bb36d2a9a46"},
+    {file = "aiohttp-3.13.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:9b16c653d38eb1a611cc898c41e76859ca27f119d25b53c12875fd0474ae31a8"},
+    {file = "aiohttp-3.13.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:999802d5fa0389f58decd24b537c54aa63c01c3219ce17d1214cbda3c2b22d2d"},
+    {file = "aiohttp-3.13.5-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:ec707059ee75732b1ba130ed5f9580fe10ff75180c812bc267ded039db5128c6"},
+    {file = "aiohttp-3.13.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2d6d44a5b48132053c2f6cd5c8cb14bc67e99a63594e336b0f2af81e94d5530c"},
+    {file = "aiohttp-3.13.5-cp313-cp313-win32.whl", hash = "sha256:329f292ed14d38a6c4c435e465f48bebb47479fd676a0411936cc371643225cc"},
+    {file = "aiohttp-3.13.5-cp313-cp313-win_amd64.whl", hash = "sha256:69f571de7500e0557801c0b51f4780482c0ec5fe2ac851af5a92cfce1af1cb83"},
+    {file = "aiohttp-3.13.5-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:eb4639f32fd4a9904ab8fb45bf3383ba71137f3d9d4ba25b3b3f3109977c5b8c"},
+    {file = "aiohttp-3.13.5-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:7e5dc4311bd5ac493886c63cbf76ab579dbe4641268e7c74e48e774c74b6f2be"},
+    {file = "aiohttp-3.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:756c3c304d394977519824449600adaf2be0ccee76d206ee339c5e76b70ded25"},
+    {file = "aiohttp-3.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecc26751323224cf8186efcf7fbcbc30f4e1d8c7970659daf25ad995e4032a56"},
+    {file = "aiohttp-3.13.5-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:10a75acfcf794edf9d8db50e5a7ec5fc818b2a8d3f591ce93bc7b1210df016d2"},
+    {file = "aiohttp-3.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0f7a18f258d124cd678c5fe072fe4432a4d5232b0657fca7c1847f599233c83a"},
+    {file = "aiohttp-3.13.5-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:df6104c009713d3a89621096f3e3e88cc323fd269dbd7c20afe18535094320be"},
+    {file = "aiohttp-3.13.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:241a94f7de7c0c3b616627aaad530fe2cb620084a8b144d3be7b6ecfe95bae3b"},
+    {file = "aiohttp-3.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c974fb66180e58709b6fc402846f13791240d180b74de81d23913abe48e96d94"},
+    {file = "aiohttp-3.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:6e27ea05d184afac78aabbac667450c75e54e35f62238d44463131bd3f96753d"},
+    {file = "aiohttp-3.13.5-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a79a6d399cef33a11b6f004c67bb07741d91f2be01b8d712d52c75711b1e07c7"},
+    {file = "aiohttp-3.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c632ce9c0b534fbe25b52c974515ed674937c5b99f549a92127c85f771a78772"},
+    {file = "aiohttp-3.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:fceedde51fbd67ee2bcc8c0b33d0126cc8b51ef3bbde2f86662bd6d5a6f10ec5"},
+    {file = "aiohttp-3.13.5-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:f92995dfec9420bb69ae629abf422e516923ba79ba4403bc750d94fb4a6c68c1"},
+    {file = "aiohttp-3.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:20ae0ff08b1f2c8788d6fb85afcb798654ae6ba0b747575f8562de738078457b"},
+    {file = "aiohttp-3.13.5-cp314-cp314-win32.whl", hash = "sha256:b20df693de16f42b2472a9c485e1c948ee55524786a0a34345511afdd22246f3"},
+    {file = "aiohttp-3.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:f85c6f327bf0b8c29da7d93b1cabb6363fb5e4e160a32fa241ed2dce21b73162"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:1efb06900858bb618ff5cee184ae2de5828896c448403d51fb633f09e109be0a"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:fee86b7c4bd29bdaf0d53d14739b08a106fdda809ca5fe032a15f52fae5fe254"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:20058e23909b9e65f9da62b396b77dfa95965cbe840f8def6e572538b1d32e36"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cf20a8d6868cb15a73cab329ffc07291ba8c22b1b88176026106ae39aa6df0f"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:330f5da04c987f1d5bdb8ae189137c77139f36bd1cb23779ca1a354a4b027800"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f1cbf0c7926d315c3c26c2da41fd2b5d2fe01ac0e157b78caefc51a782196cf"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:53fc049ed6390d05423ba33103ded7281fe897cf97878f369a527070bd95795b"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:898703aa2667e3c5ca4c54ca36cd73f58b7a38ef87a5606414799ebce4d3fd3a"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0494a01ca9584eea1e5fbd6d748e61ecff218c51b576ee1999c23db7066417d8"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6cf81fe010b8c17b09495cbd15c1d35afbc8fb405c0c9cf4738e5ae3af1d65be"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:c564dd5f09ddc9d8f2c2d0a301cd30a79a2cc1b46dd1a73bef8f0038863d016b"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2994be9f6e51046c4f864598fd9abeb4fba6e88f0b2152422c9666dcd4aea9c6"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:157826e2fa245d2ef46c83ea8a5faf77ca19355d278d425c29fda0beb3318037"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:a8aca50daa9493e9e13c0f566201a9006f080e7c50e5e90d0b06f53146a54500"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3b13560160d07e047a93f23aaa30718606493036253d5430887514715b67c9d9"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-win32.whl", hash = "sha256:9a0f4474b6ea6818b41f82172d799e4b3d29e22c2c520ce4357856fced9af2f8"},
+    {file = "aiohttp-3.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:18a2f6c1182c51baa1d28d68fea51513cb2a76612f038853c0ad3c145423d3d9"},
+    {file = "aiohttp-3.13.5-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:347542f0ea3f95b2a955ee6656461fa1c776e401ac50ebce055a6c38454a0adf"},
+    {file = "aiohttp-3.13.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:178c7b5e62b454c2bc790786e6058c3cc968613b4419251b478c153a4aec32b1"},
+    {file = "aiohttp-3.13.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:af545c2cffdb0967a96b6249e6f5f7b0d92cdfd267f9d5238d5b9ca63e8edb10"},
+    {file = "aiohttp-3.13.5-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:206b7b3ef96e4ce211754f0cd003feb28b7d81f0ad26b8d077a5d5161436067f"},
+    {file = "aiohttp-3.13.5-cp39-cp39-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:ee5e86776273de1795947d17bddd6bb19e0365fd2af4289c0d2c5454b6b1d36b"},
+    {file = "aiohttp-3.13.5-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:95d14ca7abefde230f7639ec136ade282655431fd5db03c343b19dda72dd1643"},
+    {file = "aiohttp-3.13.5-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:912d4b6af530ddb1338a66229dac3a25ff11d4448be3ec3d6340583995f56031"},
+    {file = "aiohttp-3.13.5-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e999f0c88a458c836d5fb521814e92ed2172c649200336a6df514987c1488258"},
+    {file = "aiohttp-3.13.5-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:39380e12bd1f2fdab4285b6e055ad48efbaed5c836433b142ed4f5b9be71036a"},
+    {file = "aiohttp-3.13.5-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:9efcc0f11d850cefcafdd9275b9576ad3bfb539bed96807663b32ad99c4d4b88"},
+    {file = "aiohttp-3.13.5-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:147b4f501d0292077f29d5268c16bb7c864a1f054d7001c4c1812c0421ea1ed0"},
+    {file = "aiohttp-3.13.5-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:d147004fede1b12f6013a6dbb2a26a986a671a03c6ea740ddc76500e5f1c399f"},
+    {file = "aiohttp-3.13.5-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:9277145d36a01653863899c665243871434694bcc3431922c3b35c978061bdb8"},
+    {file = "aiohttp-3.13.5-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:4e704c52438f66fdd89588346183d898bb42167cf88f8b7ff1c0f9fc957c348f"},
+    {file = "aiohttp-3.13.5-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:a8a4d3427e8de1312ddf309cc482186466c79895b3a139fed3259fc01dfa9a5b"},
+    {file = "aiohttp-3.13.5-cp39-cp39-win32.whl", hash = "sha256:6f497a6876aa4b1a102b04996ce4c1170c7040d83faa9387dd921c16e30d5c83"},
+    {file = "aiohttp-3.13.5-cp39-cp39-win_amd64.whl", hash = "sha256:cb979826071c0986a5f08333a36104153478ce6018c58cba7f9caddaf63d5d67"},
+    {file = "aiohttp-3.13.5.tar.gz", hash = "sha256:9d98cc980ecc96be6eb4c1994ce35d28d8b1f5e5208a23b421187d1209dbb7d1"},
 ]
 
 [package.dependencies]
@@ -594,65 +594,66 @@ files = [
 
 [[package]]
 name = "celery"
-version = "5.4.0"
+version = "5.6.3"
 description = "Distributed Task Queue."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "celery-5.4.0-py3-none-any.whl", hash = "sha256:369631eb580cf8c51a82721ec538684994f8277637edde2dfc0dacd73ed97f64"},
-    {file = "celery-5.4.0.tar.gz", hash = "sha256:504a19140e8d3029d5acad88330c541d4c3f64c789d85f94756762d8bca7e706"},
+    {file = "celery-5.6.3-py3-none-any.whl", hash = "sha256:0808f42f80909c4d5833202360ffafb2a4f83f4d8e23e1285d926610e9a7afa6"},
+    {file = "celery-5.6.3.tar.gz", hash = "sha256:177006bd2054b882e9f01be59abd8529e88879ef50d7918a7050c5a9f4e12912"},
 ]
 
 [package.dependencies]
-billiard = ">=4.2.0,<5.0"
+billiard = ">=4.2.1,<5.0"
 boto3 = {version = ">=1.26.143", optional = true, markers = "extra == \"sqs\""}
 click = ">=8.1.2,<9.0"
 click-didyoumean = ">=0.3.0"
 click-plugins = ">=1.1.1"
 click-repl = ">=0.2.0"
 kombu = [
-    {version = ">=5.3.4,<6.0"},
-    {version = ">=5.3.4", extras = ["sqs"], optional = true, markers = "extra == \"sqs\""},
+    {version = ">=5.6.0"},
+    {version = ">=5.5.0", extras = ["sqs"], optional = true, markers = "extra == \"sqs\""},
 ]
-pycurl = {version = ">=7.43.0.5", optional = true, markers = "sys_platform != \"win32\" and platform_python_implementation == \"CPython\" and extra == \"sqs\""}
+pycurl = {version = ">=7.45.4", optional = true, markers = "sys_platform != \"win32\" and platform_python_implementation == \"CPython\" and python_version >= \"3.9\" and extra == \"sqs\""}
 python-dateutil = ">=2.8.2"
-tzdata = ">=2022.7"
+tzlocal = "*"
 urllib3 = {version = ">=1.26.16", optional = true, markers = "extra == \"sqs\""}
 vine = ">=5.1.0,<6.0"
 
 [package.extras]
 arangodb = ["pyArango (>=2.0.2)"]
-auth = ["cryptography (==42.0.5)"]
-azureblockblob = ["azure-storage-blob (>=12.15.0)"]
+auth = ["cryptography (==46.0.5)"]
+azureblockblob = ["azure-identity (>=1.19.0)", "azure-storage-blob (>=12.15.0)"]
 brotli = ["brotli (>=1.0.0)", "brotlipy (>=0.7.0)"]
 cassandra = ["cassandra-driver (>=3.25.0,<4)"]
 consul = ["python-consul2 (==0.1.5)"]
 cosmosdbsql = ["pydocumentdb (==2.3.5)"]
 couchbase = ["couchbase (>=3.0.0)"]
-couchdb = ["pycouchdb (==1.14.2)"]
+couchdb = ["pycouchdb (==1.16.0)"]
 django = ["Django (>=2.2.28)"]
 dynamodb = ["boto3 (>=1.26.143)"]
-elasticsearch = ["elastic-transport (<=8.13.0)", "elasticsearch (<=8.13.0)"]
+elasticsearch = ["elastic-transport (<=9.2.1)", "elasticsearch (<=9.3.0)"]
 eventlet = ["eventlet (>=0.32.0)"]
-gcs = ["google-cloud-storage (>=2.10.0)"]
+gcs = ["google-cloud-firestore (==2.23.0)", "google-cloud-storage (>=2.10.0)", "grpcio (==1.76.0)"]
 gevent = ["gevent (>=1.5.0)"]
 librabbitmq = ["librabbitmq (>=2.0.0)"]
 memcache = ["pylibmc (==1.6.3)"]
-mongodb = ["pymongo[srv] (>=4.0.2)"]
-msgpack = ["msgpack (==1.0.8)"]
+mongodb = ["kombu[mongodb]"]
+msgpack = ["kombu[msgpack]"]
+pydantic = ["pydantic (>=2.12.0a1)", "pydantic (>=2.4)"]
 pymemcache = ["python-memcached (>=1.61)"]
 pyro = ["pyro4 (==4.82)"]
-pytest = ["pytest-celery[all] (>=1.0.0)"]
-redis = ["redis (>=4.5.2,!=4.5.5,<6.0.0)"]
+pytest = ["pytest-celery[all] (>=1.3.0)"]
+redis = ["kombu[redis]"]
 s3 = ["boto3 (>=1.26.143)"]
-slmq = ["softlayer-messaging (>=1.0.3)"]
-solar = ["ephem (==4.1.5)"]
-sqlalchemy = ["sqlalchemy (>=1.4.48,<2.1)"]
-sqs = ["boto3 (>=1.26.143)", "kombu[sqs] (>=5.3.4)", "pycurl (>=7.43.0.5)", "urllib3 (>=1.26.16)"]
-tblib = ["tblib (>=1.3.0)", "tblib (>=1.5.0)"]
-yaml = ["PyYAML (>=3.10)"]
+slmq = ["softlayer_messaging (>=1.0.3)"]
+solar = ["ephem (==4.2)"]
+sqlalchemy = ["kombu[sqlalchemy]"]
+sqs = ["boto3 (>=1.26.143)", "kombu[sqs] (>=5.5.0)", "pycurl (>=7.43.0.5,<7.45.4)", "pycurl (>=7.45.4)", "urllib3 (>=1.26.16)"]
+tblib = ["tblib (==3.2.2)"]
+yaml = ["kombu[yaml]"]
 zookeeper = ["kazoo (>=1.3.1)"]
-zstd = ["zstandard (==0.22.0)"]
+zstd = ["zstandard (==0.23.0)"]
 
 [[package]]
 name = "certifi"
@@ -774,151 +775,151 @@ files = [
 
 [[package]]
 name = "charset-normalizer"
-version = "3.4.6"
+version = "3.4.7"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "charset_normalizer-3.4.6-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2e1d8ca8611099001949d1cdfaefc510cf0f212484fe7c565f735b68c78c3c95"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e25369dc110d58ddf29b949377a93e0716d72a24f62bad72b2b39f155949c1fd"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:259695e2ccc253feb2a016303543d691825e920917e31f894ca1a687982b1de4"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:dda86aba335c902b6149a02a55b38e96287157e609200811837678214ba2b1db"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:51fb3c322c81d20567019778cb5a4a6f2dc1c200b886bc0d636238e364848c89"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:4482481cb0572180b6fd976a4d5c72a30263e98564da68b86ec91f0fe35e8565"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:39f5068d35621da2881271e5c3205125cc456f54e9030d3f723288c873a71bf9"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:8bea55c4eef25b0b19a0337dc4e3f9a15b00d569c77211fa8cde38684f234fb7"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:f0cdaecd4c953bfae0b6bb64910aaaca5a424ad9c72d85cb88417bb9814f7550"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:150b8ce8e830eb7ccb029ec9ca36022f756986aaaa7956aad6d9ec90089338c0"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:e68c14b04827dd76dcbd1aeea9e604e3e4b78322d8faf2f8132c7138efa340a8"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:3778fd7d7cd04ae8f54651f4a7a0bd6e39a0cf20f801720a4c21d80e9b7ad6b0"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:dad6e0f2e481fffdcf776d10ebee25e0ef89f16d691f1e5dee4b586375fdc64b"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-win32.whl", hash = "sha256:74a2e659c7ecbc73562e2a15e05039f1e22c75b7c7618b4b574a3ea9118d1557"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-win_amd64.whl", hash = "sha256:aa9cccf4a44b9b62d8ba8b4dd06c649ba683e4bf04eea606d2e94cfc2d6ff4d6"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-win_arm64.whl", hash = "sha256:e985a16ff513596f217cee86c21371b8cd011c0f6f056d0920aa2d926c544058"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:82060f995ab5003a2d6e0f4ad29065b7672b6593c8c63559beefe5b443242c3e"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60c74963d8350241a79cb8feea80e54d518f72c26db618862a8f53e5023deaf9"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f6e4333fb15c83f7d1482a76d45a0818897b3d33f00efd215528ff7c51b8e35d"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bc72863f4d9aba2e8fd9085e63548a324ba706d2ea2c83b260da08a59b9482de"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9cc4fc6c196d6a8b76629a70ddfcd4635a6898756e2d9cac5565cf0654605d73"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:0c173ce3a681f309f31b87125fecec7a5d1347261ea11ebbb856fa6006b23c8c"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c907cdc8109f6c619e6254212e794d6548373cc40e1ec75e6e3823d9135d29cc"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:404a1e552cf5b675a87f0651f8b79f5f1e6fd100ee88dc612f89aa16abd4486f"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:e3c701e954abf6fc03a49f7c579cc80c2c6cc52525340ca3186c41d3f33482ef"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:7a6967aaf043bceabab5412ed6bd6bd26603dae84d5cb75bf8d9a74a4959d398"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:5feb91325bbceade6afab43eb3b508c63ee53579fe896c77137ded51c6b6958e"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:f820f24b09e3e779fe84c3c456cb4108a7aa639b0d1f02c28046e11bfcd088ed"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b35b200d6a71b9839a46b9b7fff66b6638bb52fc9658aa58796b0326595d3021"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-win32.whl", hash = "sha256:9ca4c0b502ab399ef89248a2c84c54954f77a070f28e546a85e91da627d1301e"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-win_amd64.whl", hash = "sha256:a9e68c9d88823b274cf1e72f28cb5dc89c990edf430b0bfd3e2fb0785bfeabf4"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-win_arm64.whl", hash = "sha256:97d0235baafca5f2b09cf332cc275f021e694e8362c6bb9c96fc9a0eb74fc316"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2ef7fedc7a6ecbe99969cd09632516738a97eeb8bd7258bf8a0f23114c057dab"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a4ea868bc28109052790eb2b52a9ab33f3aa7adc02f96673526ff47419490e21"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:836ab36280f21fc1a03c99cd05c6b7af70d2697e374c7af0b61ed271401a72a2"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f1ce721c8a7dfec21fcbdfe04e8f68174183cf4e8188e0645e92aa23985c57ff"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e28d62a8fc7a1fa411c43bd65e346f3bce9716dc51b897fbe930c5987b402d5"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:530d548084c4a9f7a16ed4a294d459b4f229db50df689bfe92027452452943a0"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:30f445ae60aad5e1f8bdbb3108e39f6fbc09f4ea16c815c66578878325f8f15a"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ac2393c73378fea4e52aa56285a3d64be50f1a12395afef9cce47772f60334c2"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:90ca27cd8da8118b18a52d5f547859cc1f8354a00cd1e8e5120df3e30d6279e5"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:8e5a94886bedca0f9b78fecd6afb6629142fd2605aa70a125d49f4edc6037ee6"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:695f5c2823691a25f17bc5d5ffe79fa90972cc34b002ac6c843bb8a1720e950d"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:231d4da14bcd9301310faf492051bee27df11f2bc7549bc0bb41fef11b82daa2"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a056d1ad2633548ca18ffa2f85c202cfb48b68615129143915b8dc72a806a923"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-win32.whl", hash = "sha256:c2274ca724536f173122f36c98ce188fd24ce3dad886ec2b7af859518ce008a4"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:c8ae56368f8cc97c7e40a7ee18e1cedaf8e780cd8bc5ed5ac8b81f238614facb"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:899d28f422116b08be5118ef350c292b36fc15ec2daeb9ea987c89281c7bb5c4"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:11afb56037cbc4b1555a34dd69151e8e069bee82e613a73bef6e714ce733585f"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:423fb7e748a08f854a08a222b983f4df1912b1daedce51a72bd24fe8f26a1843"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d73beaac5e90173ac3deb9928a74763a6d230f494e4bfb422c217a0ad8e629bf"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d60377dce4511655582e300dc1e5a5f24ba0cb229005a1d5c8d0cb72bb758ab8"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:530e8cebeea0d76bdcf93357aa5e41336f48c3dc709ac52da2bb167c5b8271d9"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:a26611d9987b230566f24a0a125f17fe0de6a6aff9f25c9f564aaa2721a5fb88"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:34315ff4fc374b285ad7f4a0bf7dcbfe769e1b104230d40f49f700d4ab6bbd84"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5f8ddd609f9e1af8c7bd6e2aca279c931aefecd148a14402d4e368f3171769fd"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:80d0a5615143c0b3225e5e3ef22c8d5d51f3f72ce0ea6fb84c943546c7b25b6c"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:92734d4d8d187a354a556626c221cd1a892a4e0802ccb2af432a1d85ec012194"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:613f19aa6e082cf96e17e3ffd89383343d0d589abda756b7764cf78361fd41dc"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:2b1a63e8224e401cafe7739f77efd3f9e7f5f2026bda4aead8e59afab537784f"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6cceb5473417d28edd20c6c984ab6fee6c6267d38d906823ebfe20b03d607dc2"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-win32.whl", hash = "sha256:d7de2637729c67d67cf87614b566626057e95c303bc0a55ffe391f5205e7003d"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:572d7c822caf521f0525ba1bce1a622a0b85cf47ffbdae6c9c19e3b5ac3c4389"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a4474d924a47185a06411e0064b803c68be044be2d60e50e8bddcc2649957c1f"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:9cc6e6d9e571d2f863fa77700701dae73ed5f78881efc8b3f9a4398772ff53e8"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef5960d965e67165d75b7c7ffc60a83ec5abfc5c11b764ec13ea54fbef8b4421"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b3694e3f87f8ac7ce279d4355645b3c878d24d1424581b46282f24b92f5a4ae2"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5d11595abf8dd942a77883a39d81433739b287b6aa71620f15164f8096221b30"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7bda6eebafd42133efdca535b04ccb338ab29467b3f7bf79569883676fc628db"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:bbc8c8650c6e51041ad1be191742b8b421d05bbd3410f43fa2a00c8db87678e8"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:22c6f0c2fbc31e76c3b8a86fba1a56eda6166e238c29cdd3d14befdb4a4e4815"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7edbed096e4a4798710ed6bc75dcaa2a21b68b6c356553ac4823c3658d53743a"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:7f9019c9cb613f084481bd6a100b12e1547cf2efe362d873c2e31e4035a6fa43"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:58c948d0d086229efc484fe2f30c2d382c86720f55cd9bc33591774348ad44e0"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:419a9d91bd238052642a51938af8ac05da5b3343becde08d5cdeab9046df9ee1"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:5273b9f0b5835ff0350c0828faea623c68bfa65b792720c453e22b25cc72930f"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:0e901eb1049fdb80f5bd11ed5ea1e498ec423102f7a9b9e4645d5b8204ff2815"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-win32.whl", hash = "sha256:b4ff1d35e8c5bd078be89349b6f3a845128e685e751b6ea1169cf2160b344c4d"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:74119174722c4349af9708993118581686f343adc1c8c9c007d59be90d077f3f"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:e5bcc1a1ae744e0bb59641171ae53743760130600da8db48cbb6e4918e186e4e"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ad8faf8df23f0378c6d527d8b0b15ea4a2e23c89376877c598c4870d1b2c7866"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f5ea69428fa1b49573eef0cc44a1d43bebd45ad0c611eb7d7eac760c7ae771bc"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:06a7e86163334edfc5d20fe104db92fcd666e5a5df0977cb5680a506fe26cc8e"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e1f6e2f00a6b8edb562826e4632e26d063ac10307e80f7461f7de3ad8ef3f077"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:95b52c68d64c1878818687a473a10547b3292e82b6f6fe483808fb1468e2f52f"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:7504e9b7dc05f99a9bbb4525c67a2c155073b44d720470a148b34166a69c054e"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:172985e4ff804a7ad08eebec0a1640ece87ba5041d565fff23c8f99c1f389484"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4be9f4830ba8741527693848403e2c457c16e499100963ec711b1c6f2049b7c7"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:79090741d842f564b1b2827c0b82d846405b744d31e84f18d7a7b41c20e473ff"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:87725cfb1a4f1f8c2fc9890ae2f42094120f4b44db9360be5d99a4c6b0e03a9e"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:fcce033e4021347d80ed9c66dcf1e7b1546319834b74445f561d2e2221de5659"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:ca0276464d148c72defa8bb4390cce01b4a0e425f3b50d1435aa6d7a18107602"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:197c1a244a274bb016dd8b79204850144ef77fe81c5b797dc389327adb552407"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-win32.whl", hash = "sha256:2a24157fa36980478dd1770b585c0f30d19e18f4fb0c47c13aa568f871718579"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:cd5e2801c89992ed8c0a3f0293ae83c159a60d9a5d685005383ef4caca77f2c4"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:47955475ac79cc504ef2704b192364e51d0d473ad452caedd0002605f780101c"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:659a1e1b500fac8f2779dd9e1570464e012f43e580371470b45277a27baa7532"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f61aa92e4aad0be58eb6eb4e0c21acf32cf8065f4b2cae5665da756c4ceef982"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f50498891691e0864dc3da965f340fada0771f6142a378083dc4608f4ea513e2"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bf625105bb9eef28a56a943fec8c8a98aeb80e7d7db99bd3c388137e6eb2d237"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2bd9d128ef93637a5d7a6af25363cf5dec3fa21cf80e68055aad627f280e8afa"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-manylinux_2_31_armv7l.whl", hash = "sha256:d08ec48f0a1c48d75d0356cea971921848fb620fdeba805b28f937e90691209f"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1ed80ff870ca6de33f4d953fda4d55654b9a2b340ff39ab32fa3adbcd718f264"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:f98059e4fcd3e3e4e2d632b7cf81c2faae96c43c60b569e9c621468082f1d104"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-musllinux_1_2_armv7l.whl", hash = "sha256:ab30e5e3e706e3063bc6de96b118688cb10396b70bb9864a430f67df98c61ecc"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:d5f5d1e9def3405f60e3ca8232d56f35c98fb7bf581efcc60051ebf53cb8b611"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-musllinux_1_2_riscv64.whl", hash = "sha256:461598cd852bfa5a61b09cae2b1c02e2efcd166ee5516e243d540ac24bfa68a7"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:71be7e0e01753a89cf024abf7ecb6bca2c81738ead80d43004d9b5e3f1244e64"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:df01808ee470038c3f8dc4f48620df7225c49c2d6639e38f96e6d6ac6e6f7b0e"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-win32.whl", hash = "sha256:69dd852c2f0ad631b8b60cfbe25a28c0058a894de5abb566619c205ce0550eae"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-win_amd64.whl", hash = "sha256:517ad0e93394ac532745129ceabdf2696b609ec9f87863d337140317ebce1c14"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:31215157227939b4fb3d740cd23fe27be0439afef67b785a1eb78a3ae69cba9e"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecbbd45615a6885fe3240eb9db73b9e62518b611850fdf8ab08bd56de7ad2b17"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c45a03a4c69820a399f1dda9e1d8fbf3562eda46e7720458180302021b08f778"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e8aeb10fcbe92767f0fa69ad5a72deca50d0dca07fbde97848997d778a50c9fe"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:54fae94be3d75f3e573c9a1b5402dc593de19377013c9a0e4285e3d402dd3a2a"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-manylinux_2_31_armv7l.whl", hash = "sha256:2f7fdd9b6e6c529d6a2501a2d36b240109e78a8ceaef5687cfcfa2bbe671d297"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d1d02209e06550bdaef34af58e041ad71b88e624f5d825519da3a3308e22687"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:8bc5f0687d796c05b1e28ab0d38a50e6309906ee09375dd3aff6a9c09dd6e8f4"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:ee4ec14bc1680d6b0afab9aea2ef27e26d2024f18b24a2d7155a52b60da7e833"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:d1a2ee9c1499fc8f86f4521f27a973c914b211ffa87322f4ee33bb35392da2c5"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:48696db7f18afb80a068821504296eb0787d9ce239b91ca15059d1d3eaacf13b"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:4f41da960b196ea355357285ad1316a00099f22d0929fe168343b99b254729c9"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:802168e03fba8bbc5ce0d866d589e4b1ca751d06edee69f7f3a19c5a9fe6b597"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-win32.whl", hash = "sha256:8761ac29b6c81574724322a554605608a9960769ea83d2c73e396f3df896ad54"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-win_amd64.whl", hash = "sha256:1cf0a70018692f85172348fe06d3a4b63f94ecb055e13a00c644d368eb82e5b8"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-win_arm64.whl", hash = "sha256:3516bbb8d42169de9e61b8520cbeeeb716f12f4ecfe3fd30a9919aa16c806ca8"},
-    {file = "charset_normalizer-3.4.6-py3-none-any.whl", hash = "sha256:947cf925bc916d90adba35a64c82aace04fa39b46b52d4630ece166655905a69"},
-    {file = "charset_normalizer-3.4.6.tar.gz", hash = "sha256:1ae6b62897110aa7c79ea2f5dd38d1abca6db663687c0b1ad9aed6f6bae3d9d6"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cdd68a1fb318e290a2077696b7eb7a21a49163c455979c639bf5a5dcdc46617d"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e17b8d5d6a8c47c85e68ca8379def1303fd360c3e22093a807cd34a71cd082b8"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:511ef87c8aec0783e08ac18565a16d435372bc1ac25a91e6ac7f5ef2b0bff790"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:007d05ec7321d12a40227aae9e2bc6dca73f3cb21058999a1df9e193555a9dcc"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf29836da5119f3c8a8a70667b0ef5fdca3bb12f80fd06487cfa575b3909b393"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:12d8baf840cc7889b37c7c770f478adea7adce3dcb3944d02ec87508e2dcf153"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d560742f3c0d62afaccf9f41fe485ed69bd7661a241f86a3ef0f0fb8b1a397af"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b14b2d9dac08e28bb8046a1a0434b1750eb221c8f5b87a68f4fa11a6f97b5e34"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:bc17a677b21b3502a21f66a8cc64f5bfad4df8a0b8434d661666f8ce90ac3af1"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:750e02e074872a3fad7f233b47734166440af3cdea0add3e95163110816d6752"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:4e5163c14bffd570ef2affbfdd77bba66383890797df43dc8b4cc7d6f500bf53"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:6ed74185b2db44f41ef35fd1617c5888e59792da9bbc9190d6c7300617182616"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:94e1885b270625a9a828c9793b4d52a64445299baa1fea5a173bf1d3dd9a1a5a"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-win32.whl", hash = "sha256:6785f414ae0f3c733c437e0f3929197934f526d19dfaa75e18fdb4f94c6fb374"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-win_amd64.whl", hash = "sha256:6696b7688f54f5af4462118f0bfa7c1621eeb87154f77fa04b9295ce7a8f2943"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-win_arm64.whl", hash = "sha256:66671f93accb62ed07da56613636f3641f1a12c13046ce91ffc923721f23c008"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:e5f4d355f0a2b1a31bc3edec6795b46324349c9cb25eed068049e4f472fb4259"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16d971e29578a5e97d7117866d15889a4a07befe0e87e703ed63cd90cb348c01"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:dca4bbc466a95ba9c0234ef56d7dd9509f63da22274589ebd4ed7f1f4d4c54e3"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e80c8378d8f3d83cd3164da1ad2df9e37a666cdde7b1cb2298ed0b558064be30"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:36836d6ff945a00b88ba1e4572d721e60b5b8c98c155d465f56ad19d68f23734"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-manylinux_2_31_armv7l.whl", hash = "sha256:bd9b23791fe793e4968dba0c447e12f78e425c59fc0e3b97f6450f4781f3ee60"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aef65cd602a6d0e0ff6f9930fcb1c8fec60dd2cfcb6facaf4bdb0e5873042db0"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:82b271f5137d07749f7bf32f70b17ab6eaabedd297e75dce75081a24f76eb545"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_armv7l.whl", hash = "sha256:1efde3cae86c8c273f1eb3b287be7d8499420cf2fe7585c41d370d3e790054a5"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:c593052c465475e64bbfe5dbd81680f64a67fdc752c56d7a0ae205dc8aeefe0f"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_riscv64.whl", hash = "sha256:af21eb4409a119e365397b2adbaca4c9ccab56543a65d5dbd9f920d6ac29f686"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:84c018e49c3bf790f9c2771c45e9313a08c2c2a6342b162cd650258b57817706"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:dd915403e231e6b1809fe9b6d9fc55cf8fb5e02765ac625d9cd623342a7905d7"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-win32.whl", hash = "sha256:320ade88cfb846b8cd6b4ddf5ee9e80ee0c1f52401f2456b84ae1ae6a1a5f207"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-win_amd64.whl", hash = "sha256:1dc8b0ea451d6e69735094606991f32867807881400f808a106ee1d963c46a83"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:177a0ba5f0211d488e295aaf82707237e331c24788d8d76c96c5a41594723217"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e0d51f618228538a3e8f46bd246f87a6cd030565e015803691603f55e12afb5"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:14265bfe1f09498b9d8ec91e9ec9fa52775edf90fcbde092b25f4a33d444fea9"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:87fad7d9ba98c86bcb41b2dc8dbb326619be2562af1f8ff50776a39e55721c5a"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f22dec1690b584cea26fade98b2435c132c1b5f68e39f5a0b7627cd7ae31f1dc"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-manylinux_2_31_armv7l.whl", hash = "sha256:d61f00a0869d77422d9b2aba989e2d24afa6ffd552af442e0e58de4f35ea6d00"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6370e8686f662e6a3941ee48ed4742317cafbe5707e36406e9df792cdb535776"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:a6c5863edfbe888d9eff9c8b8087354e27618d9da76425c119293f11712a6319"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:ed065083d0898c9d5b4bbec7b026fd755ff7454e6e8b73a67f8c744b13986e24"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:2cd4a60d0e2fb04537162c62bbbb4182f53541fe0ede35cdf270a1c1e723cc42"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:813c0e0132266c08eb87469a642cb30aaff57c5f426255419572aaeceeaa7bf4"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:07d9e39b01743c3717745f4c530a6349eadbfa043c7577eef86c502c15df2c67"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:c0f081d69a6e58272819b70288d3221a6ee64b98df852631c80f293514d3b274"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-win32.whl", hash = "sha256:8751d2787c9131302398b11e6c8068053dcb55d5a8964e114b6e196cf16cb366"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-win_amd64.whl", hash = "sha256:12a6fff75f6bc66711b73a2f0addfc4c8c15a20e805146a02d147a318962c444"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-win_arm64.whl", hash = "sha256:bb8cc7534f51d9a017b93e3e85b260924f909601c3df002bcdb58ddb4dc41a5c"},
+    {file = "charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d"},
+    {file = "charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5"},
 ]
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.3.3"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.10"
 files = [
-    {file = "click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6"},
-    {file = "click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a"},
+    {file = "click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613"},
+    {file = "click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2"},
 ]
 
 [package.dependencies]
@@ -1254,13 +1255,13 @@ pcsc = ["pyscard (>=1.9,<3)"]
 
 [[package]]
 name = "filelock"
-version = "3.25.2"
+version = "3.29.0"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.10"
 files = [
-    {file = "filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70"},
-    {file = "filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694"},
+    {file = "filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258"},
+    {file = "filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90"},
 ]
 
 [[package]]
@@ -1390,7 +1391,7 @@ tests = ["coverage", "pytest", "pytest-mock"]
 
 [[package]]
 name = "Flask-SQLAlchemy"
-version = "2.3.2"
+version = "2.3.2.dev20260422"
 description = "Adds SQLAlchemy support to your Flask application"
 optional = false
 python-versions = "*"
@@ -1851,13 +1852,13 @@ tornado = ["tornado (>=0.2)"]
 
 [[package]]
 name = "identify"
-version = "2.6.18"
+version = "2.6.19"
 description = "File identification library for Python"
 optional = false
 python-versions = ">=3.10"
 files = [
-    {file = "identify-2.6.18-py2.py3-none-any.whl", hash = "sha256:8db9d3c8ea9079db92cafb0ebf97abdc09d52e97f4dcf773a2e694048b7cd737"},
-    {file = "identify-2.6.18.tar.gz", hash = "sha256:873ac56a5e3fd63e7438a7ecbc4d91aca692eb3fefa4534db2b7913f3fc352fd"},
+    {file = "identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a"},
+    {file = "identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842"},
 ]
 
 [package.extras]
@@ -2028,10 +2029,8 @@ version = "5.6.2"
 description = "Messaging library for Python."
 optional = false
 python-versions = ">=3.9"
-files = [
-    {file = "kombu-5.6.2-py3-none-any.whl", hash = "sha256:efcfc559da324d41d61ca311b0c64965ea35b4c55cc04ee36e55386145dace93"},
-    {file = "kombu-5.6.2.tar.gz", hash = "sha256:8060497058066c6f5aed7c26d7cd0d3b574990b09de842a8c5aaed0b92cc5a55"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 amqp = ">=5.1.1,<6.0.0"
@@ -2047,18 +2046,24 @@ azureservicebus = ["azure-servicebus (>=7.10.0)"]
 azurestoragequeues = ["azure-identity (>=1.12.0)", "azure-storage-queue (>=12.6.0)"]
 confluentkafka = ["confluent-kafka (>=2.2.0)"]
 consul = ["python-consul2 (==0.1.5)"]
-gcpubsub = ["google-cloud-monitoring (>=2.16.0)", "google-cloud-pubsub (>=2.18.4)", "grpcio (==1.75.1)", "protobuf (==6.32.1)"]
+gcpubsub = ["google-cloud-monitoring (>=2.16.0)", "google-cloud-pubsub (>=2.18.4)", "grpcio (==1.76.0)", "protobuf (==6.33.5)"]
 librabbitmq = ["librabbitmq (>=2.0.0)"]
 mongodb = ["pymongo (==4.15.3)"]
 msgpack = ["msgpack (==1.1.2)"]
 pyro = ["pyro4 (==4.82)"]
 qpid = ["qpid-python (==1.36.0-1)", "qpid-tools (==1.36.0-1)"]
-redis = ["redis (>=4.5.2,!=4.5.5,!=5.0.2,<6.5)"]
+redis = ["redis (>=4.5.2,!=4.5.5,!=5.0.2,<7.1)"]
 slmq = ["softlayer_messaging (>=1.0.3)"]
 sqlalchemy = ["sqlalchemy (>=1.4.48,<2.1)"]
 sqs = ["boto3 (>=1.26.143)", "pycurl (>=7.43.0.5)", "urllib3 (>=1.26.16)"]
 yaml = ["PyYAML (>=3.10)"]
 zookeeper = ["kazoo (>=2.8.0)"]
+
+[package.source]
+type = "git"
+url = "https://github.com/celery/kombu.git"
+reference = "860e40a6c904c4d8551577d9f4e8c00f03b6e06c"
+resolved_reference = "860e40a6c904c4d8551577d9f4e8c00f03b6e06c"
 
 [[package]]
 name = "locust"
@@ -2087,151 +2092,145 @@ Werkzeug = ">=2.0.0"
 
 [[package]]
 name = "lxml"
-version = "6.0.2"
+version = "6.1.0"
 description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "lxml-6.0.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e77dd455b9a16bbd2a5036a63ddbd479c19572af81b624e79ef422f929eef388"},
-    {file = "lxml-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5d444858b9f07cefff6455b983aea9a67f7462ba1f6cbe4a21e8bf6791bf2153"},
-    {file = "lxml-6.0.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f952dacaa552f3bb8834908dddd500ba7d508e6ea6eb8c52eb2d28f48ca06a31"},
-    {file = "lxml-6.0.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:71695772df6acea9f3c0e59e44ba8ac50c4f125217e84aab21074a1a55e7e5c9"},
-    {file = "lxml-6.0.2-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:17f68764f35fd78d7c4cc4ef209a184c38b65440378013d24b8aecd327c3e0c8"},
-    {file = "lxml-6.0.2-cp310-cp310-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:058027e261afed589eddcfe530fcc6f3402d7fd7e89bfd0532df82ebc1563dba"},
-    {file = "lxml-6.0.2-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a8ffaeec5dfea5881d4c9d8913a32d10cfe3923495386106e4a24d45300ef79c"},
-    {file = "lxml-6.0.2-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:f2e3b1a6bb38de0bc713edd4d612969dd250ca8b724be8d460001a387507021c"},
-    {file = "lxml-6.0.2-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d6690ec5ec1cce0385cb20896b16be35247ac8c2046e493d03232f1c2414d321"},
-    {file = "lxml-6.0.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f2a50c3c1d11cad0ebebbac357a97b26aa79d2bcaf46f256551152aa85d3a4d1"},
-    {file = "lxml-6.0.2-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:3efe1b21c7801ffa29a1112fab3b0f643628c30472d507f39544fd48e9549e34"},
-    {file = "lxml-6.0.2-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:59c45e125140b2c4b33920d21d83681940ca29f0b83f8629ea1a2196dc8cfe6a"},
-    {file = "lxml-6.0.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:452b899faa64f1805943ec1c0c9ebeaece01a1af83e130b69cdefeda180bb42c"},
-    {file = "lxml-6.0.2-cp310-cp310-win32.whl", hash = "sha256:1e786a464c191ca43b133906c6903a7e4d56bef376b75d97ccbb8ec5cf1f0a4b"},
-    {file = "lxml-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:dacf3c64ef3f7440e3167aa4b49aa9e0fb99e0aa4f9ff03795640bf94531bcb0"},
-    {file = "lxml-6.0.2-cp310-cp310-win_arm64.whl", hash = "sha256:45f93e6f75123f88d7f0cfd90f2d05f441b808562bf0bc01070a00f53f5028b5"},
-    {file = "lxml-6.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:13e35cbc684aadf05d8711a5d1b5857c92e5e580efa9a0d2be197199c8def607"},
-    {file = "lxml-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3b1675e096e17c6fe9c0e8c81434f5736c0739ff9ac6123c87c2d452f48fc938"},
-    {file = "lxml-6.0.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac6e5811ae2870953390452e3476694196f98d447573234592d30488147404d"},
-    {file = "lxml-6.0.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5aa0fc67ae19d7a64c3fe725dc9a1bb11f80e01f78289d05c6f62545affec438"},
-    {file = "lxml-6.0.2-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:de496365750cc472b4e7902a485d3f152ecf57bd3ba03ddd5578ed8ceb4c5964"},
-    {file = "lxml-6.0.2-cp311-cp311-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:200069a593c5e40b8f6fc0d84d86d970ba43138c3e68619ffa234bc9bb806a4d"},
-    {file = "lxml-6.0.2-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d2de809c2ee3b888b59f995625385f74629707c9355e0ff856445cdcae682b7"},
-    {file = "lxml-6.0.2-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:b2c3da8d93cf5db60e8858c17684c47d01fee6405e554fb55018dd85fc23b178"},
-    {file = "lxml-6.0.2-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:442de7530296ef5e188373a1ea5789a46ce90c4847e597856570439621d9c553"},
-    {file = "lxml-6.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2593c77efde7bfea7f6389f1ab249b15ed4aa5bc5cb5131faa3b843c429fbedb"},
-    {file = "lxml-6.0.2-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:3e3cb08855967a20f553ff32d147e14329b3ae70ced6edc2f282b94afbc74b2a"},
-    {file = "lxml-6.0.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:2ed6c667fcbb8c19c6791bbf40b7268ef8ddf5a96940ba9404b9f9a304832f6c"},
-    {file = "lxml-6.0.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b8f18914faec94132e5b91e69d76a5c1d7b0c73e2489ea8929c4aaa10b76bbf7"},
-    {file = "lxml-6.0.2-cp311-cp311-win32.whl", hash = "sha256:6605c604e6daa9e0d7f0a2137bdc47a2e93b59c60a65466353e37f8272f47c46"},
-    {file = "lxml-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e5867f2651016a3afd8dd2c8238baa66f1e2802f44bc17e236f547ace6647078"},
-    {file = "lxml-6.0.2-cp311-cp311-win_arm64.whl", hash = "sha256:4197fb2534ee05fd3e7afaab5d8bfd6c2e186f65ea7f9cd6a82809c887bd1285"},
-    {file = "lxml-6.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a59f5448ba2ceccd06995c95ea59a7674a10de0810f2ce90c9006f3cbc044456"},
-    {file = "lxml-6.0.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e8113639f3296706fbac34a30813929e29247718e88173ad849f57ca59754924"},
-    {file = "lxml-6.0.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a8bef9b9825fa8bc816a6e641bb67219489229ebc648be422af695f6e7a4fa7f"},
-    {file = "lxml-6.0.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:65ea18d710fd14e0186c2f973dc60bb52039a275f82d3c44a0e42b43440ea534"},
-    {file = "lxml-6.0.2-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c371aa98126a0d4c739ca93ceffa0fd7a5d732e3ac66a46e74339acd4d334564"},
-    {file = "lxml-6.0.2-cp312-cp312-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:700efd30c0fa1a3581d80a748157397559396090a51d306ea59a70020223d16f"},
-    {file = "lxml-6.0.2-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c33e66d44fe60e72397b487ee92e01da0d09ba2d66df8eae42d77b6d06e5eba0"},
-    {file = "lxml-6.0.2-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90a345bbeaf9d0587a3aaffb7006aa39ccb6ff0e96a57286c0cb2fd1520ea192"},
-    {file = "lxml-6.0.2-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:064fdadaf7a21af3ed1dcaa106b854077fbeada827c18f72aec9346847cd65d0"},
-    {file = "lxml-6.0.2-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fbc74f42c3525ac4ffa4b89cbdd00057b6196bcefe8bce794abd42d33a018092"},
-    {file = "lxml-6.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6ddff43f702905a4e32bc24f3f2e2edfe0f8fde3277d481bffb709a4cced7a1f"},
-    {file = "lxml-6.0.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:6da5185951d72e6f5352166e3da7b0dc27aa70bd1090b0eb3f7f7212b53f1bb8"},
-    {file = "lxml-6.0.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:57a86e1ebb4020a38d295c04fc79603c7899e0df71588043eb218722dabc087f"},
-    {file = "lxml-6.0.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:2047d8234fe735ab77802ce5f2297e410ff40f5238aec569ad7c8e163d7b19a6"},
-    {file = "lxml-6.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6f91fd2b2ea15a6800c8e24418c0775a1694eefc011392da73bc6cef2623b322"},
-    {file = "lxml-6.0.2-cp312-cp312-win32.whl", hash = "sha256:3ae2ce7d6fedfb3414a2b6c5e20b249c4c607f72cb8d2bb7cc9c6ec7c6f4e849"},
-    {file = "lxml-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:72c87e5ee4e58a8354fb9c7c84cbf95a1c8236c127a5d1b7683f04bed8361e1f"},
-    {file = "lxml-6.0.2-cp312-cp312-win_arm64.whl", hash = "sha256:61cb10eeb95570153e0c0e554f58df92ecf5109f75eacad4a95baa709e26c3d6"},
-    {file = "lxml-6.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9b33d21594afab46f37ae58dfadd06636f154923c4e8a4d754b0127554eb2e77"},
-    {file = "lxml-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6c8963287d7a4c5c9a432ff487c52e9c5618667179c18a204bdedb27310f022f"},
-    {file = "lxml-6.0.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1941354d92699fb5ffe6ed7b32f9649e43c2feb4b97205f75866f7d21aa91452"},
-    {file = "lxml-6.0.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bb2f6ca0ae2d983ded09357b84af659c954722bbf04dea98030064996d156048"},
-    {file = "lxml-6.0.2-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eb2a12d704f180a902d7fa778c6d71f36ceb7b0d317f34cdc76a5d05aa1dd1df"},
-    {file = "lxml-6.0.2-cp313-cp313-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:6ec0e3f745021bfed19c456647f0298d60a24c9ff86d9d051f52b509663feeb1"},
-    {file = "lxml-6.0.2-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:846ae9a12d54e368933b9759052d6206a9e8b250291109c48e350c1f1f49d916"},
-    {file = "lxml-6.0.2-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ef9266d2aa545d7374938fb5c484531ef5a2ec7f2d573e62f8ce722c735685fd"},
-    {file = "lxml-6.0.2-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:4077b7c79f31755df33b795dc12119cb557a0106bfdab0d2c2d97bd3cf3dffa6"},
-    {file = "lxml-6.0.2-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a7c5d5e5f1081955358533be077166ee97ed2571d6a66bdba6ec2f609a715d1a"},
-    {file = "lxml-6.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8f8d0cbd0674ee89863a523e6994ac25fd5be9c8486acfc3e5ccea679bad2679"},
-    {file = "lxml-6.0.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:2cbcbf6d6e924c28f04a43f3b6f6e272312a090f269eff68a2982e13e5d57659"},
-    {file = "lxml-6.0.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:dfb874cfa53340009af6bdd7e54ebc0d21012a60a4e65d927c2e477112e63484"},
-    {file = "lxml-6.0.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:fb8dae0b6b8b7f9e96c26fdd8121522ce5de9bb5538010870bd538683d30e9a2"},
-    {file = "lxml-6.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:358d9adae670b63e95bc59747c72f4dc97c9ec58881d4627fe0120da0f90d314"},
-    {file = "lxml-6.0.2-cp313-cp313-win32.whl", hash = "sha256:e8cd2415f372e7e5a789d743d133ae474290a90b9023197fd78f32e2dc6873e2"},
-    {file = "lxml-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:b30d46379644fbfc3ab81f8f82ae4de55179414651f110a1514f0b1f8f6cb2d7"},
-    {file = "lxml-6.0.2-cp313-cp313-win_arm64.whl", hash = "sha256:13dcecc9946dca97b11b7c40d29fba63b55ab4170d3c0cf8c0c164343b9bfdcf"},
-    {file = "lxml-6.0.2-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:b0c732aa23de8f8aec23f4b580d1e52905ef468afb4abeafd3fec77042abb6fe"},
-    {file = "lxml-6.0.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4468e3b83e10e0317a89a33d28f7aeba1caa4d1a6fd457d115dd4ffe90c5931d"},
-    {file = "lxml-6.0.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:abd44571493973bad4598a3be7e1d807ed45aa2adaf7ab92ab7c62609569b17d"},
-    {file = "lxml-6.0.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:370cd78d5855cfbffd57c422851f7d3864e6ae72d0da615fca4dad8c45d375a5"},
-    {file = "lxml-6.0.2-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:901e3b4219fa04ef766885fb40fa516a71662a4c61b80c94d25336b4934b71c0"},
-    {file = "lxml-6.0.2-cp314-cp314-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:a4bf42d2e4cf52c28cc1812d62426b9503cdb0c87a6de81442626aa7d69707ba"},
-    {file = "lxml-6.0.2-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b2c7fdaa4d7c3d886a42534adec7cfac73860b89b4e5298752f60aa5984641a0"},
-    {file = "lxml-6.0.2-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:98a5e1660dc7de2200b00d53fa00bcd3c35a3608c305d45a7bbcaf29fa16e83d"},
-    {file = "lxml-6.0.2-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:dc051506c30b609238d79eda75ee9cab3e520570ec8219844a72a46020901e37"},
-    {file = "lxml-6.0.2-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8799481bbdd212470d17513a54d568f44416db01250f49449647b5ab5b5dccb9"},
-    {file = "lxml-6.0.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9261bb77c2dab42f3ecd9103951aeca2c40277701eb7e912c545c1b16e0e4917"},
-    {file = "lxml-6.0.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:65ac4a01aba353cfa6d5725b95d7aed6356ddc0a3cd734de00124d285b04b64f"},
-    {file = "lxml-6.0.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:b22a07cbb82fea98f8a2fd814f3d1811ff9ed76d0fc6abc84eb21527596e7cc8"},
-    {file = "lxml-6.0.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:d759cdd7f3e055d6bc8d9bec3ad905227b2e4c785dc16c372eb5b5e83123f48a"},
-    {file = "lxml-6.0.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:945da35a48d193d27c188037a05fec5492937f66fb1958c24fc761fb9d40d43c"},
-    {file = "lxml-6.0.2-cp314-cp314-win32.whl", hash = "sha256:be3aaa60da67e6153eb15715cc2e19091af5dc75faef8b8a585aea372507384b"},
-    {file = "lxml-6.0.2-cp314-cp314-win_amd64.whl", hash = "sha256:fa25afbadead523f7001caf0c2382afd272c315a033a7b06336da2637d92d6ed"},
-    {file = "lxml-6.0.2-cp314-cp314-win_arm64.whl", hash = "sha256:063eccf89df5b24e361b123e257e437f9e9878f425ee9aae3144c77faf6da6d8"},
-    {file = "lxml-6.0.2-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:6162a86d86893d63084faaf4ff937b3daea233e3682fb4474db07395794fa80d"},
-    {file = "lxml-6.0.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:414aaa94e974e23a3e92e7ca5b97d10c0cf37b6481f50911032c69eeb3991bba"},
-    {file = "lxml-6.0.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48461bd21625458dd01e14e2c38dd0aea69addc3c4f960c30d9f59d7f93be601"},
-    {file = "lxml-6.0.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:25fcc59afc57d527cfc78a58f40ab4c9b8fd096a9a3f964d2781ffb6eb33f4ed"},
-    {file = "lxml-6.0.2-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5179c60288204e6ddde3f774a93350177e08876eaf3ab78aa3a3649d43eb7d37"},
-    {file = "lxml-6.0.2-cp314-cp314t-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:967aab75434de148ec80597b75062d8123cadf2943fb4281f385141e18b21338"},
-    {file = "lxml-6.0.2-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d100fcc8930d697c6561156c6810ab4a508fb264c8b6779e6e61e2ed5e7558f9"},
-    {file = "lxml-6.0.2-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2ca59e7e13e5981175b8b3e4ab84d7da57993eeff53c07764dcebda0d0e64ecd"},
-    {file = "lxml-6.0.2-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:957448ac63a42e2e49531b9d6c0fa449a1970dbc32467aaad46f11545be9af1d"},
-    {file = "lxml-6.0.2-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b7fc49c37f1786284b12af63152fe1d0990722497e2d5817acfe7a877522f9a9"},
-    {file = "lxml-6.0.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e19e0643cc936a22e837f79d01a550678da8377d7d801a14487c10c34ee49c7e"},
-    {file = "lxml-6.0.2-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:1db01e5cf14345628e0cbe71067204db658e2fb8e51e7f33631f5f4735fefd8d"},
-    {file = "lxml-6.0.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:875c6b5ab39ad5291588aed6925fac99d0097af0dd62f33c7b43736043d4a2ec"},
-    {file = "lxml-6.0.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:cdcbed9ad19da81c480dfd6dd161886db6096083c9938ead313d94b30aadf272"},
-    {file = "lxml-6.0.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:80dadc234ebc532e09be1975ff538d154a7fa61ea5031c03d25178855544728f"},
-    {file = "lxml-6.0.2-cp314-cp314t-win32.whl", hash = "sha256:da08e7bb297b04e893d91087df19638dc7a6bb858a954b0cc2b9f5053c922312"},
-    {file = "lxml-6.0.2-cp314-cp314t-win_amd64.whl", hash = "sha256:252a22982dca42f6155125ac76d3432e548a7625d56f5a273ee78a5057216eca"},
-    {file = "lxml-6.0.2-cp314-cp314t-win_arm64.whl", hash = "sha256:bb4c1847b303835d89d785a18801a883436cdfd5dc3d62947f9c49e24f0f5a2c"},
-    {file = "lxml-6.0.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:a656ca105115f6b766bba324f23a67914d9c728dafec57638e2b92a9dcd76c62"},
-    {file = "lxml-6.0.2-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c54d83a2188a10ebdba573f16bd97135d06c9ef60c3dc495315c7a28c80a263f"},
-    {file = "lxml-6.0.2-cp38-cp38-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:1ea99340b3c729beea786f78c38f60f4795622f36e305d9c9be402201efdc3b7"},
-    {file = "lxml-6.0.2-cp38-cp38-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:af85529ae8d2a453feee4c780d9406a5e3b17cee0dd75c18bd31adcd584debc3"},
-    {file = "lxml-6.0.2-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:fe659f6b5d10fb5a17f00a50eb903eb277a71ee35df4615db573c069bcf967ac"},
-    {file = "lxml-6.0.2-cp38-cp38-win32.whl", hash = "sha256:5921d924aa5468c939d95c9814fa9f9b5935a6ff4e679e26aaf2951f74043512"},
-    {file = "lxml-6.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:0aa7070978f893954008ab73bb9e3c24a7c56c054e00566a21b553dc18105fca"},
-    {file = "lxml-6.0.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2c8458c2cdd29589a8367c09c8f030f1d202be673f0ca224ec18590b3b9fb694"},
-    {file = "lxml-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3fee0851639d06276e6b387f1c190eb9d7f06f7f53514e966b26bae46481ec90"},
-    {file = "lxml-6.0.2-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b2142a376b40b6736dfc214fd2902409e9e3857eff554fed2d3c60f097e62a62"},
-    {file = "lxml-6.0.2-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a6b5b39cc7e2998f968f05309e666103b53e2edd01df8dc51b90d734c0825444"},
-    {file = "lxml-6.0.2-cp39-cp39-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4aec24d6b72ee457ec665344a29acb2d35937d5192faebe429ea02633151aad"},
-    {file = "lxml-6.0.2-cp39-cp39-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:b42f4d86b451c2f9d06ffb4f8bbc776e04df3ba070b9fe2657804b1b40277c48"},
-    {file = "lxml-6.0.2-cp39-cp39-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6cdaefac66e8b8f30e37a9b4768a391e1f8a16a7526d5bc77a7928408ef68e93"},
-    {file = "lxml-6.0.2-cp39-cp39-manylinux_2_31_armv7l.whl", hash = "sha256:b738f7e648735714bbb82bdfd030203360cfeab7f6e8a34772b3c8c8b820568c"},
-    {file = "lxml-6.0.2-cp39-cp39-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:daf42de090d59db025af61ce6bdb2521f0f102ea0e6ea310f13c17610a97da4c"},
-    {file = "lxml-6.0.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:66328dabea70b5ba7e53d94aa774b733cf66686535f3bc9250a7aab53a91caaf"},
-    {file = "lxml-6.0.2-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:e237b807d68a61fc3b1e845407e27e5eb8ef69bc93fe8505337c1acb4ee300b6"},
-    {file = "lxml-6.0.2-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:ac02dc29fd397608f8eb15ac1610ae2f2f0154b03f631e6d724d9e2ad4ee2c84"},
-    {file = "lxml-6.0.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:817ef43a0c0b4a77bd166dc9a09a555394105ff3374777ad41f453526e37f9cb"},
-    {file = "lxml-6.0.2-cp39-cp39-win32.whl", hash = "sha256:bc532422ff26b304cfb62b328826bd995c96154ffd2bac4544f37dbb95ecaa8f"},
-    {file = "lxml-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:995e783eb0374c120f528f807443ad5a83a656a8624c467ea73781fc5f8a8304"},
-    {file = "lxml-6.0.2-cp39-cp39-win_arm64.whl", hash = "sha256:08b9d5e803c2e4725ae9e8559ee880e5328ed61aa0935244e0515d7d9dbec0aa"},
-    {file = "lxml-6.0.2-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:e748d4cf8fef2526bb2a589a417eba0c8674e29ffcb570ce2ceca44f1e567bf6"},
-    {file = "lxml-6.0.2-pp310-pypy310_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4ddb1049fa0579d0cbd00503ad8c58b9ab34d1254c77bc6a5576d96ec7853dba"},
-    {file = "lxml-6.0.2-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cb233f9c95f83707dae461b12b720c1af9c28c2d19208e1be03387222151daf5"},
-    {file = "lxml-6.0.2-pp310-pypy310_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bc456d04db0515ce3320d714a1eac7a97774ff0849e7718b492d957da4631dd4"},
-    {file = "lxml-6.0.2-pp310-pypy310_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2613e67de13d619fd283d58bda40bff0ee07739f624ffee8b13b631abf33083d"},
-    {file = "lxml-6.0.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:24a8e756c982c001ca8d59e87c80c4d9dcd4d9b44a4cbeb8d9be4482c514d41d"},
-    {file = "lxml-6.0.2-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:1c06035eafa8404b5cf475bb37a9f6088b0aca288d4ccc9d69389750d5543700"},
-    {file = "lxml-6.0.2-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c7d13103045de1bdd6fe5d61802565f1a3537d70cd3abf596aa0af62761921ee"},
-    {file = "lxml-6.0.2-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0a3c150a95fbe5ac91de323aa756219ef9cf7fde5a3f00e2281e30f33fa5fa4f"},
-    {file = "lxml-6.0.2-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60fa43be34f78bebb27812ed90f1925ec99560b0fa1decdb7d12b84d857d31e9"},
-    {file = "lxml-6.0.2-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:21c73b476d3cfe836be731225ec3421fa2f048d84f6df6a8e70433dff1376d5a"},
-    {file = "lxml-6.0.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:27220da5be049e936c3aca06f174e8827ca6445a4353a1995584311487fc4e3e"},
-    {file = "lxml-6.0.2.tar.gz", hash = "sha256:cd79f3367bd74b317dda655dc8fcfa304d9eb6e4fb06b7168c5cf27f96e0cd62"},
+    {file = "lxml-6.1.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:41dcc4c7b10484257cbd6c37b83ddb26df2b0e5aff5ac00d095689015af868ec"},
+    {file = "lxml-6.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a31286dbb5e74c8e9a5344465b77ab4c5bd511a253b355b5ca2fae7e579fafec"},
+    {file = "lxml-6.1.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1bc4cc83fb7f66ffb16f74d6dd0162e144333fc36ebcce32246f80c8735b2551"},
+    {file = "lxml-6.1.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:20cf4d0651987c906a2f5cba4e3a8d6ba4bfdf973cfe2a96c0d6053888ea2ecd"},
+    {file = "lxml-6.1.0-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ffb34ea45a82dd637c2c97ae1bbb920850c1e59bcae79ce1c15af531d83e7215"},
+    {file = "lxml-6.1.0-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1d9b99e5b2597e4f5aed2484fef835256fa1b68a19e4265c97628ef4bf8bcf4"},
+    {file = "lxml-6.1.0-cp310-cp310-manylinux_2_28_i686.whl", hash = "sha256:d43aa26dcda363f21e79afa0668f5029ed7394b3bb8c92a6927a3d34e8b610ea"},
+    {file = "lxml-6.1.0-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:6262b87f9e5c1e5fe501d6c153247289af42eb44ad7660b9b3de17baaf92d6f6"},
+    {file = "lxml-6.1.0-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d1392c569c032f78a11a25d1de1c43fff13294c793b39e19d84fade3045cbbc3"},
+    {file = "lxml-6.1.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:045e387d1f4f42a418380930fa3f45c73c9b392faf67e495e58902e68e8f44a7"},
+    {file = "lxml-6.1.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:9f93d5b8b07f73e8c77e3c6556a3db269918390c804b5e5fcdd4858232cc8f16"},
+    {file = "lxml-6.1.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:de550d129f18d8ab819651ffe4f38b1b713c7e116707de3c0c6400d0ef34fbc1"},
+    {file = "lxml-6.1.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c08da09dc003c9e8c70e06b53a11db6fb3b250c21c4236b03c7d7b443c318e7a"},
+    {file = "lxml-6.1.0-cp310-cp310-win32.whl", hash = "sha256:37448bf9c7d7adfc5254763901e2bbd6bb876228dfc1fc7f66e58c06368a7544"},
+    {file = "lxml-6.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:2593a0a6621545b9095b71ad74ed4226eba438a7d9fc3712a99bdb15508cf93a"},
+    {file = "lxml-6.1.0-cp310-cp310-win_arm64.whl", hash = "sha256:e80807d72f96b96ad5588cb85c75616e4f2795a7737d4630784c51497beb7776"},
+    {file = "lxml-6.1.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:cec05be8c876f92a5aa07b01d60bbb4d11cfbdd654cad0561c0d7b5c043a61b9"},
+    {file = "lxml-6.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9c03e048b6ce8e77b09c734e931584894ecd58d08296804ca2d0b184c933ce50"},
+    {file = "lxml-6.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:942454ff253da14218f972b23dc72fa4edf6c943f37edd19cd697618b626fac5"},
+    {file = "lxml-6.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d036ee7b99d5148072ac7c9b847193decdfeac633db350363f7bce4fff108f0e"},
+    {file = "lxml-6.1.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ae5d8d5427f3cc317e7950f2da7ad276df0cfa37b8de2f5658959e618ea8512"},
+    {file = "lxml-6.1.0-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:363e47283bde87051b821826e71dde47f107e08614e1aa312ba0c5711e77738c"},
+    {file = "lxml-6.1.0-cp311-cp311-manylinux_2_28_i686.whl", hash = "sha256:f504d861d9f2a8f94020130adac88d66de93841707a23a86244263d1e54682f5"},
+    {file = "lxml-6.1.0-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:23a5dc68e08ed13331d61815c08f260f46b4a60fdd1640bbeb82cf89a9d90289"},
+    {file = "lxml-6.1.0-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f15401d8d3dbf239e23c818afc10c7207f7b95f9a307e092122b6f86dd43209a"},
+    {file = "lxml-6.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:fcf3da95e93349e0647d48d4b36a12783105bcc74cb0c416952f9988410846a3"},
+    {file = "lxml-6.1.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:0d082495c5fcf426e425a6e28daaba1fcb6d8f854a4ff01effb1f1f381203eb9"},
+    {file = "lxml-6.1.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:e3c4f84b24a1fcba435157d111c4b755099c6ff00a3daee1ad281817de75ed11"},
+    {file = "lxml-6.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:976a6b39b1b13e8c354ad8d3f261f3a4ac6609518af91bdb5094760a08f132c4"},
+    {file = "lxml-6.1.0-cp311-cp311-win32.whl", hash = "sha256:857efde87d365706590847b916baff69c0bc9252dc5af030e378c9800c0b10e3"},
+    {file = "lxml-6.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:183bfb45a493081943be7ea2b5adfc2b611e1cf377cefa8b8a8be404f45ef9a7"},
+    {file = "lxml-6.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:19f4164243fc206d12ed3d866e80e74f5bc3627966520da1a5f97e42c32a3f39"},
+    {file = "lxml-6.1.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d2f17a16cd8751e8eb233a7e41aecdf8e511712e00088bf9be455f604cd0d28d"},
+    {file = "lxml-6.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f0cea5b1d3e6e77d71bd2b9972eb2446221a69dc52bb0b9c3c6f6e5700592d93"},
+    {file = "lxml-6.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fc46da94826188ed45cb53bd8e3fc076ae22675aea2087843d4735627f867c6d"},
+    {file = "lxml-6.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9147d8e386ec3b82c3b15d88927f734f565b0aaadef7def562b853adca45784a"},
+    {file = "lxml-6.1.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5715e0e28736a070f3f34a7ccc09e2fdcba0e3060abbcf61a1a5718ff6d6b105"},
+    {file = "lxml-6.1.0-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4937460dc5df0cdd2f06a86c285c28afda06aefa3af949f9477d3e8df430c485"},
+    {file = "lxml-6.1.0-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bc783ee3147e60a25aa0445ea82b3e8aabb83b240f2b95d32cb75587ff781814"},
+    {file = "lxml-6.1.0-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:40d9189f80075f2e1f88db21ef815a2b17b28adf8e50aaf5c789bfe737027f32"},
+    {file = "lxml-6.1.0-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:05b9b8787e35bec69e68daf4952b2e6dfcfb0db7ecf1a06f8cdfbbac4eb71aad"},
+    {file = "lxml-6.1.0-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0f0f08beb0182e3e9a86fae124b3c47a7b41b7b69b225e1377db983802404e54"},
+    {file = "lxml-6.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73becf6d8c81d4c76b1014dbd3584cb26d904492dcf73ca85dc8bff08dcd6d2d"},
+    {file = "lxml-6.1.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:1ae225f66e5938f4fa29d37e009a3bb3b13032ac57eb4eb42afa44f6e4054e69"},
+    {file = "lxml-6.1.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:690022c7fae793b0489aa68a658822cea83e0d5933781811cabbf5ea3bcfe73d"},
+    {file = "lxml-6.1.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:63aeafc26aac0be8aff14af7871249e87ea1319be92090bfd632ec68e03b16a5"},
+    {file = "lxml-6.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:264c605ab9c0e4aa1a679636f4582c4d3313700009fac3ec9c3412ed0d8f3e1d"},
+    {file = "lxml-6.1.0-cp312-cp312-win32.whl", hash = "sha256:56971379bc5ee8037c5a0f09fa88f66cdb7d37c3e38af3e45cf539f41131ac1f"},
+    {file = "lxml-6.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:bba078de0031c219e5dd06cf3e6bf8fb8e6e64a77819b358f53bb132e3e03366"},
+    {file = "lxml-6.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:c3592631e652afa34999a088f98ba7dfc7d6aff0d535c410bea77a71743f3819"},
+    {file = "lxml-6.1.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a0092f2b107b69601adf562a57c956fbb596e05e3e6651cabd3054113b007e45"},
+    {file = "lxml-6.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fc7140d7a7386e6b545d41b7358f4d02b656d4053f5fa6859f92f4b9c2572c4d"},
+    {file = "lxml-6.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:419c58fc92cc3a2c3fa5f78c63dbf5da70c1fa9c1b25f25727ecee89a96c7de2"},
+    {file = "lxml-6.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:37fabd1452852636cf38ecdcc9dd5ca4bba7a35d6c53fa09725deeb894a87491"},
+    {file = "lxml-6.1.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2853c8b2170cc6cd54a6b4d50d2c1a8a7aeca201f23804b4898525c7a152cfc"},
+    {file = "lxml-6.1.0-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8e369cbd690e788c8d15e56222d91a09c6a417f49cbc543040cba0fe2e25a79e"},
+    {file = "lxml-6.1.0-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e69aa6805905807186eb00e66c6d97a935c928275182eb02ee40ba00da9623b2"},
+    {file = "lxml-6.1.0-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:4bd1bdb8a9e0e2dd229de19b5f8aebac80e916921b4b2c6ef8a52bc131d0c1f9"},
+    {file = "lxml-6.1.0-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:cbd7b79cdcb4986ad78a2662625882747f09db5e4cd7b2ae178a88c9c51b3dfe"},
+    {file = "lxml-6.1.0-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:43e4d297f11080ec9d64a4b1ad7ac02b4484c9f0e2179d9c4ef78e886e747b88"},
+    {file = "lxml-6.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cc16682cc987a3da00aa56a3aa3075b08edb10d9b1e476938cfdbee8f3b67181"},
+    {file = "lxml-6.1.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:d6d8efe71429635f0559579092bb5e60560d7b9115ee38c4adbea35632e7fa24"},
+    {file = "lxml-6.1.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:7e39ab3a28af7784e206d8606ec0e4bcad0190f63a492bca95e94e5a4aef7f6e"},
+    {file = "lxml-6.1.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:9eb667bf50856c4a58145f8ca2d5e5be160191e79eb9e30855a476191b3c3495"},
+    {file = "lxml-6.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7f4a77d6f7edf9230cee3e1f7f6764722a41604ee5681844f18db9a81ea0ec33"},
+    {file = "lxml-6.1.0-cp313-cp313-win32.whl", hash = "sha256:28902146ffbe5222df411c5d19e5352490122e14447e98cd118907ee3fd6ee62"},
+    {file = "lxml-6.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:4a1503c56e4e2b38dc76f2f2da7bae69670c0f1933e27cfa34b2fa5876410b16"},
+    {file = "lxml-6.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:e0af85773850417d994d019741239b901b22c6680206f46a34766926e466141d"},
+    {file = "lxml-6.1.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ab863fd37458fed6456525f297d21239d987800c46e67da5ef04fc6b3dd93ac8"},
+    {file = "lxml-6.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6fd8b1df8254ff4fd93fd31da1fc15770bde23ac045be9bb1f87425702f61cc9"},
+    {file = "lxml-6.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:47024feaae386a92a146af0d2aeed65229bf6fff738e6a11dda6b0015fb8fd03"},
+    {file = "lxml-6.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3f00972f84450204cd5d93a5395965e348956aaceaadec693a22ec743f8ae3eb"},
+    {file = "lxml-6.1.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97faa0860e13b05b15a51fb4986421ef7a30f0b3334061c416e0981e9450ca4c"},
+    {file = "lxml-6.1.0-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:972a6451204798675407beaad97b868d0c733d9a74dafefc63120b81b8c2de28"},
+    {file = "lxml-6.1.0-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fe022f20bc4569ec66b63b3fb275a3d628d9d32da6326b2982584104db6d3086"},
+    {file = "lxml-6.1.0-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:75c4c7c619a744f972f4451bf5adf6d0fb00992a1ffc9fd78e13b0bc817cc99f"},
+    {file = "lxml-6.1.0-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3648f20d25102a22b6061c688beb3a805099ea4beb0a01ce62975d926944d292"},
+    {file = "lxml-6.1.0-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:77b9f99b17cbf14026d1e618035077060fc7195dd940d025149f3e2e830fbfcb"},
+    {file = "lxml-6.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:32662519149fd7a9db354175aa5e417d83485a8039b8aaa62f873ceee7ea4cad"},
+    {file = "lxml-6.1.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:73d658216fc173cf2c939e90e07b941c5e12736b0bf6a99e7af95459cfe8eabb"},
+    {file = "lxml-6.1.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:ac4db068889f8772a4a698c5980ec302771bb545e10c4b095d4c8be26749616f"},
+    {file = "lxml-6.1.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:45e9dfbd1b661eb64ba0d4dbe762bd210c42d86dd1e5bd2bdf89d634231beb43"},
+    {file = "lxml-6.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:89e8d73d09ac696a5ba42ec69787913d53284f12092f651506779314f10ba585"},
+    {file = "lxml-6.1.0-cp314-cp314-win32.whl", hash = "sha256:ebe33f4ec1b2de38ceb225a1749a2965855bffeef435ba93cd2d5d540783bf2f"},
+    {file = "lxml-6.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:398443df51c538bd578529aa7e5f7afc6c292644174b47961f3bf87fe5741120"},
+    {file = "lxml-6.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:8c8984e1d8c4b3949e419158fda14d921ff703a9ed8a47236c6eb7a2b6cb4946"},
+    {file = "lxml-6.1.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1081dd10bc6fa437db2500e13993abf7cc30716d0a2f40e65abb935f02ec559c"},
+    {file = "lxml-6.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:dabecc48db5f42ba348d1f5d5afdc54c6c4cc758e676926c7cd327045749517d"},
+    {file = "lxml-6.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e3dd5fe19c9e0ac818a9c7f132a5e43c1339ec1cbbfecb1a938bd3a47875b7c9"},
+    {file = "lxml-6.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9e7b0a4ca6dcc007a4cef00a761bba2dea959de4bd2df98f926b33c92ca5dfb9"},
+    {file = "lxml-6.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d27bbe326c6b539c64b42638b18bc6003a8d88f76213a97ac9ed4f885efeab7"},
+    {file = "lxml-6.1.0-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c4e425db0c5445ef0ad56b0eec54f89b88b2d884656e536a90b2f52aecb4ca86"},
+    {file = "lxml-6.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b89b098105b8599dc57adac95d1813409ac476d3c948a498775d3d0c6124bfb"},
+    {file = "lxml-6.1.0-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:c4a699432846df86cc3de502ee85f445ebad748a1c6021d445f3e514d2cd4b1c"},
+    {file = "lxml-6.1.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:30e7b2ed63b6c8e97cca8af048589a788ab5c9c905f36d9cf1c2bb549f450d2f"},
+    {file = "lxml-6.1.0-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:022981127642fe19866d2907d76241bb07ed21749601f727d5d5dd1ce5d1b773"},
+    {file = "lxml-6.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:23cad0cc86046d4222f7f418910e46b89971c5a45d3c8abfad0f64b7b05e4a9b"},
+    {file = "lxml-6.1.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:21c3302068f50d1e8728c67c87ba92aa87043abee517aa2576cca1855326b405"},
+    {file = "lxml-6.1.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:be10838781cb3be19251e276910cd508fe127e27c3242e50521521a0f3781690"},
+    {file = "lxml-6.1.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:2173a7bffe97667bbf0767f8a99e587740a8c56fdf3befac4b09cb29a80276fd"},
+    {file = "lxml-6.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c6854e9cf99c84beb004eecd7d3a3868ef1109bf2b1df92d7bc11e96a36c2180"},
+    {file = "lxml-6.1.0-cp314-cp314t-win32.whl", hash = "sha256:00750d63ef0031a05331b9223463b1c7c02b9004cef2346a5b2877f0f9494dd2"},
+    {file = "lxml-6.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:80410c3a7e3c617af04de17caa9f9f20adaa817093293d69eae7d7d0522836f5"},
+    {file = "lxml-6.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:26dd9f57ee3bd41e7d35b4c98a2ffd89ed11591649f421f0ec19f67d50ec67ac"},
+    {file = "lxml-6.1.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b6c2f225662bc5ad416bdd06f72ca301b31b39ce4261f0e0097017fc2891b940"},
+    {file = "lxml-6.1.0-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a86f06f059e22a0d574990ee2df24ede03f7f3c68c1336293eee9536c4c776cd"},
+    {file = "lxml-6.1.0-cp38-cp38-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:468479e52ecf3ec23799c863336d02c05fc2f7ffd1a1424eeeb9a28d4eb69d13"},
+    {file = "lxml-6.1.0-cp38-cp38-manylinux_2_28_i686.whl", hash = "sha256:a02ca8fe48815bddcfca3248efe54451abb9dbf2f7d1c5744c8aa4142d476919"},
+    {file = "lxml-6.1.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:bb40648d96157f9081886defe13eac99253e663be969ff938a9289eff6e47b72"},
+    {file = "lxml-6.1.0-cp38-cp38-win32.whl", hash = "sha256:1dd6a1c3ad4cb674f44525d9957f3e9c209bb6dd9213245195167a281fcc2bdc"},
+    {file = "lxml-6.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:4e2c54d6b47361d0f1d3bc8d4e082ad87201e56ccdcca4d3b9ee3644ff595ec8"},
+    {file = "lxml-6.1.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:920354904d1cb86577d4b3cfe2830c2dbe81d6f4449e57ada428f1609b5985f7"},
+    {file = "lxml-6.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c871299c595ee004d186f61840f0bfc4941aa3f17c8ba4a565ead7e4f4f820ee"},
+    {file = "lxml-6.1.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d0d799ff958655781296ec870d5e2448e75150da2b3d07f13ff5b0c2c35beefd"},
+    {file = "lxml-6.1.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ba11752e346bd804ea312ec2eea2532dfa8b8d3261d81a32ef9e6ab16256280"},
+    {file = "lxml-6.1.0-cp39-cp39-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26c5272c6a4bf4cf32d3f5a7890c942b0e04438691157d341616d02cca74d4bd"},
+    {file = "lxml-6.1.0-cp39-cp39-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c53fa3a5a52122d590e847a57ccf955557b9634a7f99ff5a35131321b0a85317"},
+    {file = "lxml-6.1.0-cp39-cp39-manylinux_2_28_i686.whl", hash = "sha256:76b958b4ea3104483c20f74866d55aa056546e15ebe83dd7aecd63698f43b755"},
+    {file = "lxml-6.1.0-cp39-cp39-manylinux_2_31_armv7l.whl", hash = "sha256:8c11b984b5ce6add4dccc7144c7be5d364d298f15b0c6a57da1991baedc750ce"},
+    {file = "lxml-6.1.0-cp39-cp39-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d3829a6e6fd550a219564912d4002c537f65da4c6ae4e093cc34462f4fa027ad"},
+    {file = "lxml-6.1.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:52b0ac6903cf74ebf997eb8c682d2fbac7d1ab7e4c552413eec55868a9b73f39"},
+    {file = "lxml-6.1.0-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:29f5c00cb7d752bce2c70ebd2d31b0a42f9499ffdd3ecb2f31a5b73ee43031ad"},
+    {file = "lxml-6.1.0-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:c748ebcb6877de89f48ab90ca96642ac458fff5dec291a2b9337cd4d0934e383"},
+    {file = "lxml-6.1.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:08950a23f296b3f83521577274e3d3b0f3d739bf2e68d01a752e4288bc50d286"},
+    {file = "lxml-6.1.0-cp39-cp39-win32.whl", hash = "sha256:11a873c77a181b4fef9c2e357d08ed399542c2af1390101da66720a19c7c9618"},
+    {file = "lxml-6.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:81ff55c70b67d19d52b6fd118a114c0a4c97d799cd3089ff9bd9e2ff4b414ee2"},
+    {file = "lxml-6.1.0-cp39-cp39-win_arm64.whl", hash = "sha256:481d6e2104285d9add34f41b42b247b76b61c5b5c26c303c2e9707bbf8bd9a64"},
+    {file = "lxml-6.1.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:546b66c0dd1bb8d9fa89d7123e5fa19a8aff3a1f2141eb22df96112afb17b842"},
+    {file = "lxml-6.1.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5cfa1a34df366d9dc0d5eaf420f4cf2bb1e1bebe1066d1c2fc28c179f8a4004c"},
+    {file = "lxml-6.1.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db88156fcf544cdbf0d95588051515cfdfd4c876fc66444eb98bceb5d6db76de"},
+    {file = "lxml-6.1.0-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:07f98f5496f96bf724b1e3c933c107f0cbf2745db18c03d2e13a291c3afd2635"},
+    {file = "lxml-6.1.0-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4642e04449a1e164b5ff71ffd901ddb772dfabf5c9adf1b7be5dffe1212bc037"},
+    {file = "lxml-6.1.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:7da13bb6fbadfafb474e0226a30570a3445cfd47c86296f2446dafbd77079ace"},
+    {file = "lxml-6.1.0.tar.gz", hash = "sha256:bfd57d8008c4965709a919c3e9a98f76c2c7cb319086b3d26858250620023b13"},
 ]
 
 [package.extras]
@@ -2242,13 +2241,13 @@ htmlsoup = ["BeautifulSoup4"]
 
 [[package]]
 name = "mako"
-version = "1.3.10"
+version = "1.3.11"
 description = "A super-fast templating language that borrows the best ideas from the existing templating languages."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59"},
-    {file = "mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28"},
+    {file = "mako-1.3.11-py3-none-any.whl", hash = "sha256:e372c6e333cf004aa736a15f425087ec977e1fcbd2966aae7f17c8dc1da27a77"},
+    {file = "mako-1.3.11.tar.gz", hash = "sha256:071eb4ab4c5010443152255d77db7faa6ce5916f35226eb02dc34479b6858069"},
 ]
 
 [package.dependencies]
@@ -2981,13 +2980,13 @@ dev = ["black", "mypy", "pytest"]
 
 [[package]]
 name = "packaging"
-version = "26.0"
+version = "26.1"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529"},
-    {file = "packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4"},
+    {file = "packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f"},
+    {file = "packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de"},
 ]
 
 [[package]]
@@ -3003,13 +3002,13 @@ files = [
 
 [[package]]
 name = "platformdirs"
-version = "4.9.4"
+version = "4.9.6"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
 python-versions = ">=3.10"
 files = [
-    {file = "platformdirs-4.9.4-py3-none-any.whl", hash = "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868"},
-    {file = "platformdirs-4.9.4.tar.gz", hash = "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934"},
+    {file = "platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917"},
+    {file = "platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a"},
 ]
 
 [[package]]
@@ -3787,13 +3786,13 @@ six = ">=1.5"
 
 [[package]]
 name = "python-discovery"
-version = "1.2.1"
+version = "1.2.2"
 description = "Python interpreter discovery"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "python_discovery-1.2.1-py3-none-any.whl", hash = "sha256:b6a957b24c1cd79252484d3566d1b49527581d46e789aaf43181005e56201502"},
-    {file = "python_discovery-1.2.1.tar.gz", hash = "sha256:180c4d114bff1c32462537eac5d6a332b768242b76b69c0259c7d14b1b680c9e"},
+    {file = "python_discovery-1.2.2-py3-none-any.whl", hash = "sha256:e1ae95d9af875e78f15e19aed0c6137ab1bb49c200f21f5061786490c9585c7a"},
+    {file = "python_discovery-1.2.2.tar.gz", hash = "sha256:876e9c57139eb757cb5878cbdd9ae5379e5d96266c99ef731119e04fffe533bb"},
 ]
 
 [package.dependencies]
@@ -4239,13 +4238,13 @@ files = [
 
 [[package]]
 name = "s3transfer"
-version = "0.16.0"
+version = "0.16.1"
 description = "An Amazon S3 Transfer Manager"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe"},
-    {file = "s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920"},
+    {file = "s3transfer-0.16.1-py3-none-any.whl", hash = "sha256:61bcd00ccb83b21a0fe7e91a553fff9729d46c83b4e0106e7c314a733891f7c2"},
+    {file = "s3transfer-0.16.1.tar.gz", hash = "sha256:8e424355754b9ccb32467bdc568edf55be82692ef2002d934b1311dbb3b9e524"},
 ]
 
 [package.dependencies]
@@ -4495,13 +4494,13 @@ files = [
 
 [[package]]
 name = "types-cffi"
-version = "2.0.0.20260316"
+version = "2.0.0.20260408"
 description = "Typing stubs for cffi"
 optional = false
 python-versions = ">=3.10"
 files = [
-    {file = "types_cffi-2.0.0.20260316-py3-none-any.whl", hash = "sha256:dd504698029db4c580385f679324621cc64d886e6a23e9821d52bc5169251302"},
-    {file = "types_cffi-2.0.0.20260316.tar.gz", hash = "sha256:8fb06ed4709675c999853689941133affcd2250cd6121cc11fd22c0d81ad510c"},
+    {file = "types_cffi-2.0.0.20260408-py3-none-any.whl", hash = "sha256:68bd296742b4ff7c0afe3547f50bd0acc55416ecf322ffefd2b7344ef6388a42"},
+    {file = "types_cffi-2.0.0.20260408.tar.gz", hash = "sha256:aa8b9c456ab715c079fc655929811f21f331bfb940f4a821987c581bf4e36230"},
 ]
 
 [package.dependencies]
@@ -4520,13 +4519,13 @@ files = [
 
 [[package]]
 name = "types-psycopg2"
-version = "2.9.21.20260223"
+version = "2.9.21.20260422"
 description = "Typing stubs for psycopg2"
 optional = false
 python-versions = ">=3.10"
 files = [
-    {file = "types_psycopg2-2.9.21.20260223-py3-none-any.whl", hash = "sha256:c6228ade72d813b0624f4c03feeb89471950ac27cd0506b5debed6f053086bc8"},
-    {file = "types_psycopg2-2.9.21.20260223.tar.gz", hash = "sha256:78ed70de2e56bc6b5c26c8c1da8e9af54e49fdc3c94d1504609f3519e2b84f02"},
+    {file = "types_psycopg2-2.9.21.20260422-py3-none-any.whl", hash = "sha256:e240684ac37946c5a2a058b04ea1f2fd0e4ee2655719b8c3ec9abf37f96da5ba"},
+    {file = "types_psycopg2-2.9.21.20260422.tar.gz", hash = "sha256:ad7574fa8e25d9aa96ab96cd280c4dee20872725cd1fe6a6d3facc354f2644d4"},
 ]
 
 [[package]]
@@ -4597,13 +4596,13 @@ urllib3 = ">=2"
 
 [[package]]
 name = "types-setuptools"
-version = "82.0.0.20260210"
+version = "82.0.0.20260408"
 description = "Typing stubs for setuptools"
 optional = false
 python-versions = ">=3.10"
 files = [
-    {file = "types_setuptools-82.0.0.20260210-py3-none-any.whl", hash = "sha256:5124a7daf67f195c6054e0f00f1d97c69caad12fdcf9113eba33eff0bce8cd2b"},
-    {file = "types_setuptools-82.0.0.20260210.tar.gz", hash = "sha256:d9719fbbeb185254480ade1f25327c4654f8c00efda3fec36823379cebcdee58"},
+    {file = "types_setuptools-82.0.0.20260408-py3-none-any.whl", hash = "sha256:ece0a215cdfa6463a65fd6f68bd940f39e455729300ddfe61cab1147ed1d2462"},
+    {file = "types_setuptools-82.0.0.20260408.tar.gz", hash = "sha256:036c68caf7e672a699f5ebbf914708d40644c14e05298bc49f7272be91cf43d3"},
 ]
 
 [[package]]
@@ -4633,14 +4632,31 @@ typing-extensions = ">=4.12.0"
 
 [[package]]
 name = "tzdata"
-version = "2025.3"
+version = "2026.1"
 description = "Provider of IANA time zone data"
 optional = false
 python-versions = ">=2"
 files = [
-    {file = "tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1"},
-    {file = "tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7"},
+    {file = "tzdata-2026.1-py2.py3-none-any.whl", hash = "sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9"},
+    {file = "tzdata-2026.1.tar.gz", hash = "sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98"},
 ]
+
+[[package]]
+name = "tzlocal"
+version = "5.3.1"
+description = "tzinfo object for the local timezone"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d"},
+    {file = "tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd"},
+]
+
+[package.dependencies]
+tzdata = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+devenv = ["check-manifest", "pytest (>=4.3)", "pytest-cov", "pytest-mock (>=3.3)", "zest.releaser"]
 
 [[package]]
 name = "unidecode"
@@ -4683,20 +4699,20 @@ files = [
 
 [[package]]
 name = "virtualenv"
-version = "21.2.0"
+version = "21.2.4"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "virtualenv-21.2.0-py3-none-any.whl", hash = "sha256:1bd755b504931164a5a496d217c014d098426cddc79363ad66ac78125f9d908f"},
-    {file = "virtualenv-21.2.0.tar.gz", hash = "sha256:1720dc3a62ef5b443092e3f499228599045d7fea4c79199770499df8becf9098"},
+    {file = "virtualenv-21.2.4-py3-none-any.whl", hash = "sha256:29d21e941795206138d0f22f4e45ff7050e5da6c6472299fb7103318763861ac"},
+    {file = "virtualenv-21.2.4.tar.gz", hash = "sha256:b294ef68192638004d72524ce7ef303e9d0cf5a44c95ce2e54a7500a6381cada"},
 ]
 
 [package.dependencies]
 distlib = ">=0.3.7,<1"
 filelock = {version = ">=3.24.2,<4", markers = "python_version >= \"3.10\""}
 platformdirs = ">=3.9.1,<5"
-python-discovery = ">=1"
+python-discovery = ">=1.2.2"
 
 [[package]]
 name = "wcwidth"
@@ -5012,13 +5028,13 @@ xmlsec = ["xmlsec (>=0.6.1)"]
 
 [[package]]
 name = "zipp"
-version = "3.23.0"
+version = "3.23.1"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e"},
-    {file = "zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166"},
+    {file = "zipp-3.23.1-py3-none-any.whl", hash = "sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc"},
+    {file = "zipp-3.23.1.tar.gz", hash = "sha256:32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110"},
 ]
 
 [package.extras]
@@ -5046,42 +5062,42 @@ test = ["zope.testrunner (>=6.4)"]
 
 [[package]]
 name = "zope-interface"
-version = "8.2"
+version = "8.3"
 description = "Interfaces for Python"
 optional = false
 python-versions = ">=3.10"
 files = [
-    {file = "zope_interface-8.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:788c293f3165964ec6527b2d861072c68eef53425213f36d3893ebee89a89623"},
-    {file = "zope_interface-8.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9a4e785097e741a1c953b3970ce28f2823bd63c00adc5d276f2981dd66c96c15"},
-    {file = "zope_interface-8.2-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:16c69da19a06566664ddd4785f37cad5693a51d48df1515d264c20d005d322e2"},
-    {file = "zope_interface-8.2-cp310-cp310-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c31acfa3d7cde48bec45701b0e1f4698daffc378f559bfb296837d8c834732f6"},
-    {file = "zope_interface-8.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0723507127f8269b8f3f22663168f717e9c9742107d1b6c9f419df561b71aa6d"},
-    {file = "zope_interface-8.2-cp310-cp310-win_amd64.whl", hash = "sha256:3bf73a910bb27344def2d301a03329c559a79b308e1e584686b74171d736be4e"},
-    {file = "zope_interface-8.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c65ade7ea85516e428651048489f5e689e695c79188761de8c622594d1e13322"},
-    {file = "zope_interface-8.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a1ef4b43659e1348f35f38e7d1a6bbc1682efde239761f335ffc7e31e798b65b"},
-    {file = "zope_interface-8.2-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:dfc4f44e8de2ff4eba20af4f0a3ca42d3c43ab24a08e49ccd8558b7a4185b466"},
-    {file = "zope_interface-8.2-cp311-cp311-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8f094bfb49179ec5dc9981cb769af1275702bd64720ef94874d9e34da1390d4c"},
-    {file = "zope_interface-8.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d2bb8e7364e18f083bf6744ccf30433b2a5f236c39c95df8514e3c13007098ce"},
-    {file = "zope_interface-8.2-cp311-cp311-win_amd64.whl", hash = "sha256:6f4b4dfcfdfaa9177a600bb31cebf711fdb8c8e9ed84f14c61c420c6aa398489"},
-    {file = "zope_interface-8.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:624b6787fc7c3e45fa401984f6add2c736b70a7506518c3b537ffaacc4b29d4c"},
-    {file = "zope_interface-8.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bc9ded9e97a0ed17731d479596ed1071e53b18e6fdb2fc33af1e43f5fd2d3aaa"},
-    {file = "zope_interface-8.2-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:532367553e4420c80c0fc0cabcc2c74080d495573706f66723edee6eae53361d"},
-    {file = "zope_interface-8.2-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2bf9cf275468bafa3c72688aad8cfcbe3d28ee792baf0b228a1b2d93bd1d541a"},
-    {file = "zope_interface-8.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0009d2d3c02ea783045d7804da4fd016245e5c5de31a86cebba66dd6914d59a2"},
-    {file = "zope_interface-8.2-cp312-cp312-win_amd64.whl", hash = "sha256:845d14e580220ae4544bd4d7eb800f0b6034fe5585fc2536806e0a26c2ee6640"},
-    {file = "zope_interface-8.2-cp313-cp313-macosx_10_9_x86_64.whl", hash = "sha256:6068322004a0158c80dfd4708dfb103a899635408c67c3b10e9acec4dbacefec"},
-    {file = "zope_interface-8.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2499de92e8275d0dd68f84425b3e19e9268cd1fa8507997900fa4175f157733c"},
-    {file = "zope_interface-8.2-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:f777e68c76208503609c83ca021a6864902b646530a1a39abb9ed310d1100664"},
-    {file = "zope_interface-8.2-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b05a919fdb0ed6ea942e5a7800e09a8b6cdae6f98fee1bef1c9d1a3fc43aaa0"},
-    {file = "zope_interface-8.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ccc62b5712dd7bd64cfba3ee63089fb11e840f5914b990033beeae3b2180b6cb"},
-    {file = "zope_interface-8.2-cp313-cp313-win_amd64.whl", hash = "sha256:34f877d1d3bb7565c494ed93828fa6417641ca26faf6e8f044e0d0d500807028"},
-    {file = "zope_interface-8.2-cp314-cp314-macosx_10_9_x86_64.whl", hash = "sha256:46c7e4e8cbc698398a67e56ca985d19cb92365b4aafbeb6a712e8c101090f4cb"},
-    {file = "zope_interface-8.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a87fc7517f825a97ff4a4ca4c8a950593c59e0f8e7bfe1b6f898a38d5ba9f9cf"},
-    {file = "zope_interface-8.2-cp314-cp314-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:ccf52f7d44d669203c2096c1a0c2c15d52e36b2e7a9413df50f48392c7d4d080"},
-    {file = "zope_interface-8.2-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:aae807efc7bd26302eb2fea05cd6de7d59269ed6ae23a6de1ee47add6de99b8c"},
-    {file = "zope_interface-8.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:05a0e42d6d830f547e114de2e7cd15750dc6c0c78f8138e6c5035e51ddfff37c"},
-    {file = "zope_interface-8.2-cp314-cp314-win_amd64.whl", hash = "sha256:561ce42390bee90bae51cf1c012902a8033b2aaefbd0deed81e877562a116d48"},
-    {file = "zope_interface-8.2.tar.gz", hash = "sha256:afb20c371a601d261b4f6edb53c3c418c249db1a9717b0baafc9a9bb39ba1224"},
+    {file = "zope_interface-8.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c8a2f9c4ee0f2ad4817e9481684993d33b66d9b815f9157a716a189af483bc34"},
+    {file = "zope_interface-8.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:99c84e12efe0e17f03c6bb5a8ea18fb2841e6666ee0b8331d5967fec84337884"},
+    {file = "zope_interface-8.3-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:a918f8e73c35a1352a4b49db67b90b37d33fb7651c834def3f0e3784437bb3a8"},
+    {file = "zope_interface-8.3-cp310-cp310-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5a5b50d0dcdb4200f1936f75b6688bd86de5c14c5d20bed2e004300a04521826"},
+    {file = "zope_interface-8.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:731eaf0a0f2a683315a2dfc2953ef831ae51e062b87cff6220e0e5102a83b612"},
+    {file = "zope_interface-8.3-cp310-cp310-win_amd64.whl", hash = "sha256:5e9861493457268f923d8aae4052383922162c3d56094c4e3a9ff83173d64be3"},
+    {file = "zope_interface-8.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e8964f1a13b07c8770eab88b7a6cd0870c3e36442e4ef4937f36fd0b6d1cea2c"},
+    {file = "zope_interface-8.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ec2728e3cf685126ccd2e0f7635fb60edf116f76f402dd66f4df13d9d9348b4b"},
+    {file = "zope_interface-8.3-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:568b97cb701fd2830b52198a2885e851317a019e1912eaad107860e3cca71964"},
+    {file = "zope_interface-8.3-cp311-cp311-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:62839e4201869a29f99742df7f7139cac4ce301850d3787da37f84e271ad9b95"},
+    {file = "zope_interface-8.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d287183767926bc9841e51471a28b77c7b49fddf65016aa7faf5a1447e2b6558"},
+    {file = "zope_interface-8.3-cp311-cp311-win_amd64.whl", hash = "sha256:12a33bb596ca20520e44f97918950cfc66a632ac0278a7f40608217cc4269948"},
+    {file = "zope_interface-8.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b361b7ce566bc024e55f74eb1e88afc14039d7bd8ea13eeff3b7a8400dc59683"},
+    {file = "zope_interface-8.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f5be73ca1304daa3046ee5835f7fa6b3badadf02102b570532dd57cd25dd72d6"},
+    {file = "zope_interface-8.3-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:961af756797e36c1e77f7d0dc8ac1322de0c071eaa1a641dbe3b790061968dd9"},
+    {file = "zope_interface-8.3-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a6329f296b70f62043bf2df06eb91b4be040baee32ec4a3e0314f3893fa5c51c"},
+    {file = "zope_interface-8.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f420f6c96307ff265981c510782f0ed97475107b78ca9fca0bb04fe36f363eb4"},
+    {file = "zope_interface-8.3-cp312-cp312-win_amd64.whl", hash = "sha256:ffeae9102aa6ba5bd2f9a547016347bd87c9cf01aea564936c0d165fff0b1242"},
+    {file = "zope_interface-8.3-cp313-cp313-macosx_10_9_x86_64.whl", hash = "sha256:1aa0e1d72212cedc38b2156bbca08cf24625c057135a7947ef6b19bc732b2772"},
+    {file = "zope_interface-8.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:54ab83218a8f6947ba4b6cb1a121f1e1abe2e418b838ccdac71639d0f97e734e"},
+    {file = "zope_interface-8.3-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:34d6c10fa790005487c471e0e4ab537b0fa9a70e55a96994e51ffeef92205fa4"},
+    {file = "zope_interface-8.3-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:93108d5f8dee20177a637438bf4df4c6faf8a317c9d4a8b1d5e78123854e3317"},
+    {file = "zope_interface-8.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8f81d90f80b9fbf36602549e2f187861c9d7139837f8c9dd685ce3b933c6360f"},
+    {file = "zope_interface-8.3-cp313-cp313-win_amd64.whl", hash = "sha256:96106a5f609bb355e1aec6ab0361213c8af0843ca1e1ba9c42eacfbd0910914e"},
+    {file = "zope_interface-8.3-cp314-cp314-macosx_10_9_x86_64.whl", hash = "sha256:96f0001b49227d756770fc70ecde49f19332ae98ec98e1bbbf2fd7a87e9d4e45"},
+    {file = "zope_interface-8.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3853bfb808084e1b4a3a769b00bd8b58a52b0c4a4fc5c23de26d283cd8beb627"},
+    {file = "zope_interface-8.3-cp314-cp314-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:33a13acba79ef693fb64ceb6193ece913d39586f184797f133c1bc549da86851"},
+    {file = "zope_interface-8.3-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e9f7e4b46741a11a9e1fab8b68710f08dec700e9f1b877cdca02480fbebe4846"},
+    {file = "zope_interface-8.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ce49d43366e12aeccd14fcaebb3ef110f50f5795e0d4a95383ea057365cedf2"},
+    {file = "zope_interface-8.3-cp314-cp314-win_amd64.whl", hash = "sha256:301db4049c79a15a3b29d89795e150daf0e9ae701404b112ad6585ea863f6ef5"},
+    {file = "zope_interface-8.3.tar.gz", hash = "sha256:e1a9de7d0b5b5c249a73b91aebf4598ce05e334303af6aa94865893283e9ff10"},
 ]
 
 [package.extras]
@@ -5092,4 +5108,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.12.7"
-content-hash = "5b4b942dbea4d584c87965c9a218ba4050543a8a8bdb2a05f4b27d2a0f672590"
+content-hash = "e890603154604377ec3e7907530e2485dff57920d30b4897ec5993539ef44838"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1237,6 +1237,31 @@ files = [
 testing = ["hatch", "pre-commit", "pytest", "tox"]
 
 [[package]]
+name = "fakeredis"
+version = "2.35.1"
+description = "Python implementation of redis API, can be used for testing purposes."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "fakeredis-2.35.1-py3-none-any.whl", hash = "sha256:67d97e11f562b7870e11e5c30cf182270bfb2dd37f6707dba47cc6d91628d1b9"},
+    {file = "fakeredis-2.35.1.tar.gz", hash = "sha256:5bae5eba7b9d93cb968944ac40936373cf2397ff71667d4b595df65c3d2e413f"},
+]
+
+[package.dependencies]
+lupa = {version = ">=2.1", optional = true, markers = "extra == \"lua\""}
+redis = {version = ">=4.3", markers = "python_version > \"3.8\""}
+sortedcontainers = ">=2"
+
+[package.extras]
+bf = ["pyprobables (>=0.6)"]
+cf = ["pyprobables (>=0.6)"]
+json = ["jsonpath-ng (>=1.6)"]
+lua = ["lupa (>=2.1)"]
+probabilistic = ["pyprobables (>=0.6)"]
+valkey = ["valkey (>=6)"]
+vectorset = ["jsonpath-ng (>=1.6)", "numpy (>=2.4.0)"]
+
+[[package]]
 name = "fido2"
 version = "2.2.0"
 description = "FIDO2/WebAuthn library for implementing clients and servers."
@@ -2089,6 +2114,82 @@ pywin32 = {version = "*", markers = "sys_platform == \"win32\""}
 pyzmq = ">=25.0.0"
 requests = {version = ">=2.32.2", markers = "python_full_version > \"3.11.0\""}
 Werkzeug = ">=2.0.0"
+
+[[package]]
+name = "lupa"
+version = "2.8"
+description = "Python wrapper around Lua and LuaJIT"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "lupa-2.8-cp310-abi3-win32.whl", hash = "sha256:c2a5fd15dc62374e1661a55f01744c9ec1c56f291ba4a0749d3af2174556e78f"},
+    {file = "lupa-2.8-cp310-abi3-win_arm64.whl", hash = "sha256:9e304fb1c50cf23fd8882afbe1aa87525ef8a72667bcab3b37b2bbb2bc542269"},
+    {file = "lupa-2.8-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:97bd01e90b8031e56a5fd5bb70605aea09f1dba675c1140308a52780f93d06f1"},
+    {file = "lupa-2.8-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b5ebe1a13c45767919c86750b84fe2da9f6288b6f3cea4ce7660bb2abc9d921"},
+    {file = "lupa-2.8-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:097e7d0f1719a88020b67c82e05d53d7973c166952393afcecfd8434c7e19a15"},
+    {file = "lupa-2.8-cp310-cp310-win_amd64.whl", hash = "sha256:7bb223ee8f72d0dc076b0d65296ee72f1c69450f9d2fed5315f7707d98c4a03d"},
+    {file = "lupa-2.8-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b12e43c1fb787189dfc28cd604aef0baa2cb95e27da19498d520361d0ace070a"},
+    {file = "lupa-2.8-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6f603391dffb256e36a79fd2044084d5f4b8a0a4c0e5ad291cd3ab3aaf1fd0a"},
+    {file = "lupa-2.8-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9f6f41c91366e7d0d474f87d81c1274af861f40812bf729c9f97ab4c8f3c7ac8"},
+    {file = "lupa-2.8-cp311-cp311-win_amd64.whl", hash = "sha256:f5a6af145b0ea818f01d27bfe2583a4b538570bef61d22c8773e0eccf011234c"},
+    {file = "lupa-2.8-cp312-abi3-macosx_10_13_x86_64.whl", hash = "sha256:f4342f4de76ae7ce2ab0672d36003bdb7e1a33252f293b569298ddd792e70e33"},
+    {file = "lupa-2.8-cp312-abi3-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:4203fa1659315e939a5304e75001b8cc14234fb3cbb3ed86c049b0cc5d90fcee"},
+    {file = "lupa-2.8-cp312-abi3-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:81f2d843ce668b653146c007467570210ae44be51dac6926666c51d49536f307"},
+    {file = "lupa-2.8-cp312-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d3d0cde2c77588d1c60875a4f34f059513476c6e1775351897195b51e0f3df08"},
+    {file = "lupa-2.8-cp312-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9e0d11b8f3a8dac6413f704fef7161d048bb10c58bdac6cbffa5e60efa56e9a3"},
+    {file = "lupa-2.8-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:54cff414f21f8cd8c6be4aae52541f3b9cd39602b59e3a3db9b5c9f9f674ff18"},
+    {file = "lupa-2.8-cp312-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:24b4d8af5558e549b70daf1547f5c1c1d664ecea9fc790f83efe5d75e9a93797"},
+    {file = "lupa-2.8-cp312-abi3-musllinux_1_2_i686.whl", hash = "sha256:ce86dff1ee7f7cf45f5622065ae991949dd7bb1703581cbc58a630137bb7ccf9"},
+    {file = "lupa-2.8-cp312-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:f4d01b2a08c70bbb883a9e082b6b36b89121ed5910b710f1ba11c73295ff4fba"},
+    {file = "lupa-2.8-cp312-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:7f210d5a8353e510ea1199c42cf3cbdd630553bf2bc8fb4c00fea06fdec7c798"},
+    {file = "lupa-2.8-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4f81a02806e7c7ad26d8c6fa222c8bef1b0c1b124347c879be880b41339d41e4"},
+    {file = "lupa-2.8-cp312-abi3-win32.whl", hash = "sha256:360056453a7a4eaa4ac5a204c31a5a014b1eb2ee5490603234d2ba831684f1f2"},
+    {file = "lupa-2.8-cp312-abi3-win_arm64.whl", hash = "sha256:1628371c6592a6d5650497a9e31fb2bb3a7e9883c1f301d1111265e484045af9"},
+    {file = "lupa-2.8-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:450650f91c48c2415b0d59ab3abfcfda3b6efb5b858205f4d4bda8ad141fa529"},
+    {file = "lupa-2.8-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:27044f3363047f946b3d3aab9157cbd172b3538ada9ec1baef43432bf7d03a78"},
+    {file = "lupa-2.8-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8cf4f064a0e5531afce2d7d750120c10c10f9529139af6ca6150d13151034398"},
+    {file = "lupa-2.8-cp312-cp312-win_amd64.whl", hash = "sha256:281bedc5deb92d31e649a3552edd662449365a635904fa4d5cb4509c7245e34e"},
+    {file = "lupa-2.8-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45fc9da0145ecb0083ef5ff9975116cc784bd0258bdc2bd131ba15483ce18398"},
+    {file = "lupa-2.8-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:58e18afed57955b41130e269c78f53d4123ab86e236b53816f4cbffa25cb5d30"},
+    {file = "lupa-2.8-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fc47f536ac13a79cef47d29a2b205576a22841f042a2bcec1676b95806e7706a"},
+    {file = "lupa-2.8-cp313-cp313-win_amd64.whl", hash = "sha256:ce9404c661dbac65cc9bed351ad45e797af93d30d70be309a3fa8209ac86d93b"},
+    {file = "lupa-2.8-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:348c3f8ecabb6324dcbc05c2740d762ef8fcec7b06c79e45262ab97a217684e3"},
+    {file = "lupa-2.8-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:951496471056061598a7d1729a6cdf48d662fec777a9f2d8aa5a1e62fd30e5a5"},
+    {file = "lupa-2.8-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a591b9947ca347b41a63370e121d6e2b1458fe6dde9ae065029ec10a37f25ff4"},
+    {file = "lupa-2.8-cp314-cp314-win_amd64.whl", hash = "sha256:3903c9cf628dae2f56405503247b77a61a3a61bd2dda470e336950c74776d55d"},
+    {file = "lupa-2.8-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f711a8ab0486b9ac6fdda94a22ddcfbc9f0d4a27e3a8cf1bf79c6e48b33017c1"},
+    {file = "lupa-2.8-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc51250e76367a3e27fcd01dc769b9bfcbbc34f48df48dde53d6af6e75b7eaa5"},
+    {file = "lupa-2.8-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f8a22088a552828958603323f0a5c4b3e11e03b75d0bf4c965ef879de9b60a8d"},
+    {file = "lupa-2.8-cp314-cp314t-win32.whl", hash = "sha256:4f7c553c1d8cfffbe85d81daef730d12cae4b6002d457542914da0ac8a1145b3"},
+    {file = "lupa-2.8-cp314-cp314t-win_amd64.whl", hash = "sha256:d8766aff03a78c80ad2d188a8bdb216de5ec838359cd87e05bbdfa56394a6105"},
+    {file = "lupa-2.8-cp314-cp314t-win_arm64.whl", hash = "sha256:91d622777febda3ab1bed1d45295f2f32a4680c7b3d7caf8c669998ed5c44118"},
+    {file = "lupa-2.8-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:81b283bfb13cc43fa4910fc98ec110ab861bcb39680f48b266f99d6e3be1049e"},
+    {file = "lupa-2.8-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5caf45d15d424cee52fd67341e96e2b1dde0658ae90eb156ac56aa0d8330bc38"},
+    {file = "lupa-2.8-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:33e7e5aebca64b154b0a1679caf79e19254ff37bba51e87abab6848f97cb2de1"},
+    {file = "lupa-2.8-cp38-cp38-win32.whl", hash = "sha256:e8d4f4dd4acf4a0e42adc6b1ad220e1c86fe3028402c2f78bd0728a6d241bbe9"},
+    {file = "lupa-2.8-cp38-cp38-win_amd64.whl", hash = "sha256:1ac2b1ec7504e6148cba1bc35ac36c74d18a0ca6d367ffe7e78a3773c2694c0e"},
+    {file = "lupa-2.8-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b036738282a5acd2e71fdddb317c9df8b87c1673aa57f403d05fcc2be8abc4ba"},
+    {file = "lupa-2.8-cp39-abi3-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:ac6b6e8d0e617e26a98cbb44880bcd75de5d32b3ad7b3b3793583909292b47ed"},
+    {file = "lupa-2.8-cp39-abi3-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:ba3a7dd839f90c3d2e53bebe3c192b1f3f9fd720a6781256405123211fd0dce6"},
+    {file = "lupa-2.8-cp39-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d7edb13a7a5250b5c6c22d1495d9e842b5c9fc5081c8fe6b5efe2112fe3e41f9"},
+    {file = "lupa-2.8-cp39-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:891f72e0bffbed1e4175f975aeb2a083956586a100066525e1be485f617f7b25"},
+    {file = "lupa-2.8-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:a295f87b5b7ebbfd5191932e8cb0e51df3c7769101ac6b6c7d7c9fb27bfd1307"},
+    {file = "lupa-2.8-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:4fe5d7a810b64ea8511eb885fc8cdde042ee5ff7b7d08ae78f32449756acb177"},
+    {file = "lupa-2.8-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:bfc470012ef66ad064c7bd77416af03a3452ef630b04b9012595ea13f2e54518"},
+    {file = "lupa-2.8-cp39-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:250e035fdaffe8c87093e3ebc206ac29a26131b1568ea711d780c26001ce96e7"},
+    {file = "lupa-2.8-cp39-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:b9bddb09acfffb4f828f790f444b11dc0cca591afea1a244d9329eea2d20c003"},
+    {file = "lupa-2.8-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2e64acbbd47e9b82a64405a39e0d2b36a5a7dad8ab41c0f3437f572f7d282ba3"},
+    {file = "lupa-2.8-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f6ddca4774d5ca451768a95e378a3aa041076e29f4613b8562f8e98efb6690fd"},
+    {file = "lupa-2.8-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ffcfd8e19f943ad459136b3f60f085ae4948f024192a93ca4b4ac3023ec88d8"},
+    {file = "lupa-2.8-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9f3f3955f65f9fde2dc6eda3041ccd394cf54d4bf083f0cdf6feb3d58e5f38d3"},
+    {file = "lupa-2.8-cp39-cp39-win32.whl", hash = "sha256:9e76e45057cfcaa20ee3422c2289a91f9d51783d020da3570ee226de8f6e71cd"},
+    {file = "lupa-2.8-cp39-cp39-win_amd64.whl", hash = "sha256:6fbcc9911f05c67affbd225fc024268e61e98a18ad1b1c2aed6c8796e4056554"},
+    {file = "lupa-2.8-cp39-cp39-win_arm64.whl", hash = "sha256:6c817d5421094507662e5f8feb8cd1e154c10879921c06079b6063be9d8f33c5"},
+    {file = "lupa-2.8-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:32e4e5103bbddcdd2458fb2ccae6c8ba11c9997c711d7e379e0d45551d109c76"},
+    {file = "lupa-2.8-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7667001804657496dee9feced2daae5000b4604a3218dd8e6b7b754982ba88b8"},
+    {file = "lupa-2.8-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:86f6f668966965b15247dc32d064cfe7be67b71e584ccfacbe2f637575296878"},
+    {file = "lupa-2.8.tar.gz", hash = "sha256:d8022641b9ec8ecf2c5ecbe9f47e5a70e0b87c4b5ae921b92cb02a638e0acd08"},
+]
 
 [[package]]
 name = "lxml"
@@ -4334,6 +4435,17 @@ files = [
 tornado = ">=2.0"
 
 [[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
+optional = false
+python-versions = "*"
+files = [
+    {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
+    {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "1.4.54"
 description = "Database Abstraction Library"
@@ -5108,4 +5220,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.12.7"
-content-hash = "e890603154604377ec3e7907530e2485dff57920d30b4897ec5993539ef44838"
+content-hash = "c8aa84c112a2dfad030c65bf402373552e07d0f9fff78a3fe0fcbf9b921e5adf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,9 @@ awscli-cwlogs = "1.4.6"
 boto = "2.49.0"
 
 cachelib = "0.12.0"
-celery = {extras = ["sqs"], version = "5.4.0"}
+celery = {extras = ["sqs"], version = "5.6.3"}
+# Pin kombu to merge of PR #2342 (SQS fair queue / MessageGroupId support) until kombu 5.7 is released
+kombu = { git = "https://github.com/celery/kombu.git", rev = "860e40a6c904c4d8551577d9f4e8c00f03b6e06c" }
 
 # Pinned dependencies
 certifi = "^2024.0.0" # pinned for security reasons: https://github.com/cds-snc/notification-api/security/dependabot/119
@@ -39,7 +41,7 @@ Flask-Bcrypt = "1.0.1"
 flask-marshmallow = "0.14.0"
 Flask-Migrate = "2.7.0"
 Flask-SQLAlchemy = { git = "https://github.com/pallets-eco/flask-sqlalchemy.git", rev = "500e732dd1b975a56ab06a46bd1a20a21e682262" }
-gevent = "23.9.1"
+gevent = "23.9.1" # See if we can get rid of it now that we use gthread
 greenlet = "3.1.1"
 
 gunicorn = "23.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ Werkzeug = "3.0.6"
 
 [tool.poetry.group.test.dependencies]
 coveralls = "3.3.1"
+fakeredis = { version = "2.35.1", extras = ["lua"] }
 freezegun = "1.5.5"
 gprof2dot = "2024.6.6"
 # used for creating manifest file locally
@@ -102,6 +103,7 @@ requests-mock = "1.12.1"
 rfc3987 = "1.3.8"
 ruff = "^0.8.2"
 snakeviz = "2.2.2"
+sortedcontainers = "2.4.0"
 sqlalchemy2-stubs = "0.0.2a38"                                     # not directly required, pinned by Snyk to avoid a vulnerability
 # optional requirements for jsonschema
 strict-rfc3339 = "0.7"

--- a/scripts/run_celery_local.sh
+++ b/scripts/run_celery_local.sh
@@ -5,6 +5,6 @@
 
 set -e
 
-echo "Start celery, concurrency: ${CELERY_CONCURRENCY-4}"
+echo "Start celery, concurrency: ${CELERY_CONCURRENCY-1}"
 
-celery -A run_celery.notify_celery worker --beat --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency="${CELERY_CONCURRENCY-4}" -Q -priority-database-tasks.fifo,-normal-database-tasks,-bulk-database-tasks,job-tasks,notify-internal-tasks,periodic-tasks,priority-tasks,normal-tasks,bulk-tasks,reporting-tasks,research-mode-tasks,retry-tasks,send-sms-high,send-sms-medium,send-sms-low,send-throttled-sms-tasks,send-email-high,send-email-medium,send-email-low,service-callbacks,service-callbacks-retry,delivery-receipts,generate-reports
+celery -A run_celery.notify_celery worker --beat --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency="${CELERY_CONCURRENCY-1}" -Q -priority-database-tasks.fifo,-normal-database-tasks,-bulk-database-tasks,job-tasks,notify-internal-tasks,periodic-tasks,priority-tasks,normal-tasks,bulk-tasks,reporting-tasks,research-mode-tasks,retry-tasks,send-sms-high,send-sms-medium,send-sms-low,send-throttled-sms-tasks,send-email-high,send-email-medium,send-email-low,send-sms-fair-tasks,service-callbacks,service-callbacks-retry,delivery-receipts,generate-reports

--- a/scripts/run_celery_local.sh
+++ b/scripts/run_celery_local.sh
@@ -7,4 +7,4 @@ set -e
 
 echo "Start celery, concurrency: ${CELERY_CONCURRENCY-1}"
 
-celery -A run_celery.notify_celery worker --beat --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency="${CELERY_CONCURRENCY-1}" -Q -priority-database-tasks.fifo,-normal-database-tasks,-bulk-database-tasks,job-tasks,notify-internal-tasks,periodic-tasks,priority-tasks,normal-tasks,bulk-tasks,reporting-tasks,research-mode-tasks,retry-tasks,send-sms-high,send-sms-medium,send-sms-low,send-throttled-sms-tasks,send-email-high,send-email-medium,send-email-low,send-sms-fair-tasks,service-callbacks,service-callbacks-retry,delivery-receipts,generate-reports
+celery -A run_celery.notify_celery worker --beat --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency="${CELERY_CONCURRENCY-1}" -Q -priority-database-tasks.fifo,-normal-database-tasks,-bulk-database-tasks,job-tasks,notify-internal-tasks,periodic-tasks,priority-tasks,normal-tasks,bulk-tasks,reporting-tasks,research-mode-tasks,retry-tasks,send-sms-high,send-sms-medium,send-sms-low,send-throttled-sms-tasks,send-email-high,send-email-medium,send-email-low,send-sms-fair,service-callbacks,service-callbacks-retry,delivery-receipts,generate-reports

--- a/scripts/run_celery_send_sms_ratelimit.sh
+++ b/scripts/run_celery_send_sms_ratelimit.sh
@@ -7,4 +7,4 @@ set -e
 
 echo "Start celery SMS rate-limit worker (PLACEHOLDER), concurrency: 1"
 
-celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency=1 -Q send-sms-fair
+celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency=1 -Q send-sms-fair-tasks

--- a/scripts/run_celery_send_sms_ratelimit.sh
+++ b/scripts/run_celery_send_sms_ratelimit.sh
@@ -7,4 +7,4 @@ set -e
 
 echo "Start celery SMS rate-limit worker (PLACEHOLDER), concurrency: 1"
 
-celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency=1 -Q send-sms-fair-tasks
+celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency=1 -Q send-sms-fair

--- a/tests/app/celery/test_provider_tasks.py
+++ b/tests/app/celery/test_provider_tasks.py
@@ -1,3 +1,4 @@
+import uuid
 from unittest.mock import MagicMock, call
 
 import pytest
@@ -6,13 +7,14 @@ from notifications_utils.recipients import InvalidEmailError
 
 import app
 from app.celery import provider_tasks
-from app.celery.provider_tasks import deliver_email, deliver_sms, deliver_throttled_sms
+from app.celery.provider_tasks import deliver_email, deliver_sms, deliver_sms_rate_limited, deliver_throttled_sms
 from app.clients.email.aws_ses import AwsSesClientException
+from app.config import QueueNames
 from app.exceptions import (
     NotificationTechnicalFailureException,
     PinpointValidationException,
 )
-from celery.exceptions import MaxRetriesExceededError
+from celery.exceptions import Ignore, MaxRetriesExceededError
 
 sms_methods = [
     (deliver_sms, "deliver_sms"),
@@ -24,6 +26,7 @@ def test_should_have_decorated_tasks_functions():
     assert deliver_sms.__wrapped__.__name__ == "deliver_sms"
     assert deliver_throttled_sms.__wrapped__.__name__ == "deliver_throttled_sms"
     assert deliver_email.__wrapped__.__name__ == "deliver_email"
+    assert deliver_sms_rate_limited.__wrapped__.__name__ == "deliver_sms_rate_limited"
 
 
 @pytest.mark.parametrize("sms_method,sms_method_name", sms_methods)
@@ -248,3 +251,50 @@ def test_send_sms_should_not_switch_providers_on_non_provider_failure(
     sms_method(sample_notification.id)
 
     assert switch_provider_mock.called is False
+
+
+class TestDeliverSmsRateLimited:
+    def test_delivers_sms_when_rate_limit_acquired(self, notify_api, mocker):
+        notification_id = str(uuid.uuid4())
+        mock_limiter = MagicMock()
+        mock_limiter.acquire_lease.return_value = (True, 0)
+        mocker.patch("app.celery.provider_tasks.get_rate_limiter", return_value=mock_limiter)
+        mock_deliver = mocker.patch("app.celery.provider_tasks._deliver_sms")
+        mock_apply_async = mocker.patch("app.celery.provider_tasks.deliver_sms_rate_limited.apply_async")
+
+        deliver_sms_rate_limited(notification_id, 2)
+
+        mock_deliver.assert_called_once()
+        mock_apply_async.assert_not_called()
+
+    def test_reschedules_and_raises_ignore_when_rate_limited(self, notify_api, mocker):
+        notification_id = str(uuid.uuid4())
+        mock_limiter = MagicMock()
+        mock_limiter.acquire_lease.return_value = (False, 30)
+        mocker.patch("app.celery.provider_tasks.get_rate_limiter", return_value=mock_limiter)
+        mocker.patch("app.celery.provider_tasks._deliver_sms")
+        mock_apply_async = mocker.patch("app.celery.provider_tasks.deliver_sms_rate_limited.apply_async")
+        # In unit test context, the task object doesn't inherit NotifyTask so
+        # message_group_id property isn't available; patch it directly.
+        deliver_sms_rate_limited._get_current_object().message_group_id = None
+
+        with pytest.raises(Ignore):
+            deliver_sms_rate_limited(notification_id, 2)
+
+        mock_apply_async.assert_called_once_with(
+            queue=QueueNames.SEND_SMS_FAIR,
+            args=[notification_id, 2],
+            countdown=30,
+            MessageGroupId=None,
+        )
+
+    def test_uses_same_private_deliver_sms_method(self, notify_api, mocker):
+        notification_id = str(uuid.uuid4())
+        mock_limiter = MagicMock()
+        mock_limiter.acquire_lease.return_value = (True, 0)
+        mocker.patch("app.celery.provider_tasks.get_rate_limiter", return_value=mock_limiter)
+        mock_deliver = mocker.patch("app.celery.provider_tasks._deliver_sms")
+
+        deliver_sms_rate_limited(notification_id, 1)
+
+        mock_deliver.assert_called_once()

--- a/tests/app/celery/test_scheduled_tasks.py
+++ b/tests/app/celery/test_scheduled_tasks.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from unittest.mock import call
+from unittest.mock import ANY, call
 
 import pytest
 from freezegun import freeze_time
@@ -184,7 +184,7 @@ def test_should_send_all_scheduled_notifications_to_deliver_queue(sample_templat
 
     send_scheduled_notifications()
 
-    mocked.apply_async.assert_called_once_with([str(message_to_deliver.id)], queue=QueueNames.SEND_SMS_MEDIUM)
+    mocked.apply_async.assert_called_once_with([str(message_to_deliver.id)], queue=QueueNames.SEND_SMS_MEDIUM, MessageGroupId=ANY)
     scheduled_notifications = dao_get_scheduled_notifications()
     assert not scheduled_notifications
 
@@ -363,8 +363,8 @@ def test_replay_created_notifications(notify_db_session, sample_service, mocker)
     save_notification(create_notification(template=email_template, created_at=datetime.utcnow(), status="created"))
 
     replay_created_notifications()
-    email_delivery_queue.assert_called_once_with([str(old_email.id)], queue=QueueNames.SEND_EMAIL_MEDIUM)
-    sms_delivery_queue.assert_called_once_with([str(old_sms.id)], queue=QueueNames.SEND_SMS_MEDIUM)
+    email_delivery_queue.assert_called_once_with([str(old_email.id)], queue=QueueNames.SEND_EMAIL_MEDIUM, MessageGroupId=ANY)
+    sms_delivery_queue.assert_called_once_with([str(old_sms.id)], queue=QueueNames.SEND_SMS_MEDIUM, MessageGroupId=ANY)
 
 
 def test_check_job_status_task_does_not_raise_error(sample_template):

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -2,7 +2,7 @@ import json
 import uuid
 from datetime import datetime, timedelta
 from unittest import mock
-from unittest.mock import MagicMock, Mock, call
+from unittest.mock import ANY, MagicMock, Mock, call
 
 import pytest
 import requests_mock
@@ -1152,7 +1152,9 @@ class TestSaveSmss:
         assert persisted_notification.personalisation == {"name": "Jo"}
         assert persisted_notification._personalisation == signer_personalisation.sign({"name": "Jo"})
         assert persisted_notification.notification_type == "sms"
-        mocked_deliver_sms.assert_called_once_with([str(persisted_notification.id)], queue=QueueNames.SEND_SMS_MEDIUM)
+        mocked_deliver_sms.assert_called_once_with(
+            [str(persisted_notification.id)], queue=QueueNames.SEND_SMS_MEDIUM, MessageGroupId=ANY
+        )
 
     @pytest.mark.parametrize("sender_id", [None, "996958a8-0c06-43be-a40e-56e4a2d1655c"])
     def test_save_sms_should_use_redis_cache_to_retrieve_service_and_template_when_possible(
@@ -1207,7 +1209,9 @@ class TestSaveSmss:
         assert persisted_notification.reply_to_text == (f"+1{sms_sender.sms_sender}" if sender_id else None)
 
         mocked_deliver_sms.assert_called_once_with(
-            [str(persisted_notification.id)], queue="send-throttled-sms-tasks" if sender_id else QueueNames.SEND_SMS_MEDIUM
+            [str(persisted_notification.id)],
+            queue="send-throttled-sms-tasks" if sender_id else QueueNames.SEND_SMS_MEDIUM,
+            MessageGroupId=ANY,
         )
         if sender_id:
             mocked_get_sender_id.assert_called_once_with(persisted_notification.service_id, sender_id)
@@ -1228,7 +1232,7 @@ class TestSaveSmss:
         save_smss(template.service_id, [signer_notification.sign(notification)], notification_id)
         persisted_notification = Notification.query.one()
         provider_tasks.deliver_sms.apply_async.assert_called_once_with(
-            [str(persisted_notification.id)], queue="research-mode-tasks"
+            [str(persisted_notification.id)], queue="research-mode-tasks", MessageGroupId=ANY
         )
         assert mocked_deliver_sms.called
 
@@ -1252,11 +1256,11 @@ class TestSaveSmss:
         persisted_notification = Notification.query.one()
         if process_type == "priority":
             provider_tasks.deliver_sms.apply_async.assert_called_once_with(
-                [str(persisted_notification.id)], queue=QueueNames.SEND_SMS_HIGH
+                [str(persisted_notification.id)], queue=QueueNames.SEND_SMS_HIGH, MessageGroupId=ANY
             )
         else:
             provider_tasks.deliver_sms.apply_async.assert_called_once_with(
-                [str(persisted_notification.id)], queue=QueueNames.SEND_SMS_LOW
+                [str(persisted_notification.id)], queue=QueueNames.SEND_SMS_LOW, MessageGroupId=ANY
             )
         assert mocked_deliver_sms.called
 
@@ -1276,7 +1280,7 @@ class TestSaveSmss:
         )
         persisted_notification = Notification.query.one()
         provider_tasks.deliver_sms.apply_async.assert_called_once_with(
-            [str(persisted_notification.id)], queue=QueueNames.SEND_SMS_LOW
+            [str(persisted_notification.id)], queue=QueueNames.SEND_SMS_LOW, MessageGroupId=ANY
         )
         assert mocked_deliver_sms.called
 
@@ -1296,7 +1300,7 @@ class TestSaveSmss:
 
         persisted_notification = Notification.query.one()
         provider_tasks.deliver_throttled_sms.apply_async.assert_called_once_with(
-            [str(persisted_notification.id)], queue="send-throttled-sms-tasks"
+            [str(persisted_notification.id)], queue="send-throttled-sms-tasks", MessageGroupId=ANY
         )
         mocked_deliver_sms.assert_not_called()
         mocked_deliver_throttled_sms.assert_called_once()
@@ -1324,7 +1328,7 @@ class TestSaveSmss:
         assert not persisted_notification.personalisation
         assert persisted_notification.notification_type == "sms"
         provider_tasks.deliver_sms.apply_async.assert_called_once_with(
-            [str(persisted_notification.id)], queue=QueueNames.SEND_SMS_MEDIUM
+            [str(persisted_notification.id)], queue=QueueNames.SEND_SMS_MEDIUM, MessageGroupId=ANY
         )
 
     def test_save_sms_should_save_default_smm_sender_notification_reply_to_text_on(self, notify_db_session, mocker):
@@ -1362,7 +1366,7 @@ class TestSaveSmss:
         assert persisted_notification.notification_type == "sms"
 
         provider_tasks.deliver_sms.apply_async.assert_called_once_with(
-            [str(persisted_notification.id)], queue=QueueNames.SEND_SMS_MEDIUM
+            [str(persisted_notification.id)], queue=QueueNames.SEND_SMS_MEDIUM, MessageGroupId=ANY
         )
 
     def test_save_sms_should_go_to_retry_queue_if_database_errors(self, sample_template, mocker):
@@ -1593,7 +1597,9 @@ class TestSaveEmails:
         assert persisted_notification.personalisation == {"name": "Jo"}
         assert persisted_notification._personalisation == signer_personalisation.sign({"name": "Jo"})
         assert persisted_notification.notification_type == "email"
-        mocked_deliver_email.assert_called_once_with([str(persisted_notification.id)], queue=QueueNames.SEND_EMAIL_MEDIUM)
+        mocked_deliver_email.assert_called_once_with(
+            [str(persisted_notification.id)], queue=QueueNames.SEND_EMAIL_MEDIUM, MessageGroupId=ANY
+        )
         if sender_id:
             mocked_get_sender_id.assert_called_once_with(persisted_notification.service_id, sender_id)
 
@@ -1641,7 +1647,7 @@ class TestSaveEmails:
 
         persisted_notification = Notification.query.one()
         provider_tasks.deliver_email.apply_async.assert_called_once_with(
-            [str(persisted_notification.id)], queue="research-mode-tasks"
+            [str(persisted_notification.id)], queue="research-mode-tasks", MessageGroupId=ANY
         )
 
     @pytest.mark.parametrize(
@@ -1661,7 +1667,9 @@ class TestSaveEmails:
         save_emails(service.id, [signer_notification.sign(notification)], notification_id)
 
         persisted_notification = Notification.query.one()
-        provider_tasks.deliver_email.apply_async.assert_called_once_with([str(persisted_notification.id)], queue=expected_queue)
+        provider_tasks.deliver_email.apply_async.assert_called_once_with(
+            [str(persisted_notification.id)], queue=expected_queue, MessageGroupId=ANY
+        )
 
     def test_should_route_save_email_task_to_bulk_on_large_csv_file(self, notify_db_session, mocker):
         service = create_service()
@@ -1676,7 +1684,7 @@ class TestSaveEmails:
 
         persisted_notification = Notification.query.one()
         provider_tasks.deliver_email.apply_async.assert_called_once_with(
-            [str(persisted_notification.id)], queue=QueueNames.SEND_EMAIL_LOW
+            [str(persisted_notification.id)], queue=QueueNames.SEND_EMAIL_LOW, MessageGroupId=ANY
         )
 
     def test_should_use_email_template_and_persist(
@@ -1716,7 +1724,7 @@ class TestSaveEmails:
         assert persisted_notification.notification_type == "email"
 
         provider_tasks.deliver_email.apply_async.assert_called_once_with(
-            [str(persisted_notification.id)], queue=QueueNames.SEND_EMAIL_MEDIUM
+            [str(persisted_notification.id)], queue=QueueNames.SEND_EMAIL_MEDIUM, MessageGroupId=ANY
         )
 
     def test_save_email_should_use_template_version_from_job_not_latest(self, sample_email_template, mocker):
@@ -1744,7 +1752,7 @@ class TestSaveEmails:
         assert not persisted_notification.sent_by
         assert persisted_notification.notification_type == "email"
         provider_tasks.deliver_email.apply_async.assert_called_once_with(
-            [str(persisted_notification.id)], queue=QueueNames.SEND_EMAIL_MEDIUM
+            [str(persisted_notification.id)], queue=QueueNames.SEND_EMAIL_MEDIUM, MessageGroupId=ANY
         )
 
     def test_should_use_email_template_subject_placeholders(self, sample_email_template_with_placeholders, mocker):
@@ -1766,7 +1774,7 @@ class TestSaveEmails:
         assert not persisted_notification.reference
         assert persisted_notification.notification_type == "email"
         provider_tasks.deliver_email.apply_async.assert_called_once_with(
-            [str(persisted_notification.id)], queue=QueueNames.SEND_EMAIL_MEDIUM
+            [str(persisted_notification.id)], queue=QueueNames.SEND_EMAIL_MEDIUM, MessageGroupId=ANY
         )
 
     def test_save_email_uses_the_reply_to_text_when_provided(self, sample_email_template, mocker):
@@ -1823,7 +1831,7 @@ class TestSaveEmails:
         assert not persisted_notification.reference
         assert persisted_notification.notification_type == "email"
         provider_tasks.deliver_email.apply_async.assert_called_once_with(
-            [str(persisted_notification.id)], queue=QueueNames.SEND_EMAIL_MEDIUM
+            [str(persisted_notification.id)], queue=QueueNames.SEND_EMAIL_MEDIUM, MessageGroupId=ANY
         )
 
     def test_save_email_should_go_to_retry_queue_if_database_errors(self, sample_email_template, mocker):

--- a/tests/app/invite/test_invite_rest.py
+++ b/tests/app/invite/test_invite_rest.py
@@ -1,4 +1,5 @@
 import json
+from unittest.mock import ANY
 
 import pytest
 
@@ -63,7 +64,7 @@ def test_create_invited_user(
     assert notification.personalisation["url"].startswith(expected_start_of_invite_url)
     assert len(notification.personalisation["url"]) > len(expected_start_of_invite_url)
 
-    mocked.assert_called_once_with([(str(notification.id))], queue="notify-internal-tasks")
+    mocked.assert_called_once_with([(str(notification.id))], queue="notify-internal-tasks", MessageGroupId=ANY)
 
 
 def test_create_invited_user_without_auth_type(admin_request, sample_service, mocker, invitation_email_template):

--- a/tests/app/notifications/rest/test_send_notification.py
+++ b/tests/app/notifications/rest/test_send_notification.py
@@ -1,6 +1,7 @@
 import random
 import string
 from datetime import datetime
+from unittest.mock import ANY
 
 import pytest
 from flask import current_app, json
@@ -160,7 +161,7 @@ def test_send_notification_with_placeholders_replaced(notify_api, sample_email_t
             notification_id = response_data["notification"]["id"]
             data.update({"template_version": sample_email_template_with_placeholders.version})
 
-            mocked.assert_called_once_with([notification_id], queue=QueueNames.SEND_EMAIL_MEDIUM)
+            mocked.assert_called_once_with([notification_id], queue=QueueNames.SEND_EMAIL_MEDIUM, MessageGroupId=ANY)
             assert response.status_code == 201
             assert response_data["body"] == "Hello Jo\nThis is an email from GOV.UK"
             assert response_data["subject"] == "Jo"
@@ -382,7 +383,7 @@ def test_should_allow_valid_sms_notification(notify_api, sample_template, mocker
             response_data = json.loads(response.data)["data"]
             notification_id = response_data["notification"]["id"]
 
-            mocked.assert_called_once_with([notification_id], queue=QueueNames.SEND_SMS_MEDIUM)
+            mocked.assert_called_once_with([notification_id], queue=QueueNames.SEND_SMS_MEDIUM, MessageGroupId=ANY)
             assert response.status_code == 201
             assert notification_id
             assert "subject" not in response_data
@@ -440,7 +441,7 @@ def test_should_allow_valid_email_notification(notify_api, sample_email_template
             response_data = json.loads(response.get_data(as_text=True))["data"]
             notification_id = response_data["notification"]["id"]
             app.celery.provider_tasks.deliver_email.apply_async.assert_called_once_with(
-                [notification_id], queue=QueueNames.SEND_EMAIL_MEDIUM
+                [notification_id], queue=QueueNames.SEND_EMAIL_MEDIUM, MessageGroupId=ANY
             )
 
             assert response.status_code == 201
@@ -777,7 +778,9 @@ def test_should_send_email_if_team_api_key_and_a_service_user(client, sample_ema
         headers=[("Content-Type", "application/json"), auth_header],
     )
 
-    app.celery.provider_tasks.deliver_email.apply_async.assert_called_once_with([fake_uuid], queue=QueueNames.SEND_EMAIL_MEDIUM)
+    app.celery.provider_tasks.deliver_email.apply_async.assert_called_once_with(
+        [fake_uuid], queue=QueueNames.SEND_EMAIL_MEDIUM, MessageGroupId=ANY
+    )
     assert response.status_code == 201
 
 
@@ -815,7 +818,9 @@ def test_should_send_sms_to_anyone_with_test_key(client, sample_template, mocker
             ("Authorization", "Bearer {}".format(auth_header)),
         ],
     )
-    app.celery.provider_tasks.deliver_sms.apply_async.assert_called_once_with([fake_uuid], queue="research-mode-tasks")
+    app.celery.provider_tasks.deliver_sms.apply_async.assert_called_once_with(
+        [fake_uuid], queue="research-mode-tasks", MessageGroupId=ANY
+    )
     assert response.status_code == 201
 
 
@@ -854,7 +859,9 @@ def test_should_send_email_to_anyone_with_test_key(client, sample_email_template
         ],
     )
 
-    app.celery.provider_tasks.deliver_email.apply_async.assert_called_once_with([fake_uuid], queue="research-mode-tasks")
+    app.celery.provider_tasks.deliver_email.apply_async.assert_called_once_with(
+        [fake_uuid], queue="research-mode-tasks", MessageGroupId=ANY
+    )
     assert response.status_code == 201
 
 
@@ -892,7 +899,9 @@ def test_should_send_sms_if_team_api_key_and_a_service_user(client, sample_templ
         ],
     )
 
-    app.celery.provider_tasks.deliver_sms.apply_async.assert_called_once_with([fake_uuid], queue=QueueNames.SEND_SMS_MEDIUM)
+    app.celery.provider_tasks.deliver_sms.apply_async.assert_called_once_with(
+        [fake_uuid], queue=QueueNames.SEND_SMS_MEDIUM, MessageGroupId=ANY
+    )
     assert response.status_code == 201
 
 
@@ -945,7 +954,7 @@ def test_should_persist_notification(
         ],
     )
 
-    mocked.assert_called_once_with([fake_uuid], queue=queue_name)
+    mocked.assert_called_once_with([fake_uuid], queue=queue_name, MessageGroupId=ANY)
     assert response.status_code == 201
 
     notification = notifications_dao.get_notification_by_id(fake_uuid)
@@ -1009,7 +1018,7 @@ def test_should_delete_notification_and_return_error_if_sqs_fails(
         )
     assert str(e.value) == "failed to talk to SQS"
 
-    mocked.assert_called_once_with([fake_uuid], queue=queue_name)
+    mocked.assert_called_once_with([fake_uuid], queue=queue_name, MessageGroupId=ANY)
     assert not notifications_dao.get_notification_by_id(fake_uuid)
     assert not NotificationHistory.query.get(fake_uuid)
 
@@ -1284,7 +1293,7 @@ def test_send_notification_uses_appropriate_queue_when_template_has_process_type
         expected_queue = QueueNames.SEND_SMS_HIGH if process_type == "priority" else QueueNames.SEND_SMS_LOW
     else:
         expected_queue = QueueNames.SEND_EMAIL_HIGH if process_type == "priority" else QueueNames.SEND_EMAIL_LOW
-    mocked.assert_called_once_with([notification_id], queue=expected_queue)
+    mocked.assert_called_once_with([notification_id], queue=expected_queue, MessageGroupId=ANY)
 
 
 @pytest.mark.parametrize("notification_type, send_to", [("sms", "6502532222"), ("email", "sample@email.com")])
@@ -1336,7 +1345,7 @@ def test_should_allow_store_original_number_on_sms_notification(client, sample_t
     response_data = json.loads(response.data)["data"]
     notification_id = response_data["notification"]["id"]
 
-    mocked.assert_called_once_with([notification_id], queue=QueueNames.SEND_SMS_MEDIUM)
+    mocked.assert_called_once_with([notification_id], queue=QueueNames.SEND_SMS_MEDIUM, MessageGroupId=ANY)
     assert response.status_code == 201
     assert notification_id
     notifications = Notification.query.all()

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -3,6 +3,14 @@ import uuid
 from unittest.mock import ANY, call
 
 import pytest
+from boto3.exceptions import Boto3Error
+from freezegun import freeze_time
+from notifications_utils.recipients import (
+    validate_and_format_email_address,
+    validate_and_format_phone_number,
+)
+from sqlalchemy.exc import SQLAlchemyError
+
 from app.celery.utils import CeleryParams
 from app.config import QueueNames
 from app.dao.service_sms_sender_dao import dao_update_service_sms_sender
@@ -28,14 +36,6 @@ from app.notifications.process_notifications import (
     transform_notification,
 )
 from app.v2.errors import BadRequestError
-from boto3.exceptions import Boto3Error
-from freezegun import freeze_time
-from notifications_utils.recipients import (
-    validate_and_format_email_address,
-    validate_and_format_phone_number,
-)
-from sqlalchemy.exc import SQLAlchemyError
-
 from tests.app.conftest import create_sample_api_key
 from tests.app.db import create_service_sms_sender
 from tests.conftest import set_config, set_config_values

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -475,7 +475,7 @@ class TestSendNotificationQueue:
                 "sms",
                 "normal",
                 "+14383898585",
-                "send-throttled-sms-tasks",
+                "research-mode-tasks",
                 "deliver_throttled_sms",
             ),
             (False, None, "sms", "normal", None, QueueNames.SEND_SMS_MEDIUM, "deliver_sms"),

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -476,7 +476,7 @@ class TestSendNotificationQueue:
                 "normal",
                 "+14383898585",
                 "research-mode-tasks",
-                "deliver_throttled_sms",
+                "deliver_sms",
             ),
             (False, None, "sms", "normal", None, QueueNames.SEND_SMS_MEDIUM, "deliver_sms"),
             (False, None, "email", "normal", None, QueueNames.SEND_EMAIL_MEDIUM, "deliver_email"),

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -3,14 +3,6 @@ import uuid
 from unittest.mock import ANY, call
 
 import pytest
-from boto3.exceptions import Boto3Error
-from freezegun import freeze_time
-from notifications_utils.recipients import (
-    validate_and_format_email_address,
-    validate_and_format_phone_number,
-)
-from sqlalchemy.exc import SQLAlchemyError
-
 from app.celery.utils import CeleryParams
 from app.config import QueueNames
 from app.dao.service_sms_sender_dao import dao_update_service_sms_sender
@@ -36,6 +28,14 @@ from app.notifications.process_notifications import (
     transform_notification,
 )
 from app.v2.errors import BadRequestError
+from boto3.exceptions import Boto3Error
+from freezegun import freeze_time
+from notifications_utils.recipients import (
+    validate_and_format_email_address,
+    validate_and_format_phone_number,
+)
+from sqlalchemy.exc import SQLAlchemyError
+
 from tests.app.conftest import create_sample_api_key
 from tests.app.db import create_service_sms_sender
 from tests.conftest import set_config, set_config_values
@@ -610,9 +610,7 @@ class TestSendNotificationQueue:
                 MessageGroupId="send-sms-medium-tasks",
             )
 
-    def test_send_notification_to_queue_with_ff_sms_ratelimit_uses_incoming_queue_as_message_group(
-        self, notify_api, mocker
-    ):
+    def test_send_notification_to_queue_with_ff_sms_ratelimit_uses_incoming_queue_as_message_group(self, notify_api, mocker):
         # When a volume-adjusted queue arrives (e.g. send-sms-low), it becomes the MessageGroupId.
         with set_config(notify_api, "FF_SMS_RATELIMIT", True):
             notification = Notification(
@@ -636,9 +634,7 @@ class TestSendNotificationQueue:
                 MessageGroupId=QueueNames.SEND_SMS_LOW,
             )
 
-    def test_send_notification_to_queue_with_ff_sms_ratelimit_bypasses_for_research_mode(
-        self, notify_api, mocker
-    ):
+    def test_send_notification_to_queue_with_ff_sms_ratelimit_bypasses_for_research_mode(self, notify_api, mocker):
         with set_config(notify_api, "FF_SMS_RATELIMIT", True):
             notification = Notification(
                 id=uuid.uuid4(),
@@ -658,9 +654,7 @@ class TestSendNotificationQueue:
             )
             mock_rate_limited.assert_not_called()
 
-    def test_send_notification_to_queue_with_ff_sms_ratelimit_throttled_sms_takes_priority(
-        self, notify_api, mocker
-    ):
+    def test_send_notification_to_queue_with_ff_sms_ratelimit_throttled_sms_takes_priority(self, notify_api, mocker):
         with set_config(notify_api, "FF_SMS_RATELIMIT", True):
             notification = Notification(
                 id=uuid.uuid4(),

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -744,7 +744,7 @@ class TestChooseQueue:
                 "sms",
                 "normal",
                 "+14383898585",
-                "send-throttled-sms-tasks",
+                "research-mode-tasks",
             ),
             (False, None, "sms", "normal", None, QueueNames.SEND_SMS_MEDIUM),
             (False, None, "email", "normal", None, QueueNames.SEND_EMAIL_MEDIUM),

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -1,6 +1,6 @@
 import datetime
 import uuid
-from unittest.mock import call
+from unittest.mock import ANY, call
 
 import pytest
 from boto3.exceptions import Boto3Error
@@ -38,7 +38,7 @@ from app.notifications.process_notifications import (
 from app.v2.errors import BadRequestError
 from tests.app.conftest import create_sample_api_key
 from tests.app.db import create_service_sms_sender
-from tests.conftest import set_config
+from tests.conftest import set_config, set_config_values
 
 
 class TestContentCreation:
@@ -573,7 +573,7 @@ class TestSendNotificationQueue:
 
         send_notification_to_queue(notification=notification, research_mode=research_mode, queue=requested_queue)
 
-        mocked.assert_called_once_with([str(notification.id)], queue=expected_queue)
+        mocked.assert_called_once_with([str(notification.id)], queue=expected_queue, MessageGroupId=ANY)
 
     def test_send_notification_to_queue_throws_exception_deletes_notification(self, sample_notification, mocker):
         mocked = mocker.patch(
@@ -582,10 +582,104 @@ class TestSendNotificationQueue:
         )
         with pytest.raises(Boto3Error):
             send_notification_to_queue(sample_notification, False)
-        mocked.assert_called_once_with([(str(sample_notification.id))], queue=QueueNames.SEND_SMS_MEDIUM)
+        mocked.assert_called_once_with([(str(sample_notification.id))], queue=QueueNames.SEND_SMS_MEDIUM, MessageGroupId=ANY)
 
         assert Notification.query.count() == 0
         assert NotificationHistory.query.count() == 0
+
+    def test_send_notification_to_queue_with_ff_sms_ratelimit_routes_to_fair_queue(self, notify_api, mocker):
+        with set_config(notify_api, "FF_SMS_RATELIMIT", True):
+            notification = Notification(
+                id=uuid.uuid4(),
+                key_type="normal",
+                notification_type="sms",
+                created_at=datetime.datetime(2016, 11, 11, 16, 8, 18),
+            )
+            mock_apply = mocker.patch("app.celery.provider_tasks.deliver_sms_rate_limited.apply_async")
+            mocker.patch(
+                "app.notifications.process_notifications.get_delivery_queue_for_template",
+                return_value="send-sms-medium-tasks",
+            )
+            mocker.patch("app.notifications.process_notifications.number_of_sms_fragments", return_value=2)
+
+            send_notification_to_queue(notification=notification, research_mode=False, queue=None)
+
+            mock_apply.assert_called_once_with(
+                [str(notification.id), 2],
+                queue=QueueNames.SEND_SMS_FAIR,
+                MessageGroupId="send-sms-medium-tasks",
+            )
+
+    def test_send_notification_to_queue_with_ff_sms_ratelimit_uses_incoming_queue_as_message_group(
+        self, notify_api, mocker
+    ):
+        # When a volume-adjusted queue arrives (e.g. send-sms-low), it becomes the MessageGroupId.
+        with set_config(notify_api, "FF_SMS_RATELIMIT", True):
+            notification = Notification(
+                id=uuid.uuid4(),
+                key_type="normal",
+                notification_type="sms",
+                created_at=datetime.datetime(2016, 11, 11, 16, 8, 18),
+            )
+            mock_apply = mocker.patch("app.celery.provider_tasks.deliver_sms_rate_limited.apply_async")
+            mocker.patch("app.notifications.process_notifications.number_of_sms_fragments", return_value=3)
+
+            send_notification_to_queue(
+                notification=notification,
+                research_mode=False,
+                queue=QueueNames.SEND_SMS_LOW,
+            )
+
+            mock_apply.assert_called_once_with(
+                [str(notification.id), 3],
+                queue=QueueNames.SEND_SMS_FAIR,
+                MessageGroupId=QueueNames.SEND_SMS_LOW,
+            )
+
+    def test_send_notification_to_queue_with_ff_sms_ratelimit_bypasses_for_research_mode(
+        self, notify_api, mocker
+    ):
+        with set_config(notify_api, "FF_SMS_RATELIMIT", True):
+            notification = Notification(
+                id=uuid.uuid4(),
+                key_type="normal",
+                notification_type="sms",
+                created_at=datetime.datetime(2016, 11, 11, 16, 8, 18),
+            )
+            mock_rate_limited = mocker.patch("app.celery.provider_tasks.deliver_sms_rate_limited.apply_async")
+            mock_deliver_sms = mocker.patch("app.celery.provider_tasks.deliver_sms.apply_async")
+
+            send_notification_to_queue(notification=notification, research_mode=True, queue=None)
+
+            mock_deliver_sms.assert_called_once_with(
+                [str(notification.id)],
+                queue=QueueNames.RESEARCH_MODE,
+                MessageGroupId=ANY,
+            )
+            mock_rate_limited.assert_not_called()
+
+    def test_send_notification_to_queue_with_ff_sms_ratelimit_throttled_sms_takes_priority(
+        self, notify_api, mocker
+    ):
+        with set_config(notify_api, "FF_SMS_RATELIMIT", True):
+            notification = Notification(
+                id=uuid.uuid4(),
+                key_type="normal",
+                notification_type="sms",
+                reply_to_text="+14383898585",
+                created_at=datetime.datetime(2016, 11, 11, 16, 8, 18),
+            )
+            mock_rate_limited = mocker.patch("app.celery.provider_tasks.deliver_sms_rate_limited.apply_async")
+            mock_throttled = mocker.patch("app.celery.provider_tasks.deliver_throttled_sms.apply_async")
+
+            send_notification_to_queue(notification=notification, research_mode=False, queue=None)
+
+            mock_throttled.assert_called_once_with(
+                [str(notification.id)],
+                queue=QueueNames.SEND_THROTTLED_SMS,
+                MessageGroupId=ANY,
+            )
+            mock_rate_limited.assert_not_called()
 
 
 class TestSimulatedRecipient:
@@ -750,6 +844,40 @@ class TestChooseQueue:
         )
 
         assert choose_queue(notification, research_mode, requested_queue) == expected_queue
+
+    @pytest.mark.parametrize(
+        ("research_mode, priority_queue, key_type, reply_to_text, expected_queue"),
+        [
+            # FF on: normal SMS with no priority queue → routed to SEND_SMS_FAIR
+            (False, None, "normal", None, QueueNames.SEND_SMS_FAIR),
+            # FF on: research mode still returns RESEARCH_MODE
+            (True, None, "normal", None, QueueNames.RESEARCH_MODE),
+            # FF on: test key still returns RESEARCH_MODE
+            (False, None, "test", None, QueueNames.RESEARCH_MODE),
+            # FF on: custom number (dedicated sender) takes priority over fair queue
+            (False, None, "normal", "+14383898585", QueueNames.SEND_THROTTLED_SMS),
+            # FF on: explicit priority_queue overrides fair queue routing
+            (False, "notify-internal-tasks", "normal", None, "notify-internal-tasks"),
+        ],
+    )
+    def test_choose_queue_with_ff_sms_ratelimit(
+        self,
+        notify_api,
+        research_mode,
+        priority_queue,
+        key_type,
+        reply_to_text,
+        expected_queue,
+    ):
+        with set_config(notify_api, "FF_SMS_RATELIMIT", True):
+            notification = Notification(
+                id=uuid.uuid4(),
+                notification_type="sms",
+                key_type=key_type,
+                reply_to_text=reply_to_text,
+                created_at=datetime.datetime(2016, 11, 11, 16, 8, 18),
+            )
+            assert choose_queue(notification, research_mode, priority_queue) == expected_queue
 
 
 class TestTransformNotification:
@@ -1035,7 +1163,7 @@ class TestDBSaveAndSendNotification:
 
         db_save_and_send_notification(notification=notification)
 
-        mocked.assert_called_once_with([str(notification.id)], queue=expected_queue)
+        mocked.assert_called_once_with([str(notification.id)], queue=expected_queue, MessageGroupId=ANY)
 
     def test_db_save_and_send_notification_throws_exception_deletes_notification(
         self, sample_template, sample_api_key, sample_job, mocker
@@ -1064,7 +1192,7 @@ class TestDBSaveAndSendNotification:
 
         with pytest.raises(Boto3Error):
             db_save_and_send_notification(notification)
-        mocked.assert_called_once_with([(str(notification.id))], queue=QueueNames.SEND_SMS_MEDIUM)
+        mocked.assert_called_once_with([(str(notification.id))], queue=QueueNames.SEND_SMS_MEDIUM, MessageGroupId=ANY)
 
         assert Notification.query.count() == 0
         assert NotificationHistory.query.count() == 0
@@ -1234,6 +1362,118 @@ class TestDBSaveAndSendNotification:
         mock_incr.assert_called_once_with(
             str(sample_template.service_id) + "-2016-01-01-count",
         )
+
+    def test_db_save_and_send_with_ff_sms_ratelimit_routes_sms_to_fair_queue(
+        self, notify_api, sample_template, notify_db, notify_db_session, mocker
+    ):
+        with set_config(notify_api, "FF_SMS_RATELIMIT", True):
+            mock_apply = mocker.patch("app.celery.provider_tasks.deliver_sms_rate_limited.apply_async")
+            mocker.patch(
+                "app.notifications.process_notifications.get_delivery_queue_for_template",
+                return_value="send-sms-medium-tasks",
+            )
+            mocker.patch("app.notifications.process_notifications.number_of_sms_fragments", return_value=3)
+
+            notification = Notification(
+                id=uuid.uuid4(),
+                to="+16502532222",
+                template_id=sample_template.id,
+                template_version=sample_template.version,
+                key_type="normal",
+                notification_type="sms",
+                created_at=datetime.datetime(2016, 11, 11, 16, 8, 18),
+                queue_name=QueueNames.SEND_SMS_FAIR,
+            )
+            db_save_and_send_notification(notification=notification)
+
+            mock_apply.assert_called_once_with(
+                [str(notification.id), 3],
+                queue=QueueNames.SEND_SMS_FAIR,
+                MessageGroupId="send-sms-medium-tasks",
+            )
+
+    def test_db_save_and_send_with_ff_sms_ratelimit_uses_stored_billable_units(
+        self, notify_api, sample_template, notify_db, notify_db_session, mocker
+    ):
+        with set_config_values(notify_api, {"FF_SMS_RATELIMIT": True, "FF_USE_BILLABLE_UNITS": True}):
+            mock_apply = mocker.patch("app.celery.provider_tasks.deliver_sms_rate_limited.apply_async")
+            mocker.patch(
+                "app.notifications.process_notifications.get_delivery_queue_for_template",
+                return_value="send-sms-medium-tasks",
+            )
+            mock_fragments = mocker.patch("app.notifications.process_notifications.number_of_sms_fragments")
+
+            notification = Notification(
+                id=uuid.uuid4(),
+                to="+16502532222",
+                template_id=sample_template.id,
+                template_version=sample_template.version,
+                key_type="normal",
+                notification_type="sms",
+                billable_units=4,
+                created_at=datetime.datetime(2016, 11, 11, 16, 8, 18),
+                queue_name=QueueNames.SEND_SMS_FAIR,
+            )
+            db_save_and_send_notification(notification=notification)
+
+            mock_apply.assert_called_once_with(
+                [str(notification.id), 4],
+                queue=QueueNames.SEND_SMS_FAIR,
+                MessageGroupId="send-sms-medium-tasks",
+            )
+            mock_fragments.assert_not_called()
+
+    def test_db_save_and_send_with_ff_sms_ratelimit_bypasses_for_research_mode(
+        self, notify_api, sample_template, notify_db, notify_db_session, mocker
+    ):
+        with set_config(notify_api, "FF_SMS_RATELIMIT", True):
+            mock_rate_limited = mocker.patch("app.celery.provider_tasks.deliver_sms_rate_limited.apply_async")
+            mock_deliver_sms = mocker.patch("app.celery.provider_tasks.deliver_sms.apply_async")
+
+            notification = Notification(
+                id=uuid.uuid4(),
+                to="+16502532222",
+                template_id=sample_template.id,
+                template_version=sample_template.version,
+                key_type="test",
+                notification_type="sms",
+                created_at=datetime.datetime(2016, 11, 11, 16, 8, 18),
+                queue_name=QueueNames.RESEARCH_MODE,
+            )
+            db_save_and_send_notification(notification=notification)
+
+            mock_deliver_sms.assert_called_once_with(
+                [str(notification.id)],
+                queue=QueueNames.RESEARCH_MODE,
+                MessageGroupId=ANY,
+            )
+            mock_rate_limited.assert_not_called()
+
+    def test_db_save_and_send_with_ff_sms_ratelimit_email_unaffected(
+        self, notify_api, sample_email_template, notify_db, notify_db_session, mocker
+    ):
+        with set_config(notify_api, "FF_SMS_RATELIMIT", True):
+            mock_rate_limited = mocker.patch("app.celery.provider_tasks.deliver_sms_rate_limited.apply_async")
+            mock_deliver_email = mocker.patch("app.celery.provider_tasks.deliver_email.apply_async")
+
+            notification = Notification(
+                id=uuid.uuid4(),
+                to="test@example.com",
+                template_id=sample_email_template.id,
+                template_version=sample_email_template.version,
+                key_type="normal",
+                notification_type="email",
+                created_at=datetime.datetime(2016, 11, 11, 16, 8, 18),
+                queue_name=QueueNames.SEND_EMAIL_MEDIUM,
+            )
+            db_save_and_send_notification(notification=notification)
+
+            mock_deliver_email.assert_called_once_with(
+                [str(notification.id)],
+                queue=QueueNames.SEND_EMAIL_MEDIUM,
+                MessageGroupId=ANY,
+            )
+            mock_rate_limited.assert_not_called()
 
 
 # TODO: Remove feature flag checks after FF_USE_BILLABLE_UNITS go live

--- a/tests/app/organisation/test_invite_rest.py
+++ b/tests/app/organisation/test_invite_rest.py
@@ -1,3 +1,5 @@
+from unittest.mock import ANY
+
 import pytest
 from tests.app.db import create_invited_org_user
 
@@ -53,7 +55,7 @@ def test_create_invited_org_user(
     assert notification.personalisation["url"].startswith(expected_start_of_invite_url)
     assert len(notification.personalisation["url"]) > len(expected_start_of_invite_url)
 
-    mocked.assert_called_once_with([(str(notification.id))], queue="notify-internal-tasks")
+    mocked.assert_called_once_with([(str(notification.id))], queue="notify-internal-tasks", MessageGroupId=ANY)
 
 
 def test_create_invited_user_invalid_email(admin_request, sample_organisation, sample_user, mocker):

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -2789,7 +2789,7 @@ def test_verify_reply_to_email_address_should_send_verification_email(
     notification = Notification.query.first()
     assert notification.template_id == verify_reply_to_address_email_template.id
     assert response["data"] == {"id": str(notification.id)}
-    mocked.assert_called_once_with([str(notification.id)], queue="notify-internal-tasks")
+    mocked.assert_called_once_with([str(notification.id)], queue="notify-internal-tasks", MessageGroupId=ANY)
     assert notification.reply_to_text == notify_service.get_default_reply_to_email_address()
 
 

--- a/tests/app/test_config.py
+++ b/tests/app/test_config.py
@@ -27,7 +27,7 @@ def reload_config():
 def test_queue_names_all_queues_correct():
     # Need to ensure that all_queues() only returns queue names used in API
     queues = QueueNames.all_queues()
-    assert len(queues) == 21
+    assert len(queues) == 22
     assert set(
         [
             QueueNames.PRIORITY,
@@ -40,6 +40,7 @@ def test_queue_names_all_queues_correct():
             QueueNames.SEND_SMS_MEDIUM,
             QueueNames.SEND_SMS_LOW,
             QueueNames.SEND_THROTTLED_SMS,
+            QueueNames.SEND_SMS_FAIR,
             QueueNames.SEND_EMAIL_HIGH,
             QueueNames.SEND_EMAIL_MEDIUM,
             QueueNames.SEND_EMAIL_LOW,

--- a/tests/app/test_rate_limiter.py
+++ b/tests/app/test_rate_limiter.py
@@ -1,0 +1,191 @@
+from unittest.mock import patch
+
+import pytest
+
+from app.rate_limiter import InMemoryRateLimiter
+
+
+class TestInMemoryRateLimiter:
+    @pytest.fixture
+    def limiter(self):
+        return InMemoryRateLimiter(cap_per_minute=1000)
+
+    def test_acquire_lease_below_capacity_succeeds(self, client, limiter):
+        with client.application.app_context():
+            allow_send, wait_seconds = limiter.acquire_lease(100)
+            assert allow_send is True
+            assert wait_seconds == 0
+
+    def test_acquire_lease_at_capacity_succeeds(self, client, limiter):
+        with client.application.app_context():
+            allow_send, wait_seconds = limiter.acquire_lease(1000)
+            assert allow_send is True
+            assert wait_seconds == 0
+
+    def test_acquire_lease_exceeding_capacity_fails(self, client, limiter):
+        with client.application.app_context():
+            # Fill capacity
+            limiter.acquire_lease(1000)
+            # Try to exceed
+            allow_send, wait_seconds = limiter.acquire_lease(100)
+            assert allow_send is False
+            assert wait_seconds > 0
+
+    def test_acquire_with_zero_parts_raises_error(self, client, limiter):
+        with client.application.app_context():
+            with pytest.raises(ValueError):
+                limiter.acquire_lease(0)
+
+    def test_acquire_negative_parts_raises_error(self, client, limiter):
+        with client.application.app_context():
+            with pytest.raises(ValueError):
+                limiter.acquire_lease(-10)
+
+    def test_acquire_over_capacity_raises_error(self, client, limiter):
+        with client.application.app_context():
+            with pytest.raises(ValueError):
+                limiter.acquire_lease(limiter.cap_per_minute + 1)
+
+    def test_running_total_incremented_on_acquire(self, client, limiter):
+        with client.application.app_context():
+            assert limiter.current_usage == 0
+            limiter.acquire_lease(100)
+            assert limiter.current_usage == 100
+
+    def test_running_total_decremented_on_window_expiration(self, client, limiter):
+        with client.application.app_context():
+            limiter.acquire_lease(100)
+            assert limiter.current_usage == 100
+
+            # Mock time to simulate window expiration
+            with patch("app.rate_limiter.time") as mock_time:
+                # Simulate 10 seconds after the window should have expired
+                mock_time.return_value = limiter.window[0][0] + limiter.WINDOW_SIZE_SECONDS + 10
+                limiter.get_current_usage()
+                assert limiter.current_usage == 0
+
+    def test_window_entries_removed_after_window_expiration(self, client, limiter):
+        with client.application.app_context():
+            limiter.acquire_lease(100)
+            limiter.acquire_lease(200)
+            assert len(limiter.window) == 2
+
+            # Mock time to simulate window expiration
+            with patch("app.rate_limiter.time") as mock_time:
+                mock_time.return_value = limiter.window[0][0] + limiter.WINDOW_SIZE_SECONDS + 10
+                limiter.get_current_usage()
+                assert len(limiter.window) == 0
+
+    def test_get_current_usage_returns_running_total(self, client, limiter):
+        with client.application.app_context():
+            limiter.acquire_lease(150)
+            limiter.acquire_lease(250)
+            limiter.acquire_lease(300)
+            assert limiter.get_current_usage() == 700
+
+    def test_multiple_entries_in_window(self, client, limiter):
+        with client.application.app_context():
+            limiter.acquire_lease(10)
+            limiter.acquire_lease(20)
+            limiter.acquire_lease(30)
+
+            assert len(limiter.window) == 3
+            assert limiter.current_usage == 60
+
+    def test_retry_delay_when_single_entry_needs_to_expire(self, client, limiter):
+        with client.application.app_context():
+            with patch("app.rate_limiter.time") as mock_time:
+                base_time = 100.0  # arbitrary base time where window start is not negative (100-60 = 40)
+                mock_time.return_value = base_time
+
+                # Fill capacity
+                limiter.acquire_lease(1000)
+                # Try to exceed
+                mock_time.return_value = base_time + 5
+                allow_send, wait_seconds = limiter.acquire_lease(50)
+
+                assert allow_send is False
+                # Should wait until the first entry expires
+                assert wait_seconds >= limiter.WINDOW_SIZE_SECONDS - 5 - 1  # subtract 1 second for rounding
+                assert wait_seconds <= limiter.WINDOW_SIZE_SECONDS
+
+    def test_retry_delay_when_multiple_entries_need_to_expire(self, client, limiter):
+        with client.application.app_context():
+            with patch("app.rate_limiter.time") as mock_time:
+                base_time = 100.0  # arbitrary base time where window start is not negative (100-60 = 40)
+                mock_time.return_value = base_time
+
+                # Add multiple entries that together fill the window
+                limiter.acquire_lease(400)  # Entry 1 at time 100
+                mock_time.return_value = base_time + 5
+                limiter.acquire_lease(400)  # Entry 2 at time 105
+                mock_time.return_value = base_time + 10
+                limiter.acquire_lease(200)  # Entry 3 at time 110
+
+                # At time 110, usage is maxed out at 1000/1000 (400 + 400 + 200)
+                # Try to add 500 more parts
+                mock_time.return_value = base_time + 10
+                allow_send, wait_seconds = limiter.acquire_lease(500)
+
+                assert allow_send is False
+                # Need to free 500 parts: Entry 1 (400) + Entry 2 (400) = 800 > 500
+                # So we need to wait for Entry 2 (at time 105) to expire
+                # Entry 2 expires at time 105 + 60 = 165
+                # At current time 110, we wait 55 seconds + 1 in case of rounding
+                assert wait_seconds >= limiter.WINDOW_SIZE_SECONDS - 5 - 1
+                assert wait_seconds <= limiter.WINDOW_SIZE_SECONDS
+
+    def test_capacity_after_some_entries_expire(self, client, limiter):
+        with client.application.app_context():
+            with patch("app.rate_limiter.time") as mock_time:
+                base_time = 100.0  # arbitrary base       time where window start is not negative (100-60 = 40)
+                mock_time.return_value = base_time
+
+                # Add entry 1: 600 parts at time 100
+                limiter.acquire_lease(600)
+                mock_time.return_value = base_time + 10
+                # Add entry 2: 400 parts at time 110
+                limiter.acquire_lease(400)
+
+                # Set time to 170 seconds, entry 1 should have expired, but entry 2 should still be there
+                mock_time.return_value = base_time + 70
+                allow_send, _ = limiter.acquire_lease(500)
+
+                assert allow_send is True
+                assert limiter.current_usage == 900
+
+    def test_window_slightly_older_than_60_seconds_is_removed(self, client, limiter):
+        with client.application.app_context():
+            with patch("app.rate_limiter.time") as mock_time:
+                base_time = 100.0  # arbitrary base time where window start is not negative (100-60 = 40)
+                mock_time.return_value = base_time
+                limiter.acquire_lease(50)
+
+                # At 160.1 seconds entry should be removed
+                mock_time.return_value = base_time + 60.1
+                limiter.get_current_usage()
+                assert limiter.current_usage == 0
+
+    def test_window_exactly_60_seconds_old_is_not_removed(self, client, limiter):
+        with client.application.app_context():
+            with patch("app.rate_limiter.time") as mock_time:
+                base_time = 100.0  # arbitrary base time where window start is not negative (100-60 = 40)
+                mock_time.return_value = base_time
+                limiter.acquire_lease(50)
+
+                mock_time.return_value = base_time + 60.0
+                limiter.get_current_usage()
+                # Entry should still be in window
+                assert limiter.current_usage == 50
+
+    def test_window_slightly_under_60_seconds_is_kept(self, client, limiter):
+        with client.application.app_context():
+            with patch("app.rate_limiter.time") as mock_time:
+                base_time = 100.0  # arbitrary base time where window start is not negative (100-60 = 40)
+                mock_time.return_value = base_time
+                limiter.acquire_lease(50)
+
+                # At 59.9 seconds, entry should still be there
+                mock_time.return_value = base_time + 59.9
+                limiter.get_current_usage()
+                assert limiter.current_usage == 50

--- a/tests/app/test_rate_limiter.py
+++ b/tests/app/test_rate_limiter.py
@@ -1,8 +1,9 @@
 from unittest.mock import patch
 
+import fakeredis
 import pytest
 
-from app.rate_limiter import InMemoryRateLimiter
+from app.rate_limiter import InMemoryRateLimiter, RedisRateLimiter
 
 
 class TestInMemoryRateLimiter:
@@ -189,3 +190,149 @@ class TestInMemoryRateLimiter:
                 mock_time.return_value = base_time + 59.9
                 limiter.get_current_usage()
                 assert limiter.current_usage == 50
+
+
+class TestRedisRateLimiter:
+    @pytest.fixture
+    def limiter(self):
+        redis_client = fakeredis.FakeRedis()
+        return RedisRateLimiter(cap_per_minute=1000, redis_client=redis_client)
+
+    def test_acquire_lease_below_capacity_succeeds(self, client, limiter):
+        with client.application.app_context():
+            allow_send, wait_seconds = limiter.acquire_lease(100)
+            assert allow_send is True
+            assert wait_seconds == 0
+
+    def test_acquire_lease_at_capacity_succeeds(self, client, limiter):
+        with client.application.app_context():
+            allow_send, wait_seconds = limiter.acquire_lease(1000)
+            assert allow_send is True
+            assert wait_seconds == 0
+
+    def test_acquire_lease_exceeding_capacity_fails(self, client, limiter):
+        with client.application.app_context():
+            limiter.acquire_lease(1000)
+            allow_send, wait_seconds = limiter.acquire_lease(100)
+
+            assert allow_send is False
+            assert wait_seconds > 0
+
+    def test_acquire_with_zero_parts_raises_error(self, client, limiter):
+        with client.application.app_context():
+            with pytest.raises(ValueError):
+                limiter.acquire_lease(0)
+
+    def test_acquire_negative_parts_raises_error(self, client, limiter):
+        with client.application.app_context():
+            with pytest.raises(ValueError):
+                limiter.acquire_lease(-10)
+
+    def test_acquire_over_capacity_raises_error(self, client, limiter):
+        with client.application.app_context():
+            with pytest.raises(ValueError):
+                limiter.acquire_lease(limiter.cap_per_minute + 1)
+
+    def test_get_current_usage_returns_running_total(self, client, limiter):
+        with client.application.app_context():
+            limiter.acquire_lease(150)
+            limiter.acquire_lease(250)
+            limiter.acquire_lease(300)
+
+            assert limiter.get_current_usage() == 700
+
+    def test_multiple_entries_in_window(self, client, limiter):
+        with client.application.app_context():
+            limiter.acquire_lease(10)
+            limiter.acquire_lease(20)
+            limiter.acquire_lease(30)
+
+            usage = limiter.get_current_usage()
+            assert usage == 60
+
+    def test_retry_delay_when_single_entry_needs_to_expire(self, client, limiter):
+        with client.application.app_context():
+            with patch("app.rate_limiter.time") as mock_time:
+                base_time = 100.0
+                mock_time.return_value = base_time
+
+                limiter.acquire_lease(1000)
+
+                mock_time.return_value = base_time + 5
+                allow_send, wait_seconds = limiter.acquire_lease(50)
+
+                assert allow_send is False
+                assert wait_seconds >= limiter.WINDOW_SIZE_SECONDS - 5 - 1
+                assert wait_seconds <= limiter.WINDOW_SIZE_SECONDS
+
+    def test_retry_delay_when_multiple_entries_need_to_expire(self, client, limiter):
+        with client.application.app_context():
+            with patch("app.rate_limiter.time") as mock_time:
+                base_time = 100.0
+                mock_time.return_value = base_time
+
+                limiter.acquire_lease(400)
+
+                mock_time.return_value = base_time + 5
+                limiter.acquire_lease(400)
+
+                mock_time.return_value = base_time + 10
+                limiter.acquire_lease(200)
+
+                mock_time.return_value = base_time + 10
+                allow_send, wait_seconds = limiter.acquire_lease(500)
+
+                assert allow_send is False
+                assert wait_seconds >= limiter.WINDOW_SIZE_SECONDS - 5 - 1
+                assert wait_seconds <= limiter.WINDOW_SIZE_SECONDS
+
+    def test_capacity_after_some_entries_expire(self, client, limiter):
+        with client.application.app_context():
+            with patch("app.rate_limiter.time") as mock_time:
+                base_time = 100.0
+                mock_time.return_value = base_time
+
+                limiter.acquire_lease(600)
+
+                mock_time.return_value = base_time + 10
+                limiter.acquire_lease(400)
+
+                # First entry expires (100 + 60 = 160)
+                mock_time.return_value = base_time + 70
+                allow_send, _ = limiter.acquire_lease(500)
+
+                assert allow_send is True
+                assert limiter.get_current_usage() == 900
+
+    def test_window_slightly_older_than_60_seconds_is_removed(self, client, limiter):
+        with client.application.app_context():
+            with patch("app.rate_limiter.time") as mock_time:
+                base_time = 100.0
+                mock_time.return_value = base_time
+
+                limiter.acquire_lease(50)
+
+                mock_time.return_value = base_time + 60.1
+                assert limiter.get_current_usage() == 0
+
+    def test_window_exactly_60_seconds_old_is_not_removed(self, client, limiter):
+        with client.application.app_context():
+            with patch("app.rate_limiter.time") as mock_time:
+                base_time = 100.0
+                mock_time.return_value = base_time
+
+                limiter.acquire_lease(50)
+
+                mock_time.return_value = base_time + 60.0
+                assert limiter.get_current_usage() == 50
+
+    def test_window_slightly_under_60_seconds_is_kept(self, client, limiter):
+        with client.application.app_context():
+            with patch("app.rate_limiter.time") as mock_time:
+                base_time = 100.0
+                mock_time.return_value = base_time
+
+                limiter.acquire_lease(50)
+
+                mock_time.return_value = base_time + 59.9
+                assert limiter.get_current_usage() == 50

--- a/tests/app/test_rate_limiter.py
+++ b/tests/app/test_rate_limiter.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 import fakeredis
 import pytest
 
-from app.rate_limiter import InMemoryRateLimiter, RedisRateLimiter
+from app.rate_limiter import InMemoryRateLimiter, RedisZSetRateLimiter
 
 
 class TestInMemoryRateLimiter:
@@ -196,7 +196,7 @@ class TestRedisRateLimiter:
     @pytest.fixture
     def limiter(self):
         redis_client = fakeredis.FakeRedis()
-        return RedisRateLimiter(cap_per_minute=1000, redis_client=redis_client)
+        return RedisZSetRateLimiter(cap_per_minute=1000, redis_client=redis_client)
 
     def test_acquire_lease_below_capacity_succeeds(self, client, limiter):
         with client.application.app_context():

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime
 from unittest import mock
+from unittest.mock import ANY
 from uuid import UUID
 
 import pytest
@@ -731,7 +732,7 @@ def test_send_user_reset_password_should_send_reset_password_link(client, sample
 
     assert resp.status_code == 204
     notification = Notification.query.first()
-    mocked.assert_called_once_with([str(notification.id)], queue="notify-internal-tasks")
+    mocked.assert_called_once_with([str(notification.id)], queue="notify-internal-tasks", MessageGroupId=ANY)
     assert notification.reply_to_text == notify_service.get_default_reply_to_email_address()
 
 
@@ -751,7 +752,7 @@ def test_send_user_forced_reset_password_should_send_reset_password_link(
 
     assert resp.status_code == 204
     notification = Notification.query.first()
-    mocked.assert_called_once_with([str(notification.id)], queue="notify-internal-tasks")
+    mocked.assert_called_once_with([str(notification.id)], queue="notify-internal-tasks", MessageGroupId=ANY)
     assert notification.reply_to_text == notify_service.get_default_reply_to_email_address()
 
 
@@ -835,7 +836,7 @@ def test_send_already_registered_email(client, sample_user, already_registered_t
     assert resp.status_code == 204
 
     notification = Notification.query.first()
-    mocked.assert_called_once_with(([str(notification.id)]), queue="notify-internal-tasks")
+    mocked.assert_called_once_with(([str(notification.id)]), queue="notify-internal-tasks", MessageGroupId=ANY)
     assert notification.reply_to_text == notify_service.get_default_reply_to_email_address()
 
 
@@ -1095,7 +1096,7 @@ def test_send_user_confirm_new_email_returns_204(client, sample_user, change_ema
     )
     assert resp.status_code == 204
     notification = Notification.query.first()
-    mocked.assert_called_once_with(([str(notification.id)]), queue="notify-internal-tasks")
+    mocked.assert_called_once_with(([str(notification.id)]), queue="notify-internal-tasks", MessageGroupId=ANY)
     assert notification.reply_to_text == notify_service.get_default_reply_to_email_address()
 
 

--- a/tests/app/user/test_rest_verify.py
+++ b/tests/app/user/test_rest_verify.py
@@ -1,6 +1,7 @@
 import json
 import uuid
 from datetime import datetime, timedelta
+from unittest.mock import ANY
 
 import pytest
 from flask import current_app, url_for
@@ -204,7 +205,7 @@ def test_send_user_sms_code(client, sample_user, sms_code_template, mocker, rese
     assert notification.reply_to_text == notify_service.get_default_sms_sender()
 
     app.celery.provider_tasks.deliver_sms.apply_async.assert_called_once_with(
-        ([str(notification.id)]), queue="notify-internal-tasks"
+        ([str(notification.id)]), queue="notify-internal-tasks", MessageGroupId=ANY
     )
 
 
@@ -229,7 +230,7 @@ def test_send_user_code_for_sms_with_optional_to_field(client, sample_user, sms_
     notification = Notification.query.first()
     assert notification.to == to_number
     app.celery.provider_tasks.deliver_sms.apply_async.assert_called_once_with(
-        ([str(notification.id)]), queue="notify-internal-tasks"
+        ([str(notification.id)]), queue="notify-internal-tasks", MessageGroupId=ANY
     )
 
 
@@ -310,7 +311,7 @@ def test_send_new_user_email_verification(client, sample_user, mocker, email_ver
     assert resp.status_code == 204
     notification = Notification.query.first()
     assert VerifyCode.query.count() == 0
-    mocked.assert_called_once_with(([str(notification.id)]), queue="notify-internal-tasks")
+    mocked.assert_called_once_with(([str(notification.id)]), queue="notify-internal-tasks", MessageGroupId=ANY)
     assert notification.reply_to_text == notify_service.get_default_reply_to_email_address()
 
 
@@ -409,7 +410,7 @@ def test_send_user_email_code(
     assert mocked.call_count == 1
     assert noti.personalisation["name"] == "Test User"
     assert noti.personalisation["verify_code"] == "11111"
-    deliver_email.assert_called_once_with([str(noti.id)], queue="notify-internal-tasks")
+    deliver_email.assert_called_once_with([str(noti.id)], queue="notify-internal-tasks", MessageGroupId=ANY)
 
 
 def test_send_user_email_code_with_urlencoded_next_param(admin_request, mocker, sample_user, email_2fa_code_template):


### PR DESCRIPTION
# Summary | Résumé

Phase 1 for SMS rate limiter implementation. [ADR](https://github.com/cds-snc/ADR/blob/main/adr/notify/0029_GC_Notify_SMS_Sending_Rate_Control.md) [Issue](https://github.com/cds-snc/notification-planning-core/issues/786)

## AI disclaimer

The main code implementation was manually coded but AI assisted. The tests were generated with AI and reviewed by the developers.

## SMS Fair Queue Rate Limiting

### Overview

This PR introduces two complementary mechanisms to protect SMS delivery throughput: **SQS-level fair queuing** (immediate, per-service noisy-neighbour isolation) and a **global SMS parts rate limiter** (enforces a per-minute cap across all services). Together they prevent any single service from monopolising delivery capacity, whether at the queue level or the provider level.

---

### What changed

#### 1. SQS fair queuing for all notification types (`app/celery/celery.py`)

`NotifyCelery.send_task` now passes `MessageGroupId` both as a **Celery task header** (`notify_message_group_id`) and as a **kombu message property** (`properties["MessageGroupId"]`).

The kombu SQS transport reads `message["properties"]["MessageGroupId"]` in `Channel._put()` before calling `boto3.send_message()`. Previously the value was only stored as a header and never reached SQS.

- **Standard queues** — AWS uses `MessageGroupId` to provide fair queuing (per-tenant noisy-neighbour protection; one slow service cannot starve others).
- **FIFO queues** — `MessageGroupId` is required by SQS to preserve per-group ordering.
- The default value is `notification.service_id`, so each service gets its own fair-share slot within any given queue.

#### 2. SMS parts rate limiter (`app/rate_limiter.py`, `FF_SMS_RATELIMIT`)

A new `RateLimiter` abstraction with two implementations:

- **`InMemoryRateLimiter`** — 60-second sliding window, suitable for a single worker (Phase 1).
- **`RedisRateLimiter`** — distributed sliding window backed by Redis, suitable for multi-worker deployments (Phase 2).

The limiter enforces `CELERY_DELIVER_SMS_RATE_LIMIT_PER_MINUTE` (parts/minute) globally and is gated behind `FF_SMS_RATELIMIT`.

#### 3. New `deliver_sms_rate_limited` task (`app/celery/provider_tasks.py`)

A new Celery task that sits between the queue and the provider:

1. Calls `get_rate_limiter().acquire_lease(parts_count)`.
2. If capacity is available → proceeds to `_deliver_sms`.
3. If the cap is hit → re-queues itself on `SEND_SMS_FAIR` with `countdown=seconds_to_wait` and the same `MessageGroupId` it arrived with (read via `self.message_group_id` from the task header), then raises `Ignore` to cleanly release the original task slot.

Re-queuing preserves `MessageGroupId` so the notification stays in the same SQS group and does not lose its fair-queue position across retries.

#### 4. Routing changes (`app/notifications/process_notifications.py`)

**`choose_queue`** determines the queue at notification creation time:

- Custom SMS sender (dedicated number) → `send-throttled-sms-tasks` _(always, even in research mode — the dedicated number must be respected)_
- Research mode / `key_type=test` → `research-mode-tasks`
- `FF_SMS_RATELIMIT=True`, normal SMS → `send-sms-fair-tasks`
- Otherwise → existing queue tiers (high/medium/low based on template category)

**`choose_deliver_task`** selects the Celery task at dispatch time:

- Custom sender → `deliver_throttled_sms`
- `FF_SMS_RATELIMIT=True` and not research mode → `deliver_sms_rate_limited`
- Otherwise → `deliver_sms`

**`db_save_and_send_notification`** and **`send_notification_to_queue`** both:

- Default `MessageGroupId` to `notification.service_id` — ensures fair queuing across all services on every queue, not just the fair queue.
- When routing to the fair queue, override `MessageGroupId` with the template's delivery queue name (e.g. `send-sms-medium-tasks`). This groups messages by their original priority class within the fair queue, so high-priority notifications from any service are not held behind bulk ones from the same service.

#### 5. New queue constant (`app/config.py`)

`SEND_SMS_FAIR = "send-sms-fair-tasks"`

---

### Feature flags

| Flag | Default | Effect |
|---|---|---|
| `FF_SMS_RATELIMIT` | `False` | Enables `deliver_sms_rate_limited` routing and the `send-sms-fair-tasks` queue |
| `FF_USE_BILLABLE_UNITS` | `True` | Uses pre-computed `billable_units` from the DB as `parts_count`; otherwise recomputes from the template |
| `SMS_RATE_LIMITER_BACKEND` | `"memory"` | `"memory"` for single-worker, `"redis"` for distributed |

---

One important caveat with the current changes is that the addition of message group ID that defaults to service ID and discriminating against services is not gated by the feature flags above. This change will go in as is but it's something we can discuss amongst reviewers, if deemed safe enough or not. 

### Routing decision tree (`FF_SMS_RATELIMIT=True`)

```
SMS notification
├── research mode OR key_type=test  →  research-mode-tasks        (deliver_sms)
├── sends_with_custom_number()      →  send-throttled-sms-tasks   (deliver_throttled_sms)
├── priority_queue provided         →  priority_queue             (deliver_sms_rate_limited)
└── default                         →  send-sms-fair-tasks        (deliver_sms_rate_limited)
                                         MessageGroupId = template's delivery queue name
```

## Related Issues | Cartes liées

* [SMS Rate Limiter](https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/786) / #786

# Test instructions | Instructions pour tester la modification

1. Enable the feature flag `FF_SMS_RATELIMIT`.
1. Send tons of SMS to the API.
1. Monitor the sending rate in related AWS sending rates dashboards.

# Release Instructions | Instructions pour le déploiement

* Only enable the `FF_SMS_RATELIMIT` feature flag in staging environment; disabled in production.
* Make sure that older path (`FF_SMS_RATELIMIT` feature flag disabled) introduced no regression.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.