### PR TITLE
Don't put fake cost data in our db

### DIFF
--- a/app/celery/research_mode_tasks.py
+++ b/app/celery/research_mode_tasks.py
@@ -1,3 +1,4 @@
+import json
 import random
 from datetime import datetime, timedelta
 
@@ -81,7 +82,7 @@ def aws_pinpoint_callback(notification_id, to):
     using_test_temp_fail_number = to.strip().endswith(temp_fail)
 
     if using_test_perm_fail_number or using_test_temp_fail_number:
-        return pinpoint_failed_callback(
+        body = pinpoint_failed_callback(
             "Phone is currently unreachable/unavailable"
             if using_test_perm_fail_number
             else "Phone carrier is currently unreachable/unavailable",
@@ -90,7 +91,14 @@ def aws_pinpoint_callback(notification_id, to):
             timestamp=timestamp,
         )
     else:
-        return pinpoint_delivered_callback(notification_id, destination=to, timestamp=timestamp)
+        body = pinpoint_delivered_callback(notification_id, destination=to, timestamp=timestamp)
+
+    # Strip cost fields — research mode / test sends should not record cost data
+    message = json.loads(body["Message"])
+    message.pop("totalMessagePrice", None)
+    message.pop("totalCarrierFee", None)
+    body["Message"] = json.dumps(message)
+    return body
 
 
 @notify_celery.task(

--- a/tests/app/celery/test_research_mode_tasks.py
+++ b/tests/app/celery/test_research_mode_tasks.py
@@ -16,6 +16,7 @@ from app.aws.mocks import (
     sns_success_callback,
 )
 from app.celery.research_mode_tasks import (
+    aws_pinpoint_callback,
     create_fake_letter_response_file,
     send_email_response,
     send_sms_response,
@@ -73,7 +74,28 @@ def test_make_pinpoint_success_callback(notify_api, mocker, phone_number, pinpoi
     mock_task.apply_async.assert_called_once_with(ANY, queue=QueueNames.RESEARCH_MODE)
     message_celery = mock_task.apply_async.call_args[0][0][0]
     pinpoint_callback_args.update({"reference": some_ref, "destination": phone_number, "timestamp": timestamp})
-    assert message_celery == pinpoint_callback(**pinpoint_callback_args)
+
+    # Build expected body without cost fields (research mode strips them)
+    expected = pinpoint_callback(**pinpoint_callback_args)
+    expected_message = json.loads(expected["Message"])
+    expected_message.pop("totalMessagePrice", None)
+    expected_message.pop("totalCarrierFee", None)
+    expected["Message"] = json.dumps(expected_message)
+
+    assert message_celery == expected
+
+
+@pytest.mark.parametrize(
+    "phone_number",
+    ["+15149301630", "+15149301632", "+15149301633"],
+)
+@freeze_time("2018-01-25 14:00:30")
+def test_aws_pinpoint_callback_strips_cost_data(notify_api, phone_number):
+    some_ref = str(uuid.uuid4())
+    result = aws_pinpoint_callback(some_ref, phone_number)
+    message = json.loads(result["Message"])
+    assert "totalMessagePrice" not in message
+    assert "totalCarrierFee" not in message
 
 
 def test_make_ses_callback(notify_api, mocker):


### PR DESCRIPTION
# Summary | Résumé

For SMS sends with a "test" api key, sends to the internal test number, and for research mode services, we have been adding fake AWS cost data using a mock: https://github.com/cds-snc/notification-api/blob/ef12eeeb7776c9d1adca47e1a75885149f85450a/app/aws/mocks.py#L329-L330

The intention with this is to allow our users to simulate a real send, but this is bad because we want the `sms_total_carrier_fee`  and `sms_total_message_price` columns to be a source of truth.

This PR doesn't change the mock (it is used in various tests) but sets those values to `null` so that we don't get bad cost data in our db.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/3274

# Test instructions | Instructions pour tester la modification

1. check out branch locally
2. send a one off message to our internal test number (+16135550123)
3. copy the notification id
4. check your local db, verify that `notification.sms_total_carrier_fee` and `notification.sms_total_message_price` are null for that notification

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.