### PR TITLE
Task/create template

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -304,9 +304,9 @@ def register_v2_blueprints(application):
         v2_inbound_sms_blueprint as get_inbound_sms,
     )
     from app.v2.manage_template import (  # noqa
-        get_template as get_manage_template,
-    )
-    from app.v2.manage_template import (
+        get_template,
+        get_template_categories,
+        post_template,
         v2_manage_template_blueprint,
     )
     from app.v2.notifications import (  # noqa

--- a/app/v2/manage_template/get_template.py
+++ b/app/v2/manage_template/get_template.py
@@ -25,6 +25,8 @@ def _serialize_template(template) -> dict:
 
     return {
         "id": str(template.id),
+        "service_id": str(template.service_id),
+        "service_name": template.service.name,
         "name": template.name,
         "type": template.template_type,
         "created_at": template.created_at.strftime(DATETIME_FORMAT),

--- a/app/v2/manage_template/get_template_categories.py
+++ b/app/v2/manage_template/get_template_categories.py
@@ -1,0 +1,25 @@
+from flask import jsonify
+
+from app import api_user
+from app.dao.template_categories_dao import dao_get_all_template_categories
+from app.errors import InvalidRequest
+from app.models import ApiKeyPermission
+from app.v2.manage_template import v2_manage_template_blueprint
+
+
+@v2_manage_template_blueprint.route("/template-categories", methods=["GET"])
+def get_template_categories():
+    if not api_user.has_permission(ApiKeyPermission.MANAGE_TEMPLATES):
+        raise InvalidRequest("This API key does not have permission to manage templates.", status_code=403)
+
+    template_categories = dao_get_all_template_categories(hidden=False)
+
+    return (
+        jsonify(
+            template_categories=[
+                {"template_category_id": str(template_category.id), "name": template_category.name_en}
+                for template_category in template_categories
+            ]
+        ),
+        200,
+    )

--- a/app/v2/manage_template/post_template.py
+++ b/app/v2/manage_template/post_template.py
@@ -29,10 +29,7 @@ def post_manage_template():
         data = validate(request.get_json() or {}, post_manage_template_request)
     except ValidationError as e:
         if "template_category_id" in str(e):
-            validation_message = _get_validation_message(e)
-            if validation_message == "template_category_id is a required property":
-                validation_message = "template_category_id is not a valid UUID"
-            return _template_category_error_response("ValidationError", validation_message)
+            return _template_category_error_response("ValidationError", "template_category_id is not a valid UUID")
         raise
 
     try:

--- a/app/v2/manage_template/post_template.py
+++ b/app/v2/manage_template/post_template.py
@@ -29,7 +29,7 @@ def post_manage_template():
         data = validate(request.get_json() or {}, post_manage_template_request)
     except ValidationError as e:
         if "template_category_id" in str(e):
-            return _template_category_error_response("ValidationError", "template_category_id is not a valid UUID")
+            return _template_category_error_response("ValidationError", _get_validation_message(e))
         raise
 
     try:

--- a/app/v2/manage_template/post_template.py
+++ b/app/v2/manage_template/post_template.py
@@ -6,7 +6,7 @@ from notifications_utils import EMAIL_CHAR_COUNT_LIMIT, SMS_CHAR_COUNT_LIMIT, TE
 from notifications_utils.template import HTMLEmailTemplate, SMSMessageTemplate
 from sqlalchemy.orm.exc import NoResultFound
 
-from app import api_user, authenticated_service
+from app import api_user, authenticated_service, redis_store
 from app.dao import templates_dao
 from app.dao.template_categories_dao import dao_get_all_template_categories, dao_get_template_category_by_id
 from app.dao.template_folder_dao import dao_get_template_folder_by_id_and_service_id
@@ -56,6 +56,8 @@ def post_manage_template():
     _raise_if_content_or_name_over_limit(template)
 
     templates_dao.dao_create_template(template)
+
+    redis_store.delete(f"service-{authenticated_service.id}-templates")
 
     return jsonify(_serialize_template(template)), 201
 

--- a/app/v2/manage_template/post_template.py
+++ b/app/v2/manage_template/post_template.py
@@ -1,0 +1,90 @@
+from flask import jsonify, request
+from notifications_utils import EMAIL_CHAR_COUNT_LIMIT, SMS_CHAR_COUNT_LIMIT, TEMPLATE_NAME_CHAR_COUNT_LIMIT
+from notifications_utils.template import HTMLEmailTemplate, SMSMessageTemplate
+from sqlalchemy.orm.exc import NoResultFound
+
+from app import api_user, authenticated_service
+from app.dao import templates_dao
+from app.dao.template_categories_dao import dao_get_template_category_by_id
+from app.dao.template_folder_dao import dao_get_template_folder_by_id_and_service_id
+from app.errors import InvalidRequest
+from app.models import EMAIL_TYPE, SMS_TYPE, ApiKeyPermission, Template
+from app.notifications.validators import service_has_permission
+from app.schema_validation import validate
+from app.utils import get_public_notify_type_text
+from app.v2.manage_template import v2_manage_template_blueprint
+from app.v2.manage_template.get_template import _serialize_template
+from app.v2.manage_template.template_schemas import post_manage_template_request
+
+
+@v2_manage_template_blueprint.route("", methods=["POST"])
+def post_manage_template():
+    if not api_user.has_permission(ApiKeyPermission.MANAGE_TEMPLATES):
+        raise InvalidRequest("This API key does not have permission to manage templates.", status_code=403)
+
+    data = validate(request.get_json() or {}, post_manage_template_request)
+    _validate_template_category_id(data["template_category_id"])
+
+    folder = _validate_parent_folder(data)
+    template = Template.from_json(
+        {
+            **data,
+            "service": authenticated_service.id,
+            "created_by": api_user.created_by_id,
+        },
+        folder,
+    )
+
+    if not service_has_permission(template.template_type, authenticated_service.permissions):
+        message = "Creating {} templates is not allowed".format(get_public_notify_type_text(template.template_type))
+        raise InvalidRequest(message, status_code=403)
+
+    _raise_if_content_or_name_over_limit(template)
+
+    templates_dao.dao_create_template(template)
+
+    return jsonify(_serialize_template(template)), 201
+
+
+def _validate_template_category_id(template_category_id):
+    try:
+        dao_get_template_category_by_id(template_category_id)
+    except NoResultFound:
+        raise InvalidRequest("template_category_id not found", status_code=400)
+
+
+def _validate_parent_folder(data):
+    parent_folder_id = data.pop("parent_folder_id", None)
+    if parent_folder_id:
+        try:
+            return dao_get_template_folder_by_id_and_service_id(parent_folder_id, authenticated_service.id)
+        except NoResultFound:
+            raise InvalidRequest("parent_folder_id not found", status_code=400)
+    return None
+
+
+def _raise_if_content_or_name_over_limit(template):
+    if _content_count_greater_than_limit(template.content, template.template_type):
+        char_limit = SMS_CHAR_COUNT_LIMIT if template.template_type == SMS_TYPE else EMAIL_CHAR_COUNT_LIMIT
+        message = "Content has a character count greater than the limit of {}".format(char_limit)
+        raise InvalidRequest(message, status_code=400)
+
+    if _template_name_over_char_limit(template.name, template.content, template.template_type):
+        message = "Template name must be less than {} characters".format(TEMPLATE_NAME_CHAR_COUNT_LIMIT)
+        raise InvalidRequest(message, status_code=400)
+
+
+def _content_count_greater_than_limit(content, template_type):
+    if template_type == EMAIL_TYPE:
+        template = HTMLEmailTemplate({"content": content, "subject": "placeholder", "template_type": template_type})
+        return template.is_message_too_long()
+    if template_type == SMS_TYPE:
+        template = SMSMessageTemplate({"content": content, "template_type": template_type})
+        return template.is_message_too_long()
+    return False
+
+
+def _template_name_over_char_limit(name, content, template_type):
+    return HTMLEmailTemplate(
+        {"name": name, "content": content, "subject": "placeholder", "template_type": template_type}
+    ).is_name_too_long()

--- a/app/v2/manage_template/post_template.py
+++ b/app/v2/manage_template/post_template.py
@@ -29,7 +29,10 @@ def post_manage_template():
         data = validate(request.get_json() or {}, post_manage_template_request)
     except ValidationError as e:
         if "template_category_id" in str(e):
-            return _template_category_error_response("ValidationError", _get_validation_message(e))
+            validation_message = _get_validation_message(e)
+            if validation_message == "template_category_id is a required property":
+                validation_message = "template_category_id is not a valid UUID"
+            return _template_category_error_response("ValidationError", validation_message)
         raise
 
     try:
@@ -105,11 +108,21 @@ def _template_name_over_char_limit(name, content, template_type):
 
 
 def _template_category_error_response(error_type, message):
-    template_categories = dao_get_all_template_categories(hidden=False)
+    template_categories = dao_get_all_template_categories()
+
+    errors = [{"error": error_type, "message": message}]
+    if not template_categories:
+        errors.append(
+            {
+                "error": "TemplateCategoryUnavailable",
+                "message": "Template categories are unavailable. Please contact support; the template categories endpoint may be down.",
+            }
+        )
+
     return (
         jsonify(
             status_code=400,
-            errors=[{"error": error_type, "message": message}],
+            errors=errors,
             template_categories=[
                 {"template_category_id": str(template_category.id), "name": template_category.name_en}
                 for template_category in template_categories

--- a/app/v2/manage_template/post_template.py
+++ b/app/v2/manage_template/post_template.py
@@ -1,11 +1,14 @@
+import json
+
 from flask import jsonify, request
+from jsonschema import ValidationError
 from notifications_utils import EMAIL_CHAR_COUNT_LIMIT, SMS_CHAR_COUNT_LIMIT, TEMPLATE_NAME_CHAR_COUNT_LIMIT
 from notifications_utils.template import HTMLEmailTemplate, SMSMessageTemplate
 from sqlalchemy.orm.exc import NoResultFound
 
 from app import api_user, authenticated_service
 from app.dao import templates_dao
-from app.dao.template_categories_dao import dao_get_template_category_by_id
+from app.dao.template_categories_dao import dao_get_all_template_categories, dao_get_template_category_by_id
 from app.dao.template_folder_dao import dao_get_template_folder_by_id_and_service_id
 from app.errors import InvalidRequest
 from app.models import EMAIL_TYPE, SMS_TYPE, ApiKeyPermission, Template
@@ -22,8 +25,19 @@ def post_manage_template():
     if not api_user.has_permission(ApiKeyPermission.MANAGE_TEMPLATES):
         raise InvalidRequest("This API key does not have permission to manage templates.", status_code=403)
 
-    data = validate(request.get_json() or {}, post_manage_template_request)
-    _validate_template_category_id(data["template_category_id"])
+    try:
+        data = validate(request.get_json() or {}, post_manage_template_request)
+    except ValidationError as e:
+        if "template_category_id" in str(e):
+            return _template_category_error_response("ValidationError", _get_validation_message(e))
+        raise
+
+    try:
+        _validate_template_category_id(data["template_category_id"])
+    except InvalidRequest as e:
+        if e.message == "template_category_id not found":
+            return _template_category_error_response("InvalidRequest", e.message)
+        raise
 
     folder = _validate_parent_folder(data)
     template = Template.from_json(
@@ -88,3 +102,34 @@ def _template_name_over_char_limit(name, content, template_type):
     return HTMLEmailTemplate(
         {"name": name, "content": content, "subject": "placeholder", "template_type": template_type}
     ).is_name_too_long()
+
+
+def _template_category_error_response(error_type, message):
+    template_categories = dao_get_all_template_categories(hidden=False)
+    return (
+        jsonify(
+            status_code=400,
+            errors=[{"error": error_type, "message": message}],
+            template_categories=[
+                {"template_category_id": str(template_category.id), "name": template_category.name_en}
+                for template_category in template_categories
+            ],
+        ),
+        400,
+    )
+
+
+def _get_validation_message(error):
+    if isinstance(error.message, str):
+        try:
+            parsed_error = json.loads(error.message)
+        except ValueError:
+            return error.message
+
+        errors = parsed_error.get("errors") if isinstance(parsed_error, dict) else None
+        if isinstance(errors, list) and errors:
+            first_error = errors[0]
+            if isinstance(first_error, dict) and "message" in first_error:
+                return first_error["message"]
+
+    return str(error)

--- a/app/v2/manage_template/post_template.py
+++ b/app/v2/manage_template/post_template.py
@@ -105,7 +105,7 @@ def _template_name_over_char_limit(name, content, template_type):
 
 
 def _template_category_error_response(error_type, message):
-    template_categories = dao_get_all_template_categories()
+    template_categories = dao_get_all_template_categories(hidden=False)
 
     errors = [{"error": error_type, "message": message}]
     if not template_categories:

--- a/app/v2/manage_template/template_schemas.py
+++ b/app/v2/manage_template/template_schemas.py
@@ -1,0 +1,43 @@
+from app.models import EMAIL_TYPE, SMS_TYPE
+from app.schema_validation.definitions import uuid
+
+post_manage_template_request = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "POST schema for creating a manage template",
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "template_type": {"enum": [SMS_TYPE, EMAIL_TYPE]},
+        "content": {"type": "string"},
+        "subject": {"type": "string"},
+        "postage": {"type": "string"},
+        "template_category_id": uuid,
+        "parent_folder_id": uuid,
+    },
+    "required": ["name", "template_type", "content", "template_category_id"],
+    "if": {"properties": {"template_type": {"enum": [EMAIL_TYPE]}}},
+    "then": {"required": ["subject"]},
+    "additionalProperties": False,
+}
+
+template_categories_response = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "GET schema for listing manage template categories",
+    "type": "object",
+    "properties": {
+        "template_categories": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "template_category_id": uuid,
+                    "name": {"type": "string"},
+                },
+                "required": ["template_category_id", "name"],
+                "additionalProperties": False,
+            },
+        }
+    },
+    "required": ["template_categories"],
+    "additionalProperties": False,
+}

