### PR TITLE
Change the `ft_billing` table to use utc midnight as the cutoff

### DIFF
--- a/app/celery/reporting_tasks.py
+++ b/app/celery/reporting_tasks.py
@@ -34,7 +34,7 @@ def create_nightly_billing(day_start=None):
     # day_start is a datetime.date() object. e.g.
     # up to 4 days of data counting back from day_start is consolidated
     if day_start is None:
-        day_start = convert_utc_to_local_timezone(datetime.utcnow()).date() - timedelta(days=1)
+        day_start = datetime.utcnow().date() - timedelta(days=1)
     else:
         # When calling the task its a string in the format of "YYYY-MM-DD"
         day_start = datetime.strptime(day_start, "%Y-%m-%d").date()

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -1,5 +1,6 @@
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
+from typing import Any
 
 from flask import current_app
 from sqlalchemy import Date, Integer, and_, case, desc, func
@@ -433,7 +434,7 @@ def fetch_billing_data_for_day(process_day: date, service_id=None):
     end_date = datetime.combine(process_day + timedelta(days=1), time.min)
     # use notification_history if process day is older than 7 days
     # this is useful if we need to rebuild the ft_billing table for a date older than 7 days ago.
-    transit_data = []
+    transit_data: list[Any] = []
     if not service_id:
         service_ids = [x.id for x in Service.query.all()]
     else:

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -2,7 +2,6 @@ from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 
 from flask import current_app
-from notifications_utils.timezones import convert_utc_to_local_timezone
 from sqlalchemy import Date, Integer, and_, case, desc, func
 from sqlalchemy.dialects.postgresql import insert
 
@@ -360,12 +359,11 @@ def fetch_billing_totals_for_year(service_id, year):
 
 def fetch_monthly_billing_for_year(service_id, year):
     year_start_date, year_end_date = get_financial_year(year)
-    utcnow = datetime.utcnow()
-    today = convert_utc_to_local_timezone(utcnow)
+    today_utc = datetime.utcnow().date()
     # if year end date is less than today, we are calculating for data in the past and have no need for deltas.
-    if year_end_date >= today:
-        yesterday = today - timedelta(days=1)
-        for day in [yesterday, today]:
+    if year_end_date.date() >= today_utc:
+        yesterday_utc = today_utc - timedelta(days=1)
+        for day in [yesterday_utc, today_utc]:
             data = fetch_billing_data_for_day(process_day=day, service_id=service_id)
             for d in data:
                 update_fact_billing(data=d, process_day=day)
@@ -430,7 +428,7 @@ def delete_billing_data_for_service_for_day(process_day, service_id):
     return FactBilling.query.filter(FactBilling.bst_date == process_day, FactBilling.service_id == service_id).delete()
 
 
-def fetch_billing_data_for_day(process_day, service_id=None):
+def fetch_billing_data_for_day(process_day: date, service_id=None):
     start_date = datetime.combine(process_day, time.min)
     end_date = datetime.combine(process_day + timedelta(days=1), time.min)
     # use notification_history if process day is older than 7 days

--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -2,10 +2,7 @@ from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 
 from flask import current_app
-from notifications_utils.timezones import (
-    convert_local_timezone_to_utc,
-    convert_utc_to_local_timezone,
-)
+from notifications_utils.timezones import convert_utc_to_local_timezone
 from sqlalchemy import Date, Integer, and_, case, desc, func
 from sqlalchemy.dialects.postgresql import insert
 
