### PR TITLE
Add new `File` model & schema

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1444,7 +1444,7 @@ class TemplateRedacted(BaseModel):
     )
 
 
-class File(BaseModel):
+class Files(BaseModel):
     __tablename__ = "files"
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)

--- a/app/models.py
+++ b/app/models.py
@@ -75,6 +75,22 @@ NOTIFY_USER_ID = "00000000-0000-0000-0000-000000000000"
 
 sms_sending_vehicles = db.Enum(*[vehicle.value for vehicle in SmsSendingVehicles], name="sms_sending_vehicles")
 
+FILE_TYPE_ATTACH = "attach"
+FILE_TYPE_LINK = "link"
+FILE_TYPE_TEMPLATE_ATTACH = "template_attach"
+FILE_TYPES = [FILE_TYPE_ATTACH, FILE_TYPE_LINK, FILE_TYPE_TEMPLATE_ATTACH]
+
+FILE_STATUS_PENDING_VIRUS_SCAN = "pending_virus_scan"
+FILE_STATUS_UPLOADED = "uploaded"
+FILE_STATUS_VIRUS_SCAN_FAILED = "virus_scan_failed"
+FILE_STATUS_DELETED = "deleted"
+FILE_STATUSES = [
+    FILE_STATUS_PENDING_VIRUS_SCAN,
+    FILE_STATUS_UPLOADED,
+    FILE_STATUS_VIRUS_SCAN_FAILED,
+    FILE_STATUS_DELETED,
+]
+
 
 EMAIL_STATUS_FORMATTED = {
     "failed": "Failed",
@@ -1426,6 +1442,31 @@ class TemplateRedacted(BaseModel):
         uselist=False,
         backref=db.backref("template_redacted", uselist=False),
     )
+
+
+class File(BaseModel):
+    __tablename__ = "files"
+
+    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    template_id = db.Column(UUID(as_uuid=True), db.ForeignKey("templates.id"), index=True, nullable=False)
+    service_id = db.Column(UUID(as_uuid=True), db.ForeignKey("services.id"), index=True, nullable=False)
+    document_id = db.Column(UUID(as_uuid=True), nullable=False)
+    type = db.Column(db.Enum(*FILE_TYPES, name="notify_file_type_enum"), nullable=False)
+    name = db.Column(db.Text, nullable=False)
+    mime_type = db.Column(db.Text, nullable=True)
+    file_size = db.Column(db.Integer, nullable=True)
+    status = db.Column(db.Enum(*FILE_STATUSES, name="notify_file_status_enum"), nullable=False)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
+    updated_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow)
+
+    template = db.relationship("Template")
+    service = db.relationship("Service")
+
+    @property
+    def file_size_mib(self):
+        if self.file_size is None:
+            return None
+        return self.file_size / (1024 * 1024)
 
 
 class TemplateHistory(TemplateBase):

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -460,15 +460,15 @@ class TemplateHistorySchema(BaseSchema):
         model = models.TemplateHistory
 
 
-class FileSchema(BaseSchema):
-    template_id = field_for(models.File, "template_id", required=True)
-    service_id = field_for(models.File, "service_id", required=True)
-    document_id = field_for(models.File, "document_id", required=True)
+class FilesSchema(BaseSchema):
+    template_id = field_for(models.Files, "template_id", required=True)
+    service_id = field_for(models.Files, "service_id", required=True)
+    document_id = field_for(models.Files, "document_id", required=True)
     created_at = FlexibleDateTime()
     updated_at = FlexibleDateTime()
 
     class Meta(BaseSchema.Meta):
-        model = models.File
+        model = models.Files
         exclude = ("template", "service")
 
 
@@ -932,4 +932,4 @@ provider_details_history_schema = ProviderDetailsHistorySchema()
 day_schema = DaySchema()
 unarchived_template_schema = UnarchivedTemplateSchema()
 report_schema = ReportSchema()
-file_schema = FileSchema()
+files_schema = FilesSchema()

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -467,16 +467,6 @@ class FileSchema(BaseSchema):
     created_at = FlexibleDateTime()
     updated_at = FlexibleDateTime()
 
-    @validates("type")
-    def validate_type(self, value):
-        if value not in models.FILE_TYPES:
-            raise ValidationError("Invalid file type")
-
-    @validates("status")
-    def validate_status(self, value):
-        if value not in models.FILE_STATUSES:
-            raise ValidationError("Invalid file status")
-
     class Meta(BaseSchema.Meta):
         model = models.File
         exclude = ("template", "service")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -460,6 +460,28 @@ class TemplateHistorySchema(BaseSchema):
         model = models.TemplateHistory
 
 
