### PR TITLE
Change how we count notifications in redis

### DIFF
--- a/app/celery/process_ses_receipts_tasks.py
+++ b/app/celery/process_ses_receipts_tasks.py
@@ -221,16 +221,14 @@ def process_notifications(
 
 
 def update_annual_limit_and_bounce_rate(
-    receipt: SESReceipt, notification: Notification, aws_response_dict: Dict[str, Any]
+    receipt: SESReceipt, notification: Notification, aws_response_dict: Dict[str, Any], did_we_seed: bool = False
 ) -> None:
     new_status = aws_response_dict["notification_status"]
     is_success = aws_response_dict["success"]
     log_prefix = f"SES callback for notification {notification.id} reference {notification.reference} for service {notification.service_id}: "
-    # Check if we have already seeded the annual limit counts for today, if we have we do not need to increment later on.
-    # We seed AFTER updating the notification status, thus the current notification will already be counted.
-
-    _, did_we_seed = get_annual_limit_notifications_v3(notification.service_id)
-    current_app.logger.info(f"[alimit-debug] did_we_seed: {did_we_seed}, data: {_}")
+    # did_we_seed is now passed in by the caller (checked once per service after the batch DB write).
+    # If seeding occurred, all notifications in the batch are already counted in the seed — skip incrementing.
+    current_app.logger.info(f"[alimit-debug] did_we_seed: {did_we_seed}")
 
     if not is_success:
         current_app.logger.info(f"{log_prefix} Delivery failed with error: {aws_response_dict["message"]}")
@@ -332,9 +330,20 @@ def process_ses_results(self, response: Dict[str, Any]) -> Optional[bool]:
                 f"[batch-celery] - receipts_with_notification_and_aws_response_dict length: {len(receipts_with_notification_and_aws_response_dict)}"
             )
 
+            # Check seed state ONCE per service after the batch DB write.
+            # If seeding occurs here, all notifications in this batch are already counted
+            # in the seed, so we must skip incrementing for that service.
+            service_seed_states: Dict[str, bool] = {}
+            for _, notification, _ in receipts_with_notification_and_aws_response_dict:
+                sid = notification.service_id
+                if sid not in service_seed_states:
+                    _, did_we_seed = get_annual_limit_notifications_v3(sid)
+                    service_seed_states[sid] = did_we_seed
+
             # Update annual limits, bounce rates, and enqueue API callback tasks for successfully updated notifications
             for message, notification, aws_response_dict in receipts_with_notification_and_aws_response_dict:
-                update_annual_limit_and_bounce_rate(message, notification, aws_response_dict)
+                did_we_seed = service_seed_states.get(notification.service_id, False)
+                update_annual_limit_and_bounce_rate(message, notification, aws_response_dict, did_we_seed)
                 _check_and_queue_callback_task(notification)
 
         # Enqueue retry tasks for receipts that did not yet have a notification in the DB

--- a/tests/app/celery/test_process_ses_receipts_tasks.py
+++ b/tests/app/celery/test_process_ses_receipts_tasks.py
@@ -727,3 +727,103 @@ def test_complaint_retry_logic():
     # Should return the complaint for retry since no notification was found
     assert len(complaints_to_retry) == 1
     assert complaints_to_retry[0]["mail"]["messageId"] == "missing-notification-id"
