### PR TITLE
Add bulk API to get sms parts+costs for all services

### DIFF
--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -105,12 +105,12 @@ def dao_fetch_sms_cost_for_service_in_range(service_id, start_date, end_date):
 
 
 def dao_fetch_sms_cost_for_all_services_in_range(start_date, end_date):
-    """Return the total SMS cost and fragment count for ALL services in the given date range (inclusive).
+    """Return the total SMS cost and fragment count for ALL services in the given date range.
+    This EXCLUDES the current_day, as the ft_table aggregation happens in a nightly task
 
     Returns a dictionary keyed by service_id with fragment_count and total_cost for each service.
 
     Uses only FactBilling (the nightly-populated aggregate table) for efficiency.
-    Today's data will not be included since FactBilling is populated by a nightly task.
     For current-day data for a single service, use dao_fetch_sms_cost_for_service_in_range instead.
     """
     fact_results = (

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -104,6 +104,87 @@ def dao_fetch_sms_cost_for_service_in_range(service_id, start_date, end_date):
     return {"fragment_count": fragment_count, "total_cost": total_cost}
 
 
+def dao_fetch_sms_cost_for_all_services_in_range(start_date, end_date):
+    """Return the total SMS cost and fragment count for ALL services in the given date range (inclusive).
+
+    Returns a dictionary keyed by service_id with fragment_count and total_cost for each service.
+
+    Uses the same logic as dao_fetch_sms_cost_for_service_in_range:
+    - FactBilling for historical data (up to yesterday)
+    - Notification table for current day data (with carrier-reported costs)
+
+    This is a bulk operation suitable for fetching costs for many services efficiently.
+    """
+    today = convert_utc_to_local_timezone(datetime.utcnow()).date()
+
+    sms_cost_by_service = {}
+
+    # Historical data from FactBilling (up to yesterday)
+    if start_date < today:
+        fact_end = min(end_date, today - timedelta(days=1))
+        fact_results = (
+            db.session.query(
+                FactBilling.service_id,
+                func.coalesce(func.sum(FactBilling.billable_units), 0).label("fragment_count"),
+                func.coalesce(func.sum(FactBilling.billable_units * FactBilling.rate_multiplier * FactBilling.rate), 0).label(
+                    "total_cost"
+                ),
+            )
+            .filter(
+                FactBilling.bst_date >= start_date,
+                FactBilling.bst_date <= fact_end,
+                FactBilling.notification_type == SMS_TYPE,
+            )
+            .group_by(FactBilling.service_id)
+            .all()
+        )
+        for row in fact_results:
+            sms_cost_by_service[row.service_id] = {
+                "fragment_count": int(row.fragment_count),
+                "total_cost": Decimal(str(row.total_cost)),
+            }
+
+    # Current-day data from Notification table
+    if start_date <= today and end_date >= today:
+        today_start = convert_local_timezone_to_utc(datetime.combine(today, time.min))
+        today_end = convert_local_timezone_to_utc(datetime.combine(today + timedelta(days=1), time.min))
+        notif_results = (
+            db.session.query(
+                Notification.service_id,
+                func.coalesce(func.sum(Notification.billable_units), 0).label("fragment_count"),
+                func.coalesce(
+                    func.sum(
+                        func.coalesce(Notification.sms_total_carrier_fee, 0)
+                        + func.coalesce(Notification.sms_total_message_price, 0)
+                    ),
+                    0,
+                ).label("total_cost"),
+            )
+            .filter(
+                Notification.created_at >= today_start,
+                Notification.created_at < today_end,
+                Notification.notification_type == SMS_TYPE,
+                Notification.status.in_(NOTIFICATION_STATUS_TYPES_BILLABLE),
+                Notification.key_type != KEY_TYPE_TEST,
+            )
+            .group_by(Notification.service_id)
+            .all()
+        )
+        for row in notif_results:
+            if row.service_id in sms_cost_by_service:
+                # Add today's data to historical data
+                sms_cost_by_service[row.service_id]["fragment_count"] += int(row.fragment_count)
+                sms_cost_by_service[row.service_id]["total_cost"] += Decimal(str(row.total_cost))
+            else:
+                # Initialize with today's data
+                sms_cost_by_service[row.service_id] = {
+                    "fragment_count": int(row.fragment_count),
+                    "total_cost": Decimal(str(row.total_cost)),
+                }
+
+    return sms_cost_by_service
+
+
 def fetch_sms_free_allowance_remainder(start_date):
     # ASSUMPTION: AnnualBilling has been populated for year.
     billing_year = get_financial_year_for_datetime(start_date)

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -109,78 +109,33 @@ def dao_fetch_sms_cost_for_all_services_in_range(start_date, end_date):
 
     Returns a dictionary keyed by service_id with fragment_count and total_cost for each service.
 
-    Uses the same logic as dao_fetch_sms_cost_for_service_in_range:
-    - FactBilling for historical data (up to yesterday)
-    - Notification table for current day data (with carrier-reported costs)
-
-    This is a bulk operation suitable for fetching costs for many services efficiently.
+    Uses only FactBilling (the nightly-populated aggregate table) for efficiency.
+    Today's data will not be included since FactBilling is populated by a nightly task.
+    For current-day data for a single service, use dao_fetch_sms_cost_for_service_in_range instead.
     """