+class FileSchema(BaseSchema):
+    template_id = field_for(models.File, "template_id", required=True)
+    service_id = field_for(models.File, "service_id", required=True)
+    document_id = field_for(models.File, "document_id", required=True)
+    created_at = FlexibleDateTime()
+    updated_at = FlexibleDateTime()
+
+    @validates("type")
+    def validate_type(self, value):
+        if value not in models.FILE_TYPES:
+            raise ValidationError("Invalid file type")
+
+    @validates("status")
+    def validate_status(self, value):
+        if value not in models.FILE_STATUSES:
+            raise ValidationError("Invalid file status")
+
+    class Meta(BaseSchema.Meta):
+        model = models.File
+        exclude = ("template", "service")
+
+
 class ApiKeySchema(BaseSchema):
     created_by = field_for(models.ApiKey, "created_by", required=True)
     key_type = field_for(models.ApiKey, "key_type", required=True)
@@ -920,3 +942,4 @@ provider_details_history_schema = ProviderDetailsHistorySchema()
 day_schema = DaySchema()
 unarchived_template_schema = UnarchivedTemplateSchema()
 report_schema = ReportSchema()
+file_schema = FileSchema()

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -20,7 +20,7 @@ from app.models import (
     PRECOMPILED_TEMPLATE_NAME,
     PRIORITY,
     SMS_TYPE,
-    File,
+    Files,
     Notification,
     ServiceSafelist,
 )
@@ -413,18 +413,18 @@ class TestNotificationModel:
 
 
 def test_file_size_mib_returns_none_when_file_size_is_none():
-    file_model = File(file_size=None)
+    file_model = Files(file_size=None)
 
     assert file_model.file_size_mib is None
 
 
 def test_file_size_mib_converts_bytes_to_mebibytes():
-    file_model = File(file_size=3 * 1024 * 1024)
+    file_model = Files(file_size=3 * 1024 * 1024)
 
     assert file_model.file_size_mib == 3
 
 
 def test_file_size_mib_converts_fractional_mebibytes():
-    file_model = File(file_size=int(3.5 * 1024 * 1024))
+    file_model = Files(file_size=int(3.5 * 1024 * 1024))
 
     assert file_model.file_size_mib == 3.5

--- a/tests/app/test_model.py
+++ b/tests/app/test_model.py
@@ -20,6 +20,7 @@ from app.models import (
     PRECOMPILED_TEMPLATE_NAME,
     PRIORITY,
     SMS_TYPE,
+    File,
     Notification,
     ServiceSafelist,
 )
@@ -409,3 +410,21 @@ class TestNotificationModel:
         template = create_template(sample_service, template_type="email")
         notification = save_notification(create_notification(template, to_field="test@example.com", queue_name="tester"))
         assert notification.queue_name == "tester"
+
+
+def test_file_size_mib_returns_none_when_file_size_is_none():
+    file_model = File(file_size=None)
+
+    assert file_model.file_size_mib is None
+
+
+def test_file_size_mib_converts_bytes_to_mebibytes():
+    file_model = File(file_size=3 * 1024 * 1024)
+
+    assert file_model.file_size_mib == 3
+
+
+def test_file_size_mib_converts_fractional_mebibytes():
+    file_model = File(file_size=int(3.5 * 1024 * 1024))
+
+    assert file_model.file_size_mib == 3.5

--- a/tests/app/test_schemas.py
+++ b/tests/app/test_schemas.py
@@ -156,7 +156,7 @@ def test_service_schema_returns_annual_limits(sample_service):
 
 
 def test_file_schema_load_accepts_valid_payload(sample_template):
-    from app.schemas import file_schema
+    from app.schemas import files_schema
 
     payload = {
         "template_id": str(sample_template.id),
@@ -167,7 +167,7 @@ def test_file_schema_load_accepts_valid_payload(sample_template):
         "status": "uploaded",
     }
 
-    loaded = file_schema.load(payload)
+    loaded = files_schema.load(payload)
 
     assert str(loaded.template_id) == payload["template_id"]
     assert str(loaded.service_id) == payload["service_id"]
@@ -178,7 +178,7 @@ def test_file_schema_load_accepts_valid_payload(sample_template):
 
 
 def test_file_schema_requires_template_service_and_document_ids(sample_template):
