### PR TITLE
Migration to update free sms limit for all services for 2026

### DIFF
--- a/migrations/versions/0510_update_free_sms_limit.py
+++ b/migrations/versions/0510_update_free_sms_limit.py
@@ -1,0 +1,27 @@
+"""
+Revision ID: 0510_update_free_sms_limit
+Revises: 0509_use_custom_unsub_url
+Create Date: 2026-04-30 00:00:00
+
+Update free_sms_fragment_limit to 100000 for all annual_billing rows for the
+current fiscal year (2026, i.e. April 1, 2026 – March 31, 2027).
+"""
+from alembic import op
+
+revision = "0510_update_free_sms_limit"
+down_revision = "0509_use_custom_unsub_url"
+
+
+def upgrade():
+    op.execute(
+        """
+        UPDATE annual_billing
+        SET free_sms_fragment_limit = 100000
+        WHERE financial_year_start = 2026
+        """
+    )
+
+
+def downgrade():
+    # No-op: previous per-service values varied and are not recoverable.
+    pass


### PR DESCRIPTION
# Summary | Résumé

Migration to update free sms limit for all services for 2026. Currently we aren't using this value for anything, but we will for  services in cost recovery. 

Working on https://github.com/cds-snc/notification-planning/issues/3158

# Test instructions | Instructions pour tester la modification

1. check out the branch locally
2. run `flask db upgrade`
3. check that the migration has run successfully and that the `annual_billing` table has values of 100k for 2026

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.