### PR TITLE
Capture price data for SMS with `notification_status = "sent"`

### DIFF
--- a/app/celery/process_pinpoint_receipts_tasks.py
+++ b/app/celery/process_pinpoint_receipts_tasks.py
@@ -9,6 +9,7 @@ from app import annual_limit_client, notify_celery, statsd_client
 from app.annual_limit_utils import get_annual_limit_notifications_v3
 from app.config import QueueNames
 from app.dao import notifications_dao
+from app.dao.notifications_dao import dao_update_notification
 from app.models import (
     NOTIFICATION_DELIVERED,
     NOTIFICATION_PERMANENT_FAILURE,
@@ -65,9 +66,6 @@ def process_pinpoint_results(self, response):
 
         notification_status = determine_pinpoint_status(status, provider_response, isFinal)
 
-        if notification_status == NOTIFICATION_SENT:
-            return  # we don't want to update the status to sent if it's already sent
-
         if not notification_status:
             current_app.logger.warning(f"unhandled provider response for reference {reference}, received '{provider_response}'")
             notification_status = NOTIFICATION_PERMANENT_FAILURE  # revert to permanent failure by default
@@ -92,6 +90,18 @@ def process_pinpoint_results(self, response):
 
         if notification.status != NOTIFICATION_SENT:
             notifications_dao._duplicate_update_warning(notification, notification_status)
+            return
+
+        if notification_status == NOTIFICATION_SENT:
+            # Carrier has accepted the message but it hasn't been delivered to the handset yet.
+            # Don't update the notification status, but capture the pricing data from this receipt.
+            notification.sms_total_message_price = total_message_price
+            notification.sms_total_carrier_fee = total_carrier_fee
+            notification.sms_iso_country_code = iso_country_code
+            notification.sms_carrier_name = carrier_name
+            notification.sms_message_encoding = message_encoding
+            notification.sms_origination_phone_number = origination_phone_number
+            dao_update_notification(notification)
             return
 
         notifications_dao._update_notification_status(

--- a/app/celery/process_pinpoint_receipts_tasks.py
+++ b/app/celery/process_pinpoint_receipts_tasks.py
@@ -94,13 +94,20 @@ def process_pinpoint_results(self, response):
 
         if notification_status == NOTIFICATION_SENT:
             # Carrier has accepted the message but it hasn't been delivered to the handset yet.
-            # Don't update the notification status, but capture the pricing data from this receipt.
-            notification.sms_total_message_price = total_message_price
-            notification.sms_total_carrier_fee = total_carrier_fee
-            notification.sms_iso_country_code = iso_country_code
-            notification.sms_carrier_name = carrier_name
-            notification.sms_message_encoding = message_encoding
-            notification.sms_origination_phone_number = origination_phone_number
+            # Don't update the notification status, but capture any pricing/metadata present in this receipt.
+            # Only overwrite fields when Pinpoint provides a value, to avoid nulling previously captured data.
+            if total_message_price is not None:
+                notification.sms_total_message_price = total_message_price
+            if total_carrier_fee is not None:
+                notification.sms_total_carrier_fee = total_carrier_fee
+            if iso_country_code is not None:
+                notification.sms_iso_country_code = iso_country_code
+            if carrier_name is not None:
+                notification.sms_carrier_name = carrier_name
+            if message_encoding is not None:
+                notification.sms_message_encoding = message_encoding
+            if origination_phone_number is not None:
+                notification.sms_origination_phone_number = origination_phone_number
             dao_update_notification(notification)
             return
 

--- a/tests/app/celery/test_process_pinpoint_receipts_tasks.py
+++ b/tests/app/celery/test_process_pinpoint_receipts_tasks.py
@@ -91,6 +91,12 @@ def test_process_pinpoint_results_succeeded(sample_template, notify_db, notify_d
     mock_callback_task.assert_not_called()
     assert updated_notification.status == NOTIFICATION_SENT
     assert updated_notification.provider_response is None
+    assert float(updated_notification.sms_total_message_price) == 0.00581
+    assert float(updated_notification.sms_total_carrier_fee) == 0.00767
+    assert updated_notification.sms_iso_country_code == "CA"
+    assert updated_notification.sms_carrier_name == "Bell Cellular Inc. / Aliant Telecom"
+    assert updated_notification.sms_message_encoding == "GSM"
+    assert updated_notification.sms_origination_phone_number == "+13655550100"
 
 
 def test_process_pinpoint_results_missing_sms_data(notify_api, sample_template, notify_db, notify_db_session, mocker):


### PR DESCRIPTION
# Summary | Résumé

Capture price data for SMS with `notification_status = "sent"` if it happens to be present in the receipt from pinpoint. The [AWS documentation](http://docs.aws.amazon.com/sms-voice/latest/userguide/configuration-sets-event-format.html) is not clear on whether it will be there or not. If the data is missing it should not be a problem since these are all nullable columns.

## Background

I'm seeing an issue where we are missing AWS cost data for SMS notifications with `status="sent"`. These should be billable but we are not adding the cost data because we have not received the final "delivered" receipt. There are a lot of these in our db:

```
select count(*)
from notification_history n
where n.notification_type = 'sms'
and n.notification_status = 'sent'
and n.sms_total_carrier_fee is null 
and n.sms_total_message_price is null
limit 200
-- 138703 results
```
and
```
select count(*)
from notification_history n
where n.notification_type = 'sms'
and n.notification_status = 'sent'
and (n.sms_total_carrier_fee is not null or n.sms_total_message_price is not null)
limit 200
-- 0 results
```

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/3274

# Test instructions | Instructions pour tester la modification

Tests should pass in CI.

We won't be able to test this manually until it is deployed on staging, since we don't get AWS receipts locally. When it's deployed on staging, we can do the following test:
1. turn off your phone
2. try sending an sms to yourself
3. look in the staging db to verify the notification has a status of "sent" and non-zero price data in either the `sms_total_carrier_fee` or `sms_total_message_price` columns
4. turn your phone back on
5. wait until you receive the sms
6. look in the db again and verify the notification status is now "delivered" and the price data is still there

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.