### PR TITLE
Fix validation error that happens when `include_jobs=false`

### DIFF
--- a/app/v2/notifications/get_notifications.py
+++ b/app/v2/notifications/get_notifications.py
@@ -84,7 +84,7 @@ def get_notifications():
         older_than=data.get("older_than"),
         client_reference=data.get("reference"),
         page_size=current_app.config.get("API_PAGE_SIZE"),
-        include_jobs=data.get("include_jobs"),
+        include_jobs=data.get("include_jobs") in ("true", "True"),
         count_pages=False,
     )
 

--- a/app/v2/notifications/notification_schemas.py
+++ b/app/v2/notifications/notification_schemas.py
@@ -98,7 +98,7 @@ get_notifications_request = {
             },
         },
         "template_type": {"type": "array", "items": {"enum": TEMPLATE_TYPES}},
-        "include_jobs": {"enum": ["true", "True"]},
+        "include_jobs": {"enum": ["true", "True", "false", "False"]},
         "older_than": uuid,
     },
     "additionalProperties": False,


### PR DESCRIPTION
# Summary | Résumé

Fix validation error that happens when `include_jobs=false` for the endpoint `v2/notifications`.

This originated from a support request: https://gcdigital.slack.com/archives/C03FA4DJCCU/p1778162621536439

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-documentation/pull/219/changes

# Test instructions | Instructions pour tester la modification

1. check this out locally
2. send a job locally
3. send a request to your local api to the endpoint `v2/notifications?include_jobs=false` and verify that you don't get an error and that no notifications that were part of a job are returned.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.