+
+
+class TestBatchSeedStateFixDoubleCounting:
+    """Tests for the fix that checks seed state once per service after the batch DB write,
+    preventing double-counting when multiple notifications in a batch trigger seeding."""
+
+    def test_batch_does_not_double_count_when_seeding_occurs(self, sample_email_template, notify_api, mocker):
+        """When seeding occurs for a batch of notifications, none of them should be individually incremented
+        because they are all already included in the seed."""
+        mock_increment_delivered = mocker.patch("app.annual_limit_client.increment_email_delivered")
+        mock_increment_failed = mocker.patch("app.annual_limit_client.increment_email_failed")
+        mocker.patch("app.annual_limit_client.get_all_notification_counts", return_value={})
+
+        # Simulate seeding occurring (did_we_seed=True) — this means all notifications
+        # in the batch were counted during the seed
+        mocker.patch(
+            "app.celery.process_ses_receipts_tasks.get_annual_limit_notifications_v3",
+            return_value=({}, True),
+        )
+
+        refs = []
+        for i in range(5):
+            ref = f"ref_batch_{i}"
+            save_notification(
+                create_notification(
+                    sample_email_template,
+                    reference=ref,
+                    sent_at=datetime.utcnow(),
+                    status="sending",
+                )
+            )
+            refs.append(ref)
+
+        with set_config(notify_api, "REDIS_ENABLED", True):
+            assert process_ses_results(generate_ses_notification_callbacks(references=refs))
+
+        # No individual increments should have occurred since seeding counted them all
+        mock_increment_delivered.assert_not_called()
+        mock_increment_failed.assert_not_called()
+
+    def test_batch_increments_each_notification_when_already_seeded(self, sample_email_template, notify_api, mocker):
+        """When already seeded (did_we_seed=False), each notification in the batch should be incremented."""
+        mock_increment_delivered = mocker.patch("app.annual_limit_client.increment_email_delivered")
+        mocker.patch("app.annual_limit_client.increment_email_failed")
+        mocker.patch("app.annual_limit_client.get_all_notification_counts", return_value={})
+
+        # Simulate already seeded (did_we_seed=False) — these notifications are NOT in the seed
+        mocker.patch(
+            "app.celery.process_ses_receipts_tasks.get_annual_limit_notifications_v3",
+            return_value=({}, False),
+        )
+
+        refs = []
+        for i in range(5):
+            ref = f"ref_incr_{i}"
+            save_notification(
+                create_notification(
+                    sample_email_template,
+                    reference=ref,
+                    sent_at=datetime.utcnow(),
+                    status="sending",
+                )
+            )
+            refs.append(ref)
+
+        with set_config(notify_api, "REDIS_ENABLED", True):
+            assert process_ses_results(generate_ses_notification_callbacks(references=refs))
+
+        # Each notification should be individually incremented
+        assert mock_increment_delivered.call_count == 5
+
+    def test_seed_state_checked_once_per_service(self, sample_email_template, notify_api, mocker):
+        """The seed state should be checked exactly once per service, not once per notification."""
+        mocker.patch("app.annual_limit_client.increment_email_delivered")
+        mocker.patch("app.annual_limit_client.increment_email_failed")
+        mocker.patch("app.annual_limit_client.get_all_notification_counts", return_value={})
+
+        mock_get_annual_limit = mocker.patch(
+            "app.celery.process_ses_receipts_tasks.get_annual_limit_notifications_v3",
+            return_value=({}, False),
+        )
+
+        refs = []
+        for i in range(5):
+            ref = f"ref_once_{i}"
+            save_notification(
+                create_notification(
+                    sample_email_template,
+                    reference=ref,
+                    sent_at=datetime.utcnow(),
+                    status="sending",
+                )
+            )
+            refs.append(ref)
+
+        with set_config(notify_api, "REDIS_ENABLED", True):
+            assert process_ses_results(generate_ses_notification_callbacks(references=refs))
+
+        # Should be called once for the service, not 5 times
+        mock_get_annual_limit.assert_called_once_with(sample_email_template.service_id)


### PR DESCRIPTION
## Summary
The batch write pattern in process_ses_results:

1. process_notifications() calls notifications_dao._update_notification_statuses(updates) — bulk-writes ALL N terminal statuses to the DB atomically
2. Then loops over each notification calling update_annual_limit_and_bounce_rate()
Inside that function, get_annual_limit_notifications_v3() is called which checks if seeding has occurred

The race condition:

1. Notification #1 in the batch: not yet seeded → seed_data_in_redis() fires → queries DB → finds ALL N notifications already at terminal status (from step 1) → seeds Redis with all N → did_we_seed=True → skips increment ✓
2. Notification #2..N in the batch: already seeded → did_we_seed=False → increments count → but these were already counted during the seed → double count ✗
