### PR TITLE
Allow setting gunicorn threads

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -20,7 +20,7 @@ default_worker_class = "gevent_otel_worker.OTelAwareGeventWorker" if ff_enable_o
 workers = int(os.getenv("GUNICORN_WORKERS", "4"))
 worker_class = os.getenv("GUNICORN_WORKER_CLASS", default_worker_class)
 worker_connections = int(os.getenv("GUNICORN_WORKER_CONNECTIONS", "256"))
-threads = int(os.getenv("GUNICORN_THREADS", "1"))
+threads = int(os.getenv("GUNICORN_THREADS", "1"))  # Only valid with gthread
 preload_app = env.bool("GUNICORN_PRELOAD_APP", default=False)
 bind = "0.0.0.0:{}".format(os.getenv("PORT"))
 accesslog = "-"

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -20,6 +20,7 @@ default_worker_class = "gevent_otel_worker.OTelAwareGeventWorker" if ff_enable_o
 workers = int(os.getenv("GUNICORN_WORKERS", "4"))
 worker_class = os.getenv("GUNICORN_WORKER_CLASS", default_worker_class)
 worker_connections = int(os.getenv("GUNICORN_WORKER_CONNECTIONS", "256"))
+threads = int(os.getenv("GUNICORN_THREADS", "1"))
 preload_app = env.bool("GUNICORN_PRELOAD_APP", default=False)
 bind = "0.0.0.0:{}".format(os.getenv("PORT"))
 accesslog = "-"


### PR DESCRIPTION
# Summary | Résumé

Allow setting gunicorn threads at runtime. 

## Related Issues | Cartes liées

Perf testing crap

# Test instructions | Instructions pour tester la modification

Merge to staging, perf test, set threads to 4, perf test again.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.