--- a/app/v2/manage_template/template_schemas.py
+++ b/app/v2/manage_template/template_schemas.py
@@ -10,7 +10,6 @@ post_manage_template_request = {
         "template_type": {"enum": [SMS_TYPE, EMAIL_TYPE]},
         "content": {"type": "string"},
         "subject": {"type": "string"},
-        "postage": {"type": "string"},
         "template_category_id": uuid,
         "parent_folder_id": uuid,
     },

--- a/tests/app/v2/manage_template/test_get_template.py
+++ b/tests/app/v2/manage_template/test_get_template.py
@@ -22,6 +22,8 @@ class TestGetTemplateV2ManageTemplate:
         assert response.status_code == 200
         data = json.loads(response.get_data(as_text=True))
         assert data["id"] == str(template.id)
+        assert data["service_id"] == str(sample_service.id)
+        assert data["service_name"] == sample_service.name
         assert data["name"] == template.name
         assert data["type"] == SMS_TYPE
         assert data["body"] == template.content
@@ -46,6 +48,8 @@ class TestGetTemplateV2ManageTemplate:
         assert "process_type" not in data
 
         assert "id" in data
+        assert "service_id" in data
+        assert "service_name" in data
         assert "name" in data
         assert "type" in data
         assert "body" in data

--- a/tests/app/v2/manage_template/test_get_template_categories.py
+++ b/tests/app/v2/manage_template/test_get_template_categories.py
@@ -1,0 +1,33 @@
+from flask import json
+from tests import create_authorization_header
+
+
+class TestGetTemplateCategoriesV2ManageTemplate:
+    def test_get_template_categories_returns_200_with_manage_templates_permission(
+        self, client, sample_template_category, create_api_key_with_manage_api_perm
+    ):
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_api_perm)
+
+        response = client.get(
+            "/v2/manage-template/template-categories",
+            headers=[("Content-Type", "application/json"), auth_header],
+        )
+
+        assert response.status_code == 200
+        data = json.loads(response.get_data(as_text=True))
+        assert "template_categories" in data
+        assert len(data["template_categories"]) > 0
+        category = data["template_categories"][0]
+        assert "template_category_id" in category
+        assert "name" in category
+        assert "template_type" not in category
+
+    def test_get_template_categories_returns_403_without_manage_templates_permission(self, client, create_api_key_no_perm):
+        auth_header = create_authorization_header(api_key=create_api_key_no_perm)
+
+        response = client.get(
+            "/v2/manage-template/template-categories",
+            headers=[("Content-Type", "application/json"), auth_header],
+        )
+
+        assert response.status_code == 403

