### PR TITLE
Add new `files` table

### DIFF
--- a/migrations/versions/0514_add_files_table.py
+++ b/migrations/versions/0514_add_files_table.py
@@ -18,7 +18,7 @@ def upgrade():
         sa.Column('template_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('templates.id'), nullable=False),
         sa.Column('service_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('services.id'), nullable=False),
         sa.Column('document_id', postgresql.UUID(as_uuid=True), nullable=False),
-        sa.Column('type', sa.Enum('attach', 'link', 'template', name='notify_file_type_enum'), nullable=False),
+        sa.Column('type', sa.Enum('attach', 'link', 'template_attach', name='notify_file_type_enum'), nullable=False),
         sa.Column('name', sa.Text(), nullable=False),
         sa.Column('mime_type', sa.Text(), nullable=True),
         sa.Column('file_size', sa.Integer(), nullable=True),

--- a/migrations/versions/0514_add_files_table.py
+++ b/migrations/versions/0514_add_files_table.py
@@ -1,6 +1,6 @@
 """
 Revision ID: 0514_add_files_table
-Revises: 
+Revises: 0513_backfill_api_key_perm
 Create Date: 2026-05-21
 
 """

--- a/migrations/versions/0514_add_files_table.py
+++ b/migrations/versions/0514_add_files_table.py
@@ -26,12 +26,12 @@ def upgrade():
         sa.Column('created_at', sa.DateTime(), server_default=sa.func.now(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), server_default=sa.func.now(), nullable=False),
     )
-    op.create_index('ix_files_template_id', 'files', ['template_id'])
-    op.create_index('ix_files_service_id', 'files', ['service_id'])
+    op.create_index(op.f('ix_files_template_id'), 'files', ['template_id'])
+    op.create_index(op.f('ix_files_service_id'), 'files', ['service_id'])
 
 def downgrade():
-    op.drop_index('ix_files_service_id', table_name='files')
-    op.drop_index('ix_files_template_id', table_name='files')
+    op.drop_index(op.f('ix_files_service_id'), table_name='files')
+    op.drop_index(op.f('ix_files_template_id'), table_name='files')
     op.drop_table('files')
     file_type_enum = postgresql.ENUM('attach', 'link', 'template', name='notify_file_type_enum')
     file_status_enum = postgresql.ENUM('pending_virus_scan', 'uploaded', 'virus_scan_failed', 'deleted', name='notify_file_status_enum')

--- a/migrations/versions/0514_add_files_table.py
+++ b/migrations/versions/0514_add_files_table.py
@@ -1,0 +1,39 @@
+"""
+Revision ID: 0514_add_files_table
+Revises: 
+Create Date: 2026-05-21
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0514_add_files_table'
+down_revision = '0513_backfill_api_key_perm'
+
+def upgrade():
+    op.create_table(
+        'files',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column('template_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('templates.id'), nullable=False),
+        sa.Column('service_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('services.id'), nullable=False),
+        sa.Column('document_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('type', sa.Enum('attach', 'link', 'template', name='notify_file_type_enum'), nullable=False),
+        sa.Column('name', sa.Text(), nullable=False),
+        sa.Column('mime_type', sa.Text(), nullable=True),
+        sa.Column('file_size', sa.Integer(), nullable=True),
+        sa.Column('status', sa.Enum('pending_virus_scan', 'uploaded', 'virus_scan_failed', 'deleted', name='notify_file_status_enum'), nullable=False),
+        sa.Column('created_at', sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), server_default=sa.func.now(), nullable=False),
+    )
+    op.create_index('ix_files_template_id', 'files', ['template_id'])
+    op.create_index('ix_files_service_id', 'files', ['service_id'])
+
+def downgrade():
+    op.drop_index('ix_files_service_id', table_name='files')
+    op.drop_index('ix_files_template_id', table_name='files')
+    op.drop_table('files')
+    file_type_enum = postgresql.ENUM('attach', 'link', 'template', name='notify_file_type_enum')
+    file_status_enum = postgresql.ENUM('pending_virus_scan', 'uploaded', 'virus_scan_failed', 'deleted', name='notify_file_status_enum')
+    file_type_enum.drop(op.get_bind(), checkfirst=True)
+    file_status_enum.drop(op.get_bind(), checkfirst=True)


### PR DESCRIPTION
# Summary | Résumé
This PR adds the `files` table that will be used to store file attachment metadata linked to a given template per the [file attachment ADR](https://docs.google.com/document/d/1-BMzanUA6F49Tume26l424Gf_U07DxY0FHKm0eT1Ktc/edit?tab=t.0#heading=h.kljzf7iwphzr).

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/3221
* [File attachments ADR](https://docs.google.com/document/d/1-BMzanUA6F49Tume26l424Gf_U07DxY0FHKm0eT1Ktc/edit?tab=t.0#heading=h.kljzf7iwphzr)

# Test instructions | Instructions pour tester la modification
- [ ] `flask db upgrade|downgrade` work as expected

# Release Instructions | Instructions pour le déploiement

None.

# AI disclaimer
AI was used to generate the barebones of the migration. Indexes, FKs, and value constraints were added by hand

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.