### PR TITLE
Add page_size param to `get_jobs_by_service`

### DIFF
--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -143,6 +143,8 @@ def get_jobs_by_service(service_id):
         except ValueError:
             errors = {"page_size": ["{} is not an integer".format(request.args["page_size"])]}
             raise InvalidRequest(errors, status_code=400)
+        if page_size < 1:
+            raise InvalidRequest({"page_size": ["page_size must be a positive integer"]}, status_code=400)
 
     statuses = [x.strip() for x in request.args.get("statuses", "").split(",")]
 
@@ -322,9 +324,18 @@ def get_paginated_jobs(service_id, limit_days, statuses, page, page_size=None):
     end_time = time.time()
     current_app.logger.info(f"[get_paginated_jobs] took {"{:.3f}".format(end_time - start_time)} seconds")
 
+    # Build extra kwargs so pagination links preserve all original query params.
+    link_kwargs = {"service_id": service_id}
+    if limit_days is not None:
+        link_kwargs["limit_days"] = limit_days
+    if page_size is not None:
+        link_kwargs["page_size"] = page_size
+    if statuses:
+        link_kwargs["statuses"] = ",".join(statuses)
+
     return {
         "data": data,
         "page_size": pagination.per_page,
         "total": pagination.total,
-        "links": pagination_links(pagination, ".get_jobs_by_service", service_id=service_id),
+        "links": pagination_links(pagination, ".get_jobs_by_service", **link_kwargs),
     }

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -136,10 +136,18 @@ def get_jobs_by_service(service_id):
     else:
         limit_days = None
 
+    page_size = None
+    if request.args.get("page_size"):
+        try:
+            page_size = int(request.args["page_size"])
+        except ValueError:
+            errors = {"page_size": ["{} is not an integer".format(request.args["page_size"])]}
+            raise InvalidRequest(errors, status_code=400)
+
     statuses = [x.strip() for x in request.args.get("statuses", "").split(",")]
 
     page = int(request.args.get("page", 1))
-    return jsonify(**get_paginated_jobs(service_id, limit_days, statuses, page))
+    return jsonify(**get_paginated_jobs(service_id, limit_days, statuses, page, page_size=page_size))
 
 
 @job_blueprint.route("", methods=["POST"])
@@ -253,13 +261,13 @@ def get_service_has_jobs(service_id):
     return jsonify(data={"has_jobs": has_jobs}), 200
 
 
-def get_paginated_jobs(service_id, limit_days, statuses, page):
+def get_paginated_jobs(service_id, limit_days, statuses, page, page_size=None):
     start_time = time.time()
     pagination = dao_get_jobs_by_service_id(
         service_id,
         limit_days=limit_days,
         page=page,
-        page_size=current_app.config["PAGE_SIZE"],
+        page_size=page_size if page_size is not None else current_app.config["PAGE_SIZE"],
         statuses=statuses,
     )
     data = job_schema.dump(pagination.items, many=True)

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -149,6 +149,7 @@ def get_jobs_by_service(service_id):
     statuses = [x.strip() for x in request.args.get("statuses", "").split(",")]
 
     page = int(request.args.get("page", 1))
+
     return jsonify(**get_paginated_jobs(service_id, limit_days, statuses, page, page_size=page_size))
 
 

--- a/tests/app/job/test_rest.py
+++ b/tests/app/job/test_rest.py
@@ -966,6 +966,8 @@ def test_get_jobs_accepts_page_size_parameter(admin_request, sample_template):
     assert resp_json["total"] == 10
     assert "links" in resp_json
     assert set(resp_json["links"].keys()) == {"next", "last"}
+    assert "page_size=3" in resp_json["links"]["next"]
+    assert "page_size=3" in resp_json["links"]["last"]
 
 
 def test_get_jobs_accepts_page_size_and_page_parameters(admin_request, sample_template):