-    today = convert_utc_to_local_timezone(datetime.utcnow()).date()
+    fact_results = (
+        db.session.query(
+            FactBilling.service_id,
+            func.coalesce(func.sum(FactBilling.billable_units), 0).label("fragment_count"),
+            func.coalesce(func.sum(FactBilling.billable_units * FactBilling.rate_multiplier * FactBilling.rate), 0).label(
+                "total_cost"
+            ),
+        )
+        .filter(
+            FactBilling.bst_date >= start_date,
+            FactBilling.bst_date <= end_date,
+            FactBilling.notification_type == SMS_TYPE,
+        )
+        .group_by(FactBilling.service_id)
+        .all()
+    )
 
     sms_cost_by_service = {}
-
-    # Historical data from FactBilling (up to yesterday)
-    if start_date < today:
-        fact_end = min(end_date, today - timedelta(days=1))
-        fact_results = (
-            db.session.query(
-                FactBilling.service_id,
-                func.coalesce(func.sum(FactBilling.billable_units), 0).label("fragment_count"),
-                func.coalesce(func.sum(FactBilling.billable_units * FactBilling.rate_multiplier * FactBilling.rate), 0).label(
-                    "total_cost"
-                ),
-            )
-            .filter(
-                FactBilling.bst_date >= start_date,
-                FactBilling.bst_date <= fact_end,
-                FactBilling.notification_type == SMS_TYPE,
-            )
-            .group_by(FactBilling.service_id)
-            .all()
-        )
-        for row in fact_results:
-            sms_cost_by_service[row.service_id] = {
-                "fragment_count": int(row.fragment_count),
-                "total_cost": Decimal(str(row.total_cost)),
-            }
-
-    # Current-day data from Notification table
-    if start_date <= today and end_date >= today:
-        today_start = convert_local_timezone_to_utc(datetime.combine(today, time.min))
-        today_end = convert_local_timezone_to_utc(datetime.combine(today + timedelta(days=1), time.min))
-        notif_results = (
-            db.session.query(
-                Notification.service_id,
-                func.coalesce(func.sum(Notification.billable_units), 0).label("fragment_count"),
-                func.coalesce(
-                    func.sum(
-                        func.coalesce(Notification.sms_total_carrier_fee, 0)
-                        + func.coalesce(Notification.sms_total_message_price, 0)
-                    ),
-                    0,
-                ).label("total_cost"),
-            )
-            .filter(
-                Notification.created_at >= today_start,
-                Notification.created_at < today_end,
-                Notification.notification_type == SMS_TYPE,
-                Notification.status.in_(NOTIFICATION_STATUS_TYPES_BILLABLE),
-                Notification.key_type != KEY_TYPE_TEST,
-            )
-            .group_by(Notification.service_id)
-            .all()
-        )
-        for row in notif_results:
-            if row.service_id in sms_cost_by_service:
-                # Add today's data to historical data
-                sms_cost_by_service[row.service_id]["fragment_count"] += int(row.fragment_count)
-                sms_cost_by_service[row.service_id]["total_cost"] += Decimal(str(row.total_cost))
-            else:
-                # Initialize with today's data
-                sms_cost_by_service[row.service_id] = {
-                    "fragment_count": int(row.fragment_count),
-                    "total_cost": Decimal(str(row.total_cost)),
-                }
+    for row in fact_results:
+        sms_cost_by_service[row.service_id] = {
+            "fragment_count": int(row.fragment_count),
+            "total_cost": Decimal(str(row.total_cost)),
+        }
 
     return sms_cost_by_service
 

