### PR TITLE
Change some logs from debug to info so we can investigate expired inflights

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -321,7 +321,7 @@ def save_smss(self, service_id: Optional[str], signed_notifications: List[Signed
     try:
         # If the data is not present in the encrypted data then fallback on whats needed for process_job.
         saved_notifications = persist_notifications(verified_notifications)
-        current_app.logger.debug(
+        current_app.logger.info(
             f"Saved following notifications into db: {notification_id_queue.keys()} associated with receipt {receipt}"
         )
         if receipt:
@@ -436,7 +436,7 @@ def save_emails(self, _service_id: Optional[str], signed_notifications: List[Sig
     try:
         # If the data is not present in the encrypted data then fallback on whats needed for process_job
         saved_notifications = persist_notifications(verified_notifications)
-        current_app.logger.debug(
+        current_app.logger.info(
             f"Saved following notifications into db: {notification_id_queue.keys()} associated with receipt {receipt}"
         )
         if receipt:


### PR DESCRIPTION
# Summary | Résumé

Currently we get logs like:

```
 inflights [b'in-flight:email:priority:afd44afd-a8ba-4280-b1df-c70a4b9e3db9', b'in-flight:email:priority:636b4867-a4ad-45ad-a9cc-03650743c759', b'in-flight:email:priority:9c941d22-2dea-44d1-abd7-8d6ce7db17c4', b'in-flight:email:priority:2f3bc541-4082-466a-abb5-2332bc8bc05d'] back to inbox inbox:email:priority
```

But there is no way to connect these receipt ids to the eventual notification ids that are created. This log change will let us do that and will help us investigate when we get expired inflight alarms.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/3247

# Test instructions | Instructions pour tester la modification

NA

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.