### PR TITLE
Added new celery error category for metrics related errors

### DIFF
--- a/app/celery/error_registry.py
+++ b/app/celery/error_registry.py
@@ -19,14 +19,17 @@ class CeleryErrorCategory(str, Enum):
     # Incomplete jobs due to deploys or other interruptions — don't ignore too much though
     JOB_INCOMPLETE = "CELERY_KNOWN_ERROR::JOB_INCOMPLETE"
 
+    # Metrics related errors — these are expected to be noisy but should be monitored in case of spikes
+    METRICS = "CELERY_KNOWN_ERROR::METRICS"
+
     # Notification not found for SES references — safe to ignore, but should be investigated if it spikes
     NOTIFICATION_NOT_FOUND = "CELERY_KNOWN_ERROR::NOTIFICATION_NOT_FOUND"
 
-    # Celery retry mechanism -- these errors are normal and used by Celery to retry a task
-    TASK_RETRY = "CELERY_KNOWN_ERROR::TASK_RETRY"
-
     # Shutdown related errors — expected during deploys, safe to ignore
     SHUTDOWN = "CELERY_KNOWN_ERROR::SHUTDOWN"
+
+    # Celery retry mechanism -- these errors are normal and used by Celery to retry a task
+    TASK_RETRY = "CELERY_KNOWN_ERROR::TASK_RETRY"
 
     # Transient AWS errors — expected under load, retry will handle them
     THROTTLING = "CELERY_KNOWN_ERROR::THROTTLING"
@@ -70,6 +73,7 @@ _MESSAGE_SUBSTRING_MAP: dict[str, CeleryErrorCategory] = {
     "Throttling": CeleryErrorCategory.THROTTLING,
     "Too Many Requests": CeleryErrorCategory.THROTTLING,
     "notifications have been updated to technical-failure because they have timed out": CeleryErrorCategory.TIMEOUT_NOTIFICATION,
+    "Failed to export span batch code": CeleryErrorCategory.METRICS,
 }
 
 

--- a/tests/app/celery/test_celery_error_classification.py
+++ b/tests/app/celery/test_celery_error_classification.py
@@ -99,6 +99,13 @@ class TestClassifyError:
         assert category == CeleryErrorCategory.TIMEOUT_NOTIFICATION
         assert root_exc is exc  # Should return the original exception as root
 
+    def test_metrics_error_by_message(self):
+        """Metrics export errors are classified as METRICS."""
+        exc = Exception("Failed to export span batch code: service unavailable")
+        category, root_exc = classify_error(exc)
+        assert category == CeleryErrorCategory.METRICS
+        assert root_exc is exc  # Should return the original exception as root
+
     def test_timeout_client_error_by_class_name(self):
         """TimeoutError exceptions are classified as TIMEOUT_CLIENT."""
 


### PR DESCRIPTION
# Summary | Résumé

Added new celery error category for metrics related errors

## Related Issues | Cartes liées

* [Reduce Celery errors with business exception translation layer](https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/634) #634

# Test instructions | Instructions pour tester la modification

Fetch cloudwatch logs and check for the new error category.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.