--- a/app/platform_stats/rest.py
+++ b/app/platform_stats/rest.py
@@ -165,10 +165,10 @@ def get_sms_cost_for_all_services():
     result_list = [
         {
             "service_id": str(service_id),
-            "fragment_count": int(data["fragment_count"]),
-            "total_cost": float(data["total_cost"]),
+            "fragment_count": int(service_costs["fragment_count"]),
+            "total_cost": float(service_costs["total_cost"]),
         }
-        for service_id, data in sorted(result_dict.items())
+        for service_id, service_costs in sorted(result_dict.items())
     ]
 
     return jsonify(

--- a/app/platform_stats/rest.py
+++ b/app/platform_stats/rest.py
@@ -158,7 +158,7 @@ def get_sms_cost_for_all_services():
     end_date = datetime.strptime(data["end_date"], "%Y-%m-%d").date()
 
     if start_date > end_date:
-        raise InvalidRequest("start_date must on or before end_date", 400)
+        raise InvalidRequest("start_date must be on or before end_date", 400)
 
     result_dict = dao_fetch_sms_cost_for_all_services_in_range(start_date, end_date)
 

--- a/app/platform_stats/rest.py
+++ b/app/platform_stats/rest.py
@@ -2,8 +2,10 @@ from datetime import datetime
 
 from flask import Blueprint, jsonify, request
 
+from app.billing.billing_schemas import get_sms_cost_for_service_schema
 from app.dao.date_util import get_financial_year_for_datetime
 from app.dao.fact_billing_dao import (
+    dao_fetch_sms_cost_for_all_services_in_range,
     fetch_letter_costs_for_all_services,
     fetch_letter_line_items_for_all_services,
     fetch_sms_billing_for_all_services,
@@ -132,3 +134,47 @@ def get_send_methods_stats_by_service():
     end_date = datetime.strptime(request.args.get("end_date"), "%Y-%m-%d").date()
 
     return jsonify(send_method_stats_by_service(start_date, end_date))
+
+
+@platform_stats_blueprint.route("sms-cost-for-all-services", methods=["GET"])
+def get_sms_cost_for_all_services():
+    """Fetch SMS cost and fragment count for ALL services in a date range.
+
+    Query parameters:
+        start_date (required): ISO format date string (YYYY-MM-DD)
+        end_date (required): ISO format date string (YYYY-MM-DD)
+
+    Returns:
+        JSON object with start_date, end_date, and services array.
+    """
+    data = {
+        "start_date": request.args.get("start_date"),
+        "end_date": request.args.get("end_date"),
+    }
+
+    validate(data, get_sms_cost_for_service_schema)
+
+    start_date = datetime.strptime(data["start_date"], "%Y-%m-%d").date()
+    end_date = datetime.strptime(data["end_date"], "%Y-%m-%d").date()
+
+    if start_date > end_date:
+        raise InvalidRequest("start_date must on or before end_date", 400)
+
+    result_dict = dao_fetch_sms_cost_for_all_services_in_range(start_date, end_date)
+
+    result_list = [
+        {
+            "service_id": str(service_id),
+            "fragment_count": int(data["fragment_count"]),
+            "total_cost": float(data["total_cost"]),
+        }
+        for service_id, data in sorted(result_dict.items())
+    ]
+
+    return jsonify(
+        {
+            "start_date": data["start_date"],
+            "end_date": data["end_date"],
+            "services": result_list,
+        }
+    ), 200

--- a/tests/app/dao/test_ft_billing_dao.py
+++ b/tests/app/dao/test_ft_billing_dao.py
@@ -11,6 +11,7 @@ from notifications_utils.timezones import convert_utc_to_local_timezone
 from app import db
 from app.dao.fact_billing_dao import (
     create_billing_record,
+    dao_fetch_sms_cost_for_all_services_in_range,
     dao_fetch_sms_cost_for_service_in_range,
     delete_billing_data_for_service_for_day,
     fetch_billing_data_for_day,
@@ -1274,3 +1275,204 @@ def test_dao_fetch_sms_cost_for_service_in_range_empty_range(notify_db_session):
 
     assert result["fragment_count"] == 0
     assert result["total_cost"] == Decimal("0")
+
+
+@freeze_time("2026-04-08 14:00:00")
+def test_dao_fetch_sms_cost_for_all_services_historical_only(notify_db_session):
+    """When the date range is entirely in the past, only FactBilling is queried."""
+    service_a = create_service(service_name="Service A")
+    template_a = create_template(service=service_a, template_type="sms")
+    service_b = create_service(service_name="Service B")
+    template_b = create_template(service=service_b, template_type="sms")
+
+    create_ft_billing(
+        utc_date="2026-04-05",
+        service=service_a,
+        template=template_a,
+        notification_type="sms",
+        billable_unit=3,
+        rate=Decimal("0.0165"),
+        rate_multiplier=1,
+    )
+    create_ft_billing(
+        utc_date="2026-04-06",
+        service=service_b,
+        template=template_b,
+        notification_type="sms",
+        billable_unit=5,
+        rate=Decimal("0.0165"),
+        rate_multiplier=2,
+    )
+
+    result = dao_fetch_sms_cost_for_all_services_in_range(date(2026, 4, 5), date(2026, 4, 6))
+
+    assert len(result) == 2
+    assert result[service_a.id]["fragment_count"] == 3
+    assert result[service_a.id]["total_cost"] == Decimal("0.0495")
+    assert result[service_b.id]["fragment_count"] == 5
+    assert result[service_b.id]["total_cost"] == Decimal("0.165")
+
+
+@freeze_time("2026-04-08 14:00:00")
+def test_dao_fetch_sms_cost_for_all_services_today_only(notify_db_session):
+    """When the date range is today only, data comes from the Notification table."""
+    service = create_service()
+    template = create_template(service=service, template_type="sms")
+
+    notif = save_notification(
+        create_notification(
+            template=template,
+            status="delivered",
+            billable_units=4,
+            key_type="normal",
+        )
+    )
+    notif.sms_total_carrier_fee = Decimal("0.005")
+    notif.sms_total_message_price = Decimal("0.010")
+    db.session.commit()
+
+    result = dao_fetch_sms_cost_for_all_services_in_range(date(2026, 4, 8), date(2026, 4, 8))
+
+    assert len(result) == 1
+    assert result[service.id]["fragment_count"] == 4
+    assert result[service.id]["total_cost"] == Decimal("0.015")
+
+
+@freeze_time("2026-04-08 14:00:00")
+def test_dao_fetch_sms_cost_for_all_services_combined(notify_db_session):
+    """When the range spans historical days and today, both sources are combined."""
+    service = create_service()
+    template = create_template(service=service, template_type="sms")
+
+    # Historical: yesterday in FactBilling
+    create_ft_billing(
+        utc_date="2026-04-07",
+        service=service,
+        template=template,
+        notification_type="sms",
+        billable_unit=10,
+        rate=Decimal("0.02"),
+        rate_multiplier=1,
+    )
+
+    # Today: Notification table
+    notif = save_notification(
+        create_notification(
+            template=template,
+            status="delivered",
+            billable_units=2,
+        )
+    )
+    notif.sms_total_carrier_fee = Decimal("0.003")
+    notif.sms_total_message_price = Decimal("0.007")
+    db.session.commit()
+
+    result = dao_fetch_sms_cost_for_all_services_in_range(date(2026, 4, 7), date(2026, 4, 8))
+
+    assert len(result) == 1
+    # fragment_count = 10 (ft_billing) + 2 (notification) = 12
+    assert result[service.id]["fragment_count"] == 12
+    # total_cost = (10 * 1 * 0.02) + (0.003 + 0.007) = 0.20 + 0.01 = 0.21
+    assert result[service.id]["total_cost"] == Decimal("0.21")
+
+
+@freeze_time("2026-04-08 14:00:00")
+def test_dao_fetch_sms_cost_for_all_services_excludes_test_keys(notify_db_session):
+    """Notifications sent with test keys should not be counted for today's data."""
+    service = create_service()
+    template = create_template(service=service, template_type="sms")
+
+    # A 'test' key notification -- should be excluded
+    notif_test = save_notification(
+        create_notification(
+            template=template,
+            status="delivered",
+            billable_units=5,
+            key_type="test",
+        )
+    )
+    notif_test.sms_total_carrier_fee = Decimal("0.100")
+    notif_test.sms_total_message_price = Decimal("0.100")
+
+    # A 'normal' key notification -- should be included
+    notif_normal = save_notification(
+        create_notification(
+            template=template,
+            status="delivered",
+            billable_units=1,
+            key_type="normal",
+        )
+    )
+    notif_normal.sms_total_carrier_fee = Decimal("0.002")
+    notif_normal.sms_total_message_price = Decimal("0.003")
+    db.session.commit()
+
+    result = dao_fetch_sms_cost_for_all_services_in_range(date(2026, 4, 8), date(2026, 4, 8))
+
+    assert len(result) == 1
+    assert result[service.id]["fragment_count"] == 1
+    assert result[service.id]["total_cost"] == Decimal("0.005")
+
+
+@freeze_time("2026-04-08 14:00:00")
+def test_dao_fetch_sms_cost_for_all_services_excludes_non_billable_status(notify_db_session):
+    """Notifications with non-billable statuses (e.g. created) should not be counted."""
+    service = create_service()
+    template = create_template(service=service, template_type="sms")
+
+    notif_created = save_notification(
+        create_notification(
+            template=template,
+            status="created",
+            billable_units=3,
+        )
+    )
+    notif_created.sms_total_carrier_fee = Decimal("0.100")
+    notif_created.sms_total_message_price = Decimal("0.100")
+
+    notif_delivered = save_notification(
+        create_notification(
+            template=template,
+            status="delivered",
+            billable_units=2,
+        )
+    )
+    notif_delivered.sms_total_carrier_fee = Decimal("0.004")
+    notif_delivered.sms_total_message_price = Decimal("0.006")
+    db.session.commit()
+
+    result = dao_fetch_sms_cost_for_all_services_in_range(date(2026, 4, 8), date(2026, 4, 8))
+
+    assert len(result) == 1
+    assert result[service.id]["fragment_count"] == 2
+    assert result[service.id]["total_cost"] == Decimal("0.010")
+
+
+@freeze_time("2026-04-08 14:00:00")
+def test_dao_fetch_sms_cost_for_all_services_null_carrier_fees(notify_db_session):
+    """Null sms_total_carrier_fee / sms_total_message_price are treated as 0."""
+    service = create_service()
+    template = create_template(service=service, template_type="sms")
+
+    save_notification(
+        create_notification(
+            template=template,
+            status="delivered",
+            billable_units=3,
+        )
+    )
+    # Don't set carrier fees -- they remain NULL
+
+    result = dao_fetch_sms_cost_for_all_services_in_range(date(2026, 4, 8), date(2026, 4, 8))
+
+    assert len(result) == 1
+    assert result[service.id]["fragment_count"] == 3
+    assert result[service.id]["total_cost"] == Decimal("0")
+
+
+@freeze_time("2026-04-08 14:00:00")
+def test_dao_fetch_sms_cost_for_all_services_empty_range(notify_db_session):
+    """Returns empty dict when there is no data in the range."""
+    result = dao_fetch_sms_cost_for_all_services_in_range(date(2026, 4, 1), date(2026, 4, 7))
+
+    assert result == {}

--- a/tests/app/dao/test_ft_billing_dao.py
+++ b/tests/app/dao/test_ft_billing_dao.py
@@ -1314,11 +1314,12 @@ def test_dao_fetch_sms_cost_for_all_services_historical_only(notify_db_session):
 
 
 @freeze_time("2026-04-08 14:00:00")
-def test_dao_fetch_sms_cost_for_all_services_today_only(notify_db_session):
-    """When the date range is today only, data comes from the Notification table."""
+def test_dao_fetch_sms_cost_for_all_services_today_only_returns_empty(notify_db_session):
+    """When the date range is today only, no FactBilling data exists yet so result is empty."""
     service = create_service()
     template = create_template(service=service, template_type="sms")
 
+    # Notification table data for today -- should NOT be picked up
     notif = save_notification(
         create_notification(
             template=template,
@@ -1333,14 +1334,13 @@ def test_dao_fetch_sms_cost_for_all_services_today_only(notify_db_session):
 
     result = dao_fetch_sms_cost_for_all_services_in_range(date(2026, 4, 8), date(2026, 4, 8))
 
-    assert len(result) == 1
-    assert result[service.id]["fragment_count"] == 4
-    assert result[service.id]["total_cost"] == Decimal("0.015")
+    # No FactBilling rows for today, so empty
+    assert result == {}
 
 
 @freeze_time("2026-04-08 14:00:00")
-def test_dao_fetch_sms_cost_for_all_services_combined(notify_db_session):
-    """When the range spans historical days and today, both sources are combined."""
+def test_dao_fetch_sms_cost_for_all_services_combined_uses_only_fact_billing(notify_db_session):
+    """When the range spans historical days and today, only FactBilling data is used."""
     service = create_service()
     template = create_template(service=service, template_type="sms")
 
@@ -1355,7 +1355,7 @@ def test_dao_fetch_sms_cost_for_all_services_combined(notify_db_session):
         rate_multiplier=1,
     )
 
-    # Today: Notification table
+    # Today: Notification table -- should NOT be picked up
     notif = save_notification(
         create_notification(
             template=template,
@@ -1370,104 +1370,9 @@ def test_dao_fetch_sms_cost_for_all_services_combined(notify_db_session):
     result = dao_fetch_sms_cost_for_all_services_in_range(date(2026, 4, 7), date(2026, 4, 8))
 
     assert len(result) == 1
-    # fragment_count = 10 (ft_billing) + 2 (notification) = 12
-    assert result[service.id]["fragment_count"] == 12
-    # total_cost = (10 * 1 * 0.02) + (0.003 + 0.007) = 0.20 + 0.01 = 0.21
-    assert result[service.id]["total_cost"] == Decimal("0.21")
-
-
-@freeze_time("2026-04-08 14:00:00")
-def test_dao_fetch_sms_cost_for_all_services_excludes_test_keys(notify_db_session):
-    """Notifications sent with test keys should not be counted for today's data."""
-    service = create_service()
-    template = create_template(service=service, template_type="sms")
-
-    # A 'test' key notification -- should be excluded
-    notif_test = save_notification(
-        create_notification(
-            template=template,
-            status="delivered",
-            billable_units=5,
-            key_type="test",
-        )
-    )
-    notif_test.sms_total_carrier_fee = Decimal("0.100")
-    notif_test.sms_total_message_price = Decimal("0.100")
-
-    # A 'normal' key notification -- should be included
-    notif_normal = save_notification(
-        create_notification(
-            template=template,
-            status="delivered",
-            billable_units=1,
-            key_type="normal",
-        )
-    )
-    notif_normal.sms_total_carrier_fee = Decimal("0.002")
-    notif_normal.sms_total_message_price = Decimal("0.003")
-    db.session.commit()
-
-    result = dao_fetch_sms_cost_for_all_services_in_range(date(2026, 4, 8), date(2026, 4, 8))
-
-    assert len(result) == 1
-    assert result[service.id]["fragment_count"] == 1
-    assert result[service.id]["total_cost"] == Decimal("0.005")
-
-
-@freeze_time("2026-04-08 14:00:00")
-def test_dao_fetch_sms_cost_for_all_services_excludes_non_billable_status(notify_db_session):
-    """Notifications with non-billable statuses (e.g. created) should not be counted."""
-    service = create_service()
-    template = create_template(service=service, template_type="sms")
-
-    notif_created = save_notification(
-        create_notification(
-            template=template,
-            status="created",
-            billable_units=3,
-        )
-    )
-    notif_created.sms_total_carrier_fee = Decimal("0.100")
-    notif_created.sms_total_message_price = Decimal("0.100")
-
-    notif_delivered = save_notification(
-        create_notification(
-            template=template,
-            status="delivered",
-            billable_units=2,
-        )
-    )
-    notif_delivered.sms_total_carrier_fee = Decimal("0.004")
-    notif_delivered.sms_total_message_price = Decimal("0.006")
-    db.session.commit()
-
-    result = dao_fetch_sms_cost_for_all_services_in_range(date(2026, 4, 8), date(2026, 4, 8))
-
-    assert len(result) == 1
-    assert result[service.id]["fragment_count"] == 2
-    assert result[service.id]["total_cost"] == Decimal("0.010")
-
-
-@freeze_time("2026-04-08 14:00:00")
-def test_dao_fetch_sms_cost_for_all_services_null_carrier_fees(notify_db_session):
-    """Null sms_total_carrier_fee / sms_total_message_price are treated as 0."""
-    service = create_service()
-    template = create_template(service=service, template_type="sms")
-
-    save_notification(
-        create_notification(
-            template=template,
-            status="delivered",
-            billable_units=3,
-        )
-    )
-    # Don't set carrier fees -- they remain NULL
-
-    result = dao_fetch_sms_cost_for_all_services_in_range(date(2026, 4, 8), date(2026, 4, 8))
-
-    assert len(result) == 1
-    assert result[service.id]["fragment_count"] == 3
-    assert result[service.id]["total_cost"] == Decimal("0")
+    # Only FactBilling data: fragment_count = 10, total_cost = 10 * 1 * 0.02 = 0.20
+    assert result[service.id]["fragment_count"] == 10
+    assert result[service.id]["total_cost"] == Decimal("0.20")
 
 
 @freeze_time("2026-04-08 14:00:00")

--- a/tests/app/platform_stats/test_rest.py
+++ b/tests/app/platform_stats/test_rest.py
@@ -7,6 +7,7 @@ from app.errors import InvalidRequest
 from app.models import EMAIL_TYPE, SMS_TYPE
 from app.platform_stats.rest import validate_date_range_is_within_a_financial_year
 from tests.app.db import (
+    create_ft_billing,
     create_ft_notification_status,
     create_notification,
     create_service,
@@ -207,3 +208,78 @@ def test_get_send_methods_stats_by_service(mocker, admin_request):
         date(2020, 12, 1),
         date(2020, 12, 7),
     )
+
+
+@freeze_time("2026-04-08 14:00:00")
+def test_get_sms_cost_for_all_services_happy_path(notify_db_session, admin_request):
+    """Happy path: returns aggregated SMS costs for multiple services."""
+    service_a = create_service(service_name="Service A")
+    template_a = create_template(service=service_a, template_type="sms")
+    service_b = create_service(service_name="Service B")
+    template_b = create_template(service=service_b, template_type="sms")
+
+    create_ft_billing(
+        utc_date="2026-04-05",
+        service=service_a,
+        template=template_a,
+        notification_type="sms",
+        billable_unit=10,
+        rate=0.02,
+        rate_multiplier=1,
+    )
+    create_ft_billing(
+        utc_date="2026-04-06",
+        service=service_b,
+        template=template_b,
+        notification_type="sms",
+        billable_unit=5,
+        rate=0.03,
+        rate_multiplier=1,
+    )
+
+    response = admin_request.get(
+        "platform_stats.get_sms_cost_for_all_services",
+        start_date="2026-04-01",
+        end_date="2026-04-07",
+    )
+
+    assert response["start_date"] == "2026-04-01"
+    assert response["end_date"] == "2026-04-07"
+    assert len(response["services"]) == 2
+
+    by_id = {s["service_id"]: s for s in response["services"]}
+    assert by_id[str(service_a.id)]["fragment_count"] == 10
+    assert by_id[str(service_a.id)]["total_cost"] == pytest.approx(10 * 0.02)
+    assert by_id[str(service_b.id)]["fragment_count"] == 5
+    assert by_id[str(service_b.id)]["total_cost"] == pytest.approx(5 * 0.03)
+
+
+def test_get_sms_cost_for_all_services_returns_400_when_start_date_after_end_date(admin_request):
+    """Validation: start_date > end_date should return 400."""
+    response = admin_request.get(
+        "platform_stats.get_sms_cost_for_all_services",
+        start_date="2026-06-30",
+        end_date="2026-06-01",
+        _expected_status=400,
+    )
+
+    assert response["message"] == "start_date must on or before end_date"
+
+
+def test_get_sms_cost_for_all_services_returns_400_when_dates_missing(admin_request):
+    """Validation: missing required date params should return 400."""
+    admin_request.get(
+        "platform_stats.get_sms_cost_for_all_services",
+        _expected_status=400,
+    )
+
+
+def test_get_sms_cost_for_all_services_returns_empty_services_when_no_data(notify_db_session, admin_request):
+    """When no billing data exists, services list should be empty."""
+    response = admin_request.get(
+        "platform_stats.get_sms_cost_for_all_services",
+        start_date="2026-01-01",
+        end_date="2026-01-31",
+    )
+
+    assert response["services"] == []

--- a/tests/app/platform_stats/test_rest.py
+++ b/tests/app/platform_stats/test_rest.py
@@ -263,7 +263,7 @@ def test_get_sms_cost_for_all_services_returns_400_when_start_date_after_end_dat
         _expected_status=400,
     )
 
-    assert response["message"] == "start_date must on or before end_date"
+    assert response["message"] == "start_date must be on or before end_date"
 
 
 def test_get_sms_cost_for_all_services_returns_400_when_dates_missing(admin_request):


### PR DESCRIPTION
# Summary | Résumé
This PR adds a new API endpoint to bulk fetch SMS parts + cost for all services. Previously we fetched these stats one service at a time by id, which resulted in massive slow downs on the platform admin service list page and unnecessary load on the DB. 

# Test instructions | Instructions pour tester la modification
 - [ ] Test steps in the 
# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.