### PR TITLE
Isolate long-running nightly delete tasks to a dedicated worker

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -98,6 +98,11 @@ class QueueNames(object):
     REPORTING = "reporting-tasks"
     GENERATE_REPORTS = "generate-reports"
 
+    # Long-running nightly tasks (delete notifications, etc.) — isolated so that
+    # a dedicated worker deployment can use a higher terminationGracePeriodSeconds
+    # without affecting the short-lived periodic-tasks workers.
+    NIGHTLY = "nightly-tasks"
+
     # Queue for scheduled notifications.
     JOBS = "job-tasks"
 
@@ -135,6 +140,7 @@ class QueueNames(object):
         return [
             QueueNames.PRIORITY,
             QueueNames.PERIODIC,
+            QueueNames.NIGHTLY,
             QueueNames.BULK,
             QueueNames.PRIORITY_DATABASE,
             QueueNames.NORMAL_DATABASE,
@@ -491,22 +497,22 @@ class Config(object):
         "delete-sms-notifications": {
             "task": "delete-sms-notifications",
             "schedule": crontab(hour=9, minute=15),  # 4:15 EST in UTC,  after 'create-nightly-notification-status'
-            "options": {"queue": QueueNames.PERIODIC},
+            "options": {"queue": QueueNames.NIGHTLY},
         },
         "delete-email-notifications": {
             "task": "delete-email-notifications",
             "schedule": crontab(hour=9, minute=30),  # 4:30 EST in UTC, after 'create-nightly-notification-status'
-            "options": {"queue": QueueNames.PERIODIC},
+            "options": {"queue": QueueNames.NIGHTLY},
         },
         "delete-letter-notifications": {
             "task": "delete-letter-notifications",
             "schedule": crontab(hour=9, minute=45),  # 4:45 EST in UTC, after 'create-nightly-notification-status'
-            "options": {"queue": QueueNames.PERIODIC},
+            "options": {"queue": QueueNames.NIGHTLY},
         },
         "delete-inbound-sms": {
             "task": "delete-inbound-sms",
             "schedule": crontab(hour=6, minute=40),  # 1:40 EST in UTC
-            "options": {"queue": QueueNames.PERIODIC},
+            "options": {"queue": QueueNames.NIGHTLY},
         },
         "send-daily-performance-platform-stats": {
             "task": "send-daily-performance-platform-stats",

--- a/scripts/run_celery.sh
+++ b/scripts/run_celery.sh
@@ -2,8 +2,9 @@
 
 set -e
 
-# Runs celery with all celery queues except the throtted sms queue.
+# Runs celery with all celery queues except the throttled sms queue,
+# periodic-tasks, and job-tasks.
 
 echo "Start celery, concurrency: ${CELERY_CONCURRENCY-4}"
 
-celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency="${CELERY_CONCURRENCY-4}" -Q -priority-database-tasks.fifo,-normal-database-tasks,-bulk-database-tasks,job-tasks,notify-internal-tasks,periodic-tasks,priority-tasks,normal-tasks,bulk-tasks,reporting-tasks,research-mode-tasks,retry-tasks,send-sms-high,send-sms-medium,send-sms-low,service-callbacks,service-callbacks-retry,delivery-receipts
+celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency="${CELERY_CONCURRENCY-4}" -Q -priority-database-tasks.fifo,-normal-database-tasks,-bulk-database-tasks,notify-internal-tasks,priority-tasks,normal-tasks,bulk-tasks,reporting-tasks,research-mode-tasks,retry-tasks,send-sms-high,send-sms-medium,send-sms-low,service-callbacks,service-callbacks-retry,delivery-receipts

--- a/scripts/run_celery_beat_local.sh
+++ b/scripts/run_celery_beat_local.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# runs the celery beat process. This runs the periodic tasks
+# runs the celery beat process. This runs the scheduler.
 
 set -e
 

--- a/scripts/run_celery_core_tasks.sh
+++ b/scripts/run_celery_core_tasks.sh
@@ -2,9 +2,9 @@
 
 set -e
 
-# Runs celery with all celery queues except send-throttled-sms-tasks, 
-# send-sms-* and send-email-*.
+# Runs celery with all celery queues except send-throttled-sms-tasks,
+# send-sms-*, send-email-*, periodic-tasks, and job-tasks.
 
 echo "Start celery, concurrency: ${CELERY_CONCURRENCY-4}"
 
-celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency="${CELERY_CONCURRENCY-4}" -Q -priority-database-tasks.fifo,-normal-database-tasks,-bulk-database-tasks,job-tasks,notify-internal-tasks,periodic-tasks,priority-tasks,normal-tasks,bulk-tasks,reporting-tasks,research-mode-tasks,retry-tasks,service-callbacks,service-callbacks-retry,delivery-receipts
+celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency="${CELERY_CONCURRENCY-4}" -Q -priority-database-tasks.fifo,-normal-database-tasks,-bulk-database-tasks,notify-internal-tasks,priority-tasks,normal-tasks,bulk-tasks,reporting-tasks,research-mode-tasks,retry-tasks,service-callbacks,service-callbacks-retry,delivery-receipts

--- a/scripts/run_celery_nightly.sh
+++ b/scripts/run_celery_nightly.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -e
+
+# Runs a dedicated Celery worker for long-running nightly tasks (notification
+# deletes, inbound SMS cleanup, etc.).
+#
+# This worker is intentionally isolated from the main periodic-tasks worker so
+# that its Kubernetes deployment can carry a high terminationGracePeriodSeconds
+# (e.g. 2100s / 35 min) without forcing the same slow shutdown on workers that
+# handle short-lived per-minute tasks.
+#
+# The corresponding K8s deployment should set:
+#   terminationGracePeriodSeconds: 2100
+
+echo "Start nightly celery worker, concurrency: 1"
+
+celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency=1 -Q nightly-tasks

--- a/scripts/run_celery_no_sms_sending.sh
+++ b/scripts/run_celery_no_sms_sending.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-# Runs celery with all celery queues except send-throttled-sms-tasks,
-# send-sms-high, send-sms-medium, send-sms-low, periodic-tasks, and job-tasks.
+# Runs celery with all celery queues except send-throttled-sms-tasks, 
+# send-sms-high, send-sms-medium, or send-sms-low.
 
 # Check and see if this is running in K8s and if so, wait for cloudwatch agent
 if [ -n "${STATSD_HOST}" ]; then
@@ -28,4 +28,4 @@ fi
 
 echo "Start celery, concurrency: ${CELERY_CONCURRENCY-4}"
 
-celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency="${CELERY_CONCURRENCY-4}" -Q -priority-database-tasks.fifo,-normal-database-tasks,-bulk-database-tasks,notify-internal-tasks,priority-tasks,normal-tasks,bulk-tasks,reporting-tasks,research-mode-tasks,retry-tasks,send-email-high,send-email-medium,send-email-low,service-callbacks,service-callbacks-retry,delivery-receipts
+celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency="${CELERY_CONCURRENCY-4}" -Q -priority-database-tasks.fifo,-normal-database-tasks,-bulk-database-tasks,job-tasks,notify-internal-tasks,periodic-tasks,priority-tasks,normal-tasks,bulk-tasks,reporting-tasks,research-mode-tasks,retry-tasks,send-email-high,send-email-medium,send-email-low,service-callbacks,service-callbacks-retry,delivery-receipts

--- a/scripts/run_celery_no_sms_sending.sh
+++ b/scripts/run_celery_no_sms_sending.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-# Runs celery with all celery queues except send-throttled-sms-tasks, 
-# send-sms-high, send-sms-medium, or send-sms-low.
+# Runs celery with all celery queues except send-throttled-sms-tasks,
+# send-sms-high, send-sms-medium, send-sms-low, periodic-tasks, and job-tasks.
 
 # Check and see if this is running in K8s and if so, wait for cloudwatch agent
 if [ -n "${STATSD_HOST}" ]; then
@@ -28,4 +28,4 @@ fi
 
 echo "Start celery, concurrency: ${CELERY_CONCURRENCY-4}"
 
-celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency="${CELERY_CONCURRENCY-4}" -Q -priority-database-tasks.fifo,-normal-database-tasks,-bulk-database-tasks,job-tasks,notify-internal-tasks,periodic-tasks,priority-tasks,normal-tasks,bulk-tasks,reporting-tasks,research-mode-tasks,retry-tasks,send-email-high,send-email-medium,send-email-low,service-callbacks,service-callbacks-retry,delivery-receipts
+celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency="${CELERY_CONCURRENCY-4}" -Q -priority-database-tasks.fifo,-normal-database-tasks,-bulk-database-tasks,notify-internal-tasks,priority-tasks,normal-tasks,bulk-tasks,reporting-tasks,research-mode-tasks,retry-tasks,send-email-high,send-email-medium,send-email-low,service-callbacks,service-callbacks-retry,delivery-receipts

--- a/scripts/run_celery_periodic.sh
+++ b/scripts/run_celery_periodic.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+# Runs celery with periodic-tasks and job-tasks queues.
+
+echo "Start celery, concurrency: ${CELERY_CONCURRENCY-4}"
+
+celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency="${CELERY_CONCURRENCY-4}" -Q periodic-tasks,job-tasks

--- a/tests/app/test_config.py
+++ b/tests/app/test_config.py
@@ -27,12 +27,13 @@ def reload_config():
 def test_queue_names_all_queues_correct():
     # Need to ensure that all_queues() only returns queue names used in API
     queues = QueueNames.all_queues()
-    assert len(queues) == 22
+    assert len(queues) == 23
     assert set(
         [
             QueueNames.PRIORITY,
             QueueNames.BULK,
             QueueNames.PERIODIC,
+            QueueNames.NIGHTLY,
             QueueNames.PRIORITY_DATABASE,
             QueueNames.NORMAL_DATABASE,
             QueueNames.BULK_DATABASE,


### PR DESCRIPTION
# Summary | Résumé

The nightly notification delete tasks delete-sms/email/letter-notifications, delete-inbound-sms share the periodic-tasks queue with short-lived per-minute tasks run-scheduled-jobs, check-job-status, etc.). When a delete task runs, potentially for 30+ minutes on high-volume days, any Kubernetes pod termination event (rolling update, scale-in) sends SIGTERM to the worker. Celery's warm shutdown waits indefinitely for the in-progress task to finish, then Kubernetes SIGKILLs the pod after terminationGracePeriodSeconds. This disrupts the in-flight task AND kills the workers handling the short-lived periodic tasks in the same pod.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/854

# Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.