### PR TITLE
Do not select all columns when just trying to do a count

### DIFF
--- a/app/v2/notifications/get_notifications.py
+++ b/app/v2/notifications/get_notifications.py
@@ -85,6 +85,7 @@ def get_notifications():
         client_reference=data.get("reference"),
         page_size=current_app.config.get("API_PAGE_SIZE"),
         include_jobs=data.get("include_jobs"),
+        count_pages=False,
     )
 
     def _build_links(notifications):


### PR DESCRIPTION
# Summary | Résumé

We're seeing long running queries (~4 seconds under load) on getting the count when doing /v2/notifications GET. SQL Alchemy appears to be selecting all columns just to do the count, which is wasteful. This should tell it to just get the count.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/761

# Test instructions | Instructions pour tester la modification

Re-run perf test and verify whether or not the performance is improved.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.