@@ -981,6 +983,9 @@ def test_get_jobs_accepts_page_size_and_page_parameters(admin_request, sample_te
     assert resp_json["total"] == 10
     assert "links" in resp_json
     assert set(resp_json["links"].keys()) == {"prev", "next", "last"}
+    assert "page_size=3" in resp_json["links"]["prev"]
+    assert "page_size=3" in resp_json["links"]["next"]
+    assert "page_size=3" in resp_json["links"]["last"]
 
 
 @pytest.mark.parametrize(
@@ -989,6 +994,8 @@ def test_get_jobs_accepts_page_size_and_page_parameters(admin_request, sample_te
         ("abc", "abc is not an integer"),
         ("3.14", "3.14 is not an integer"),
         ("not_a_number", "not_a_number is not an integer"),
+        ("0", "page_size must be a positive integer"),
+        ("-1", "page_size must be a positive integer"),
     ],
 )
 def test_get_jobs_with_invalid_page_size_returns_400(admin_request, sample_template, invalid_page_size, expected_error):

--- a/tests/app/job/test_rest.py
+++ b/tests/app/job/test_rest.py
@@ -1009,6 +1009,37 @@ def test_get_jobs_with_invalid_page_size_returns_400(admin_request, sample_templ
     assert expected_error in resp_json["message"]["page_size"][0]
 
 
+def test_get_jobs_pagination_links_preserve_all_query_params(admin_request, sample_template):
+    """Test that pagination links preserve page_size, limit_days, and statuses together"""
+    # Create jobs with different statuses
+    create_job(sample_template, job_status="pending")
+    create_job(sample_template, job_status="pending")
+    create_job(sample_template, job_status="pending")
+    create_job(sample_template, job_status="finished")
+    create_job(sample_template, job_status="finished")
+
+    resp_json = admin_request.get(
+        "job.get_jobs_by_service",
+        service_id=sample_template.service_id,
+        page_size=2,
+        limit_days=7,
+        statuses="pending,finished",
+    )
+
+    assert resp_json["page_size"] == 2
+    assert resp_json["total"] == 5
+    assert "links" in resp_json
+
+    # Verify all query parameters are preserved in pagination links
+    if "next" in resp_json["links"]:
+        assert "page_size=2" in resp_json["links"]["next"]
+        assert "limit_days=7" in resp_json["links"]["next"]
+        assert (
+            "statuses=pending%2Cfinished" in resp_json["links"]["next"]
+            or "statuses=pending,finished" in resp_json["links"]["next"]
+        )
+
+
 @pytest.mark.parametrize(
     "statuses_filter, expected_statuses",
     [

--- a/tests/app/job/test_rest.py
+++ b/tests/app/job/test_rest.py
@@ -953,6 +953,55 @@ def test_get_jobs_accepts_page_parameter(admin_request, sample_template):
     assert set(resp_json["links"].keys()) == {"prev", "next", "last"}
 
 
+def test_get_jobs_accepts_page_size_parameter(admin_request, sample_template):
+    create_10_jobs(sample_template)
+
+    resp_json = admin_request.get("job.get_jobs_by_service", service_id=sample_template.service_id, page_size=3)
+
+    assert len(resp_json["data"]) == 3
+    assert resp_json["data"][0]["created_at"] == "2015-01-01T10:00:00.000000+00:00"
+    assert resp_json["data"][1]["created_at"] == "2015-01-01T09:00:00.000000+00:00"
+    assert resp_json["data"][2]["created_at"] == "2015-01-01T08:00:00.000000+00:00"
+    assert resp_json["page_size"] == 3
+    assert resp_json["total"] == 10
+    assert "links" in resp_json
+    assert set(resp_json["links"].keys()) == {"next", "last"}
+
+
+def test_get_jobs_accepts_page_size_and_page_parameters(admin_request, sample_template):
+    create_10_jobs(sample_template)
+
+    resp_json = admin_request.get("job.get_jobs_by_service", service_id=sample_template.service_id, page=2, page_size=3)
+
+    assert len(resp_json["data"]) == 3
+    assert resp_json["data"][0]["created_at"] == "2015-01-01T07:00:00.000000+00:00"
+    assert resp_json["data"][1]["created_at"] == "2015-01-01T06:00:00.000000+00:00"
+    assert resp_json["data"][2]["created_at"] == "2015-01-01T05:00:00.000000+00:00"
+    assert resp_json["page_size"] == 3
+    assert resp_json["total"] == 10
+    assert "links" in resp_json
+    assert set(resp_json["links"].keys()) == {"prev", "next", "last"}
+
+
+@pytest.mark.parametrize(
+    "invalid_page_size, expected_error",
+    [
+        ("abc", "abc is not an integer"),
+        ("3.14", "3.14 is not an integer"),
+        ("not_a_number", "not_a_number is not an integer"),
+    ],
+)
+def test_get_jobs_with_invalid_page_size_returns_400(admin_request, sample_template, invalid_page_size, expected_error):
+    resp_json = admin_request.get(
+        "job.get_jobs_by_service",
+        service_id=sample_template.service_id,
+        page_size=invalid_page_size,
+        _expected_status=400,
+    )
+    assert resp_json["result"] == "error"
+    assert expected_error in resp_json["message"]["page_size"][0]
+
+
 @pytest.mark.parametrize(
     "statuses_filter, expected_statuses",
     [


### PR DESCRIPTION
# Summary | Résumé

This PR adds a page_size param to the `get_jobs_by_service` endpoint. by default the app's page size is 50. This is fine for UI pages with specific purposes (e.g. View all bulk jobs, View all templates used, etc.). For pages like the dashboard that load a lot of various data elements, and renders multiple components this can cause DOM loading / rendering slow downs. Flexible page sizes let us tune performance on a per page basis.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/3208

# Test instructions | Instructions pour tester la modification
Once merged this can be tested against staging and prod locally.
- [ ] CI is passing

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.