### PR TITLE
Log when a notification without receipt data is timed out

### DIFF
--- a/app/celery/nightly_tasks.py
+++ b/app/celery/nightly_tasks.py
@@ -7,7 +7,7 @@ from notifications_utils.statsd_decorators import statsd
 from sqlalchemy import func
 from sqlalchemy.exc import SQLAlchemyError
 
-from app import notify_celery, performance_platform_client, zendesk_client
+from app import notify_celery, performance_platform_client, statsd_client, zendesk_client
 from app.aws import s3
 from app.celery.service_callback_tasks import send_delivery_status_to_service
 from app.config import QueueNames
@@ -141,6 +141,13 @@ def timeout_notifications():
             )
 
     current_app.logger.info("Timeout period reached for {} notifications, status has been updated.".format(len(notifications)))
+    if temporary_failure_notifications:
+        current_app.logger.info(
+            f"Timeout: {len(temporary_failure_notifications)} notifications set to temporary-failure (no receipt; billable), "
+            f"{len(technical_failure_notifications)} notifications set to technical-failure (never dispatched)."
+        )
+        statsd_client.incr("notifications.timeout.temporary_failure", len(temporary_failure_notifications))
+
     if technical_failure_notifications:
         message = (
             "{} notifications have been updated to technical-failure because they "

--- a/tests/app/celery/test_nightly_tasks.py
+++ b/tests/app/celery/test_nightly_tasks.py
@@ -247,6 +247,52 @@ def test_timeout_notifications_sends_status_update_to_service(client, sample_tem
     mocked.assert_called_once_with([str(notification.id), signed_data, notification.service_id], queue=QueueNames.CALLBACKS)
 
 
+def test_timeout_notifications_logs_and_increments_statsd_for_temporary_failures(notify_api, sample_template, mocker):
+    """When notifications time out without a receipt (sending/pending -> temporary-failure),
+    we should log the count and increment a statsd counter so we can track the rate of
+    no-receipt billable notifications."""
+    statsd_mock = mocker.patch("app.celery.nightly_tasks.statsd_client.incr")
+    logger_mock = mocker.patch.object(nightly_tasks.current_app.logger, "info")
+
+    with notify_api.test_request_context():
+        timeout_seconds = current_app.config.get("SENDING_NOTIFICATIONS_TIMEOUT_PERIOD") + 10
+        save_notification(
+            create_notification(
+                template=sample_template,
+                status="sending",
+                created_at=datetime.utcnow() - timedelta(seconds=timeout_seconds),
+            )
+        )
+        save_notification(
+            create_notification(
+                template=sample_template,
+                status="pending",
+                created_at=datetime.utcnow() - timedelta(seconds=timeout_seconds),
+            )
+        )
+
+        timeout_notifications()
+
+        statsd_mock.assert_any_call("notifications.timeout.temporary_failure", 2)
+        assert any("temporary-failure (no receipt; billable)" in str(call_args) for call_args in logger_mock.call_args_list)
+
+
+def test_timeout_notifications_does_not_log_or_increment_when_no_temporary_failures(notify_api, sample_template, mocker):
+    """When no notifications time out into temporary-failure, we should not emit the
+    temporary-failure log line or the statsd counter."""
+    statsd_mock = mocker.patch("app.celery.nightly_tasks.statsd_client.incr")
+    logger_mock = mocker.patch.object(nightly_tasks.current_app.logger, "info")
+
+    with notify_api.test_request_context():
+        timeout_notifications()
+
+        assert not any(
+            call_args.args and call_args.args[0] == "notifications.timeout.temporary_failure"
+            for call_args in statsd_mock.call_args_list
+        )
+        assert not any("temporary-failure (no receipt; billable)" in str(call_args) for call_args in logger_mock.call_args_list)
+
+
 def test_send_daily_performance_stats_calls_does_not_send_if_inactive(client, mocker):
     send_mock = mocker.patch("app.celery.nightly_tasks.total_sent_notifications.send_total_notifications_sent_for_day_stats")  # noqa
 


### PR DESCRIPTION
# Summary | Résumé

This PR introduces logging to capture how many notifications had no receipt data associated with them (stuck in `sending` / `pending`) when the nightly task times them out.


## Related Issues | Cartes liées
* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/3104

# Test instructions | Instructions pour tester la modification
- [ ] CI is passing
- [ ] Check logs in prod/staging after this has sat for a few days.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.