### PR TITLE
Remove unnecessary ORM identity-map sync from bulk notification deletes

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -513,11 +513,11 @@ def _delete_notifications(notification_type, date_to_delete_from, service_id, qu
 
 
 def _delete_for_query(subquery):
-    number_deleted = db.session.query(Notification).filter(Notification.id.in_(subquery)).delete(synchronize_session="fetch")
+    number_deleted = db.session.query(Notification).filter(Notification.id.in_(subquery)).delete(synchronize_session=False)
     deleted = number_deleted
     db.session.commit()
     while number_deleted > 0:
-        number_deleted = db.session.query(Notification).filter(Notification.id.in_(subquery)).delete(synchronize_session="fetch")
+        number_deleted = db.session.query(Notification).filter(Notification.id.in_(subquery)).delete(synchronize_session=False)
         deleted += number_deleted
         db.session.commit()
     return deleted


### PR DESCRIPTION
# Summary | Résumé

## AI Usage

That PR and its description was generated by AI. Code paths were manually verified by hooman to check if these are safe changes, along with SQL Alchemy. I also [verified recent GDS changes](https://github.com/alphagov/notifications-api/blob/abea0fd981fc32da748c23d7211a02fdd446cd39/app/dao/notifications_dao.py#L506) and noticed they are aligned with the changes enclosed in this pull request. 

## Remove unnecessary ORM identity-map sync from bulk notification deletes

### Problem

`_delete_for_query` in `app/dao/notifications_dao.py` was using `synchronize_session="fetch"` on its bulk DELETE statements. With this mode, SQLAlchemy issues a SELECT before every DELETE to load all matching rows as `Notification` ORM objects into the session's identity map, then removes them after the delete executes.

At `qry_limit=10000`, this materialises 10,000 `Notification` objects into Python memory per batch. For a service with millions of notifications past their retention period, this runs for hundreds of batches and is the direct cause of worker OOM kills — the Python heap grows with each batch faster than GC can reclaim it.

### Change

`synchronize_session=False` skips the pre-fetch entirely and issues the DELETE directly against the database. No `Notification` objects are allocated in Python.

### Why this is safe

`synchronize_session="fetch"` only matters when you have live ORM objects in the session's identity map that you need to keep consistent after a bulk delete — i.e., you loaded some `Notification` objects, deleted them, and then want to access those same Python objects without re-querying. That pattern does not exist in this call chain:

1. **Nothing is loaded before the delete.** The entire call chain — `delete_notifications_older_than_retention_by_type` → `_delete_notifications` → `_delete_for_query` — never loads `Notification` ORM objects into the session. Only `ServiceDataRetention` and `Service.id` tuples are materialised. `insert_update_notification_history` is a pure server-side INSERT...SELECT with no ORM objects.

2. **`db.session.commit()` follows every batch.** `commit()` calls `session.expire_all()`, which marks every object in the session as expired unconditionally. Even if stale `Notification` objects somehow existed, they would be cleared by the commit before any subsequent code could observe them.

3. **`_delete_for_query` has exactly two call sites**, both inside `_delete_notifications`, which itself has exactly two call sites inside `delete_notifications_older_than_retention_by_type`. The return value in all cases is the integer row count. No caller inspects session state after the call.

4. **All tests assert on fresh DB queries** (`Notification.query.count()`, `.filter_by(...).all()`) after the full function returns, not on pre-loaded ORM objects.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/854

# Test instructions | Instructions pour tester la modification

Monitor the scheduled tasks, the notifications deletion and its memory usage. 

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.