### PR TITLE
here's a crack at removing these

### DIFF
--- a/app/clients/sms/aws_pinpoint.py
+++ b/app/clients/sms/aws_pinpoint.py
@@ -45,13 +45,9 @@ class AwsPinpointClient(SmsClient):
             destinationNumber = to
             try:
                 start_time = monotonic()
-                send_with_dedicated_phone_number = self._send_with_dedicated_phone_number(sender) and self.current_app.config.get(
-                    "FF_USE_PINPOINT_FOR_DEDICATED", False
-                )
+                send_with_dedicated_phone_number = self._send_with_dedicated_phone_number(sender)
                 # If the number is US based, we must use a US Toll Free number to send the message
-                if phonenumbers.region_code_for_number(match.number) == "US" and self.current_app.config.get(
-                    "FF_USE_PINPOINT_FOR_US", False
-                ):
+                if phonenumbers.region_code_for_number(match.number) == "US":
                     response = self._dedicated_client.send_text_message(
                         DestinationPhoneNumber=destinationNumber,
                         OriginationIdentity=self.current_app.config["AWS_US_TOLL_FREE_NUMBER"],

--- a/app/config.py
+++ b/app/config.py
@@ -270,12 +270,6 @@ class Config(object):
     AWS_PINPOINT_DEFAULT_POOL_ID = os.getenv("AWS_PINPOINT_DEFAULT_POOL_ID", "")
     AWS_PINPOINT_CONFIGURATION_SET_NAME = os.getenv("AWS_PINPOINT_CONFIGURATION_SET_NAME", "pinpoint-configuration")
     AWS_PINPOINT_SC_TEMPLATE_IDS = env.list("AWS_PINPOINT_SC_TEMPLATE_IDS", [])
-    FF_USE_PINPOINT_FOR_DEDICATED = env.bool(
-        "FF_USE_PINPOINT_FOR_DEDICATED", False
-    )  # Feature flag to control whether to use Pinpoint for sending messages from long dedicated numbers
-    FF_USE_PINPOINT_FOR_US = env.bool(
-        "FF_USE_PINPOINT_FOR_US", False
-    )  # Feature flag to control whether to use Pinpoint for sending messages to US numbers
     AWS_US_TOLL_FREE_NUMBER = os.getenv("AWS_US_TOLL_FREE_NUMBER")
     CSV_UPLOAD_BUCKET_NAME = os.getenv("CSV_UPLOAD_BUCKET_NAME", "notification-alpha-canada-ca-csv-upload")
     ASSET_DOMAIN = os.getenv("ASSET_DOMAIN", "assets.notification.canada.ca")

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -451,28 +451,18 @@ def provider_to_use(
         provider: Provider to use to send the notification.
     """
 
-    has_dedicated_number = sender is not None and sender.startswith("+1")
     cannot_determine_recipient_country = False
     recipient_outside_canada = False
-    sending_to_us_number = False
     if to is not None:
         match = next(iter(phonenumbers.PhoneNumberMatcher(to, "US")), None)
         if match is None:
             cannot_determine_recipient_country = True
-        elif (
-            phonenumbers.region_code_for_number(match.number) == "US"
-        ):  # The US is a special case that needs to send from a US toll free number
-            sending_to_us_number = True
-        elif phonenumbers.region_code_for_number(match.number) != "CA":
+        elif phonenumbers.region_code_for_number(match.number) not in ["CA", "US"]:
             recipient_outside_canada = True
     using_sc_pool_template = template_id is not None and str(template_id) in current_app.config["AWS_PINPOINT_SC_TEMPLATE_IDS"]
     zone_1_outside_canada = recipient_outside_canada and not international
-    use_pinpoint_for_dedicated = current_app.config.get("FF_USE_PINPOINT_FOR_DEDICATED", False)
-    use_pinpoint_for_us = current_app.config.get("FF_USE_PINPOINT_FOR_US", False)
     do_not_use_pinpoint = (
-        (has_dedicated_number and not use_pinpoint_for_dedicated)
-        or (sending_to_us_number and not use_pinpoint_for_us)
-        or cannot_determine_recipient_country
+        cannot_determine_recipient_country
         or zone_1_outside_canada
         or not current_app.config["AWS_PINPOINT_SC_POOL_ID"]
         or ((not current_app.config["AWS_PINPOINT_DEFAULT_POOL_ID"]) and not using_sc_pool_template)

--- a/tests/app/clients/test_aws_pinpoint.py
+++ b/tests/app/clients/test_aws_pinpoint.py
@@ -215,7 +215,7 @@ def test_send_sms_uses_dryrun(notify_api, mocker, sample_template, template_id):
 
 
 @pytest.mark.serial
-def test_send_sms_uses_dedicated_number_when_flag_enabled(notify_api, mocker):
+def test_send_sms_uses_dedicated_number_with_long_code_sender(notify_api, mocker):
     # Mock AWS clients
     dedicated_mock = mocker.patch.object(aws_pinpoint_client, "_dedicated_client", create=True)
     default_mock = mocker.patch.object(aws_pinpoint_client, "_client", create=True)
@@ -232,7 +232,6 @@ def test_send_sms_uses_dedicated_number_when_flag_enabled(notify_api, mocker):
             "AWS_PINPOINT_SC_POOL_ID": "sc_pool_id",
             "AWS_PINPOINT_DEFAULT_POOL_ID": "default_pool_id",
             "AWS_PINPOINT_CONFIGURATION_SET_NAME": "config_set_name",
-            "FF_USE_PINPOINT_FOR_DEDICATED": True,
         },
     ):
         aws_pinpoint_client.send_sms(
@@ -257,7 +256,7 @@ def test_send_sms_uses_dedicated_number_when_flag_enabled(notify_api, mocker):
 
 
 @pytest.mark.serial
-def test_send_sms_to_us_number_uses_pinpoint_when_flag_enabled(notify_api, mocker):
+def test_send_sms_to_us_number_uses_US_toll_free_number(notify_api, mocker):
     dedicated_mock = mocker.patch.object(aws_pinpoint_client, "_dedicated_client", create=True)
     default_mock = mocker.patch.object(aws_pinpoint_client, "_client", create=True)
     mocker.patch.object(aws_pinpoint_client, "statsd_client", create=True)
@@ -271,7 +270,6 @@ def test_send_sms_to_us_number_uses_pinpoint_when_flag_enabled(notify_api, mocke
         {
             "AWS_US_TOLL_FREE_NUMBER": us_toll_free_number,
             "AWS_PINPOINT_CONFIGURATION_SET_NAME": "config_set_name",
-            "FF_USE_PINPOINT_FOR_US": True,
         },
     ):
         aws_pinpoint_client.send_sms(to, content, reference)

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -88,48 +88,23 @@ class TestProviderToUse:
             provider = send_to_providers.provider_to_use("sms", "1234", "+16135551234", template_id=sc_template)
         assert provider.name == "pinpoint"
 
-    def test_should_use_sns_for_sms_if_dedicated_number(self, restore_provider_details, notify_api):
+    def test_should_use_pinpoint_for_sms_if_dedicated_number(self, restore_provider_details, notify_api):
         with set_config_values(
             notify_api,
             {
                 "AWS_PINPOINT_SC_POOL_ID": "sc_pool_id",
                 "AWS_PINPOINT_DEFAULT_POOL_ID": "default_pool_id",
-                "FF_USE_PINPOINT_FOR_DEDICATED": False,
-            },
-        ):
-            provider = send_to_providers.provider_to_use("sms", "1234", "+16135551234", False, "+12345678901")
-        assert provider.name == "sns"
-
-    def test_should_use_pinpoint_for_sms_if_dedicated_number_and_ff_enabled(self, restore_provider_details, notify_api):
-        with set_config_values(
-            notify_api,
-            {
-                "AWS_PINPOINT_SC_POOL_ID": "sc_pool_id",
-                "AWS_PINPOINT_DEFAULT_POOL_ID": "default_pool_id",
-                "FF_USE_PINPOINT_FOR_DEDICATED": True,
             },
         ):
             provider = send_to_providers.provider_to_use("sms", "1234", "+16135551234", False, "+12345678901")
         assert provider.name == "pinpoint"
 
-    def test_should_use_sns_for_sms_if_sending_to_the_US(self, restore_provider_details, notify_api):
+    def test_should_use_pinpoint_for_sms_if_sending_to_the_US(self, restore_provider_details, notify_api):
         with set_config_values(
             notify_api,
             {
                 "AWS_PINPOINT_SC_POOL_ID": "sc_pool_id",
                 "AWS_PINPOINT_DEFAULT_POOL_ID": "default_pool_id",
-            },
-        ):
-            provider = send_to_providers.provider_to_use("sms", "1234", "+17065551234")
-        assert provider.name == "sns"
-
-    def test_should_use_pinpoint_for_sms_if_sending_to_the_US_and_flag_enabled(self, restore_provider_details, notify_api):
-        with set_config_values(
-            notify_api,
-            {
-                "AWS_PINPOINT_SC_POOL_ID": "sc_pool_id",
-                "AWS_PINPOINT_DEFAULT_POOL_ID": "default_pool_id",
-                "FF_USE_PINPOINT_FOR_US": True,
             },
         ):
             provider = send_to_providers.provider_to_use("sms", "1234", "+17065551234")


### PR DESCRIPTION
# Summary | Résumé
This pull request removes the feature flags controlling the use of AWS Pinpoint for dedicated numbers and US numbers, simplifying the logic for SMS provider selection. Now, Pinpoint is always used for sending SMS from dedicated numbers and to US numbers, without needing to enable feature flags. Related tests and configuration options have also been updated to reflect this change.

**Removal of feature flags and related logic:**

* Eliminated the `FF_USE_PINPOINT_FOR_DEDICATED` and `FF_USE_PINPOINT_FOR_US` feature flags from `app/config.py` and all code paths that referenced them, so Pinpoint is now always used for dedicated numbers and US numbers. [[1]](diffhunk://#diff-84f1a9419471e289c6b6e2b0209b329e20df6cef81d1f7f0a193ddc2fc6ad69dL273-L278) [[2]](diffhunk://#diff-2325d60ac54e4ee805ce0420070847e370de01f64df3c8a03accceb2ab4e2709L48-R50) [[3]](diffhunk://#diff-3fe434ecc066e2e198a29fd09e9429d094792fdcde3a8562357c5ea2f8a33347L454-R465)

**Code simplification:**

* Simplified the logic in `send_sms` and `provider_to_use` by removing checks for the feature flags and always using Pinpoint for dedicated numbers and US numbers, reducing conditional complexity. [[1]](diffhunk://#diff-2325d60ac54e4ee805ce0420070847e370de01f64df3c8a03accceb2ab4e2709L48-R50) [[2]](diffhunk://#diff-3fe434ecc066e2e198a29fd09e9429d094792fdcde3a8562357c5ea2f8a33347L454-R465)

**Test updates:**

* Updated test names and logic in `test_aws_pinpoint.py` and `test_send_to_providers.py` to reflect that Pinpoint is always used for dedicated numbers and US numbers, and removed test configuration for the deleted feature flags. [[1]](diffhunk://#diff-c8e7dbfbcfd3d16733efb1345eede7449c4738c2b2e11b61c02e46a11787d3a8L218-R218) [[2]](diffhunk://#diff-c8e7dbfbcfd3d16733efb1345eede7449c4738c2b2e11b61c02e46a11787d3a8L235) [[3]](diffhunk://#diff-c8e7dbfbcfd3d16733efb1345eede7449c4738c2b2e11b61c02e46a11787d3a8L260-R259) [[4]](diffhunk://#diff-c8e7dbfbcfd3d16733efb1345eede7449c4738c2b2e11b61c02e46a11787d3a8L274) [[5]](diffhunk://#diff-02c29fc296d9772f1f68e8043f9b61f6c0fd91146156822bf27e1f793b70a39eL91-L132)

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/805

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.