### PR TITLE
Add support for `unsub_link` to the unsubscribe feature

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -261,11 +261,17 @@ def _validate_unsubscribe_url(url, notification_id):
     """Validates that the unsubscribe URL is a well-formed https URL with a proper hostname.
     Reuses the same criteria as the existing https_url JSON Schema definition in the project
     (scheme must be https, host must look like a real domain with at least one dot).
+    Also rejects URLs containing control characters (CR, LF, etc.) to prevent header injection,
+    since this value is placed directly into an email header.
     Returns the URL if valid, None otherwise.
     """
     if not url:
         return None
     try:
+        # Reject any control characters before further parsing — they can enable header injection
+        # when the URL is interpolated into a List-Unsubscribe header value.
+        if any(c < "\x20" for c in url):
+            raise ValueError("URL contains control characters")
         parsed = urlparse(url)
         if parsed.scheme != "https":
             raise ValueError("scheme must be https")

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -356,11 +356,15 @@ def send_email_to_provider(notification: Notification):
             contains_pii(notification, str(plain_text_email))
 
         # Service-managed one-click unsubscribe: if the template has use_custom_unsubscribe_url
-        # enabled and the personalisation contains ((unsubscribe_url)) or ((unsub_url)), use that
-        # URL for the RFC 8058 List-Unsubscribe header only (no Notify-hosted page or body link).
+        # enabled and the personalisation contains ((unsubscribe_url)), ((unsub_url)), or ((unsub_link)),
+        # use that URL for the RFC 8058 List-Unsubscribe header only (no Notify-hosted page or body link).
         unsubscribe_link_for_header = None
         if getattr(template_obj, "use_custom_unsubscribe_url", False) and personalisation_data:
-            raw_url = personalisation_data.get("unsubscribe_url") or personalisation_data.get("unsub_url")
+            raw_url = (
+                personalisation_data.get("unsubscribe_url")
+                or personalisation_data.get("unsub_url")
+                or personalisation_data.get("unsub_link")
+            )
             unsubscribe_link_for_header = _validate_unsubscribe_url(raw_url, notification.id)
 
         current_app.logger.info(

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -304,6 +304,7 @@ def test_should_send_personalised_template_to_correct_email_provider_and_persist
     [
         ("unsubscribe_url", "https://example.com/unsubscribe/abc123"),
         ("unsub_url", "https://example.com/unsub/abc123"),
+        ("unsub_link", "https://example.com/unsub-link/abc123"),
     ],
 )
 def test_send_email_adds_one_click_unsubscribe_headers_when_use_custom_unsubscribe_url_enabled(

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -378,6 +378,8 @@ def test_send_email_does_not_add_unsubscribe_headers_when_use_custom_unsubscribe
         "example.com/unsub",
         "http://example.com/unsub",  # http is not allowed, only https
         "https://hi",  # no dot in hostname
+        "https://example.com/unsub\r\nX-Injected: evil",  # CRLF header injection attempt
+        "https://example.com/unsub\nX-Injected: evil",  # LF header injection attempt
         "",
     ],
 )


### PR DESCRIPTION
# Summary | Résumé

Add support for `unsub_link` to the unsubscribe feature

## Related Issues | Cartes liées

https://github.com/cds-snc/notification-planning/issues/3096

# Test instructions | Instructions pour tester la modification

Tests should pass.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.