--- a/tests/app/v2/manage_template/test_post_template.py
+++ b/tests/app/v2/manage_template/test_post_template.py
@@ -181,3 +181,24 @@ class TestPostTemplateV2ManageTemplate:
         assert "template_category_id" in data["errors"][0]["message"]
         assert "template_categories" in data
         assert len(data["template_categories"]) > 0
+
+    def test_post_template_deletes_service_templates_cache(
+        self, client, sample_service, sample_template_category, create_api_key_with_manage_api_perm, mocker
+    ):
+        mock_redis_delete = mocker.patch("app.v2.manage_template.post_template.redis_store.delete")
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_api_perm)
+        payload = {
+            "name": "Cache Bust Template",
+            "template_type": SMS_TYPE,
+            "content": "Hello",
+            "template_category_id": str(sample_template_category.id),
+        }
+
+        response = client.post(
+            "/v2/manage-template",
+            data=json.dumps(payload),
+            headers=[("Content-Type", "application/json"), auth_header],
+        )
+
+        assert response.status_code == 201
+        mock_redis_delete.assert_called_once_with(f"service-{sample_service.id}-templates")

--- a/tests/app/v2/manage_template/test_post_template.py
+++ b/tests/app/v2/manage_template/test_post_template.py
@@ -1,0 +1,126 @@
+from flask import json
+from tests import create_authorization_header
+
+from app.models import EMAIL_TYPE, SMS_TYPE
+
+
+class TestPostTemplateV2ManageTemplate:
+    def test_post_template_returns_201_with_manage_templates_permission(
+        self, client, sample_service, sample_template_category, create_api_key_with_manage_api_perm
+    ):
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_api_perm)
+        payload = {
+            "name": "New API Template",
+            "template_type": SMS_TYPE,
+            "content": "Hello from API",
+            "template_category_id": str(sample_template_category.id),
+        }
+
+        response = client.post(
+            "/v2/manage-template",
+            data=json.dumps(payload),
+            headers=[("Content-Type", "application/json"), auth_header],
+        )
+
+        assert response.status_code == 201
+        data = json.loads(response.get_data(as_text=True))
+        assert data["name"] == payload["name"]
+        assert data["type"] == payload["template_type"]
+        assert data["body"] == payload["content"]
+        assert data["subject"] is None
+
+    def test_post_template_returns_403_without_manage_templates_permission(
+        self, client, sample_template_category, create_api_key_no_perm
+    ):
+        auth_header = create_authorization_header(api_key=create_api_key_no_perm)
+        payload = {
+            "name": "No Permission Template",
+            "template_type": SMS_TYPE,
+            "content": "Hello",
+            "template_category_id": str(sample_template_category.id),
+        }
+
+        response = client.post(
+            "/v2/manage-template",
+            data=json.dumps(payload),
+            headers=[("Content-Type", "application/json"), auth_header],
+        )
+
+        assert response.status_code == 403
+        data = json.loads(response.get_data(as_text=True))
+        assert "manage templates" in data["errors"][0]["message"].lower()
+
+    def test_post_email_or_letter_requires_subject(self, client, sample_template_category, create_api_key_with_manage_api_perm):
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_api_perm)
+
+        response = client.post(
+            "/v2/manage-template",
+            data=json.dumps(
+                {
+                    "name": "Missing Subject",
+                    "template_type": EMAIL_TYPE,
+                    "content": "Body",
+                    "template_category_id": str(sample_template_category.id),
+                }
+            ),
+            headers=[("Content-Type", "application/json"), auth_header],
+        )
+
+        assert response.status_code == 400
+
+    def test_post_email_template_with_subject_returns_201(
+        self, client, sample_template_category, create_api_key_with_manage_api_perm
+    ):
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_api_perm)
+        payload = {
+            "name": "Email Template",
+            "template_type": EMAIL_TYPE,
+            "subject": "Email subject",
+            "content": "Email body",
+            "template_category_id": str(sample_template_category.id),
+        }
+
+        response = client.post(
+            "/v2/manage-template",
+            data=json.dumps(payload),
+            headers=[("Content-Type", "application/json"), auth_header],
+        )
+
+        assert response.status_code == 201
+        data = json.loads(response.get_data(as_text=True))
+        assert data["subject"] == payload["subject"]
+
+    def test_post_template_requires_template_category_id(self, client, create_api_key_with_manage_api_perm):
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_api_perm)
+        payload = {
+            "name": "Missing Category",
+            "template_type": SMS_TYPE,
+            "content": "Hello",
+        }
+
+        response = client.post(
+            "/v2/manage-template",
+            data=json.dumps(payload),
+            headers=[("Content-Type", "application/json"), auth_header],
+        )
+
+        assert response.status_code == 400
+
+    def test_post_template_returns_400_for_invalid_template_category_id(self, client, create_api_key_with_manage_api_perm):
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_api_perm)
+        payload = {
+            "name": "Invalid Category",
+            "template_type": SMS_TYPE,
+            "content": "Hello",
+            "template_category_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        }
+
+        response = client.post(
+            "/v2/manage-template",
+            data=json.dumps(payload),
+            headers=[("Content-Type", "application/json"), auth_header],
+        )
+
+        assert response.status_code == 400
+        data = json.loads(response.get_data(as_text=True))
+        assert data["errors"][0]["message"] == "template_category_id not found"

--- a/tests/app/v2/manage_template/test_post_template.py
+++ b/tests/app/v2/manage_template/test_post_template.py
@@ -62,7 +62,7 @@ class TestPostTemplateV2ManageTemplate:
         data = json.loads(response.get_data(as_text=True))
         assert "manage templates" in data["errors"][0]["message"].lower()
 
-    def test_post_email_or_letter_requires_subject(self, client, sample_template_category, create_api_key_with_manage_api_perm):
+    def test_post_email_requires_subject(self, client, sample_template_category, create_api_key_with_manage_api_perm):
         auth_header = create_authorization_header(api_key=create_api_key_with_manage_api_perm)
 
         response = client.post(
@@ -123,7 +123,7 @@ class TestPostTemplateV2ManageTemplate:
         assert response.status_code == 400
         data = json.loads(response.get_data(as_text=True))
         assert data["errors"][0]["error"] == "ValidationError"
-        assert data["errors"][0]["message"] == "template_category_id is not a valid UUID"
+        assert data["errors"][0]["message"] == "template_category_id is a required property"
         assert "template_categories" in data
         assert len(data["template_categories"]) > 0
         assert "template_category_id" in data["template_categories"][0]
@@ -166,7 +166,7 @@ class TestPostTemplateV2ManageTemplate:
             "name": "Invalid UUID Category",
             "template_type": SMS_TYPE,
             "content": "Hello",
-            "template_category_id": "REPLACE_WITH_CATEGORY_UUID",
+            "template_category_id": "not-a-valid-uuid",
         }
 
         response = client.post(

--- a/tests/app/v2/manage_template/test_post_template.py
+++ b/tests/app/v2/manage_template/test_post_template.py
@@ -1,3 +1,6 @@
+import uuid
+from types import SimpleNamespace
+
 from flask import json
 from tests import create_authorization_header
 
@@ -5,6 +8,13 @@ from app.models import EMAIL_TYPE, SMS_TYPE
 
 
 class TestPostTemplateV2ManageTemplate:
+    @staticmethod
+    def _mock_template_categories(mocker):
+        return mocker.patch(
+            "app.v2.manage_template.post_template.dao_get_all_template_categories",
+            return_value=[SimpleNamespace(id=uuid.uuid4(), name_en="General")],
+        )
+
     def test_post_template_returns_201_with_manage_templates_permission(
         self, client, sample_service, sample_template_category, create_api_key_with_manage_api_perm
     ):
@@ -94,7 +104,9 @@ class TestPostTemplateV2ManageTemplate:
         assert "service_name" in data
         assert data["subject"] == payload["subject"]
 
-    def test_post_template_requires_template_category_id(self, client, create_api_key_with_manage_api_perm):
+    def test_post_template_requires_template_category_id(self, client, create_api_key_with_manage_api_perm, mocker):
+        self._mock_template_categories(mocker)
+
         auth_header = create_authorization_header(api_key=create_api_key_with_manage_api_perm)
         payload = {
             "name": "Missing Category",
@@ -117,7 +129,11 @@ class TestPostTemplateV2ManageTemplate:
         assert "template_category_id" in data["template_categories"][0]
         assert "name" in data["template_categories"][0]
 
-    def test_post_template_returns_400_for_invalid_template_category_id(self, client, create_api_key_with_manage_api_perm):
+    def test_post_template_returns_400_for_invalid_template_category_id(
+        self, client, create_api_key_with_manage_api_perm, mocker
+    ):
+        self._mock_template_categories(mocker)
+
         auth_header = create_authorization_header(api_key=create_api_key_with_manage_api_perm)
         payload = {
             "name": "Invalid Category",
@@ -141,8 +157,10 @@ class TestPostTemplateV2ManageTemplate:
         assert "name" in data["template_categories"][0]
 
     def test_post_template_returns_400_with_categories_for_invalid_template_category_uuid(
-        self, client, create_api_key_with_manage_api_perm
+        self, client, create_api_key_with_manage_api_perm, mocker
     ):
+        self._mock_template_categories(mocker)
+
         auth_header = create_authorization_header(api_key=create_api_key_with_manage_api_perm)
         payload = {
             "name": "Invalid UUID Category",

--- a/tests/app/v2/manage_template/test_post_template.py
+++ b/tests/app/v2/manage_template/test_post_template.py
@@ -24,6 +24,8 @@ class TestPostTemplateV2ManageTemplate:
 
         assert response.status_code == 201
         data = json.loads(response.get_data(as_text=True))
+        assert data["service_id"] == str(sample_service.id)
+        assert data["service_name"] == sample_service.name
         assert data["name"] == payload["name"]
         assert data["type"] == payload["template_type"]
         assert data["body"] == payload["content"]
@@ -88,6 +90,8 @@ class TestPostTemplateV2ManageTemplate:
 
         assert response.status_code == 201
         data = json.loads(response.get_data(as_text=True))
+        assert "service_id" in data
+        assert "service_name" in data
         assert data["subject"] == payload["subject"]
 
     def test_post_template_requires_template_category_id(self, client, create_api_key_with_manage_api_perm):
@@ -105,6 +109,13 @@ class TestPostTemplateV2ManageTemplate:
         )
 
         assert response.status_code == 400
+        data = json.loads(response.get_data(as_text=True))
+        assert data["errors"][0]["error"] == "ValidationError"
+        assert data["errors"][0]["message"] == "template_category_id is not a valid UUID"
+        assert "template_categories" in data
+        assert len(data["template_categories"]) > 0
+        assert "template_category_id" in data["template_categories"][0]
+        assert "name" in data["template_categories"][0]
 
     def test_post_template_returns_400_for_invalid_template_category_id(self, client, create_api_key_with_manage_api_perm):
         auth_header = create_authorization_header(api_key=create_api_key_with_manage_api_perm)
@@ -124,3 +135,31 @@ class TestPostTemplateV2ManageTemplate:
         assert response.status_code == 400
         data = json.loads(response.get_data(as_text=True))
         assert data["errors"][0]["message"] == "template_category_id not found"
+        assert "template_categories" in data
+        assert len(data["template_categories"]) > 0
+        assert "template_category_id" in data["template_categories"][0]
+        assert "name" in data["template_categories"][0]
+
+    def test_post_template_returns_400_with_categories_for_invalid_template_category_uuid(
+        self, client, create_api_key_with_manage_api_perm
+    ):
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_api_perm)
+        payload = {
+            "name": "Invalid UUID Category",
+            "template_type": SMS_TYPE,
+            "content": "Hello",
+            "template_category_id": "REPLACE_WITH_CATEGORY_UUID",
+        }
+
+        response = client.post(
+            "/v2/manage-template",
+            data=json.dumps(payload),
+            headers=[("Content-Type", "application/json"), auth_header],
+        )
+
+        assert response.status_code == 400
+        data = json.loads(response.get_data(as_text=True))
+        assert data["errors"][0]["error"] == "ValidationError"
+        assert "template_category_id" in data["errors"][0]["message"]
+        assert "template_categories" in data
+        assert len(data["template_categories"]) > 0


### PR DESCRIPTION
# Summary | Résumé

This PR add a create template functionality

## Related Issues | Cartes liées

[* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/1](https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/3139)

# Test instructions | Instructions pour tester la modification

1. Create an API key that has manage_template permissions
2. Send a POST command with the following:

```
{"name": "Welcome email",
 "template_type": "email",
 "subject": "Welcome to Notify",
 "content": "Hi ((first_name)), welcome!", "template_category_id": "REPLACE_WITH_CATEGORY_UUID"
}
```
3. After you get a failure, pick the template_category_id you desire.
4. Check the frontend that a template was created
5. you might have to clear the cache for the template to show (if you were on the page previously)