@@ -47,7 +44,7 @@ def dao_fetch_sms_cost_for_service_in_range(service_id, start_date, end_date):
     1. Check if `ft_billing` has been populated for the requested date range and if not, fall back to the `notifications` table
     2. Always use the `notifications` table for today and yesterday's data, and `ft_billing` for anything older
     """
-    today = convert_utc_to_local_timezone(datetime.utcnow()).date()
+    today = datetime.utcnow().date()
 
     fragment_count = 0
     total_cost = Decimal(0)
@@ -75,8 +72,8 @@ def dao_fetch_sms_cost_for_service_in_range(service_id, start_date, end_date):
 
     # Current-day data from Notification table
     if start_date <= today and end_date >= today:
-        today_start = convert_local_timezone_to_utc(datetime.combine(today, time.min))
-        today_end = convert_local_timezone_to_utc(datetime.combine(today + timedelta(days=1), time.min))
+        today_start = datetime.combine(today, time.min)
+        today_end = datetime.combine(today + timedelta(days=1), time.min)
         notif_result = (
             db.session.query(
                 func.coalesce(func.sum(Notification.billable_units), 0).label("fragment_count"),
@@ -434,8 +431,8 @@ def delete_billing_data_for_service_for_day(process_day, service_id):
 
 
 def fetch_billing_data_for_day(process_day, service_id=None):
-    start_date = convert_local_timezone_to_utc(datetime.combine(process_day, time.min))
-    end_date = convert_local_timezone_to_utc(datetime.combine(process_day + timedelta(days=1), time.min))
+    start_date = datetime.combine(process_day, time.min)
+    end_date = datetime.combine(process_day + timedelta(days=1), time.min)
     # use notification_history if process day is older than 7 days
     # this is useful if we need to rebuild the ft_billing table for a date older than 7 days ago.
     transit_data = []

--- a/tests/app/dao/test_ft_billing_dao.py
+++ b/tests/app/dao/test_ft_billing_dao.py
@@ -119,11 +119,11 @@ def test_fetch_billing_data_for_today_includes_data_with_the_right_key_type(
 
 
 @freeze_time("2018-04-02 06:20:00")
-# This test assumes the local timezone is EST
 def test_fetch_billing_data_for_today_includes_data_with_the_right_date(
     notify_db_session,
 ):
-    process_day = datetime(2018, 4, 1, 13, 30, 0)
+    # Uses UTC midnight as the day boundary
+    process_day = datetime(2018, 4, 1, 13, 30, 0)  # UTC
     service = create_service()
     template = create_template(service=service, template_type="sms")
     save_notification(create_notification(template=template, status="delivered", created_at=process_day))
@@ -131,7 +131,7 @@ def test_fetch_billing_data_for_today_includes_data_with_the_right_date(
         create_notification(
             template=template,
             status="delivered",
-            created_at=datetime(2018, 4, 1, 4, 23, 23),
+            created_at=datetime(2018, 4, 1, 4, 23, 23),  # UTC - still within April 1 UTC
         )
     )
 
@@ -139,13 +139,12 @@ def test_fetch_billing_data_for_today_includes_data_with_the_right_date(
         create_notification(
             template=template,
             status="delivered",
-            created_at=datetime(2018, 3, 31, 20, 23, 23),
+            created_at=datetime(2018, 3, 31, 20, 23, 23),  # UTC - prior day, excluded
         )
     )
     save_notification(create_notification(template=template, status="sending", created_at=process_day + timedelta(days=1)))
 
-    day_under_test = convert_utc_to_local_timezone(process_day)
-    results = fetch_billing_data_for_day(day_under_test)
+    results = fetch_billing_data_for_day(process_day.date())
     assert len(results) == 1
     assert results[0].notifications_sent == 2
 

--- a/tests/app/dao/test_ft_billing_dao.py
+++ b/tests/app/dao/test_ft_billing_dao.py
@@ -6,7 +6,6 @@ from types import SimpleNamespace
 
 import pytest
 from freezegun import freeze_time
-from notifications_utils.timezones import convert_utc_to_local_timezone
 
 from app import db
 from app.dao.fact_billing_dao import (
@@ -94,7 +93,7 @@ def test_fetch_billing_data_for_today_includes_data_with_the_right_status(
     for status in ["created", "technical-failure"]:
         save_notification(create_notification(template=template, status=status))
 
-    today = convert_utc_to_local_timezone(datetime.utcnow())
+    today = datetime.utcnow().date()
     results = fetch_billing_data_for_day(today)
     assert results == []
     for status in ["delivered", "sending", "temporary-failure"]:
@@ -112,7 +111,7 @@ def test_fetch_billing_data_for_today_includes_data_with_the_right_key_type(
     for key_type in ["normal", "test", "team"]:
         save_notification(create_notification(template=template, status="delivered", key_type=key_type))
 
-    today = convert_utc_to_local_timezone(datetime.utcnow())
+    today = datetime.utcnow().date()
     results = fetch_billing_data_for_day(today)
     assert len(results) == 1
     assert results[0].notifications_sent == 2
@@ -158,7 +157,7 @@ def test_fetch_billing_data_for_day_is_grouped_by_template_and_notification_type
     save_notification(create_notification(template=sms_template_1, status="delivered"))
     save_notification(create_notification(template=sms_template_2, status="delivered"))
 
-    today = convert_utc_to_local_timezone(datetime.utcnow())
+    today = datetime.utcnow().date()
     results = fetch_billing_data_for_day(today)
     assert len(results) == 2
     assert results[0].notifications_sent == 1
@@ -173,7 +172,7 @@ def test_fetch_billing_data_for_day_is_grouped_by_service(notify_db_session):
     save_notification(create_notification(template=sms_template_1, status="delivered"))
     save_notification(create_notification(template=sms_template_2, status="delivered"))
 
-    today = convert_utc_to_local_timezone(datetime.utcnow())
+    today = datetime.utcnow().date()
     results = fetch_billing_data_for_day(today)
     assert len(results) == 2
     assert results[0].notifications_sent == 1
@@ -186,7 +185,7 @@ def test_fetch_billing_data_for_day_is_grouped_by_provider(notify_db_session):
     save_notification(create_notification(template=template, status="delivered", sent_by="sns"))
     save_notification(create_notification(template=template, status="delivered", sent_by="pinpoint"))
 
-    today = convert_utc_to_local_timezone(datetime.utcnow())
+    today = datetime.utcnow().date()
     results = fetch_billing_data_for_day(today)
     assert len(results) == 2
     assert results[0].notifications_sent == 1
@@ -199,7 +198,7 @@ def test_fetch_billing_data_for_day_is_grouped_by_rate_mulitplier(notify_db_sess
     save_notification(create_notification(template=template, status="delivered", rate_multiplier=1))
     save_notification(create_notification(template=template, status="delivered", rate_multiplier=2))
 
-    today = convert_utc_to_local_timezone(datetime.utcnow())
+    today = datetime.utcnow().date()
     results = fetch_billing_data_for_day(today)
     assert len(results) == 2
     assert results[0].notifications_sent == 1
@@ -212,7 +211,7 @@ def test_fetch_billing_data_for_day_is_grouped_by_international(notify_db_sessio
     save_notification(create_notification(template=template, status="delivered", international=True))
     save_notification(create_notification(template=template, status="delivered", international=False))
 
-    today = convert_utc_to_local_timezone(datetime.utcnow())
+    today = datetime.utcnow().date()
     results = fetch_billing_data_for_day(today)
     assert len(results) == 2
     assert results[0].notifications_sent == 1
@@ -227,7 +226,7 @@ def test_fetch_billing_data_for_day_is_grouped_by_sms_sending_vehicle(notify_db_
     # Short code: origination number does not match the long code pattern
     save_notification(create_notification(template=template, status="delivered", sms_origination_phone_number="12345"))
 
-    today = convert_utc_to_local_timezone(datetime.utcnow())
+    today = datetime.utcnow().date()
     results = fetch_billing_data_for_day(today)
     assert len(results) == 2
     vehicles = {r.sms_sending_vehicle for r in results}
@@ -241,7 +240,7 @@ def test_fetch_billing_data_for_day_null_origination_number_is_long_code(notify_
     # NULL origination number should fall back to template category's sms_sending_vehicle (long_code by default)
     save_notification(create_notification(template=template, status="delivered", sms_origination_phone_number=None))
 
-    today = convert_utc_to_local_timezone(datetime.utcnow())
+    today = datetime.utcnow().date()
     results = fetch_billing_data_for_day(today)
     assert len(results) == 1
     assert results[0].sms_sending_vehicle == "long_code"
@@ -254,7 +253,7 @@ def test_fetch_billing_data_for_day_null_origination_uses_template_category_vehi
     # NULL origination + short_code category → should yield short_code
     save_notification(create_notification(template=template, status="delivered", sms_origination_phone_number=None))
 
-    today = convert_utc_to_local_timezone(datetime.utcnow())
+    today = datetime.utcnow().date()
     results = fetch_billing_data_for_day(today)
     assert len(results) == 1
     assert results[0].sms_sending_vehicle == "short_code"
@@ -270,7 +269,7 @@ def test_fetch_billing_data_for_day_is_grouped_by_notification_type(notify_db_se
     save_notification(create_notification(template=sms_template, status="delivered"))
     save_notification(create_notification(template=sms_template, status="delivered"))
 
-    today = convert_utc_to_local_timezone(datetime.utcnow())
+    today = datetime.utcnow().date()
     results = fetch_billing_data_for_day(today)
     assert len(results) == 1
     notification_types = [x[2] for x in results if x[2] in ["email", "sms", "letter"]]
@@ -278,7 +277,7 @@ def test_fetch_billing_data_for_day_is_grouped_by_notification_type(notify_db_se
 
 
 def test_fetch_billing_data_for_day_returns_empty_list(notify_db_session):
-    today = convert_utc_to_local_timezone(datetime.utcnow())
+    today = datetime.utcnow().date()
     results = fetch_billing_data_for_day(today)
     assert results == []
 
@@ -305,8 +304,8 @@ def test_fetch_billing_data_for_day_uses_notification_history(notify_db_session)
     Notification.query.delete()
     db.session.commit()
 
-    # Query using the local timezone converted from the same reference time
-    local_history_date = convert_utc_to_local_timezone(history_time)
+    # Query using the UTC date of the same reference time
+    local_history_date = history_time.date()
     results = fetch_billing_data_for_day(process_day=local_history_date, service_id=service.id)
     assert len(results) == 1
     assert results[0].notifications_sent == 2
@@ -320,7 +319,7 @@ def test_fetch_billing_data_for_day_returns_list_for_given_service(notify_db_ses
     save_notification(create_notification(template=template, status="delivered"))
     save_notification(create_notification(template=template_2, status="delivered"))
 
-    today = convert_utc_to_local_timezone(datetime.utcnow())
+    today = datetime.utcnow().date()
     results = fetch_billing_data_for_day(process_day=today, service_id=service.id)
     assert len(results) == 1
     assert results[0].service_id == service.id
@@ -333,7 +332,7 @@ def test_fetch_billing_data_for_day_bills_correctly_for_status(notify_db_session
     for status in NOTIFICATION_STATUS_TYPES:
         save_notification(create_notification(template=sms_template, status=status))
 
-    today = convert_utc_to_local_timezone(datetime.utcnow())
+    today = datetime.utcnow().date()
     results = fetch_billing_data_for_day(process_day=today, service_id=service.id)
 
     sms_results = [x for x in results if x[2] == "sms"]
@@ -979,7 +978,7 @@ def test_fetch_billing_data_for_day_long_code_origination_is_long_code(notify_db
         )
     )
 
-    today = convert_utc_to_local_timezone(datetime.utcnow())
+    today = datetime.utcnow().date()
     results = fetch_billing_data_for_day(today)
     assert len(results) == 1
     assert results[0].sms_sending_vehicle == "long_code"
@@ -1013,7 +1012,7 @@ def test_update_fact_billing_persists_billing_total(notify_db_session, billing_r
     """End-to-end: billing_total is written to ft_billing by update_fact_billing."""
     service = create_service()
     template = create_template(service=service, template_type="sms")
-    today = convert_utc_to_local_timezone(datetime.utcnow())
+    today = datetime.utcnow().date()
 
     save_notification(
         create_notification(
@@ -1029,7 +1028,7 @@ def test_update_fact_billing_persists_billing_total(notify_db_session, billing_r
     rows = fetch_billing_data_for_day(today)
     assert len(rows) == 1
 
-    update_fact_billing(rows[0], today.date())
+    update_fact_billing(rows[0], today)
 
     record = FactBilling.query.one()
     # 2 billable_units * 1 rate_multiplier * 0.162 (long_code rate from billing_rates) = 0.324
@@ -1042,7 +1041,7 @@ def test_update_fact_billing_international_sms_uses_long_code_rate(notify_db_ses
     """
     service = create_service()
     template = create_template(service=service, template_type="sms")
