### PR TITLE
Move some technical-failure statuses to be permanent failures

### DIFF
--- a/app/celery/process_pinpoint_receipts_tasks.py
+++ b/app/celery/process_pinpoint_receipts_tasks.py
@@ -13,7 +13,6 @@ from app.models import (
     NOTIFICATION_DELIVERED,
     NOTIFICATION_PERMANENT_FAILURE,
     NOTIFICATION_SENT,
-    NOTIFICATION_TECHNICAL_FAILURE,
     NOTIFICATION_TEMPORARY_FAILURE,
     PINPOINT_PROVIDER,
 )
@@ -70,7 +69,7 @@ def process_pinpoint_results(self, response):
 
         if not notification_status:
             current_app.logger.warning(f"unhandled provider response for reference {reference}, received '{provider_response}'")
-            notification_status = NOTIFICATION_TECHNICAL_FAILURE  # revert to tech failure by default
+            notification_status = NOTIFICATION_PERMANENT_FAILURE  # revert to permanent failure by default
 
         try:
             notification = notifications_dao.dao_get_notification_by_reference(reference)
@@ -195,7 +194,7 @@ def determine_pinpoint_status(status: str, provider_response: str, isFinal: bool
     elif "invalid" in response_lower:
         return NOTIFICATION_PERMANENT_FAILURE
     elif "is opted out" in response_lower:
-        return NOTIFICATION_TECHNICAL_FAILURE
+        return NOTIFICATION_PERMANENT_FAILURE
     elif "unknown error" in response_lower:
         return NOTIFICATION_PERMANENT_FAILURE
     elif "exceed max price" in response_lower:

--- a/app/celery/process_pinpoint_receipts_tasks.py
+++ b/app/celery/process_pinpoint_receipts_tasks.py
@@ -13,6 +13,7 @@ from app.models import (
     NOTIFICATION_DELIVERED,
     NOTIFICATION_PERMANENT_FAILURE,
     NOTIFICATION_SENT,
+    NOTIFICATION_TECHNICAL_FAILURE,
     NOTIFICATION_TEMPORARY_FAILURE,
     PINPOINT_PROVIDER,
 )
@@ -194,7 +195,7 @@ def determine_pinpoint_status(status: str, provider_response: str, isFinal: bool
     elif "invalid" in response_lower:
         return NOTIFICATION_PERMANENT_FAILURE
     elif "is opted out" in response_lower:
-        return NOTIFICATION_PERMANENT_FAILURE
+        return NOTIFICATION_TECHNICAL_FAILURE
     elif "unknown error" in response_lower:
         return NOTIFICATION_PERMANENT_FAILURE
     elif "exceed max price" in response_lower:
@@ -204,6 +205,8 @@ def determine_pinpoint_status(status: str, provider_response: str, isFinal: bool
     elif "phone is currently unreachable/unavailable" in response_lower:
         return NOTIFICATION_PERMANENT_FAILURE
     elif "unhandled provider" in response_lower:
+        return NOTIFICATION_PERMANENT_FAILURE
+    elif "delivery TTL has expired" in response_lower:
         return NOTIFICATION_PERMANENT_FAILURE
     else:
         return None

--- a/app/celery/process_sns_receipts_tasks.py
+++ b/app/celery/process_sns_receipts_tasks.py
@@ -141,6 +141,6 @@ def determine_status(sns_status, provider_response):
     if not status:
         # TODO: Pattern matching in Python 3.10 should simplify this overall function logic.
         if "is opted out" in provider_response:
-            return NOTIFICATION_PERMANENT_FAILURE
+            return NOTIFICATION_TECHNICAL_FAILURE
 
     return status

--- a/app/celery/process_sns_receipts_tasks.py
+++ b/app/celery/process_sns_receipts_tasks.py
@@ -12,6 +12,7 @@ from app.models import (
     NOTIFICATION_DELIVERED,
     NOTIFICATION_PERMANENT_FAILURE,
     NOTIFICATION_SENT,
+    NOTIFICATION_TECHNICAL_FAILURE,
     NOTIFICATION_TEMPORARY_FAILURE,
     SNS_PROVIDER,
 )
@@ -130,7 +131,7 @@ def determine_status(sns_status, provider_response):
         "Phone has blocked SMS": NOTIFICATION_TEMPORARY_FAILURE,
         "Phone is on a blocked list": NOTIFICATION_TEMPORARY_FAILURE,
         "Phone is currently unreachable/unavailable": NOTIFICATION_PERMANENT_FAILURE,
-        "Phone number is opted out": NOTIFICATION_PERMANENT_FAILURE,
+        "Phone number is opted out": NOTIFICATION_TECHNICAL_FAILURE,
         "This delivery would exceed max price": NOTIFICATION_TEMPORARY_FAILURE,
         "Unknown error attempting to reach phone": NOTIFICATION_PERMANENT_FAILURE,
         "Unhandled provider": NOTIFICATION_PERMANENT_FAILURE,

--- a/app/celery/process_sns_receipts_tasks.py
+++ b/app/celery/process_sns_receipts_tasks.py
@@ -12,7 +12,6 @@ from app.models import (
     NOTIFICATION_DELIVERED,
     NOTIFICATION_PERMANENT_FAILURE,
     NOTIFICATION_SENT,
-    NOTIFICATION_TECHNICAL_FAILURE,
     NOTIFICATION_TEMPORARY_FAILURE,
     SNS_PROVIDER,
 )
@@ -34,7 +33,7 @@ def process_sns_results(self, response):
         notification_status = determine_status(sns_status, provider_response)
         if not notification_status:
             current_app.logger.warning(f"unhandled provider response for reference {reference}, received '{provider_response}'")
-            notification_status = NOTIFICATION_TECHNICAL_FAILURE  # revert to tech failure by default
+            notification_status = NOTIFICATION_PERMANENT_FAILURE  # revert to permanent failure by default
 
         try:
             notification = notifications_dao.dao_get_notification_by_reference(reference)
@@ -131,7 +130,7 @@ def determine_status(sns_status, provider_response):
         "Phone has blocked SMS": NOTIFICATION_TEMPORARY_FAILURE,
         "Phone is on a blocked list": NOTIFICATION_TEMPORARY_FAILURE,
         "Phone is currently unreachable/unavailable": NOTIFICATION_PERMANENT_FAILURE,
-        "Phone number is opted out": NOTIFICATION_TECHNICAL_FAILURE,
+        "Phone number is opted out": NOTIFICATION_PERMANENT_FAILURE,
         "This delivery would exceed max price": NOTIFICATION_TEMPORARY_FAILURE,
         "Unknown error attempting to reach phone": NOTIFICATION_PERMANENT_FAILURE,
         "Unhandled provider": NOTIFICATION_PERMANENT_FAILURE,
@@ -141,6 +140,6 @@ def determine_status(sns_status, provider_response):
     if not status:
         # TODO: Pattern matching in Python 3.10 should simplify this overall function logic.
         if "is opted out" in provider_response:
-            return NOTIFICATION_TECHNICAL_FAILURE
+            return NOTIFICATION_PERMANENT_FAILURE
 
     return status

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -54,7 +54,6 @@ from app.models import (
     EMAIL_TYPE,
     KEY_TYPE_TEST,
     NOTIFICATION_CONTAINS_PII,
-    NOTIFICATION_PERMANENT_FAILURE,
     NOTIFICATION_SENDING,
     NOTIFICATION_SENT,
     NOTIFICATION_TECHNICAL_FAILURE,
@@ -434,7 +433,7 @@ def update_notification_to_sending(notification, provider):
 def update_notification_to_opted_out(notification, provider):
     notification.sent_at = datetime.utcnow()
     notification.sent_by = provider.get_name()
-    notification.status = NOTIFICATION_PERMANENT_FAILURE
+    notification.status = NOTIFICATION_TECHNICAL_FAILURE
     notification.provider_response = "Phone number is opted out"
     dao_update_notification(notification)
 

--- a/tests/app/celery/test_process_pinpoint_receipts_tasks.py
+++ b/tests/app/celery/test_process_pinpoint_receipts_tasks.py
@@ -24,7 +24,6 @@ from app.models import (
     NOTIFICATION_DELIVERED,
     NOTIFICATION_PERMANENT_FAILURE,
     NOTIFICATION_SENT,
-    NOTIFICATION_TECHNICAL_FAILURE,
     NOTIFICATION_TEMPORARY_FAILURE,
 )
 from app.notifications.callbacks import create_delivery_status_callback_data
@@ -180,7 +179,7 @@ def test_process_pinpoint_results_missing_sms_data(notify_api, sample_template, 
         ),
         (
             "Phone number is opted out",
-            NOTIFICATION_TECHNICAL_FAILURE,
+            NOTIFICATION_PERMANENT_FAILURE,
             False,
             True,
         ),
@@ -202,7 +201,7 @@ def test_process_pinpoint_results_missing_sms_data(notify_api, sample_template, 
             False,
             True,
         ),
-        ("This is not a real response", NOTIFICATION_TECHNICAL_FAILURE, True, True),
+        ("This is not a real response", NOTIFICATION_PERMANENT_FAILURE, True, True),
     ],
 )
 def test_process_pinpoint_results_failed(

--- a/tests/app/celery/test_process_pinpoint_receipts_tasks.py
+++ b/tests/app/celery/test_process_pinpoint_receipts_tasks.py
@@ -24,6 +24,7 @@ from app.models import (
     NOTIFICATION_DELIVERED,
     NOTIFICATION_PERMANENT_FAILURE,
     NOTIFICATION_SENT,
+    NOTIFICATION_TECHNICAL_FAILURE,
     NOTIFICATION_TEMPORARY_FAILURE,
 )
 from app.notifications.callbacks import create_delivery_status_callback_data
@@ -179,7 +180,7 @@ def test_process_pinpoint_results_missing_sms_data(notify_api, sample_template, 
         ),
         (
             "Phone number is opted out",
-            NOTIFICATION_PERMANENT_FAILURE,
+            NOTIFICATION_TECHNICAL_FAILURE,
             False,
             True,
         ),

--- a/tests/app/celery/test_process_sns_receipts_tasks.py
+++ b/tests/app/celery/test_process_sns_receipts_tasks.py
@@ -23,7 +23,6 @@ from app.models import (
     NOTIFICATION_DELIVERED,
     NOTIFICATION_PERMANENT_FAILURE,
     NOTIFICATION_SENT,
-    NOTIFICATION_TECHNICAL_FAILURE,
     NOTIFICATION_TEMPORARY_FAILURE,
 )
 from app.notifications.callbacks import create_delivery_status_callback_data
@@ -110,7 +109,7 @@ def test_process_sns_results_delivered(sample_template, notify_db, notify_db_ses
         ),
         (
             "Phone number is opted out",
-            NOTIFICATION_TECHNICAL_FAILURE,
+            NOTIFICATION_PERMANENT_FAILURE,
             False,
             True,
         ),
@@ -132,7 +131,7 @@ def test_process_sns_results_delivered(sample_template, notify_db, notify_db_ses
             False,
             True,
         ),
-        ("This is not a real response", NOTIFICATION_TECHNICAL_FAILURE, True, True),
+        ("This is not a real response", NOTIFICATION_PERMANENT_FAILURE, True, True),
     ],
 )
 def test_process_sns_results_failed(

--- a/tests/app/celery/test_process_sns_receipts_tasks.py
+++ b/tests/app/celery/test_process_sns_receipts_tasks.py
@@ -23,6 +23,7 @@ from app.models import (
     NOTIFICATION_DELIVERED,
     NOTIFICATION_PERMANENT_FAILURE,
     NOTIFICATION_SENT,
+    NOTIFICATION_TECHNICAL_FAILURE,
     NOTIFICATION_TEMPORARY_FAILURE,
 )
 from app.notifications.callbacks import create_delivery_status_callback_data
@@ -109,7 +110,7 @@ def test_process_sns_results_delivered(sample_template, notify_db, notify_db_ses
         ),
         (
             "Phone number is opted out",
-            NOTIFICATION_PERMANENT_FAILURE,
+            NOTIFICATION_TECHNICAL_FAILURE,
             False,
             True,
         ),

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -211,7 +211,7 @@ def test_should_handle_opted_out_phone_numbers_if_using_pinpoint(notify_api, sam
         send_to_providers.send_sms_to_provider(db_notification)
 
         notification = Notification.query.filter_by(id=db_notification.id).one()
-        assert notification.status == "permanent-failure"
+        assert notification.status == "technical-failure"
         assert notification.provider_response == "Phone number is opted out"
 
 


### PR DESCRIPTION
# Summary | Résumé

We have been assigning a status of `technical-failure` for some cases where we are actually getting billed by AWS. And we had permanent-failure for a case that was not billable (sms recipient opted out). This is a problem for our billing calculations because `technical-failure` is not a billable status and permanent-failure is (https://github.com/cds-snc/notification-api/blob/main/app/models.py#L1737).

This PR makes the following changes to notification statuses for sms:
- if a user has opted out of sms messages, treat this as a technical-failure (this is not a billable case)
- add handling for "The delivery TTL has expired" -> permanent-failure (this is billable)
- if we don't handle the provider response, default to permanent-failure since we have already passed this notification to AWS and we will likely be billed for it


## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/3274

# Test instructions | Instructions pour tester la modification

Tests should pass.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.