### PR TITLE
Paginate monthly template usage stats

### DIFF
--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -1002,6 +1002,132 @@ def fetch_monthly_template_usage_for_service(start_date, end_date, service_id):
     return query.all()
 
 
+def fetch_monthly_template_usage_for_service_paginated(start_date, end_date, service_id, page=1, page_size=50):
+    """
+    Returns monthly template usage for a service, paginated by unique template
+    (sorted by total count descending). Pagination is performed at the DB level via
+    a two-step query:
+    1. The page of template IDs is selected with LIMIT/OFFSET,
+    2. Only those template's monthly rows are fetched.
+
+    Returns a tuple of (results, total_unique_templates).
+    """
+    # Step 1: Get the page of template IDs sorted by total count desc.
+    template_id_query = (
+        db.session.query(
+            FactNotificationStatus.template_id.label("template_id"),
+            func.sum(FactNotificationStatus.notification_count).label("total_count"),
+        )
+        .filter(
+            FactNotificationStatus.service_id == service_id,
+            FactNotificationStatus.bst_date >= start_date.strftime("%Y-%m-%d"),
+            FactNotificationStatus.bst_date < end_date.strftime("%Y-%m-%d"),
+            FactNotificationStatus.key_type != KEY_TYPE_TEST,
+            FactNotificationStatus.notification_status != NOTIFICATION_CANCELLED,
+        )
+        .group_by(FactNotificationStatus.template_id)
+        .order_by(func.sum(FactNotificationStatus.notification_count).desc())
+    )
+
+    total = template_id_query.count()
+    paginated_template_ids = [row.template_id for row in template_id_query.offset((page - 1) * page_size).limit(page_size).all()]
+
+    if not paginated_template_ids:
+        return [], total
+
+    # Step 2: Fetch full monthly rows for only the templates on this page.
+    stats = (
+        db.session.query(
+            FactNotificationStatus.template_id.label("template_id"),
+            Template.name.label("name"),
+            Template.template_type.label("template_type"),
+            Template.is_precompiled_letter.label("is_precompiled_letter"),
+            extract("month", FactNotificationStatus.bst_date).label("month"),
+            extract("year", FactNotificationStatus.bst_date).label("year"),
+            func.sum(FactNotificationStatus.notification_count).label("count"),
+        )
+        .join(Template, FactNotificationStatus.template_id == Template.id)
+        .filter(
+            FactNotificationStatus.service_id == service_id,
+            FactNotificationStatus.bst_date >= start_date.strftime("%Y-%m-%d"),
+            FactNotificationStatus.bst_date < end_date.strftime("%Y-%m-%d"),
+            FactNotificationStatus.key_type != KEY_TYPE_TEST,
+            FactNotificationStatus.notification_status != NOTIFICATION_CANCELLED,
+            FactNotificationStatus.template_id.in_(paginated_template_ids),
+        )
+        .group_by(
+            FactNotificationStatus.template_id,
+            Template.name,
+            Template.template_type,
+            Template.is_precompiled_letter,
+            extract("month", FactNotificationStatus.bst_date).label("month"),
+            extract("year", FactNotificationStatus.bst_date).label("year"),
+        )
+        .order_by(
+            extract("year", FactNotificationStatus.bst_date),
+            extract("month", FactNotificationStatus.bst_date),
+            Template.name,
+        )
+    )
+
+    if start_date <= datetime.utcnow() <= end_date:
+        today = get_local_timezone_midnight_in_utc(datetime.utcnow())
+        month = get_local_timezone_month_from_utc_column(Notification.created_at)
+
+        stats_for_today = (
+            db.session.query(
+                Notification.template_id.label("template_id"),
+                Template.name.label("name"),
+                Template.template_type.label("template_type"),
+                Template.is_precompiled_letter.label("is_precompiled_letter"),
+                extract("month", month).label("month"),
+                extract("year", month).label("year"),
+                func.count().label("count"),
+            )
+            .join(Template, Notification.template_id == Template.id)
+            .filter(
+                Notification.created_at >= today,
+                Notification.service_id == service_id,
+                Notification.key_type != KEY_TYPE_TEST,
+                Notification.status != NOTIFICATION_CANCELLED,
+                Notification.template_id.in_(paginated_template_ids),
+            )
+            .group_by(
+                Notification.template_id,
+                Template.hidden,
+                Template.name,
+                Template.template_type,
+                month,
+            )
+        )
+
+        all_stats_table = stats.union_all(stats_for_today).subquery()
+        query = (
+            db.session.query(
+                all_stats_table.c.template_id,
+                all_stats_table.c.name,
+                all_stats_table.c.is_precompiled_letter,
+                all_stats_table.c.template_type,
+                func.cast(all_stats_table.c.month, Integer).label("month"),
+                func.cast(all_stats_table.c.year, Integer).label("year"),
+                func.cast(func.sum(all_stats_table.c.count), Integer).label("count"),
+            )
+            .group_by(
+                all_stats_table.c.template_id,
+                all_stats_table.c.name,
+                all_stats_table.c.is_precompiled_letter,
+                all_stats_table.c.template_type,
+                all_stats_table.c.month,
+                all_stats_table.c.year,
+            )
+            .order_by(all_stats_table.c.year, all_stats_table.c.month, all_stats_table.c.name)
+        )
+    else:
+        query = stats
+
+    return query.all(), total
+
+
 def get_total_sent_notifications_for_day_and_type(day, notification_type):
     result = (
         db.session.query(func.sum(FactNotificationStatus.notification_count).label("count"))

--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -999,6 +999,7 @@ def fetch_monthly_template_usage_for_service(start_date, end_date, service_id):
         )
     else:
         query = stats
