### PR TITLE
Fixed cleanup action of the data generation script

### DIFF
--- a/tests-simulate-prod-data/generate.py
+++ b/tests-simulate-prod-data/generate.py
@@ -1377,6 +1377,17 @@ def cleanup(session):
             print("    Deleting templates_history...")
             session.execute(text("DELETE FROM templates_history WHERE service_id = :sid"), {"sid": sid})
 
+            # template_redacted (FK: template_redacted.template_id -> templates.id)
+            print("    Deleting template_redacted...")
+            session.execute(
+                text("""
+                DELETE FROM template_redacted WHERE template_id IN (
+                    SELECT id FROM templates WHERE service_id = :sid
+                )
+            """),
+                {"sid": sid},
+            )
+
             # templates
             print("    Deleting templates...")
             session.execute(text("DELETE FROM templates WHERE service_id = :sid"), {"sid": sid})
@@ -1427,6 +1438,10 @@ def cleanup(session):
             # user_to_service
             print("    Deleting user_to_service...")
             session.execute(text("DELETE FROM user_to_service WHERE service_id = :sid"), {"sid": sid})
+
+            # reports (FK: reports.service_id -> services.id)
+            print("    Deleting reports...")
+            session.execute(text("DELETE FROM reports WHERE service_id = :sid"), {"sid": sid})
 
             # service
             print("    Deleting services_history...")


### PR DESCRIPTION
# Summary | Résumé

Fixed cleanup action of the data generation script. The script didn't have all tables to clean up and dependencies were preventing the action from executing. 

## Related Issues | Cartes liées

#incident-2026-05-25-oom-sigkills-on-celery-workers

# Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.