### PR TITLE
chore: bump utils

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2869,7 +2869,7 @@ requests = ">=2.0.0"
 
 [[package]]
 name = "notifications-utils"
-version = "53.2.23"
+version = "53.2.24"
 description = "Shared python code for Notification - Provides logging utils etc."
 optional = false
 python-versions = "~3.12.7"
@@ -2905,8 +2905,8 @@ werkzeug = "3.0.6"
 [package.source]
 type = "git"
 url = "https://github.com/cds-snc/notifier-utils.git"
-reference = "renovate/pypi-cryptography-vulnerability"
-resolved_reference = "fa8736f8f35d9f52beee0d8aef9acf78eeba8d8e"
+reference = "53.2.24"
+resolved_reference = "4c1b806a12c7690639ce7f24990a32374e803f3f"
 
 [[package]]
 name = "opentelemetry-api"
@@ -5220,4 +5220,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.12.7"
-content-hash = "c8aa84c112a2dfad030c65bf402373552e07d0f9fff78a3fe0fcbf9b921e5adf"
+content-hash = "fb1aa2623f0c9c087b533290c8d69a5e189ea7fba8e6a2ec448dbf2f1d912f19"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ opentelemetry-instrumentation-celery = "0.55b1"
 opentelemetry-instrumentation-flask = "0.55b1"
 opentelemetry-instrumentation-redis = "0.55b1"
 opentelemetry-instrumentation-sqlalchemy = "0.55b1"
-notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", branch = "renovate/pypi-cryptography-vulnerability"}
+notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", tag = "53.2.24" }
 pre-commit = "^3.7.1"
 psycopg2-binary = "2.9.11"
 pwnedpasswords = "2.0.0"


### PR DESCRIPTION
# Summary | Résumé
This pull request updates the `notifications-utils` dependency in `pyproject.toml` to use a specific tagged release instead of tracking a branch. This change helps ensure more predictable and stable builds by locking the dependency to version `53.2.24`. 

# Test instructions | Instructions pour tester la modification

- [ ] Sending to a blocked country raises an error (you can use +249)

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.