+
     return query.all()
 
 
@@ -1012,21 +1013,46 @@ def fetch_monthly_template_usage_for_service_paginated(start_date, end_date, ser
 
     Returns a tuple of (results, total_unique_templates).
     """
+    today_in_range = start_date <= datetime.utcnow() <= end_date
+    today = get_local_timezone_midnight_in_utc(datetime.utcnow()) if today_in_range else None
+
     # Step 1: Get the page of template IDs sorted by total count desc.
+    fact_template_counts = db.session.query(
+        FactNotificationStatus.template_id.label("template_id"),
+        FactNotificationStatus.notification_count.label("count"),
+    ).filter(
+        FactNotificationStatus.service_id == service_id,
+        FactNotificationStatus.bst_date >= start_date.strftime("%Y-%m-%d"),
+        FactNotificationStatus.bst_date < end_date.strftime("%Y-%m-%d"),
+        FactNotificationStatus.key_type != KEY_TYPE_TEST,
+        FactNotificationStatus.notification_status != NOTIFICATION_CANCELLED,
+    )
+
+    if today_in_range:
+        today_template_counts = (
+            db.session.query(
+                Notification.template_id.label("template_id"),
+                func.count().label("count"),
+            )
+            .filter(
+                Notification.created_at >= today,
+                Notification.service_id == service_id,
+                Notification.key_type != KEY_TYPE_TEST,
+                Notification.status != NOTIFICATION_CANCELLED,
+            )
+            .group_by(Notification.template_id)
+        )
+        combined_subq = fact_template_counts.union_all(today_template_counts).subquery()
+    else:
+        combined_subq = fact_template_counts.subquery()
+
     template_id_query = (
         db.session.query(
-            FactNotificationStatus.template_id.label("template_id"),
-            func.sum(FactNotificationStatus.notification_count).label("total_count"),
+            combined_subq.c.template_id.label("template_id"),
+            func.sum(combined_subq.c.count).label("total_count"),
         )
-        .filter(
-            FactNotificationStatus.service_id == service_id,
-            FactNotificationStatus.bst_date >= start_date.strftime("%Y-%m-%d"),
-            FactNotificationStatus.bst_date < end_date.strftime("%Y-%m-%d"),
-            FactNotificationStatus.key_type != KEY_TYPE_TEST,
-            FactNotificationStatus.notification_status != NOTIFICATION_CANCELLED,
-        )
-        .group_by(FactNotificationStatus.template_id)
-        .order_by(func.sum(FactNotificationStatus.notification_count).desc())
+        .group_by(combined_subq.c.template_id)
+        .order_by(func.sum(combined_subq.c.count).desc(), combined_subq.c.template_id)
     )
 
     total = template_id_query.count()
@@ -1070,8 +1096,7 @@ def fetch_monthly_template_usage_for_service_paginated(start_date, end_date, ser
         )
     )
 
-    if start_date <= datetime.utcnow() <= end_date:
-        today = get_local_timezone_midnight_in_utc(datetime.utcnow())
+    if today_in_range:
         month = get_local_timezone_month_from_utc_column(Notification.created_at)
 
         stats_for_today = (

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -856,11 +856,11 @@ def resume_service(service_id):
 
 @service_blueprint.route("/<uuid:service_id>/notifications/templates_usage/monthly", methods=["GET"])
 def get_monthly_template_usage(service_id):
-    query_args = {
-        "year": request.args.get("year", type=int),
-        "page": request.args.get("page", type=int),
-        "page_size": request.args.get("page_size", type=int),
-    }
+    query_args = {"year": request.args.get("year", type=int)}
+    if "page" in request.args:
+        query_args["page"] = request.args.get("page", type=int)
+    if "page_size" in request.args:
+        query_args["page_size"] = request.args.get("page_size", type=int)
     validate(query_args, get_monthly_template_usage_request)
 
     start_date, end_date = get_financial_year(query_args["year"])

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -127,6 +127,7 @@ from app.service.service_senders_schema import (
     add_service_email_reply_to_request,
     add_service_sms_sender_request,
 )
+from app.service.service_statistics_schema import get_monthly_template_usage_request
 from app.service.utils import (
     get_organisation_id_from_crm_org_notes,
     get_safelist_objects,
@@ -855,72 +856,63 @@ def resume_service(service_id):
 
 @service_blueprint.route("/<uuid:service_id>/notifications/templates_usage/monthly", methods=["GET"])
 def get_monthly_template_usage(service_id):
-    try:
-        start_date, end_date = get_financial_year(int(request.args.get("year", "NaN")))
+    query_args = {
+        "year": request.args.get("year", type=int),
+        "page": request.args.get("page", type=int),
+        "page_size": request.args.get("page_size", type=int),
+    }
+    validate(query_args, get_monthly_template_usage_request)
 
-        # If page param provided, paginate by unique templates at the DB level.
-        page = request.args.get("page")
-        if page is not None:
-            try:
-                page = int(page)
-            except ValueError:
-                raise InvalidRequest("page must be an integer", status_code=400)
-            if page < 1:
-                raise InvalidRequest("page must be greater than 0", status_code=400)
+    start_date, end_date = get_financial_year(query_args["year"])
+    page = query_args["page"] if "page" in query_args else None
+    page_size = query_args["page_size"] if "page_size" in query_args else 50
 
-            page_size = int(request.args.get("page_size", 50))
-            if page_size < 1 or page_size > 100:
-                raise InvalidRequest("page_size must be between 1 and 100", status_code=400)
+    if page is not None:
+        data, total_templates = fetch_monthly_template_usage_for_service_paginated(
+            start_date=start_date,
+            end_date=end_date,
+            service_id=service_id,
+            page=page,
+            page_size=page_size,
+        )
+        paginated_stats = [
+            {
+                "template_id": str(i.template_id),
+                "name": i.name,
+                "type": i.template_type,
+                "month": i.month,
+                "year": i.year,
+                "count": i.count,
+                "is_precompiled_letter": i.is_precompiled_letter,
+            }
+            for i in data
+        ]
 
-            data, total_templates = fetch_monthly_template_usage_for_service_paginated(
-                start_date=start_date,
-                end_date=end_date,
-                service_id=service_id,
-                page=page,
-                page_size=page_size,
-            )
-            paginated_stats = [
-                {
-                    "template_id": str(i.template_id),
-                    "name": i.name,
-                    "type": i.template_type,
-                    "month": i.month,
-                    "year": i.year,
-                    "count": i.count,
-                    "is_precompiled_letter": i.is_precompiled_letter,
-                }
-                for i in data
-            ]
+        has_next = (page * page_size) < total_templates
+        has_prev = page > 1
+        links = {}
+        if has_prev:
+            links["prev"] = f"page {page - 1}"
+        if has_next:
+            links["next"] = f"page {page + 1}"
 
-            has_next = (page * page_size) < total_templates
-            has_prev = page > 1
-            links = {}
-            if has_prev:
-                links["prev"] = "page {}".format(page - 1)
-            if has_next:
-                links["next"] = "page {}".format(page + 1)
+        return jsonify(data=paginated_stats, total=total_templates, page=page, page_size=page_size, links=links), 200
 
-            return jsonify(data=paginated_stats, total=total_templates, page=page, page_size=page_size, links=links), 200
-
-        # If no page param provided, return all templates without pagination.
-        data = fetch_monthly_template_usage_for_service(start_date=start_date, end_date=end_date, service_id=service_id)
-        stats = list()
-        for i in data:
-            stats.append(
-                {
-                    "template_id": str(i.template_id),
-                    "name": i.name,
-                    "type": i.template_type,
-                    "month": i.month,
-                    "year": i.year,
-                    "count": i.count,
-                    "is_precompiled_letter": i.is_precompiled_letter,
-                }
-            )
-
-        return jsonify(stats=stats), 200
-    except ValueError:
-        raise InvalidRequest("Year must be a number", status_code=400)
+    # If no page param provided, return all templates without pagination.
+    data = fetch_monthly_template_usage_for_service(start_date=start_date, end_date=end_date, service_id=service_id)
+    stats = [
+        {
+            "template_id": str(i.template_id),
+            "name": i.name,
+            "type": i.template_type,
+            "month": i.month,
+            "year": i.year,
+            "count": i.count,
+            "is_precompiled_letter": i.is_precompiled_letter,
+        }
+        for i in data
+    ]
+    return jsonify(stats=stats), 200
 
 
 @service_blueprint.route("/<uuid:service_id>/send-notification", methods=["POST"])

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -34,6 +34,7 @@ from app.dao.date_util import get_financial_year
 from app.dao.fact_notification_status_dao import (
     fetch_delivered_notification_stats_by_month,
     fetch_monthly_template_usage_for_service,
+    fetch_monthly_template_usage_for_service_paginated,
     fetch_notification_status_for_service_by_month,
     fetch_notification_status_for_service_for_today_and_7_previous_days,
     fetch_stats_for_all_services_by_date_range,
@@ -856,6 +857,52 @@ def resume_service(service_id):
 def get_monthly_template_usage(service_id):
     try:
         start_date, end_date = get_financial_year(int(request.args.get("year", "NaN")))
+
+        # If page param provided, paginate by unique templates at the DB level.
+        page = request.args.get("page")
+        if page is not None:
+            try:
+                page = int(page)
+            except ValueError:
+                raise InvalidRequest("page must be an integer", status_code=400)
+            if page < 1:
+                raise InvalidRequest("page must be greater than 0", status_code=400)
+
+            page_size = int(request.args.get("page_size", 50))
+            if page_size < 1 or page_size > 100:
+                raise InvalidRequest("page_size must be between 1 and 100", status_code=400)
+
+            data, total_templates = fetch_monthly_template_usage_for_service_paginated(
+                start_date=start_date,
+                end_date=end_date,
+                service_id=service_id,
+                page=page,
+                page_size=page_size,
+            )
+            paginated_stats = [
+                {
+                    "template_id": str(i.template_id),
+                    "name": i.name,
+                    "type": i.template_type,
+                    "month": i.month,
+                    "year": i.year,
+                    "count": i.count,
+                    "is_precompiled_letter": i.is_precompiled_letter,
+                }
+                for i in data
+            ]
+
+            has_next = (page * page_size) < total_templates
+            has_prev = page > 1
+            links = {}
+            if has_prev:
+                links["prev"] = "page {}".format(page - 1)
+            if has_next:
+                links["next"] = "page {}".format(page + 1)
+
+            return jsonify(data=paginated_stats, total=total_templates, page=page, page_size=page_size, links=links), 200
+
+        # If no page param provided, return all templates without pagination.
         data = fetch_monthly_template_usage_for_service(start_date=start_date, end_date=end_date, service_id=service_id)
         stats = list()
         for i in data:

--- a/app/service/service_statistics_schema.py
+++ b/app/service/service_statistics_schema.py
@@ -1,0 +1,12 @@
+get_monthly_template_usage_request = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "GET monthly template usage schema",
+    "title": "Get monthly template usage for a service",
+    "type": "object",
+    "properties": {
+        "page": {"type": "integer", "minimum": 1},
+        "page_size": {"type": "integer", "minimum": 10, "maximum": 100},
+        "year": {"type": "integer"},
+    },
+    "required": ["year"],
+}

--- a/tests/app/dao/test_fact_notification_status_dao.py
+++ b/tests/app/dao/test_fact_notification_status_dao.py
@@ -13,6 +13,7 @@ from app.dao.fact_notification_status_dao import (
     fetch_delivered_notification_stats_by_month,
     fetch_monthly_notification_statuses_per_service,
     fetch_monthly_template_usage_for_service,
+    fetch_monthly_template_usage_for_service_paginated,
     fetch_notification_billable_units_for_service_for_today_and_7_previous_days,
     fetch_notification_stats_for_trial_services,
     fetch_notification_status_for_day,
@@ -1113,6 +1114,140 @@ def test_fetch_monthly_template_usage_for_service_does_not_include_test_notifica
     results = fetch_monthly_template_usage_for_service(datetime(2018, 1, 1), datetime(2018, 3, 31), sample_template.service_id)
 
     assert len(results) == 0
+
+
+@freeze_time("2018-03-30 14:00")
+def test_fetch_monthly_template_usage_for_service_paginated_returns_total_unique_templates(sample_service):
+    template_a = create_template(service=sample_service, template_name="a")
+    template_b = create_template(service=sample_service, template_name="b")
+    template_c = create_template(service=sample_service, template_name="c")
+    create_ft_notification_status(utc_date=date(2018, 1, 5), service=sample_service, template=template_a, count=5)
+    create_ft_notification_status(utc_date=date(2018, 2, 5), service=sample_service, template=template_a, count=3)
+    create_ft_notification_status(utc_date=date(2018, 1, 5), service=sample_service, template=template_b, count=10)
+    create_ft_notification_status(utc_date=date(2018, 1, 5), service=sample_service, template=template_c, count=1)
+
+    results, total = fetch_monthly_template_usage_for_service_paginated(
+        datetime(2018, 1, 1), datetime(2018, 3, 31), sample_service.id, page=1, page_size=50
+    )
+
+    assert total == 3
+    template_ids_returned = {str(r.template_id) for r in results}
+    assert template_ids_returned == {str(template_a.id), str(template_b.id), str(template_c.id)}
+
+
+@freeze_time("2018-03-30 14:00")
+def test_fetch_monthly_template_usage_for_service_paginated_orders_by_total_count_desc(sample_service):
+    template_low = create_template(service=sample_service, template_name="low")
+    template_high = create_template(service=sample_service, template_name="high")
+    create_ft_notification_status(utc_date=date(2018, 1, 5), service=sample_service, template=template_low, count=2)
+    create_ft_notification_status(utc_date=date(2018, 1, 5), service=sample_service, template=template_high, count=20)
+
+    results, total = fetch_monthly_template_usage_for_service_paginated(
+        datetime(2018, 1, 1), datetime(2018, 3, 31), sample_service.id, page=1, page_size=1
+    )
+
+    assert total == 2
+    template_ids_returned = {str(r.template_id) for r in results}
+    assert template_ids_returned == {str(template_high.id)}
+
+
+@freeze_time("2018-03-30 14:00")
+def test_fetch_monthly_template_usage_for_service_paginated_returns_all_months_for_page(sample_service):
+    template = create_template(service=sample_service, template_name="t")
+    create_ft_notification_status(utc_date=date(2018, 1, 5), service=sample_service, template=template, count=2)
+    create_ft_notification_status(utc_date=date(2018, 2, 5), service=sample_service, template=template, count=3)
+    create_ft_notification_status(utc_date=date(2018, 3, 5), service=sample_service, template=template, count=4)
+
+    results, total = fetch_monthly_template_usage_for_service_paginated(
+        datetime(2018, 1, 1), datetime(2018, 3, 31), sample_service.id, page=1, page_size=50
+    )
+
+    assert total == 1
+    months = sorted(r.month for r in results)
+    assert months == [1, 2, 3]
+    counts = {r.month: r.count for r in results}
+    assert counts == {1: 2, 2: 3, 3: 4}
+
+
+@freeze_time("2018-03-30 14:00")
+def test_fetch_monthly_template_usage_for_service_paginated_offsets_correctly(sample_service):
+    template_a = create_template(service=sample_service, template_name="a")
+    template_b = create_template(service=sample_service, template_name="b")
+    create_ft_notification_status(utc_date=date(2018, 1, 5), service=sample_service, template=template_a, count=10)
+    create_ft_notification_status(utc_date=date(2018, 1, 5), service=sample_service, template=template_b, count=1)
+
+    results, total = fetch_monthly_template_usage_for_service_paginated(
+        datetime(2018, 1, 1), datetime(2018, 3, 31), sample_service.id, page=2, page_size=1
+    )
+
+    assert total == 2
+    assert len(results) == 1
+    assert str(results[0].template_id) == str(template_b.id)
+
+
+@freeze_time("2018-03-30 14:00")
+def test_fetch_monthly_template_usage_for_service_paginated_returns_empty_when_no_data(sample_service):
+    results, total = fetch_monthly_template_usage_for_service_paginated(
+        datetime(2018, 1, 1), datetime(2018, 3, 31), sample_service.id, page=1, page_size=50
+    )
+
+    assert results == []
+    assert total == 0
+
+
+@freeze_time("2018-03-30 14:00")
+def test_fetch_monthly_template_usage_for_service_paginated_excludes_cancelled(sample_service):
+    template = create_template(service=sample_service, template_name="t")
+    create_ft_notification_status(
+        utc_date=date(2018, 1, 5),
+        service=sample_service,
+        template=template,
+        notification_status="cancelled",
+        count=10,
+    )
+
+    results, total = fetch_monthly_template_usage_for_service_paginated(
+        datetime(2018, 1, 1), datetime(2018, 3, 31), sample_service.id, page=1, page_size=50
+    )
+
+    assert results == []
+    assert total == 0
+
+
+@freeze_time("2018-03-30 14:00")
+def test_fetch_monthly_template_usage_for_service_paginated_excludes_test_keys(sample_service):
+    template = create_template(service=sample_service, template_name="t")
+    create_ft_notification_status(
+        utc_date=date(2018, 1, 5),
+        service=sample_service,
+        template=template,
+        key_type="test",
+        count=10,
+    )
+
+    results, total = fetch_monthly_template_usage_for_service_paginated(
+        datetime(2018, 1, 1), datetime(2018, 3, 31), sample_service.id, page=1, page_size=50
+    )
+
+    assert results == []
+    assert total == 0
+
+
+@freeze_time("2018-03-30 14:00")
+def test_fetch_monthly_template_usage_for_service_paginated_includes_today_for_paged_templates(sample_service):
+    template = create_template(service=sample_service, template_name="t")
+    create_ft_notification_status(utc_date=date(2018, 1, 5), service=sample_service, template=template, count=5)
+    save_notification(create_notification(template=template, created_at=datetime.utcnow(), status="delivered"))
+
+    results, total = fetch_monthly_template_usage_for_service_paginated(
+        datetime(2018, 1, 1), datetime(2018, 3, 31), sample_service.id, page=1, page_size=50
+    )
+
+    assert total == 1
+    months = sorted(r.month for r in results)
+    assert months == [1, 3]
+    counts = {r.month: r.count for r in results}
+    assert counts == {1: 5, 3: 1}
 
 
 @pytest.mark.parametrize("notification_type, count", [("sms", 3), ("email", 5), ("letter", 7)])

--- a/tests/app/dao/test_fact_notification_status_dao.py
+++ b/tests/app/dao/test_fact_notification_status_dao.py
@@ -1250,6 +1250,24 @@ def test_fetch_monthly_template_usage_for_service_paginated_includes_today_for_p
     assert counts == {1: 5, 3: 1}
 
 
+@freeze_time("2018-03-30 14:00")
+def test_fetch_monthly_template_usage_for_service_paginated_picks_up_today_only_templates(sample_service):
+    """A template that only has notifications today (not yet in fact table) should still
+    be counted in `total` and returned when on the page."""
+    fact_template = create_template(service=sample_service, template_name="historic")
+    today_only_template = create_template(service=sample_service, template_name="today_only")
+    create_ft_notification_status(utc_date=date(2018, 1, 5), service=sample_service, template=fact_template, count=5)
+    save_notification(create_notification(template=today_only_template, created_at=datetime.utcnow(), status="delivered"))
+
+    results, total = fetch_monthly_template_usage_for_service_paginated(
+        datetime(2018, 1, 1), datetime(2018, 3, 31), sample_service.id, page=1, page_size=50
+    )
+
+    assert total == 2
+    template_ids_returned = {str(r.template_id) for r in results}
+    assert template_ids_returned == {str(fact_template.id), str(today_only_template.id)}
+
+
 @pytest.mark.parametrize("notification_type, count", [("sms", 3), ("email", 5), ("letter", 7)])
 def test_get_total_sent_notifications_for_day_and_type_returns_right_notification_type(
     notification_type,

--- a/tests/app/service/test_statistics_rest.py
+++ b/tests/app/service/test_statistics_rest.py
@@ -123,23 +123,27 @@ def test_get_template_usage_by_month_paginated_returns_paginated_shape(admin_req
 
 @freeze_time("2017-11-11 06:00")
 def test_get_template_usage_by_month_paginated_orders_templates_by_total_count_desc(admin_request, sample_service):
+    high_count_templates = []
+    for i in range(10):
+        template = create_template(sample_service, template_name=f"high_{i:02d}")
+        create_ft_notification_status(utc_date=date(2017, 4, 2), template=template, count=100 - i)
+        high_count_templates.append(template)
+
     template_low = create_template(sample_service, template_name="low")
-    template_high = create_template(sample_service, template_name="high")
     create_ft_notification_status(utc_date=date(2017, 4, 2), template=template_low, count=1)
-    create_ft_notification_status(utc_date=date(2017, 4, 2), template=template_high, count=10)
-    create_ft_notification_status(utc_date=date(2017, 5, 2), template=template_high, count=5)
 
     resp_json = admin_request.get(
         "service.get_monthly_template_usage",
         service_id=sample_service.id,
         year=2017,
         page=1,
-        page_size=1,
+        page_size=10,
     )
 
-    assert resp_json["total"] == 2
+    assert resp_json["total"] == 11
     template_ids_in_page = {row["template_id"] for row in resp_json["data"]}
-    assert template_ids_in_page == {str(template_high.id)}
+    assert template_ids_in_page == {str(t.id) for t in high_count_templates}
+    assert str(template_low.id) not in template_ids_in_page
     assert resp_json["links"] == {"next": "page 2"}
 
 
@@ -165,32 +169,33 @@ def test_get_template_usage_by_month_paginated_returns_all_months_for_templates_
 
 @freeze_time("2017-11-11 06:00")
 def test_get_template_usage_by_month_paginated_page_2_returns_prev_link(admin_request, sample_service):
-    template_a = create_template(sample_service, template_name="a")
-    template_b = create_template(sample_service, template_name="b")
-    create_ft_notification_status(utc_date=date(2017, 4, 2), template=template_a, count=10)
-    create_ft_notification_status(utc_date=date(2017, 4, 2), template=template_b, count=1)
+    templates = []
+    for i in range(11):
+        template = create_template(sample_service, template_name=f"t{i:02d}")
+        create_ft_notification_status(utc_date=date(2017, 4, 2), template=template, count=11 - i)
+        templates.append(template)
 
     resp_json = admin_request.get(
         "service.get_monthly_template_usage",
         service_id=sample_service.id,
         year=2017,
         page=2,
-        page_size=1,
+        page_size=10,
     )
 
     assert resp_json["page"] == 2
     assert resp_json["links"] == {"prev": "page 1"}
-    assert {row["template_id"] for row in resp_json["data"]} == {str(template_b.id)}
+    assert {row["template_id"] for row in resp_json["data"]} == {str(templates[-1].id)}
 
 
 @pytest.mark.parametrize(
     "kwargs, expected_message",
     [
-        ({"page": "abc"}, "page must be an integer"),
-        ({"page": 0}, "page must be greater than 0"),
-        ({"page": -1}, "page must be greater than 0"),
-        ({"page": 1, "page_size": 0}, "page_size must be between 1 and 100"),
-        ({"page": 1, "page_size": 101}, "page_size must be between 1 and 100"),
+        ({"page": "abc"}, "is not of type integer"),
+        ({"page": "0"}, "is less than the minimum of 1"),
+        ({"page": "-1"}, "is less than the minimum of 1"),
+        ({"page": "1", "page_size": "0"}, "is less than the minimum of 10"),
+        ({"page": "1", "page_size": "101"}, "is greater than the maximum of 100"),
     ],
 )
 def test_get_template_usage_by_month_paginated_invalid_args_returns_400(admin_request, sample_service, kwargs, expected_message):
@@ -201,7 +206,12 @@ def test_get_template_usage_by_month_paginated_invalid_args_returns_400(admin_re
         _expected_status=400,
         **kwargs,
     )
-    assert expected_message in resp_json["message"]
+    # Accept either a list of errors or a single error string
+    errors = resp_json.get("errors")
+    if isinstance(errors, list):
+        assert any(expected_message in err["message"] for err in errors)
+    else:
+        assert expected_message in errors
 
 
 @pytest.mark.parametrize(

--- a/tests/app/service/test_statistics_rest.py
+++ b/tests/app/service/test_statistics_rest.py
@@ -99,6 +99,111 @@ def test_get_template_usage_by_month_returns_two_templates(admin_request, sample
     assert resp_json[2]["is_precompiled_letter"] is False
 
 
+@freeze_time("2017-11-11 06:00")
+def test_get_template_usage_by_month_paginated_returns_paginated_shape(admin_request, sample_template):
+    create_ft_notification_status(utc_date=date(2017, 4, 2), template=sample_template, count=3)
+
+    resp_json = admin_request.get(
+        "service.get_monthly_template_usage",
+        service_id=sample_template.service_id,
+        year=2017,
+        page=1,
+        page_size=50,
+    )
+
+    assert "data" in resp_json
+    assert "total" in resp_json
+    assert resp_json["page"] == 1
+    assert resp_json["page_size"] == 50
+    assert resp_json["links"] == {}
+    assert resp_json["total"] == 1
+    assert len(resp_json["data"]) == 1
+    assert resp_json["data"][0]["template_id"] == str(sample_template.id)
+
+
+@freeze_time("2017-11-11 06:00")
+def test_get_template_usage_by_month_paginated_orders_templates_by_total_count_desc(admin_request, sample_service):
+    template_low = create_template(sample_service, template_name="low")
+    template_high = create_template(sample_service, template_name="high")
+    create_ft_notification_status(utc_date=date(2017, 4, 2), template=template_low, count=1)
+    create_ft_notification_status(utc_date=date(2017, 4, 2), template=template_high, count=10)
+    create_ft_notification_status(utc_date=date(2017, 5, 2), template=template_high, count=5)
+
+    resp_json = admin_request.get(
+        "service.get_monthly_template_usage",
+        service_id=sample_service.id,
+        year=2017,
+        page=1,
+        page_size=1,
+    )
+
+    assert resp_json["total"] == 2
+    template_ids_in_page = {row["template_id"] for row in resp_json["data"]}
+    assert template_ids_in_page == {str(template_high.id)}
+    assert resp_json["links"] == {"next": "page 2"}
+
+
+@freeze_time("2017-11-11 06:00")
+def test_get_template_usage_by_month_paginated_returns_all_months_for_templates_on_page(admin_request, sample_service):
+    template = create_template(sample_service, template_name="t")
+    create_ft_notification_status(utc_date=date(2017, 4, 2), template=template, count=2)
+    create_ft_notification_status(utc_date=date(2017, 5, 2), template=template, count=3)
+
+    resp_json = admin_request.get(
+        "service.get_monthly_template_usage",
+        service_id=sample_service.id,
+        year=2017,
+        page=1,
+        page_size=50,
+    )
+
+    assert resp_json["total"] == 1
+    assert len(resp_json["data"]) == 2
+    months = sorted(row["month"] for row in resp_json["data"])
+    assert months == [4, 5]
+
+
+@freeze_time("2017-11-11 06:00")
+def test_get_template_usage_by_month_paginated_page_2_returns_prev_link(admin_request, sample_service):
+    template_a = create_template(sample_service, template_name="a")
+    template_b = create_template(sample_service, template_name="b")
+    create_ft_notification_status(utc_date=date(2017, 4, 2), template=template_a, count=10)
+    create_ft_notification_status(utc_date=date(2017, 4, 2), template=template_b, count=1)
+
+    resp_json = admin_request.get(
+        "service.get_monthly_template_usage",
+        service_id=sample_service.id,
+        year=2017,
+        page=2,
+        page_size=1,
+    )
+
+    assert resp_json["page"] == 2
+    assert resp_json["links"] == {"prev": "page 1"}
+    assert {row["template_id"] for row in resp_json["data"]} == {str(template_b.id)}
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected_message",
+    [
+        ({"page": "abc"}, "page must be an integer"),
+        ({"page": 0}, "page must be greater than 0"),
+        ({"page": -1}, "page must be greater than 0"),
+        ({"page": 1, "page_size": 0}, "page_size must be between 1 and 100"),
+        ({"page": 1, "page_size": 101}, "page_size must be between 1 and 100"),
+    ],
+)
+def test_get_template_usage_by_month_paginated_invalid_args_returns_400(admin_request, sample_service, kwargs, expected_message):
+    resp_json = admin_request.get(
+        "service.get_monthly_template_usage",
+        service_id=sample_service.id,
+        year=2017,
+        _expected_status=400,
+        **kwargs,
+    )
+    assert expected_message in resp_json["message"]
+
+
 @pytest.mark.parametrize(
     "today_only, stats",
     [


### PR DESCRIPTION
# Summary | Résumé
This PR aims to improve performance of the "Monthly Template Usage" page in admin with optimizations to the underlying query. For the average service load times should be similar, the real gain is for services with high sending volume across a large number of templates. The JSON payload from the API is bound by the page size, and the browser won't choke trying to render thousands of table rows.

Added `fetch_monthly_template_usage_for_service_paginated` dao method that performs pagination at the query level, splitting the query into two and running the more expensive par on the templates on the current "page" only.
1. Get the page of `template_ids`, sorting them by count descending. We use a combination of `offset` and `limit` to construct the page. 
2. Fetch the detailed template stats using that subset of templates rather than fetching everything all at once.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/3208

# Test instructions | Instructions pour tester la modification
- [ ] CI is passing
- [ ] Release instructions test has been performed

# Release Instructions | Instructions pour le déploiement
1. Check out this branch and with your local Admin on `main` to ensure backwards compatibility (not the associated [admin PR](https://github.com/cds-snc/notification-admin/pull/2687))
- [ ] The dashboard loads without error
- [ ] The `/template-usage` page loads without error (See all templates used link on the dashboard)

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.