-    from app.schemas import file_schema
+    from app.schemas import files_schema
 
     payload = {
         "template_id": str(sample_template.id),
@@ -192,12 +192,12 @@ def test_file_schema_requires_template_service_and_document_ids(sample_template)
     for required_field in ["template_id", "service_id", "document_id"]:
         data = payload.copy()
         data.pop(required_field)
-        errors = file_schema.validate(data)
+        errors = files_schema.validate(data)
         assert required_field in errors
 
 
 def test_file_schema_rejects_invalid_type(sample_template):
-    from app.schemas import file_schema
+    from app.schemas import files_schema
 
     payload = {
         "template_id": str(sample_template.id),
@@ -209,14 +209,14 @@ def test_file_schema_rejects_invalid_type(sample_template):
     }
 
     with pytest.raises(ValidationError) as exc:
-        file_schema.load(payload)
+        files_schema.load(payload)
 
     assert "type" in exc.value.messages
     assert exc.value.messages["type"][0].startswith("Must be one of:")
 
 
 def test_file_schema_rejects_invalid_status(sample_template):
-    from app.schemas import file_schema
+    from app.schemas import files_schema
 
     payload = {
         "template_id": str(sample_template.id),
@@ -228,14 +228,14 @@ def test_file_schema_rejects_invalid_status(sample_template):
     }
 
     with pytest.raises(ValidationError) as exc:
-        file_schema.load(payload)
+        files_schema.load(payload)
 
     assert "status" in exc.value.messages
     assert exc.value.messages["status"][0].startswith("Must be one of:")
 
 
 def test_file_schema_allows_optional_mime_type_and_file_size(sample_template):
-    from app.schemas import file_schema
+    from app.schemas import files_schema
 
     payload = {
         "template_id": str(sample_template.id),
@@ -248,7 +248,7 @@ def test_file_schema_allows_optional_mime_type_and_file_size(sample_template):
         "status": "pending_virus_scan",
     }
 
-    loaded = file_schema.load(payload)
+    loaded = files_schema.load(payload)
 
     assert loaded.mime_type is None
     assert loaded.file_size is None

--- a/tests/app/test_schemas.py
+++ b/tests/app/test_schemas.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 import pytest
 from marshmallow import ValidationError
 from sqlalchemy import desc
@@ -151,3 +153,102 @@ def test_service_schema_returns_annual_limits(sample_service):
 
     assert data["sms_annual_limit"] == 100000
     assert data["email_annual_limit"] == 20000000
+
+
+def test_file_schema_load_accepts_valid_payload(sample_template):
+    from app.schemas import file_schema
+
+    payload = {
+        "template_id": str(sample_template.id),
+        "service_id": str(sample_template.service_id),
+        "document_id": str(uuid4()),
+        "type": "attach",
+        "name": "evidence.pdf",
+        "status": "uploaded",
+    }
+
+    loaded = file_schema.load(payload)
+
+    assert str(loaded.template_id) == payload["template_id"]
+    assert str(loaded.service_id) == payload["service_id"]
+    assert str(loaded.document_id) == payload["document_id"]
+    assert loaded.type == payload["type"]
+    assert loaded.name == payload["name"]
+    assert loaded.status == payload["status"]
+
+
+def test_file_schema_requires_template_service_and_document_ids(sample_template):
+    from app.schemas import file_schema
+
+    payload = {
+        "template_id": str(sample_template.id),
+        "service_id": str(sample_template.service_id),
+        "document_id": str(uuid4()),
+        "type": "attach",
+        "name": "evidence.pdf",
+        "status": "uploaded",
+    }
+
+    for required_field in ["template_id", "service_id", "document_id"]:
+        data = payload.copy()
+        data.pop(required_field)
+        errors = file_schema.validate(data)
+        assert required_field in errors
+
+
+def test_file_schema_rejects_invalid_type(sample_template):
+    from app.schemas import file_schema
+
+    payload = {
+        "template_id": str(sample_template.id),
+        "service_id": str(sample_template.service_id),
+        "document_id": str(uuid4()),
+        "type": "not-a-valid-type",
+        "name": "evidence.pdf",
+        "status": "uploaded",
+    }
+
+    with pytest.raises(ValidationError) as exc:
+        file_schema.load(payload)
+
+    assert "type" in exc.value.messages
+    assert exc.value.messages["type"][0].startswith("Must be one of:")
+
+
+def test_file_schema_rejects_invalid_status(sample_template):
+    from app.schemas import file_schema
+
+    payload = {
+        "template_id": str(sample_template.id),
+        "service_id": str(sample_template.service_id),
+        "document_id": str(uuid4()),
+        "type": "attach",
+        "name": "evidence.pdf",
+        "status": "not-a-valid-status",
+    }
+
+    with pytest.raises(ValidationError) as exc:
+        file_schema.load(payload)
+
+    assert "status" in exc.value.messages
+    assert exc.value.messages["status"][0].startswith("Must be one of:")
+
+
+def test_file_schema_allows_optional_mime_type_and_file_size(sample_template):
+    from app.schemas import file_schema
+
+    payload = {
+        "template_id": str(sample_template.id),
+        "service_id": str(sample_template.service_id),
+        "document_id": str(uuid4()),
+        "type": "link",
+        "name": "reference.txt",
+        "mime_type": None,
+        "file_size": None,
+        "status": "pending_virus_scan",
+    }
+
+    loaded = file_schema.load(payload)
+
+    assert loaded.mime_type is None
+    assert loaded.file_size is None


### PR DESCRIPTION
# Summary | Résumé

This PR is a follow up to [2869](https://github.com/cds-snc/notification-api/pull/2869). It adds the model and schema for the new `Files` table. 

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/3221

# Test instructions | Instructions pour tester la modification
- [ ] CI is passing

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.