-    today = convert_utc_to_local_timezone(datetime.utcnow())
+    today = datetime.utcnow().date()
 
     # Insert both rates; short_code is purposely higher to prove it isn't chosen
     create_rate(start_date=datetime(2016, 1, 1), value=0.162, notification_type="sms", sms_sending_vehicle="long_code")
@@ -1065,7 +1064,7 @@ def test_update_fact_billing_international_sms_uses_long_code_rate(notify_db_ses
     assert len(rows) == 1
     assert rows[0].sms_sending_vehicle == "long_code"  # international always reported as long_code
 
-    update_fact_billing(rows[0], today.date())
+    update_fact_billing(rows[0], today)
 
     record = FactBilling.query.one()
     # Should use long_code rate (0.162), not short_code rate (0.999)

--- a/tests/app/dao/test_ft_billing_dao.py
+++ b/tests/app/dao/test_ft_billing_dao.py
@@ -148,6 +148,54 @@ def test_fetch_billing_data_for_today_includes_data_with_the_right_date(
     assert results[0].notifications_sent == 2
 
 
+def test_fetch_billing_data_for_day_uses_utc_midnight_boundaries(notify_db_session):
+    service = create_service()
+    template = create_template(service=service, template_type="sms")
+
+    # Exactly around UTC midnight: only records in [2026-05-11 00:00:00, 2026-05-12 00:00:00)
+    # should be counted for process_day=2026-05-11.
+    save_notification(
+        create_notification(
+            template=template,
+            status="delivered",
+            created_at=datetime(2026, 5, 10, 23, 59, 59),
+        )
+    )
+    save_notification(
+        create_notification(
+            template=template,
+            status="delivered",
+            created_at=datetime(2026, 5, 11, 0, 0, 0),
+        )
+    )
+    save_notification(
+        create_notification(
+            template=template,
+            status="delivered",
+            created_at=datetime(2026, 5, 11, 23, 59, 59),
+        )
+    )
+    save_notification(
+        create_notification(
+            template=template,
+            status="delivered",
+            created_at=datetime(2026, 5, 12, 0, 0, 0),
+        )
+    )
+
+    day_results = fetch_billing_data_for_day(process_day=date(2026, 5, 11), service_id=service.id)
+    assert len(day_results) == 1
+    assert day_results[0].notifications_sent == 2
+
+    previous_day_results = fetch_billing_data_for_day(process_day=date(2026, 5, 10), service_id=service.id)
+    assert len(previous_day_results) == 1
+    assert previous_day_results[0].notifications_sent == 1
+
+    next_day_results = fetch_billing_data_for_day(process_day=date(2026, 5, 12), service_id=service.id)
+    assert len(next_day_results) == 1
+    assert next_day_results[0].notifications_sent == 1
+
+
 def test_fetch_billing_data_for_day_is_grouped_by_template_and_notification_type(
     notify_db_session,
 ):


### PR DESCRIPTION
# Summary | Résumé

Change the `ft_billing` table to use utc midnight as the cutoff.

This was previously using midnight in Eastern time to do the aggregation by date. The `ft_notification_status` table uses utc midnight already, as does the daily/annual limit code.

This code change will mean that future data in the `ft_billing` table uses UTC midnight, but we will need an additional PR to regenerate the historical data in that table.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/3156

# Test instructions | Instructions pour tester la modification

I added a new pytest case which is passing. We will also want to check the results on staging after the nightly celery task runs and updates `ft_billing`.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.