### PR TITLE
Add RedisTokenBucketRateLimiter and improve rate limiter factory

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -142,7 +142,7 @@ def create_app(application, config=None):
         salesforce_client.init_app(application)
 
     # Initialize the global rate limiter instance with the configured rate limit for SMS delivery tasks.
-    initialize_rate_limiter(application.config["CELERY_DELIVER_SMS_RATE_LIMIT_PER_MINUTE"])
+    initialize_rate_limiter(application.config["CELERY_DELIVER_SMS_RATE_LIMIT_PER_MINUTE"], namespace="sms")
 
     flask_redis.init_app(application)
     flask_cache_ops.init_app(application)

--- a/app/config.py
+++ b/app/config.py
@@ -606,7 +606,7 @@ class Config(object):
     CELERY_QUEUES: List[Any] = []
     CELERY_DELIVER_SMS_RATE_LIMIT = os.getenv("CELERY_DELIVER_SMS_RATE_LIMIT", "1/s")
     CELERY_DELIVER_SMS_RATE_LIMIT_PER_MINUTE = env.int("CELERY_DELIVER_SMS_RATE_LIMIT_PER_MINUTE", 6_000)
-    # SMS rate limiter backend class name. Must match a key in rate_limiter._LIMITER_CLASSES.
+    # SMS rate limiter backend class name. Must match a key in an implementation class in the rate_limiter module.
     # Options: "InMemoryRateLimiter", "RedisSlidingWindowLogRateLimiter", "RedisTokenBucketRateLimiter"
     SMS_RATE_LIMITER_BACKEND = os.getenv("SMS_RATE_LIMITER_BACKEND", "InMemoryRateLimiter")
     AWS_SEND_SMS_BOTO_CALL_LATENCY = os.getenv("AWS_SEND_SMS_BOTO_CALL_LATENCY", 0.06)  # average delay in production

--- a/app/config.py
+++ b/app/config.py
@@ -606,8 +606,9 @@ class Config(object):
     CELERY_QUEUES: List[Any] = []
     CELERY_DELIVER_SMS_RATE_LIMIT = os.getenv("CELERY_DELIVER_SMS_RATE_LIMIT", "1/s")
     CELERY_DELIVER_SMS_RATE_LIMIT_PER_MINUTE = env.int("CELERY_DELIVER_SMS_RATE_LIMIT_PER_MINUTE", 6_000)
-    # SMS rate limiter backend: "memory" for in-process (Phase 1), "redis" for distributed (Phase 2, multi-worker)
-    SMS_RATE_LIMITER_BACKEND = os.getenv("SMS_RATE_LIMITER_BACKEND", "memory")
+    # SMS rate limiter backend class name. Must match a key in rate_limiter._LIMITER_CLASSES.
+    # Options: "InMemoryRateLimiter", "RedisZSetRateLimiter", "RedisTokenBucketRateLimiter"
+    SMS_RATE_LIMITER_BACKEND = os.getenv("SMS_RATE_LIMITER_BACKEND", "InMemoryRateLimiter")
     AWS_SEND_SMS_BOTO_CALL_LATENCY = os.getenv("AWS_SEND_SMS_BOTO_CALL_LATENCY", 0.06)  # average delay in production
 
     CONTACT_FORM_EMAIL_ADDRESS = os.getenv("CONTACT_FORM_EMAIL_ADDRESS", "helpdesk@cds-snc.ca")

--- a/app/config.py
+++ b/app/config.py
@@ -607,7 +607,7 @@ class Config(object):
     CELERY_DELIVER_SMS_RATE_LIMIT = os.getenv("CELERY_DELIVER_SMS_RATE_LIMIT", "1/s")
     CELERY_DELIVER_SMS_RATE_LIMIT_PER_MINUTE = env.int("CELERY_DELIVER_SMS_RATE_LIMIT_PER_MINUTE", 6_000)
     # SMS rate limiter backend class name. Must match a key in rate_limiter._LIMITER_CLASSES.
-    # Options: "InMemoryRateLimiter", "RedisZSetRateLimiter", "RedisTokenBucketRateLimiter"
+    # Options: "InMemoryRateLimiter", "RedisSlidingWindowLogRateLimiter", "RedisTokenBucketRateLimiter"
     SMS_RATE_LIMITER_BACKEND = os.getenv("SMS_RATE_LIMITER_BACKEND", "InMemoryRateLimiter")
     AWS_SEND_SMS_BOTO_CALL_LATENCY = os.getenv("AWS_SEND_SMS_BOTO_CALL_LATENCY", 0.06)  # average delay in production
 

--- a/app/rate_limiter.py
+++ b/app/rate_limiter.py
@@ -601,7 +601,7 @@ class RedisTokenBucketRateLimiter(RateLimiter):
         tokens_str = self.redis.hget(self.REDIS_KEY, "tokens")
         last_refill_str = self.redis.hget(self.REDIS_KEY, "last_refill")
 
-        if tokens_str is None:
+        if tokens_str is None or last_refill_str is None:
             return 0
 
         tokens = float(tokens_str if isinstance(tokens_str, str) else tokens_str.decode("utf-8"))

--- a/app/rate_limiter.py
+++ b/app/rate_limiter.py
@@ -190,7 +190,7 @@ def _build_limiter_registry() -> dict[str, type[RateLimiter]]:
     """Lazily populate the registry after all classes are defined."""
     return {
         "InMemoryRateLimiter": InMemoryRateLimiter,
-        "RedisZSetRateLimiter": RedisSlidingWindowLogRateLimiter,
+        "RedisSlidingWindowLogRateLimiter": RedisSlidingWindowLogRateLimiter,
         "RedisTokenBucketRateLimiter": RedisTokenBucketRateLimiter,
     }
 

--- a/app/rate_limiter.py
+++ b/app/rate_limiter.py
@@ -23,6 +23,9 @@ class RateLimiter(ABC):
     Phase 2 will provide a Redis-backed implementation.
     """
 
+    def __init__(self, cap_per_minute: int) -> None:
+        self.cap_per_minute = cap_per_minute
+
     @abstractmethod
     def acquire_lease(self, parts_count: int) -> Tuple[bool, int]:
         """
@@ -181,10 +184,6 @@ class InMemoryRateLimiter(RateLimiter):
 
 _rate_limiter_instance: RateLimiter | None = None
 
-# Registry mapping config name strings to implementation classes.
-# Used by initialize_rate_limiter when no explicit class is provided.
-_LIMITER_CLASSES: dict[str, type[RateLimiter]] = {}
-
 
 def _build_limiter_registry() -> dict[str, type[RateLimiter]]:
     """Lazily populate the registry after all classes are defined."""
@@ -240,8 +239,7 @@ def initialize_rate_limiter(cap_per_minute: int, limiter_class: type[RateLimiter
 
         if class_name not in registry:
             logger.warning(
-                "SMS rate limiter: unknown class name %r in SMS_RATE_LIMITER_BACKEND; "
-                "falling back to InMemoryRateLimiter.",
+                "SMS rate limiter: unknown class name %r in SMS_RATE_LIMITER_BACKEND; " "falling back to InMemoryRateLimiter.",
                 class_name,
             )
             resolved_class = InMemoryRateLimiter

--- a/app/rate_limiter.py
+++ b/app/rate_limiter.py
@@ -181,21 +181,37 @@ class InMemoryRateLimiter(RateLimiter):
 
 _rate_limiter_instance: RateLimiter | None = None
 
+# Registry mapping config name strings to implementation classes.
+# Used by initialize_rate_limiter when no explicit class is provided.
+_LIMITER_CLASSES: dict[str, type[RateLimiter]] = {}
 
-def initialize_rate_limiter(cap_per_minute: int, use_redis: bool = False) -> RateLimiter:
+
+def _build_limiter_registry() -> dict[str, type[RateLimiter]]:
+    """Lazily populate the registry after all classes are defined."""
+    return {
+        "InMemoryRateLimiter": InMemoryRateLimiter,
+        "RedisZSetRateLimiter": RedisZSetRateLimiter,
+        "RedisTokenBucketRateLimiter": RedisTokenBucketRateLimiter,
+    }
+
+
+def initialize_rate_limiter(cap_per_minute: int, limiter_class: type[RateLimiter] | None = None) -> RateLimiter:
     """
     Initialize the global rate limiter instance.
 
     Called during app initialization (see app/__init__.py).
 
-    The backend is chosen based on:
-    1. use_redis parameter (if provided)
-    2. Config value from app.config.SMS_RATE_LIMITER_BACKEND (if set to 'redis')
-    3. Default: InMemoryRateLimiter
+    The backend is chosen in this order:
+    1. limiter_class argument — if provided, instantiated directly.
+    2. SMS_RATE_LIMITER_BACKEND config value — must be the exact class name
+       (e.g. "RedisTokenBucketRateLimiter"). Unknown names fall back to
+       InMemoryRateLimiter with a warning.
+    3. Default: InMemoryRateLimiter.
 
     Args:
         cap_per_minute (int): Maximum SMS parts per minute.
-        use_redis (bool, optional): Force Redis backend if True, in-memory if False.
+        limiter_class (type[RateLimiter] | None): Implementation class to use.
+            If None, the class is resolved from config/default.
 
     Returns:
         RateLimiter: The initialized rate limiter instance.
@@ -206,32 +222,34 @@ def initialize_rate_limiter(cap_per_minute: int, use_redis: bool = False) -> Rat
 
     logger = logging.getLogger(__name__)
 
-    # Determine which backend to use
-    backend = "memory"  # default
-
-    if use_redis is not None:
-        backend = "redis" if use_redis else "memory"
+    if limiter_class is not None:
+        resolved_class = limiter_class
     else:
-        # Check config
+        registry = _build_limiter_registry()
+        class_name = "InMemoryRateLimiter"  # default
         try:
             from app.config import Config
 
-            config_backend = getattr(Config, "SMS_RATE_LIMITER_BACKEND", "memory")
-            if config_backend.lower() == "redis":
-                backend = "redis"
+            class_name = getattr(Config, "SMS_RATE_LIMITER_BACKEND", "InMemoryRateLimiter")
         except (ImportError, AttributeError) as exc:
             logger.warning(
-                "SMS rate limiter: failed to read backend from config; " "falling back to in-memory backend. Error: %s",
+                "SMS rate limiter: failed to read SMS_RATE_LIMITER_BACKEND from config; "
+                "falling back to InMemoryRateLimiter. Error: %s",
                 exc,
             )
 
-    # Create the appropriate backend
-    if backend == "redis":
-        logger.info("SMS rate limiter: initializing with Redis backend")
-        _rate_limiter_instance = RedisZSetRateLimiter(cap_per_minute)
-    else:
-        logger.info("SMS rate limiter: initializing with in-memory backend")
-        _rate_limiter_instance = InMemoryRateLimiter(cap_per_minute)
+        if class_name not in registry:
+            logger.warning(
+                "SMS rate limiter: unknown class name %r in SMS_RATE_LIMITER_BACKEND; "
+                "falling back to InMemoryRateLimiter.",
+                class_name,
+            )
+            resolved_class = InMemoryRateLimiter
+        else:
+            resolved_class = registry[class_name]
+
+    logger.info("SMS rate limiter: initializing with %s", resolved_class.__name__)
+    _rate_limiter_instance = resolved_class(cap_per_minute)
 
     return _rate_limiter_instance
 
@@ -441,3 +459,160 @@ class RedisZSetRateLimiter(RateLimiter):
         self.redis.delete(self.REDIS_KEY_ENTRIES)
 
         current_app.logger.info("SMS rate limiter entries cleared")
+
+
+class RedisTokenBucketRateLimiter(RateLimiter):
+    """
+    Redis-backed SMS parts rate limiter using a token bucket algorithm.
+
+    Key structure:
+    - `sms:rate_limit:token_bucket` (hash)
+      - Field `tokens`: current available capacity (float, stored as string)
+      - Field `last_refill`: timestamp of last refill (float, stored as string)
+
+    Algorithm:
+    - Tokens refill continuously at rate cap_per_minute / 60 per second.
+    - On each request, elapsed time since last refill is computed, tokens are
+      topped up (capped at cap_per_minute), and the requested parts are
+      subtracted atomically in Lua.
+    - If tokens are insufficient, the exact wait time is returned:
+      deficit / (cap_per_minute / 60) seconds.
+    - Burst after idle: if the system is idle, the bucket refills to cap,
+      allowing a full cap's worth of parts to be sent immediately.
+
+    Complexity: O(1) for all operations.
+    """
+
+    REDIS_KEY = "sms:rate_limit:token_bucket"
+
+    def __init__(self, cap_per_minute: int, redis_client=None):
+        """
+        Initialize the Redis token bucket rate limiter.
+
+        Args:
+            cap_per_minute (int): Maximum SMS parts allowed per minute.
+            redis_client: Redis client instance. If None, uses app's redis_store.
+        """
+        self.cap_per_minute = cap_per_minute
+        self.redis_client = redis_client
+        self._lua_scripts: dict[str, object] = {}
+
+    @property
+    def redis(self):
+        # Lazy-load Redis client to avoid circular imports at init time.
+        if self.redis_client is not None:
+            return self.redis_client
+        from app import redis_store
+
+        return redis_store
+
+    def _get_acquire_lua_script(self):
+        if "acquire" not in self._lua_scripts:
+            lua_code = """
+            local key = KEYS[1]
+            local cap = tonumber(ARGV[1])
+            local parts_count = tonumber(ARGV[2])
+            local now = tonumber(ARGV[3])
+            local refill_rate = cap / 60.0
+
+            -- Read current state; default to full bucket on first call
+            local tokens_str = redis.call('HGET', key, 'tokens')
+            local last_refill_str = redis.call('HGET', key, 'last_refill')
+
+            local tokens
+            local last_refill
+            if tokens_str == false then
+                tokens = cap
+                last_refill = now
+            else
+                tokens = tonumber(tokens_str)
+                last_refill = tonumber(last_refill_str)
+            end
+
+            -- Refill tokens based on elapsed time
+            local elapsed = now - last_refill
+            tokens = math.min(cap, tokens + elapsed * refill_rate)
+
+            if tokens >= parts_count then
+                -- Admit: subtract parts and persist new state
+                tokens = tokens - parts_count
+                redis.call('HSET', key, 'tokens', tostring(tokens), 'last_refill', tostring(now))
+                return {1, 0}
+            else
+                -- Reject: compute exact wait time
+                local deficit = parts_count - tokens
+                local seconds_to_wait = math.ceil(deficit / refill_rate)
+                seconds_to_wait = math.max(1, seconds_to_wait)
+                -- Persist refreshed token count and timestamp even on reject
+                redis.call('HSET', key, 'tokens', tostring(tokens), 'last_refill', tostring(now))
+                return {0, seconds_to_wait}
+            end
+            """
+            self._lua_scripts["acquire"] = self.redis.register_script(lua_code)
+
+        return self._lua_scripts["acquire"]
+
+    def acquire_lease(self, parts_count: int) -> Tuple[bool, int]:
+        """
+        Attempt to acquire capacity for SMS parts.
+
+        Args:
+            parts_count (int): Number of parts (fragments) to send.
+
+        Returns:
+            Tuple[bool, int]:
+                - (True, 0) if parts can be sent immediately.
+                - (False, seconds_remaining) if rate limit exhausted;
+                  seconds_remaining is the exact time until enough tokens refill.
+        """
+        if parts_count <= 0:
+            raise ValueError("parts_count must be positive")
+
+        if parts_count > self.cap_per_minute:
+            raise ValueError("parts_count must be smaller than or equal to the cap_per_minute")
+
+        now = time()
+        script = self._get_acquire_lua_script()
+        result = script(
+            keys=[self.REDIS_KEY],
+            args=[self.cap_per_minute, parts_count, now],
+        )
+
+        success, wait_seconds = result[0], result[1]
+
+        if success:
+            current_app.logger.info(f"SMS rate limiter (token bucket): acquired {parts_count} parts.")
+        else:
+            current_app.logger.warning(
+                f"SMS rate limiter (token bucket): capacity exhausted. Requested {parts_count} parts. "
+                f"Will retry in {wait_seconds} seconds."
+            )
+
+        return bool(success), int(wait_seconds)
+
+    def get_current_usage(self) -> int:
+        """
+        Get current consumed capacity equivalent.
+
+        Returns cap minus available tokens after applying any pending refill.
+        This is a non-atomic read — do not rely on it for admission decisions.
+        """
+        now = time()
+        tokens_str = self.redis.hget(self.REDIS_KEY, "tokens")
+        last_refill_str = self.redis.hget(self.REDIS_KEY, "last_refill")
+
+        if tokens_str is None:
+            return 0
+
+        tokens = float(tokens_str if isinstance(tokens_str, str) else tokens_str.decode("utf-8"))
+        last_refill = float(last_refill_str if isinstance(last_refill_str, str) else last_refill_str.decode("utf-8"))
+
+        elapsed = now - last_refill
+        refill_rate = self.cap_per_minute / 60.0
+        tokens = min(self.cap_per_minute, tokens + elapsed * refill_rate)
+
+        return max(0, int(self.cap_per_minute - tokens))
+
+    def reset_limiter(self):
+        self.redis.delete(self.REDIS_KEY)
+        current_app.logger.info("SMS rate limiter (token bucket): reset")

--- a/app/rate_limiter.py
+++ b/app/rate_limiter.py
@@ -190,7 +190,7 @@ def _build_limiter_registry() -> dict[str, type[RateLimiter]]:
     """Lazily populate the registry after all classes are defined."""
     return {
         "InMemoryRateLimiter": InMemoryRateLimiter,
-        "RedisZSetRateLimiter": RedisZSetRateLimiter,
+        "RedisZSetRateLimiter": RedisSlidingWindowLogRateLimiter,
         "RedisTokenBucketRateLimiter": RedisTokenBucketRateLimiter,
     }
 
@@ -274,7 +274,7 @@ def get_rate_limiter() -> RateLimiter:
     return _rate_limiter_instance
 
 
-class RedisZSetRateLimiter(RateLimiter):
+class RedisSlidingWindowLogRateLimiter(RateLimiter):
     """
     Redis-backed SMS parts rate limiter using a 60-second sliding window.
 

--- a/app/rate_limiter.py
+++ b/app/rate_limiter.py
@@ -245,8 +245,7 @@ def initialize_rate_limiter(
 
         if class_name not in registry:
             logger.warning(
-                "Rate limiter: unknown class name %r in SMS_RATE_LIMITER_BACKEND; "
-                "falling back to InMemoryRateLimiter.",
+                "Rate limiter: unknown class name %r in SMS_RATE_LIMITER_BACKEND; " "falling back to InMemoryRateLimiter.",
                 class_name,
             )
             resolved_class = InMemoryRateLimiter
@@ -428,9 +427,7 @@ class RedisSlidingWindowLogRateLimiter(RateLimiter):
         success, wait_seconds = result[0], result[1]
 
         if success:
-            current_app.logger.debug(
-                f"Rate limiter [{self.namespace}]: acquired {units} units. Entry ID: {entry_id}"
-            )
+            current_app.logger.debug(f"Rate limiter [{self.namespace}]: acquired {units} units. Entry ID: {entry_id}")
         else:
             current_app.logger.warning(
                 f"Rate limiter [{self.namespace}]: capacity exhausted. Requested {units} units. "

--- a/app/rate_limiter.py
+++ b/app/rate_limiter.py
@@ -2,8 +2,8 @@
 """
 Rate Limiting Module
 
-This module provides rate limiting for SMS parts delivery. It enforces a cap
-on the number of SMS parts (fragments) that can be sent per minute.
+This module provides a generic rate limiter that enforces a cap on the number
+of units that can be acquired per minute.
 """
 
 import math
@@ -19,24 +19,24 @@ class RateLimiter(ABC):
     """
     Abstract base class defining the rate limiter interface.
 
-    Implementations should track parts capacity over time and enforce limits.
-    Phase 2 will provide a Redis-backed implementation.
+    Implementations should track unit capacity over time and enforce limits.
     """
 
-    def __init__(self, cap_per_minute: int) -> None:
+    def __init__(self, cap_per_minute: int, namespace: str) -> None:
         self.cap_per_minute = cap_per_minute
+        self.namespace = namespace
 
     @abstractmethod
-    def acquire_lease(self, parts_count: int) -> Tuple[bool, int]:
+    def acquire_lease(self, units: int) -> Tuple[bool, int]:
         """
-        Attempt to acquire a lease for the given number of SMS parts.
+        Attempt to acquire a lease for the given number of units.
 
         Args:
-            parts_count (int): Number of SMS parts (fragments) to send.
+            units (int): Number of units to acquire.
 
         Returns:
             Tuple[bool, int]:
-                - bool: True if parts can be sent now, False if rate limit hit.
+                - bool: True if units can be acquired now, False if rate limit hit.
                 - int: If True, returns 0. If False, returns seconds to wait before retry.
         """
         pass
@@ -44,26 +44,26 @@ class RateLimiter(ABC):
     @abstractmethod
     def get_current_usage(self) -> int:
         """
-        Get the current parts count in the active window.
+        Get the current unit count in the active window.
 
         Returns:
-            int: Number of parts used in the current window.
+            int: Number of units used in the current window.
         """
         pass
 
 
 class InMemoryRateLimiter(RateLimiter):
     """
-    In-memory SMS parts rate limiter using a 60-second sliding window.
+    In-memory rate limiter using a 60-second sliding window.
 
-    This implementation tracks parts sent in the current minute and enforces
-    the configured parts cap.
+    This implementation tracks units acquired in the current minute and enforces
+    the configured cap.
 
     Algorithm:
-    - Maintains a deque of (timestamp, parts_count) tuples.
+    - Maintains a deque of (timestamp, units) tuples.
     - Keeps a running total (current_usage) updated on append/popleft.
     - On each acquire_lease(), removes entries older than 60 seconds.
-    - Checks if current_usage + new_parts exceeds the cap.
+    - Checks if current_usage + new_units exceeds the cap.
     - If capacity available, records the entry and updates running total.
     - If capacity exhausted, calculates when enough entries will have expired
       to accommodate the new request.
@@ -71,66 +71,68 @@ class InMemoryRateLimiter(RateLimiter):
 
     WINDOW_SIZE_SECONDS = 60
 
-    def __init__(self, cap_per_minute: int):
+    def __init__(self, cap_per_minute: int, namespace: str):
         """
         Initialize the in-memory rate limiter.
 
         Args:
-            cap_per_minute (int): Maximum SMS parts allowed per minute.
-                                  E.g., 1000 parts/minute.
+            cap_per_minute (int): Maximum units allowed per minute.
+                                  E.g., 1000 units/minute.
+            namespace (str): Logical name for this limiter (used in log messages).
         """
-        super().__init__(cap_per_minute)
-        self.window: deque = deque()  # Stores (timestamp, parts_count) tuples
-        self.current_usage: int = 0  # Running total of parts in the current window
+        super().__init__(cap_per_minute, namespace)
+        self.window: deque = deque()  # Stores (timestamp, units) tuples
+        self.current_usage: int = 0  # Running total of units in the current window
 
-    def acquire_lease(self, parts_count: int) -> Tuple[bool, int]:
+    def acquire_lease(self, units: int) -> Tuple[bool, int]:
         """
-        Attempt to acquire capacity for SMS parts.
+        Attempt to acquire capacity for the given number of units.
 
         Args:
-            parts_count (int): Number of parts to send.
+            units (int): Number of units to acquire.
 
         Returns:
             Tuple[bool, int]:
-                - (True, 0) if parts can be sent immediately.
+                - (True, 0) if units can be acquired immediately.
                 - (False, seconds_remaining) if rate limit exhausted;
                   seconds_remaining is the time until enough entries expire to
-                  accommodate the requested parts.
+                  accommodate the requested units.
         """
-        if parts_count <= 0:
-            raise ValueError("parts_count must be positive")
+        if units <= 0:
+            raise ValueError("units must be positive")
 
-        if parts_count > self.cap_per_minute:
-            raise ValueError("parts_count must be smaller than or equal to the cap_per_minute")
+        if units > self.cap_per_minute:
+            raise ValueError("units must be smaller than or equal to the cap_per_minute")
 
         now = time()
         window_start = now - self.WINDOW_SIZE_SECONDS
 
         # Remove entries older than the 60-second window and update running total
         while self.window and self.window[0][0] < window_start:
-            _, old_parts = self.window.popleft()
-            self.current_usage -= old_parts
+            _, old_units = self.window.popleft()
+            self.current_usage -= old_units
 
-        # Check if adding new parts exceeds the cap
-        if self.current_usage + parts_count <= self.cap_per_minute:
-            # Enough parts available: record the entry and update running total
-            self.window.append((now, parts_count))
-            self.current_usage += parts_count
+        # Check if adding new units exceeds the cap
+        if self.current_usage + units <= self.cap_per_minute:
+            # Enough capacity available: record the entry and update running total
+            self.window.append((now, units))
+            self.current_usage += units
             current_app.logger.info(
-                f"SMS rate limiter: acquired {parts_count} parts. " f"Window usage: {self.current_usage}/{self.cap_per_minute}"
+                f"Rate limiter [{self.namespace}]: acquired {units} units. "
+                f"Window usage: {self.current_usage}/{self.cap_per_minute}"
             )
             return True, 0
 
-        # Not enough capacity: calculate when enough parts will be available for the new request
-        remaining_parts_needed = self.current_usage + parts_count - self.cap_per_minute
-        parts_freed = 0
+        # Not enough capacity: calculate when enough units will be available for the new request
+        units_needed = self.current_usage + units - self.cap_per_minute
+        units_freed = 0
         last_timestamp_to_wait_for = None
 
         # Iterate through window entries (oldest first) to find when we'll have enough space
-        for timestamp, parts in self.window:
-            parts_freed += parts
+        for timestamp, entry_units in self.window:
+            units_freed += entry_units
             last_timestamp_to_wait_for = timestamp
-            if parts_freed >= remaining_parts_needed:
+            if units_freed >= units_needed:
                 # This entry needs to expire to free enough space
                 break
 
@@ -143,7 +145,7 @@ class InMemoryRateLimiter(RateLimiter):
             seconds_to_wait = 1
 
         current_app.logger.warning(
-            f"SMS rate limiter: capacity exhausted. Requested {parts_count} parts "
+            f"Rate limiter [{self.namespace}]: capacity exhausted. Requested {units} units "
             f"but only {self.cap_per_minute - self.current_usage} available in current window. "
             f"Will retry in {seconds_to_wait} seconds."
         )
@@ -153,17 +155,17 @@ class InMemoryRateLimiter(RateLimiter):
         """Reset the rate limiter (clears all entries and running total)."""
         self.window.clear()
         self.current_usage = 0
-        current_app.logger.info("SMS rate limiter: reset (window cleared)")
+        current_app.logger.info(f"Rate limiter [{self.namespace}]: reset (window cleared)")
 
     def get_current_usage(self) -> int:
-        """Get the current parts count in the active 60-second window."""
+        """Get the current unit count in the active 60-second window."""
         now = time()
         window_start = now - self.WINDOW_SIZE_SECONDS
 
         # Remove expired entries and update running total
         while self.window and self.window[0][0] < window_start:
-            _, old_parts = self.window.popleft()
-            self.current_usage -= old_parts
+            _, old_units = self.window.popleft()
+            self.current_usage -= old_units
 
         return self.current_usage
 
@@ -178,8 +180,8 @@ class InMemoryRateLimiter(RateLimiter):
 #
 # As a result, the in-memory backend does not provide a true global cap unless
 # deployment is constrained so that only a single worker process/pod consumes
-# the relevant queue. Phase 2 should use a Redis-backed implementation to
-# enforce a global cross-process rate limit without changing task code.
+# the relevant queue. A Redis-backed implementation enforces a global
+# cross-process rate limit without changing task code.
 # ============================================================================
 
 _rate_limiter_instance: RateLimiter | None = None
@@ -194,7 +196,9 @@ def _build_limiter_registry() -> dict[str, type[RateLimiter]]:
     }
 
 
-def initialize_rate_limiter(cap_per_minute: int, limiter_class: type[RateLimiter] | None = None) -> RateLimiter:
+def initialize_rate_limiter(
+    cap_per_minute: int, limiter_class: type[RateLimiter] | None = None, *, namespace: str
+) -> RateLimiter:
     """
     Initialize the global rate limiter instance.
 
@@ -208,9 +212,11 @@ def initialize_rate_limiter(cap_per_minute: int, limiter_class: type[RateLimiter
     3. Default: InMemoryRateLimiter.
 
     Args:
-        cap_per_minute (int): Maximum SMS parts per minute.
+        cap_per_minute (int): Maximum units per minute.
         limiter_class (type[RateLimiter] | None): Implementation class to use.
             If None, the class is resolved from config/default.
+        namespace (str): Logical name for this limiter instance (e.g. "sms").
+            Used in Redis key construction and log messages.
 
     Returns:
         RateLimiter: The initialized rate limiter instance.
@@ -232,22 +238,23 @@ def initialize_rate_limiter(cap_per_minute: int, limiter_class: type[RateLimiter
             class_name = getattr(Config, "SMS_RATE_LIMITER_BACKEND", "InMemoryRateLimiter")
         except (ImportError, AttributeError) as exc:
             logger.warning(
-                "SMS rate limiter: failed to read SMS_RATE_LIMITER_BACKEND from config; "
+                "Rate limiter: failed to read SMS_RATE_LIMITER_BACKEND from config; "
                 "falling back to InMemoryRateLimiter. Error: %s",
                 exc,
             )
 
         if class_name not in registry:
             logger.warning(
-                "SMS rate limiter: unknown class name %r in SMS_RATE_LIMITER_BACKEND; " "falling back to InMemoryRateLimiter.",
+                "Rate limiter: unknown class name %r in SMS_RATE_LIMITER_BACKEND; "
+                "falling back to InMemoryRateLimiter.",
                 class_name,
             )
             resolved_class = InMemoryRateLimiter
         else:
             resolved_class = registry[class_name]
 
-    logger.info("SMS rate limiter: initializing with %s", resolved_class.__name__)
-    _rate_limiter_instance = resolved_class(cap_per_minute)
+    logger.info("Rate limiter [%s]: initializing with %s", namespace, resolved_class.__name__)
+    _rate_limiter_instance = resolved_class(cap_per_minute, namespace)
 
     return _rate_limiter_instance
 
@@ -267,36 +274,38 @@ def get_rate_limiter() -> RateLimiter:
     """
     if _rate_limiter_instance is None:
         raise RuntimeError(
-            "SMS rate limiter not initialized. " "Call initialize_rate_limiter() during app startup (app/__init__.py)."
+            "Rate limiter not initialized. " "Call initialize_rate_limiter() during app startup (app/__init__.py)."
         )
     return _rate_limiter_instance
 
 
 class RedisSlidingWindowLogRateLimiter(RateLimiter):
     """
-    Redis-backed SMS parts rate limiter using a 60-second sliding window.
+    Redis-backed rate limiter using a 60-second sliding window.
 
     Key structure:
-    - `sms:rate_limit:entries` (sorted set)
+    - `app.rate_limit:{namespace}:entries` (sorted set)
       - Score: timestamp of when entry was added
-      - Member: "entry_id:parts_count" (parts count is encoded in the member)
+      - Member: "entry_id:units" (unit count is encoded in the member)
 
     This approach avoids separate key tracking and usage cache inconsistency.
-    Parts counts are extracted via regex when needed.
+    Unit counts are extracted by splitting on ":" when needed.
     """
 
     WINDOW_SIZE_SECONDS = 60
-    REDIS_KEY_ENTRIES = "sms:rate_limit:entries"
 
-    def __init__(self, cap_per_minute: int, redis_client=None):
+    def __init__(self, cap_per_minute: int, namespace: str, redis_client=None):
         """
         Initialize the Redis-backed rate limiter.
 
         Args:
-            cap_per_minute (int): Maximum SMS parts allowed per minute.
+            cap_per_minute (int): Maximum units allowed per minute.
+            namespace (str): Logical name for this limiter instance (e.g. "sms").
+                Used to construct the Redis key: app.rate_limit:{namespace}:entries.
             redis_client: Redis client instance. If None, uses app's redis_store.
         """
-        super().__init__(cap_per_minute)
+        super().__init__(cap_per_minute, namespace)
+        self._entries_key = f"app.rate_limit:{namespace}:entries"
         self.redis_client = redis_client
         self._lua_scripts: dict[str, object] = {}
 
@@ -315,7 +324,7 @@ class RedisSlidingWindowLogRateLimiter(RateLimiter):
             local entries_key = KEYS[1]
 
             local cap_per_minute = tonumber(ARGV[1])
-            local parts_count = tonumber(ARGV[2])
+            local units = tonumber(ARGV[2])
             local now = tonumber(ARGV[3])
             local entry_id = ARGV[4]
             local window_size = tonumber(ARGV[5])
@@ -325,20 +334,20 @@ class RedisSlidingWindowLogRateLimiter(RateLimiter):
             -- 1. Remove expired entries
             redis.call('ZREMRANGEBYSCORE', entries_key, '-inf', '(' .. window_start)
 
-            -- 2. Compute current usage by summing parts from members
+            -- 2. Compute current usage by summing units from members
             local current_usage = 0
             local entries = redis.call('ZRANGE', entries_key, 0, -1)
 
             for i = 1, #entries do
                 local member = entries[i]
                 local sep = string.find(member, ":")
-                local parts = tonumber(string.sub(member, sep + 1)) or 0
-                current_usage = current_usage + parts
+                local entry_units = tonumber(string.sub(member, sep + 1)) or 0
+                current_usage = current_usage + entry_units
             end
 
             -- 3. Check capacity
-            if current_usage + parts_count <= cap_per_minute then
-                local member = entry_id .. ":" .. parts_count
+            if current_usage + units <= cap_per_minute then
+                local member = entry_id .. ":" .. units
 
                 redis.call('ZADD', entries_key, now, member)
                 redis.call('EXPIRE', entries_key, window_size + 10)
@@ -346,8 +355,8 @@ class RedisSlidingWindowLogRateLimiter(RateLimiter):
                 return {1, 0}
             else
                 -- 4. Calculate wait time
-                local remaining_needed = current_usage + parts_count - cap_per_minute
-                local parts_freed = 0
+                local units_needed = current_usage + units - cap_per_minute
+                local units_freed = 0
                 local last_timestamp_to_wait = nil
 
                 local entries_with_scores = redis.call('ZRANGE', entries_key, 0, -1, 'WITHSCORES')
@@ -357,11 +366,11 @@ class RedisSlidingWindowLogRateLimiter(RateLimiter):
                     local timestamp = tonumber(entries_with_scores[i + 1])
 
                     local sep = string.find(member, ":")
-                    local parts = tonumber(string.sub(member, sep + 1)) or 0
-                    parts_freed = parts_freed + parts
+                    local entry_units = tonumber(string.sub(member, sep + 1)) or 0
+                    units_freed = units_freed + entry_units
                     last_timestamp_to_wait = timestamp
 
-                    if parts_freed >= remaining_needed then
+                    if units_freed >= units_needed then
                         break
                     end
                 end
@@ -379,25 +388,25 @@ class RedisSlidingWindowLogRateLimiter(RateLimiter):
 
         return self._lua_scripts["acquire"]
 
-    def acquire_lease(self, parts_count: int) -> Tuple[bool, int]:
+    def acquire_lease(self, units: int) -> Tuple[bool, int]:
         """
-        Attempt to acquire capacity for SMS parts.
+        Attempt to acquire capacity for the given number of units.
 
         Args:
-            parts_count (int): Number of parts (fragments) to send.
+            units (int): Number of units to acquire.
 
         Returns:
             Tuple[bool, int]:
-                - (True, 0) if parts can be sent immediately.
+                - (True, 0) if units can be acquired immediately.
                 - (False, seconds_remaining) if rate limit exhausted;
                   seconds_remaining is the time until enough entries expire to
-                  accommodate the requested parts.
+                  accommodate the requested units.
         """
-        if parts_count <= 0:
-            raise ValueError("parts_count must be positive")
+        if units <= 0:
+            raise ValueError("units must be positive")
 
-        if parts_count > self.cap_per_minute:
-            raise ValueError("parts_count must be smaller than or equal to the cap_per_minute")
+        if units > self.cap_per_minute:
+            raise ValueError("units must be smaller than or equal to the cap_per_minute")
 
         import uuid
 
@@ -406,10 +415,10 @@ class RedisSlidingWindowLogRateLimiter(RateLimiter):
 
         script = self._get_acquire_lua_script()
         result = script(
-            keys=[self.REDIS_KEY_ENTRIES],
+            keys=[self._entries_key],
             args=[
                 self.cap_per_minute,
-                parts_count,
+                units,
                 now,
                 entry_id,
                 self.WINDOW_SIZE_SECONDS,
@@ -419,79 +428,82 @@ class RedisSlidingWindowLogRateLimiter(RateLimiter):
         success, wait_seconds = result[0], result[1]
 
         if success:
-            current_app.logger.debug(f"SMS rate limiter (Redis): acquired {parts_count} parts. " f"Entry ID: {entry_id}")
+            current_app.logger.debug(
+                f"Rate limiter [{self.namespace}]: acquired {units} units. Entry ID: {entry_id}"
+            )
         else:
             current_app.logger.warning(
-                f"SMS rate limiter (Redis): capacity exhausted. Requested {parts_count} parts. "
+                f"Rate limiter [{self.namespace}]: capacity exhausted. Requested {units} units. "
                 f"Will retry in {wait_seconds} seconds."
             )
 
         return bool(success), wait_seconds
 
     def get_current_usage(self) -> int:
-        """Get the current parts count in the active 60-second window from Redis."""
+        """Get the current unit count in the active 60-second window from Redis."""
         now = time()
         window_start = now - self.WINDOW_SIZE_SECONDS
 
         # Remove expired entries
-        self.redis.zremrangebyscore(self.REDIS_KEY_ENTRIES, "-inf", f"({window_start}")
+        self.redis.zremrangebyscore(self._entries_key, "-inf", f"({window_start}")
 
-        # Recalculate usage by summing parts from members (encoded as "entry_id:parts")
+        # Recalculate usage by summing units from members (encoded as "entry_id:units")
         current_usage = 0
-        entries = self.redis.zrange(self.REDIS_KEY_ENTRIES, 0, -1)
+        entries = self.redis.zrange(self._entries_key, 0, -1)
         for member in entries:
-            # Extract parts count from member string format "entry_id:parts_count"
+            # Extract unit count from member string format "entry_id:units"
             if isinstance(member, bytes):
                 member = member.decode("utf-8")
-            parts_str = member.split(":")[-1] if ":" in member else "0"
+            units_str = member.split(":")[-1] if ":" in member else "0"
             try:
-                current_usage += int(parts_str)
+                current_usage += int(units_str)
             except ValueError:
                 current_app.logger.warning(
-                    f"SMS rate limiter (Redis): skipping malformed usage entry member={member!r}, parts={parts_str!r}"
+                    f"Rate limiter [{self.namespace}]: skipping malformed usage entry member={member!r}, units={units_str!r}"
                 )
 
         return current_usage
 
     def reset_limiter(self):
-        self.redis.delete(self.REDIS_KEY_ENTRIES)
+        self.redis.delete(self._entries_key)
 
-        current_app.logger.info("SMS rate limiter entries cleared")
+        current_app.logger.info(f"Rate limiter [{self.namespace}]: entries cleared")
 
 
 class RedisTokenBucketRateLimiter(RateLimiter):
     """
-    Redis-backed SMS parts rate limiter using a token bucket algorithm.
+    Redis-backed rate limiter using a token bucket algorithm.
 
     Key structure:
-    - `sms:rate_limit:token_bucket` (hash)
+    - `app.rate_limit:{namespace}:token_bucket` (hash)
       - Field `tokens`: current available capacity (float, stored as string)
       - Field `last_refill`: timestamp of last refill (float, stored as string)
 
     Algorithm:
     - Tokens refill continuously at rate cap_per_minute / 60 per second.
     - On each request, elapsed time since last refill is computed, tokens are
-      topped up (capped at cap_per_minute), and the requested parts are
+      topped up (capped at cap_per_minute), and the requested units are
       subtracted atomically in Lua.
     - If tokens are insufficient, the exact wait time is returned:
       deficit / (cap_per_minute / 60) seconds.
     - Burst after idle: if the system is idle, the bucket refills to cap,
-      allowing a full cap's worth of parts to be sent immediately.
+      allowing a full cap's worth of units to be acquired immediately.
 
     Complexity: O(1) for all operations.
     """
 
-    REDIS_KEY = "sms:rate_limit:token_bucket"
-
-    def __init__(self, cap_per_minute: int, redis_client=None):
+    def __init__(self, cap_per_minute: int, namespace: str, redis_client=None):
         """
         Initialize the Redis token bucket rate limiter.
 
         Args:
-            cap_per_minute (int): Maximum SMS parts allowed per minute.
+            cap_per_minute (int): Maximum units allowed per minute.
+            namespace (str): Logical name for this limiter instance (e.g. "sms").
+                Used to construct the Redis key: app.rate_limit:{namespace}:token_bucket.
             redis_client: Redis client instance. If None, uses app's redis_store.
         """
-        super().__init__(cap_per_minute)
+        super().__init__(cap_per_minute, namespace)
+        self._key = f"app.rate_limit:{namespace}:token_bucket"
         self.redis_client = redis_client
         self._lua_scripts: dict[str, object] = {}
 
@@ -509,7 +521,7 @@ class RedisTokenBucketRateLimiter(RateLimiter):
             lua_code = """
             local key = KEYS[1]
             local cap = tonumber(ARGV[1])
-            local parts_count = tonumber(ARGV[2])
+            local units = tonumber(ARGV[2])
             local now = tonumber(ARGV[3])
             local refill_rate = cap / 60.0
 
@@ -533,14 +545,14 @@ class RedisTokenBucketRateLimiter(RateLimiter):
             local elapsed = now - last_refill
             tokens = math.min(cap, tokens + elapsed * refill_rate)
 
-            if tokens >= parts_count then
-                -- Admit: subtract parts and persist new state
-                tokens = tokens - parts_count
+            if tokens >= units then
+                -- Admit: subtract units and persist new state
+                tokens = tokens - units
                 redis.call('HSET', key, 'tokens', tostring(tokens), 'last_refill', tostring(now))
                 return {1, 0}
             else
                 -- Reject: compute exact wait time
-                local deficit = parts_count - tokens
+                local deficit = units - tokens
                 local seconds_to_wait = math.ceil(deficit / refill_rate)
                 seconds_to_wait = math.max(1, seconds_to_wait)
                 -- Persist refreshed token count and timestamp even on reject
@@ -552,39 +564,39 @@ class RedisTokenBucketRateLimiter(RateLimiter):
 
         return self._lua_scripts["acquire"]
 
-    def acquire_lease(self, parts_count: int) -> Tuple[bool, int]:
+    def acquire_lease(self, units: int) -> Tuple[bool, int]:
         """
-        Attempt to acquire capacity for SMS parts.
+        Attempt to acquire capacity for the given number of units.
 
         Args:
-            parts_count (int): Number of parts (fragments) to send.
+            units (int): Number of units to acquire.
 
         Returns:
             Tuple[bool, int]:
-                - (True, 0) if parts can be sent immediately.
+                - (True, 0) if units can be acquired immediately.
                 - (False, seconds_remaining) if rate limit exhausted;
                   seconds_remaining is the exact time until enough tokens refill.
         """
-        if parts_count <= 0:
-            raise ValueError("parts_count must be positive")
+        if units <= 0:
+            raise ValueError("units must be positive")
 
-        if parts_count > self.cap_per_minute:
-            raise ValueError("parts_count must be smaller than or equal to the cap_per_minute")
+        if units > self.cap_per_minute:
+            raise ValueError("units must be smaller than or equal to the cap_per_minute")
 
         now = time()
         script = self._get_acquire_lua_script()
         result = script(
-            keys=[self.REDIS_KEY],
-            args=[self.cap_per_minute, parts_count, now],
+            keys=[self._key],
+            args=[self.cap_per_minute, units, now],
         )
 
         success, wait_seconds = result[0], result[1]
 
         if success:
-            current_app.logger.debug(f"SMS rate limiter (token bucket): acquired {parts_count} parts.")
+            current_app.logger.debug(f"Rate limiter [{self.namespace}]: acquired {units} units.")
         else:
             current_app.logger.warning(
-                f"SMS rate limiter (token bucket): capacity exhausted. Requested {parts_count} parts. "
+                f"Rate limiter [{self.namespace}]: capacity exhausted. Requested {units} units. "
                 f"Will retry in {wait_seconds} seconds."
             )
 
@@ -598,8 +610,8 @@ class RedisTokenBucketRateLimiter(RateLimiter):
         This is a non-atomic read — do not rely on it for admission decisions.
         """
         now = time()
-        tokens_str = self.redis.hget(self.REDIS_KEY, "tokens")
-        last_refill_str = self.redis.hget(self.REDIS_KEY, "last_refill")
+        tokens_str = self.redis.hget(self._key, "tokens")
+        last_refill_str = self.redis.hget(self._key, "last_refill")
 
         if tokens_str is None or last_refill_str is None:
             return 0
@@ -614,5 +626,5 @@ class RedisTokenBucketRateLimiter(RateLimiter):
         return max(0, int(self.cap_per_minute - tokens))
 
     def reset_limiter(self):
-        self.redis.delete(self.REDIS_KEY)
-        current_app.logger.info("SMS rate limiter (token bucket): reset")
+        self.redis.delete(self._key)
+        current_app.logger.info(f"Rate limiter [{self.namespace}]: reset (token bucket)")

--- a/app/rate_limiter.py
+++ b/app/rate_limiter.py
@@ -80,7 +80,6 @@ class InMemoryRateLimiter(RateLimiter):
                                   E.g., 1000 parts/minute.
         """
         super().__init__(cap_per_minute)
-        self.cap_per_minute = cap_per_minute
         self.window: deque = deque()  # Stores (timestamp, parts_count) tuples
         self.current_usage: int = 0  # Running total of parts in the current window
 
@@ -298,7 +297,6 @@ class RedisSlidingWindowLogRateLimiter(RateLimiter):
             redis_client: Redis client instance. If None, uses app's redis_store.
         """
         super().__init__(cap_per_minute)
-        self.cap_per_minute = cap_per_minute
         self.redis_client = redis_client
         self._lua_scripts: dict[str, object] = {}
 
@@ -494,7 +492,6 @@ class RedisTokenBucketRateLimiter(RateLimiter):
             redis_client: Redis client instance. If None, uses app's redis_store.
         """
         super().__init__(cap_per_minute)
-        self.cap_per_minute = cap_per_minute
         self.redis_client = redis_client
         self._lua_scripts: dict[str, object] = {}
 

--- a/app/rate_limiter.py
+++ b/app/rate_limiter.py
@@ -79,6 +79,7 @@ class InMemoryRateLimiter(RateLimiter):
             cap_per_minute (int): Maximum SMS parts allowed per minute.
                                   E.g., 1000 parts/minute.
         """
+        super().__init__(cap_per_minute)
         self.cap_per_minute = cap_per_minute
         self.window: deque = deque()  # Stores (timestamp, parts_count) tuples
         self.current_usage: int = 0  # Running total of parts in the current window
@@ -296,6 +297,7 @@ class RedisSlidingWindowLogRateLimiter(RateLimiter):
             cap_per_minute (int): Maximum SMS parts allowed per minute.
             redis_client: Redis client instance. If None, uses app's redis_store.
         """
+        super().__init__(cap_per_minute)
         self.cap_per_minute = cap_per_minute
         self.redis_client = redis_client
         self._lua_scripts: dict[str, object] = {}
@@ -491,6 +493,7 @@ class RedisTokenBucketRateLimiter(RateLimiter):
             cap_per_minute (int): Maximum SMS parts allowed per minute.
             redis_client: Redis client instance. If None, uses app's redis_store.
         """
+        super().__init__(cap_per_minute)
         self.cap_per_minute = cap_per_minute
         self.redis_client = redis_client
         self._lua_scripts: dict[str, object] = {}

--- a/app/rate_limiter.py
+++ b/app/rate_limiter.py
@@ -419,7 +419,7 @@ class RedisSlidingWindowLogRateLimiter(RateLimiter):
         success, wait_seconds = result[0], result[1]
 
         if success:
-            current_app.logger.info(f"SMS rate limiter (Redis): acquired {parts_count} parts. " f"Entry ID: {entry_id}")
+            current_app.logger.debug(f"SMS rate limiter (Redis): acquired {parts_count} parts. " f"Entry ID: {entry_id}")
         else:
             current_app.logger.warning(
                 f"SMS rate limiter (Redis): capacity exhausted. Requested {parts_count} parts. "
@@ -523,8 +523,10 @@ class RedisTokenBucketRateLimiter(RateLimiter):
                 tokens = cap
                 last_refill = now
             else
-                tokens = tonumber(tokens_str)
-                last_refill = tonumber(last_refill_str)
+                -- Default to cap or now if tokens and last refill aren't available
+                -- for defensive programming reasons.
+                tokens = tonumber(tokens_str) or cap
+                last_refill = tonumber(last_refill_str) or now
             end
 
             -- Refill tokens based on elapsed time
@@ -579,7 +581,7 @@ class RedisTokenBucketRateLimiter(RateLimiter):
         success, wait_seconds = result[0], result[1]
 
         if success:
-            current_app.logger.info(f"SMS rate limiter (token bucket): acquired {parts_count} parts.")
+            current_app.logger.debug(f"SMS rate limiter (token bucket): acquired {parts_count} parts.")
         else:
             current_app.logger.warning(
                 f"SMS rate limiter (token bucket): capacity exhausted. Requested {parts_count} parts. "

--- a/tests/app/test_rate_limiter.py
+++ b/tests/app/test_rate_limiter.py
@@ -3,7 +3,12 @@ from unittest.mock import patch
 import fakeredis
 import pytest
 
-from app.rate_limiter import InMemoryRateLimiter, RedisTokenBucketRateLimiter, RedisZSetRateLimiter, initialize_rate_limiter
+from app.rate_limiter import (
+    InMemoryRateLimiter,
+    RedisSlidingWindowLogRateLimiter,
+    RedisTokenBucketRateLimiter,
+    initialize_rate_limiter,
+)
 
 
 class TestInMemoryRateLimiter:
@@ -196,7 +201,7 @@ class TestRedisRateLimiter:
     @pytest.fixture
     def limiter(self):
         redis_client = fakeredis.FakeRedis()
-        return RedisZSetRateLimiter(cap_per_minute=1000, redis_client=redis_client)
+        return RedisSlidingWindowLogRateLimiter(cap_per_minute=1000, redis_client=redis_client)
 
     def test_acquire_lease_below_capacity_succeeds(self, client, limiter):
         with client.application.app_context():
@@ -488,7 +493,7 @@ class TestInitializeRateLimiter:
             with patch("app.rate_limiter._build_limiter_registry") as mock_registry:
                 mock_registry.return_value = {
                     "InMemoryRateLimiter": InMemoryRateLimiter,
-                    "RedisZSetRateLimiter": RedisZSetRateLimiter,
+                    "RedisZSetRateLimiter": RedisSlidingWindowLogRateLimiter,
                     "RedisTokenBucketRateLimiter": RedisTokenBucketRateLimiter,
                 }
                 with patch("app.rate_limiter.InMemoryRateLimiter", InMemoryRateLimiter):
@@ -501,19 +506,19 @@ class TestInitializeRateLimiter:
             with patch("app.rate_limiter._build_limiter_registry") as mock_registry:
                 mock_registry.return_value = {
                     "InMemoryRateLimiter": InMemoryRateLimiter,
-                    "RedisZSetRateLimiter": RedisZSetRateLimiter,
+                    "RedisZSetRateLimiter": RedisSlidingWindowLogRateLimiter,
                     "RedisTokenBucketRateLimiter": RedisTokenBucketRateLimiter,
                 }
                 with patch("app.config.Config.SMS_RATE_LIMITER_BACKEND", "RedisZSetRateLimiter", create=True):
                     instance = initialize_rate_limiter(1000)
-                    assert isinstance(instance, RedisZSetRateLimiter)
+                    assert isinstance(instance, RedisSlidingWindowLogRateLimiter)
 
     def test_unknown_config_name_falls_back_to_in_memory(self, client):
         with client.application.app_context():
             with patch("app.rate_limiter._build_limiter_registry") as mock_registry:
                 mock_registry.return_value = {
                     "InMemoryRateLimiter": InMemoryRateLimiter,
-                    "RedisZSetRateLimiter": RedisZSetRateLimiter,
+                    "RedisZSetRateLimiter": RedisSlidingWindowLogRateLimiter,
                     "RedisTokenBucketRateLimiter": RedisTokenBucketRateLimiter,
                 }
                 with patch("app.config.Config.SMS_RATE_LIMITER_BACKEND", "UnknownClass", create=True):

--- a/tests/app/test_rate_limiter.py
+++ b/tests/app/test_rate_limiter.py
@@ -15,7 +15,7 @@ from app.rate_limiter import (
 class TestInMemoryRateLimiter:
     @pytest.fixture
     def limiter(self):
-        return InMemoryRateLimiter(cap_per_minute=1000)
+        return InMemoryRateLimiter(cap_per_minute=1000, namespace="test")
 
     def test_acquire_lease_below_capacity_succeeds(self, client, limiter):
         with client.application.app_context():
@@ -202,7 +202,7 @@ class TestRedisRateLimiter:
     @pytest.fixture
     def limiter(self):
         redis_client = fakeredis.FakeRedis()
-        return RedisSlidingWindowLogRateLimiter(cap_per_minute=1000, redis_client=redis_client)
+        return RedisSlidingWindowLogRateLimiter(cap_per_minute=1000, namespace="test", redis_client=redis_client)
 
     def test_acquire_lease_below_capacity_succeeds(self, client, limiter):
         with client.application.app_context():
@@ -348,7 +348,7 @@ class TestRedisTokenBucketRateLimiter:
     @pytest.fixture
     def limiter(self):
         redis_client = fakeredis.FakeRedis()
-        return RedisTokenBucketRateLimiter(cap_per_minute=1000, redis_client=redis_client)
+        return RedisTokenBucketRateLimiter(cap_per_minute=1000, namespace="test", redis_client=redis_client)
 
     def test_acquire_lease_below_capacity_succeeds(self, client, limiter):
         with client.application.app_context():
@@ -480,12 +480,12 @@ class TestInitializeRateLimiter:
 
     def test_explicit_class_arg_takes_precedence(self, client):
         with client.application.app_context():
-            instance = initialize_rate_limiter(1000, RedisTokenBucketRateLimiter)
+            instance = initialize_rate_limiter(1000, RedisTokenBucketRateLimiter, namespace="test")
             assert isinstance(instance, RedisTokenBucketRateLimiter)
 
     def test_explicit_in_memory_class_arg(self, client):
         with client.application.app_context():
-            instance = initialize_rate_limiter(1000, InMemoryRateLimiter)
+            instance = initialize_rate_limiter(1000, InMemoryRateLimiter, namespace="test")
             assert isinstance(instance, InMemoryRateLimiter)
 
     def test_config_name_resolves_token_bucket(self, client):
@@ -498,7 +498,7 @@ class TestInitializeRateLimiter:
                 }
                 with patch("app.rate_limiter.InMemoryRateLimiter", InMemoryRateLimiter):
                     with patch("app.config.Config.SMS_RATE_LIMITER_BACKEND", "RedisTokenBucketRateLimiter", create=True):
-                        instance = initialize_rate_limiter(1000)
+                        instance = initialize_rate_limiter(1000, namespace="test")
                         assert isinstance(instance, RedisTokenBucketRateLimiter)
 
     def test_config_name_resolves_zset(self, client):
@@ -510,7 +510,7 @@ class TestInitializeRateLimiter:
                     "RedisTokenBucketRateLimiter": RedisTokenBucketRateLimiter,
                 }
                 with patch("app.config.Config.SMS_RATE_LIMITER_BACKEND", "RedisSlidingWindowLogRateLimiter", create=True):
-                    instance = initialize_rate_limiter(1000)
+                    instance = initialize_rate_limiter(1000, namespace="test")
                     assert isinstance(instance, RedisSlidingWindowLogRateLimiter)
 
     def test_unknown_config_name_falls_back_to_in_memory(self, client):
@@ -522,11 +522,11 @@ class TestInitializeRateLimiter:
                     "RedisTokenBucketRateLimiter": RedisTokenBucketRateLimiter,
                 }
                 with patch("app.config.Config.SMS_RATE_LIMITER_BACKEND", "UnknownClass", create=True):
-                    instance = initialize_rate_limiter(1000)
+                    instance = initialize_rate_limiter(1000, namespace="test")
                     assert isinstance(instance, InMemoryRateLimiter)
 
     def test_default_no_args_uses_in_memory(self, client):
         with client.application.app_context():
             with patch("app.config.Config.SMS_RATE_LIMITER_BACKEND", "InMemoryRateLimiter", create=True):
-                instance = initialize_rate_limiter(1000)
+                instance = initialize_rate_limiter(1000, namespace="test")
                 assert isinstance(instance, InMemoryRateLimiter)

--- a/tests/app/test_rate_limiter.py
+++ b/tests/app/test_rate_limiter.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 import fakeredis
 import pytest
 
-from app.rate_limiter import InMemoryRateLimiter, RedisZSetRateLimiter
+from app.rate_limiter import InMemoryRateLimiter, RedisTokenBucketRateLimiter, RedisZSetRateLimiter, initialize_rate_limiter
 
 
 class TestInMemoryRateLimiter:
@@ -336,3 +336,192 @@ class TestRedisRateLimiter:
 
                 mock_time.return_value = base_time + 59.9
                 assert limiter.get_current_usage() == 50
+
+
+class TestRedisTokenBucketRateLimiter:
+    @pytest.fixture
+    def limiter(self):
+        redis_client = fakeredis.FakeRedis()
+        return RedisTokenBucketRateLimiter(cap_per_minute=1000, redis_client=redis_client)
+
+    def test_acquire_lease_below_capacity_succeeds(self, client, limiter):
+        with client.application.app_context():
+            allow_send, wait_seconds = limiter.acquire_lease(100)
+            assert allow_send is True
+            assert wait_seconds == 0
+
+    def test_acquire_lease_at_capacity_succeeds(self, client, limiter):
+        with client.application.app_context():
+            allow_send, wait_seconds = limiter.acquire_lease(1000)
+            assert allow_send is True
+            assert wait_seconds == 0
+
+    def test_acquire_lease_exceeding_capacity_fails(self, client, limiter):
+        with client.application.app_context():
+            limiter.acquire_lease(1000)
+            allow_send, wait_seconds = limiter.acquire_lease(100)
+            assert allow_send is False
+            assert wait_seconds > 0
+
+    def test_acquire_with_zero_parts_raises_error(self, client, limiter):
+        with client.application.app_context():
+            with pytest.raises(ValueError):
+                limiter.acquire_lease(0)
+
+    def test_acquire_negative_parts_raises_error(self, client, limiter):
+        with client.application.app_context():
+            with pytest.raises(ValueError):
+                limiter.acquire_lease(-10)
+
+    def test_acquire_over_capacity_raises_error(self, client, limiter):
+        with client.application.app_context():
+            with pytest.raises(ValueError):
+                limiter.acquire_lease(limiter.cap_per_minute + 1)
+
+    def test_get_current_usage_returns_consumed_parts(self, client, limiter):
+        with client.application.app_context():
+            with patch("app.rate_limiter.time") as mock_time:
+                mock_time.return_value = 100.0
+                limiter.acquire_lease(150)
+                limiter.acquire_lease(250)
+                # freeze time so no refill occurs during get_current_usage
+                assert limiter.get_current_usage() == 400
+
+    def test_get_current_usage_zero_when_bucket_empty(self, client, limiter):
+        with client.application.app_context():
+            assert limiter.get_current_usage() == 0
+
+    def test_retry_delay_is_precise(self, client, limiter):
+        # Token bucket wait time = ceil(deficit / refill_rate)
+        # refill_rate = 1000 / 60 ≈ 16.67 parts/sec
+        # After consuming 1000/1000, requesting 100 more:
+        # deficit = 100, wait = ceil(100 / 16.67) = ceil(5.999) = 6
+        with client.application.app_context():
+            with patch("app.rate_limiter.time") as mock_time:
+                mock_time.return_value = 100.0
+                limiter.acquire_lease(1000)
+                allow_send, wait_seconds = limiter.acquire_lease(100)
+                assert allow_send is False
+                import math
+                expected = math.ceil(100 / (1000 / 60))
+                assert wait_seconds == expected
+
+    def test_capacity_refills_over_time(self, client, limiter):
+        with client.application.app_context():
+            with patch("app.rate_limiter.time") as mock_time:
+                mock_time.return_value = 100.0
+                limiter.acquire_lease(1000)
+
+                # Advance 30 seconds — should have refilled 1000/60 * 30 = 500 tokens
+                mock_time.return_value = 130.0
+                allow_send, _ = limiter.acquire_lease(500)
+                assert allow_send is True
+
+    def test_bucket_does_not_exceed_cap_after_idle(self, client, limiter):
+        with client.application.app_context():
+            with patch("app.rate_limiter.time") as mock_time:
+                mock_time.return_value = 100.0
+                limiter.acquire_lease(500)
+
+                # Advance 120 seconds — bucket should be capped at 1000, not 500 + 1000/60*120
+                mock_time.return_value = 220.0
+                allow_send, _ = limiter.acquire_lease(1000)
+                assert allow_send is True
+
+    def test_burst_after_idle_allows_full_cap(self, client, limiter):
+        with client.application.app_context():
+            with patch("app.rate_limiter.time") as mock_time:
+                mock_time.return_value = 100.0
+                # Use up full capacity
+                limiter.acquire_lease(1000)
+
+                # Advance 60 seconds — bucket fully refilled
+                mock_time.return_value = 160.0
+                allow_send, _ = limiter.acquire_lease(1000)
+                assert allow_send is True
+
+    def test_reset_clears_bucket(self, client, limiter):
+        with client.application.app_context():
+            with patch("app.rate_limiter.time") as mock_time:
+                mock_time.return_value = 100.0
+                limiter.acquire_lease(1000)
+                allow_send, _ = limiter.acquire_lease(100)
+                assert allow_send is False
+
+                limiter.reset_limiter()
+                # After reset, bucket is gone; next call initialises fresh full bucket
+                allow_send, _ = limiter.acquire_lease(1000)
+                assert allow_send is True
+
+    def test_multiple_sequential_acquires_deplete_tokens(self, client, limiter):
+        with client.application.app_context():
+            with patch("app.rate_limiter.time") as mock_time:
+                mock_time.return_value = 100.0
+                limiter.acquire_lease(400)
+                limiter.acquire_lease(400)
+                limiter.acquire_lease(200)
+                # Bucket now at 0
+                allow_send, _ = limiter.acquire_lease(1)
+                assert allow_send is False
+
+
+class TestInitializeRateLimiter:
+    def teardown_method(self):
+        # Reset global singleton between tests
+        import app.rate_limiter as rl
+        rl._rate_limiter_instance = None
+
+    def test_explicit_class_arg_takes_precedence(self, client):
+        with client.application.app_context():
+            redis_client = fakeredis.FakeRedis()
+            # Pass class directly; config should be ignored
+            instance = initialize_rate_limiter(1000, RedisTokenBucketRateLimiter)
+            assert isinstance(instance, RedisTokenBucketRateLimiter)
+
+    def test_explicit_in_memory_class_arg(self, client):
+        with client.application.app_context():
+            instance = initialize_rate_limiter(1000, InMemoryRateLimiter)
+            assert isinstance(instance, InMemoryRateLimiter)
+
+    def test_config_name_resolves_token_bucket(self, client):
+        with client.application.app_context():
+            with patch("app.rate_limiter._build_limiter_registry") as mock_registry:
+                mock_registry.return_value = {
+                    "InMemoryRateLimiter": InMemoryRateLimiter,
+                    "RedisZSetRateLimiter": RedisZSetRateLimiter,
+                    "RedisTokenBucketRateLimiter": RedisTokenBucketRateLimiter,
+                }
+                with patch("app.rate_limiter.InMemoryRateLimiter", InMemoryRateLimiter):
+                    with patch("app.config.Config.SMS_RATE_LIMITER_BACKEND", "RedisTokenBucketRateLimiter", create=True):
+                        instance = initialize_rate_limiter(1000)
+                        assert isinstance(instance, RedisTokenBucketRateLimiter)
+
+    def test_config_name_resolves_zset(self, client):
+        with client.application.app_context():
+            with patch("app.rate_limiter._build_limiter_registry") as mock_registry:
+                mock_registry.return_value = {
+                    "InMemoryRateLimiter": InMemoryRateLimiter,
+                    "RedisZSetRateLimiter": RedisZSetRateLimiter,
+                    "RedisTokenBucketRateLimiter": RedisTokenBucketRateLimiter,
+                }
+                with patch("app.config.Config.SMS_RATE_LIMITER_BACKEND", "RedisZSetRateLimiter", create=True):
+                    instance = initialize_rate_limiter(1000)
+                    assert isinstance(instance, RedisZSetRateLimiter)
+
+    def test_unknown_config_name_falls_back_to_in_memory(self, client):
+        with client.application.app_context():
+            with patch("app.rate_limiter._build_limiter_registry") as mock_registry:
+                mock_registry.return_value = {
+                    "InMemoryRateLimiter": InMemoryRateLimiter,
+                    "RedisZSetRateLimiter": RedisZSetRateLimiter,
+                    "RedisTokenBucketRateLimiter": RedisTokenBucketRateLimiter,
+                }
+                with patch("app.config.Config.SMS_RATE_LIMITER_BACKEND", "UnknownClass", create=True):
+                    instance = initialize_rate_limiter(1000)
+                    assert isinstance(instance, InMemoryRateLimiter)
+
+    def test_default_no_args_uses_in_memory(self, client):
+        with client.application.app_context():
+            with patch("app.config.Config.SMS_RATE_LIMITER_BACKEND", "InMemoryRateLimiter", create=True):
+                instance = initialize_rate_limiter(1000)
+                assert isinstance(instance, InMemoryRateLimiter)

--- a/tests/app/test_rate_limiter.py
+++ b/tests/app/test_rate_limiter.py
@@ -474,14 +474,11 @@ class TestRedisTokenBucketRateLimiter:
 class TestInitializeRateLimiter:
     def teardown_method(self):
         # Reset global singleton between tests
-        import app.rate_limiter as rl
-
-        rl._rate_limiter_instance = None
+        global _rate_limiter_instance
+        _rate_limiter_instance = None
 
     def test_explicit_class_arg_takes_precedence(self, client):
         with client.application.app_context():
-            redis_client = fakeredis.FakeRedis()
-            # Pass class directly; config should be ignored
             instance = initialize_rate_limiter(1000, RedisTokenBucketRateLimiter)
             assert isinstance(instance, RedisTokenBucketRateLimiter)
 

--- a/tests/app/test_rate_limiter.py
+++ b/tests/app/test_rate_limiter.py
@@ -447,6 +447,20 @@ class TestRedisTokenBucketRateLimiter:
                 allow_send, _ = limiter.acquire_lease(1000)
                 assert allow_send is True
 
+    def test_full_cap_available_slightly_after_60_seconds(self, client, limiter):
+        # Mirrors test_window_slightly_older_than_60_seconds_is_removed: after
+        # depleting all tokens and waiting 60.1 s the bucket is at full cap and
+        # a full-cap request must be granted.
+        with client.application.app_context():
+            with patch("app.rate_limiter.time") as mock_time:
+                base_time = 100.0
+                mock_time.return_value = base_time
+                limiter.acquire_lease(1000)
+
+                mock_time.return_value = base_time + 60.1
+                allow_send, _ = limiter.acquire_lease(1000)
+                assert allow_send is True
+
     def test_reset_clears_bucket(self, client, limiter):
         with client.application.app_context():
             with patch("app.rate_limiter.time") as mock_time:
@@ -470,6 +484,35 @@ class TestRedisTokenBucketRateLimiter:
                 # Bucket now at 0
                 allow_send, _ = limiter.acquire_lease(1)
                 assert allow_send is False
+
+    def test_bucket_not_fully_refilled_after_59_9_seconds(self, client, limiter):
+        # After depleting all tokens, 59.9 s of refill restores only
+        # 1000/60 * 59.9 ≈ 998.3 tokens — not enough to grant 1000.
+        with client.application.app_context():
+            with patch("app.rate_limiter.time") as mock_time:
+                base_time = 100.0
+                mock_time.return_value = base_time
+                limiter.acquire_lease(1000)
+
+                mock_time.return_value = base_time + 59.9
+                allow_send, _ = limiter.acquire_lease(1000)
+                assert allow_send is False
+
+    def test_retry_delay_with_partial_prior_consumption(self, client, limiter):
+        # Two partial acquires leave 100 tokens remaining; requesting 200 creates
+        # a deficit of 100.  wait = ceil(100 / (1000/60)) = ceil(6.0) = 6 s.
+        with client.application.app_context():
+            with patch("app.rate_limiter.time") as mock_time:
+                import math
+
+                mock_time.return_value = 100.0
+                limiter.acquire_lease(500)
+                limiter.acquire_lease(400)
+                # 100 tokens remain; requesting 200 → deficit 100
+                allow_send, wait_seconds = limiter.acquire_lease(200)
+                assert allow_send is False
+                expected = math.ceil(100 / (1000 / 60))
+                assert wait_seconds == expected
 
 
 class TestInitializeRateLimiter:

--- a/tests/app/test_rate_limiter.py
+++ b/tests/app/test_rate_limiter.py
@@ -3,14 +3,12 @@ from unittest.mock import patch
 import fakeredis
 import pytest
 
+from app import rate_limiter
 from app.rate_limiter import (
     InMemoryRateLimiter,
     RedisSlidingWindowLogRateLimiter,
     RedisTokenBucketRateLimiter,
     initialize_rate_limiter,
-)
-from app.rate_limiter import (
-    rate_limiter as rate_limiter_module,
 )
 
 
@@ -477,7 +475,7 @@ class TestRedisTokenBucketRateLimiter:
 class TestInitializeRateLimiter:
     def teardown_method(self):
         # Reset global singleton between tests
-        with patch.object(rate_limiter_module, "_rate_limiter_instance", None):
+        with patch.object(rate_limiter, "_rate_limiter_instance", None):
             pass
 
     def test_explicit_class_arg_takes_precedence(self, client):

--- a/tests/app/test_rate_limiter.py
+++ b/tests/app/test_rate_limiter.py
@@ -198,7 +198,7 @@ class TestInMemoryRateLimiter:
                 assert limiter.current_usage == 50
 
 
-class TestRedisRateLimiter:
+class TestRedisSlidingWindowLogRateLimiter:
     @pytest.fixture
     def limiter(self):
         redis_client = fakeredis.FakeRedis()

--- a/tests/app/test_rate_limiter.py
+++ b/tests/app/test_rate_limiter.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import fakeredis
 import pytest
 
+import app.rate_limiter as rate_limiter_module
 from app.rate_limiter import (
     InMemoryRateLimiter,
     RedisSlidingWindowLogRateLimiter,
@@ -474,8 +475,8 @@ class TestRedisTokenBucketRateLimiter:
 class TestInitializeRateLimiter:
     def teardown_method(self):
         # Reset global singleton between tests
-        global _rate_limiter_instance
-        _rate_limiter_instance = None
+        with patch.object(rate_limiter_module, "_rate_limiter_instance", None):
+            pass
 
     def test_explicit_class_arg_takes_precedence(self, client):
         with client.application.app_context():

--- a/tests/app/test_rate_limiter.py
+++ b/tests/app/test_rate_limiter.py
@@ -408,6 +408,7 @@ class TestRedisTokenBucketRateLimiter:
                 allow_send, wait_seconds = limiter.acquire_lease(100)
                 assert allow_send is False
                 import math
+
                 expected = math.ceil(100 / (1000 / 60))
                 assert wait_seconds == expected
 
@@ -474,6 +475,7 @@ class TestInitializeRateLimiter:
     def teardown_method(self):
         # Reset global singleton between tests
         import app.rate_limiter as rl
+
         rl._rate_limiter_instance = None
 
     def test_explicit_class_arg_takes_precedence(self, client):

--- a/tests/app/test_rate_limiter.py
+++ b/tests/app/test_rate_limiter.py
@@ -3,12 +3,12 @@ from unittest.mock import patch
 import fakeredis
 import pytest
 
-import app.rate_limiter as rate_limiter_module
 from app.rate_limiter import (
     InMemoryRateLimiter,
     RedisSlidingWindowLogRateLimiter,
     RedisTokenBucketRateLimiter,
     initialize_rate_limiter,
+    rate_limiter as rate_limiter_module,
 )
 
 

--- a/tests/app/test_rate_limiter.py
+++ b/tests/app/test_rate_limiter.py
@@ -493,7 +493,7 @@ class TestInitializeRateLimiter:
             with patch("app.rate_limiter._build_limiter_registry") as mock_registry:
                 mock_registry.return_value = {
                     "InMemoryRateLimiter": InMemoryRateLimiter,
-                    "RedisZSetRateLimiter": RedisSlidingWindowLogRateLimiter,
+                    "RedisSlidingWindowLogRateLimiter": RedisSlidingWindowLogRateLimiter,
                     "RedisTokenBucketRateLimiter": RedisTokenBucketRateLimiter,
                 }
                 with patch("app.rate_limiter.InMemoryRateLimiter", InMemoryRateLimiter):
@@ -506,10 +506,10 @@ class TestInitializeRateLimiter:
             with patch("app.rate_limiter._build_limiter_registry") as mock_registry:
                 mock_registry.return_value = {
                     "InMemoryRateLimiter": InMemoryRateLimiter,
-                    "RedisZSetRateLimiter": RedisSlidingWindowLogRateLimiter,
+                    "RedisSlidingWindowLogRateLimiter": RedisSlidingWindowLogRateLimiter,
                     "RedisTokenBucketRateLimiter": RedisTokenBucketRateLimiter,
                 }
-                with patch("app.config.Config.SMS_RATE_LIMITER_BACKEND", "RedisZSetRateLimiter", create=True):
+                with patch("app.config.Config.SMS_RATE_LIMITER_BACKEND", "RedisSlidingWindowLogRateLimiter", create=True):
                     instance = initialize_rate_limiter(1000)
                     assert isinstance(instance, RedisSlidingWindowLogRateLimiter)
 
@@ -518,7 +518,7 @@ class TestInitializeRateLimiter:
             with patch("app.rate_limiter._build_limiter_registry") as mock_registry:
                 mock_registry.return_value = {
                     "InMemoryRateLimiter": InMemoryRateLimiter,
-                    "RedisZSetRateLimiter": RedisSlidingWindowLogRateLimiter,
+                    "RedisSlidingWindowLogRateLimiter": RedisSlidingWindowLogRateLimiter,
                     "RedisTokenBucketRateLimiter": RedisTokenBucketRateLimiter,
                 }
                 with patch("app.config.Config.SMS_RATE_LIMITER_BACKEND", "UnknownClass", create=True):

--- a/tests/app/test_rate_limiter.py
+++ b/tests/app/test_rate_limiter.py
@@ -8,6 +8,8 @@ from app.rate_limiter import (
     RedisSlidingWindowLogRateLimiter,
     RedisTokenBucketRateLimiter,
     initialize_rate_limiter,
+)
+from app.rate_limiter import (
     rate_limiter as rate_limiter_module,
 )
 

--- a/tests/app/test_rate_limiter_scaling.py
+++ b/tests/app/test_rate_limiter_scaling.py
@@ -1,0 +1,90 @@
+"""
+Scaling benchmark: RedisZSetRateLimiter vs RedisTokenBucketRateLimiter.
+
+Measures how acquire_lease() time changes as the number of pre-existing
+ZSet entries grows.  The token bucket is O(1) and unaffected by history;
+the ZSet implementation is O(N) and should grow linearly.
+
+Run explicitly with:
+    pytest tests/app/test_rate_limiter_scaling.py -v -s -m scaling
+"""
+
+import time
+
+import fakeredis
+import pytest
+
+from app.rate_limiter import RedisTokenBucketRateLimiter, RedisZSetRateLimiter
+
+# N values to sweep. Each represents the number of prior entries in the
+# ZSet window before the timed call.
+N_VALUES = [1, 10, 50, 100, 250, 500, 750, 1000]
+
+# Repetitions per N value -- averaged to reduce noise.
+REPS = 20
+
+# Cap large enough that pre-filling N entries (1 part each) never hits it.
+CAP = N_VALUES[-1] * 2 + REPS
+
+
+def _prefill_zset(limiter: RedisZSetRateLimiter, n: int) -> None:
+    """Add n entries (1 part each) at staggered fake timestamps so none expire."""
+    base = time.time()
+    for i in range(n):
+        # Spread entries across the 60 s window so none are cleaned on admit
+        fake_now = base - 59.0 + (59.0 / max(n, 1)) * i
+        limiter._get_acquire_lua_script()(
+            keys=[limiter.REDIS_KEY_ENTRIES],
+            args=[CAP, 1, fake_now, f"prefill-{i}", limiter.WINDOW_SIZE_SECONDS],
+        )
+
+
+def _time_acquire(limiter, reps: int) -> float:
+    """Return mean us for acquire_lease(1) over reps calls."""
+    total = 0.0
+    for _ in range(reps):
+        t0 = time.perf_counter()
+        limiter.acquire_lease(1)
+        total += time.perf_counter() - t0
+    return (total / reps) * 1_000_000  # us
+
+
+@pytest.mark.scaling
+def test_scaling_comparison(client):
+    """
+    Print a timing table comparing ZSet (O(N)) vs token bucket (O(1))
+    as the number of pre-existing entries grows.
+    """
+    rows = []
+
+    with client.application.app_context():
+        for n in N_VALUES:
+            # ---- ZSet ----
+            zset_redis = fakeredis.FakeRedis()
+            zset = RedisZSetRateLimiter(cap_per_minute=CAP, redis_client=zset_redis)
+            _prefill_zset(zset, n)
+            zset_us = _time_acquire(zset, REPS)
+
+            # ---- Token bucket ----
+            tb_redis = fakeredis.FakeRedis()
+            tb = RedisTokenBucketRateLimiter(cap_per_minute=CAP, redis_client=tb_redis)
+            tb_us = _time_acquire(tb, REPS)
+
+            ratio = zset_us / tb_us if tb_us > 0 else float("inf")
+            rows.append((n, zset_us, tb_us, ratio))
+
+    # Print table
+    header = f"\n{'N entries':>10}  {'ZSet (us)':>12}  {'TokenBucket (us)':>18}  {'ratio (ZSet/TB)':>16}"
+    separator = "-" * len(header)
+    print(header)
+    print(separator)
+    for n, zset_us, tb_us, ratio in rows:
+        print(f"{n:>10}  {zset_us:>12.1f}  {tb_us:>18.1f}  {ratio:>16.2f}x")
+
+    # Soft assertion: ZSet at max N should be slower than token bucket.
+    # This confirms O(N) vs O(1) divergence is observable even in fakeredis.
+    _, zset_max, tb_max, _ = rows[-1]
+    assert zset_max > tb_max, (
+        f"Expected ZSet to be slower than token bucket at N={N_VALUES[-1]}, "
+        f"but ZSet={zset_max:.1f}us, TokenBucket={tb_max:.1f}us"
+    )

--- a/tests/app/test_rate_limiter_scaling.py
+++ b/tests/app/test_rate_limiter_scaling.py
@@ -14,7 +14,7 @@ import time
 import fakeredis
 import pytest
 
-from app.rate_limiter import RedisTokenBucketRateLimiter, RedisZSetRateLimiter
+from app.rate_limiter import RedisSlidingWindowLogRateLimiter, RedisTokenBucketRateLimiter
 
 # N values to sweep. Each represents the number of prior entries in the
 # ZSet window before the timed call.
@@ -27,7 +27,7 @@ REPS = 20
 CAP = N_VALUES[-1] * 2 + REPS
 
 
-def _prefill_zset(limiter: RedisZSetRateLimiter, n: int) -> None:
+def _prefill_zset(limiter: RedisSlidingWindowLogRateLimiter, n: int) -> None:
     """Add n entries (1 part each) at staggered fake timestamps so none expire."""
     base = time.time()
     for i in range(n):
@@ -61,7 +61,7 @@ def test_scaling_comparison(client):
         for n in N_VALUES:
             # ---- ZSet ----
             zset_redis = fakeredis.FakeRedis()
-            zset = RedisZSetRateLimiter(cap_per_minute=CAP, redis_client=zset_redis)
+            zset = RedisSlidingWindowLogRateLimiter(cap_per_minute=CAP, redis_client=zset_redis)
             _prefill_zset(zset, n)
             zset_us = _time_acquire(zset, REPS)
 

--- a/tests/app/test_rate_limiter_scaling.py
+++ b/tests/app/test_rate_limiter_scaling.py
@@ -1,23 +1,24 @@
 """
-Scaling benchmark: RedisZSetRateLimiter vs RedisTokenBucketRateLimiter.
+Scaling benchmark: RedisSlidingWindowLogRateLimiter vs RedisTokenBucketRateLimiter vs InMemoryRateLimiter.
 
 Measures how acquire_lease() time changes as the number of pre-existing
-ZSet entries grows.  The token bucket is O(1) and unaffected by history;
-the ZSet implementation is O(N) and should grow linearly.
+entries grows.  The sliding window log is O(N); the token bucket and
+in-memory admit path are O(1) and unaffected by history size.
 
 Run explicitly with:
     pytest tests/app/test_rate_limiter_scaling.py -v -s -m scaling
 """
 
 import time
+from unittest.mock import patch
 
 import fakeredis
 import pytest
 
-from app.rate_limiter import RedisSlidingWindowLogRateLimiter, RedisTokenBucketRateLimiter
+from app.rate_limiter import InMemoryRateLimiter, RedisSlidingWindowLogRateLimiter, RedisTokenBucketRateLimiter
 
 # N values to sweep. Each represents the number of prior entries in the
-# ZSet window before the timed call.
+# window before the timed call.
 N_VALUES = [1, 10, 50, 100, 250, 500, 750, 1000]
 
 # Repetitions per N value -- averaged to reduce noise.
@@ -39,6 +40,14 @@ def _prefill_zset(limiter: RedisSlidingWindowLogRateLimiter, n: int) -> None:
         )
 
 
+def _prefill_in_memory(limiter: InMemoryRateLimiter, n: int) -> None:
+    """Fill the deque with n entries by calling acquire_lease() n times at a fixed timestamp."""
+    fixed_time = time.time()
+    with patch("app.rate_limiter.time", return_value=fixed_time):
+        for _ in range(n):
+            limiter.acquire_lease(1)
+
+
 def _time_acquire(limiter, reps: int) -> float:
     """Return mean us for acquire_lease(1) over reps calls."""
     total = 0.0
@@ -52,8 +61,11 @@ def _time_acquire(limiter, reps: int) -> float:
 @pytest.mark.scaling
 def test_scaling_comparison(client):
     """
-    Print a timing table comparing ZSet (O(N)) vs token bucket (O(1))
-    as the number of pre-existing entries grows.
+    Print a timing table comparing all three implementations as prior entry
+    count grows.  Only the sliding window log is O(N); the other two are O(1).
+
+    Note: in-memory has no Redis overhead, so its absolute numbers are lower
+    than the Redis implementations -- compare slopes, not absolute values.
     """
     rows = []
 
@@ -65,26 +77,34 @@ def test_scaling_comparison(client):
             _prefill_zset(zset, n)
             zset_us = _time_acquire(zset, REPS)
 
-            # ---- Token bucket ----
+            # ---- Token bucket (Redis hash) ----
             tb_redis = fakeredis.FakeRedis()
             tb = RedisTokenBucketRateLimiter(cap_per_minute=CAP, redis_client=tb_redis)
             tb_us = _time_acquire(tb, REPS)
 
-            ratio = zset_us / tb_us if tb_us > 0 else float("inf")
-            rows.append((n, zset_us, tb_us, ratio))
+            # ---- In-memory (deque, process-local baseline) ----
+            mem = InMemoryRateLimiter(cap_per_minute=CAP)
+            _prefill_in_memory(mem, n)
+            mem_us = _time_acquire(mem, REPS)
+
+            rows.append((n, zset_us, tb_us, mem_us))
 
     # Print table
-    header = f"\n{'N entries':>10}  {'ZSet (us)':>12}  {'TokenBucket (us)':>18}  {'ratio (ZSet/TB)':>16}"
+    header = (
+        f"\n{'N entries':>10}  {'SlidingLog (us)':>16}  "
+        f"{'TokenBucket (us)':>16}  {'InMemory (us)':>14}  {'ratio (Log/TB)':>14}"
+    )
     separator = "-" * len(header)
     print(header)
     print(separator)
-    for n, zset_us, tb_us, ratio in rows:
-        print(f"{n:>10}  {zset_us:>12.1f}  {tb_us:>18.1f}  {ratio:>16.2f}x")
+    for n, zset_us, tb_us, mem_us in rows:
+        ratio = zset_us / tb_us if tb_us > 0 else float("inf")
+        print(f"{n:>10}  {zset_us:>16.1f}  {tb_us:>16.1f}  {mem_us:>14.1f}  {ratio:>14.2f}x")
 
-    # Soft assertion: ZSet at max N should be slower than token bucket.
+    # Soft assertion: sliding window log at max N should be slower than token bucket.
     # This confirms O(N) vs O(1) divergence is observable even in fakeredis.
     _, zset_max, tb_max, _ = rows[-1]
     assert zset_max > tb_max, (
-        f"Expected ZSet to be slower than token bucket at N={N_VALUES[-1]}, "
-        f"but ZSet={zset_max:.1f}us, TokenBucket={tb_max:.1f}us"
+        f"Expected sliding window log to be slower than token bucket at N={N_VALUES[-1]}, "
+        f"but SlidingLog={zset_max:.1f}us, TokenBucket={tb_max:.1f}us"
     )

--- a/tests/app/test_rate_limiter_scaling.py
+++ b/tests/app/test_rate_limiter_scaling.py
@@ -35,7 +35,7 @@ def _prefill_zset(limiter: RedisSlidingWindowLogRateLimiter, n: int) -> None:
         # Spread entries across the 60 s window so none are cleaned on admit
         fake_now = base - 59.0 + (59.0 / max(n, 1)) * i
         limiter._get_acquire_lua_script()(
-            keys=[limiter.REDIS_KEY_ENTRIES],
+            keys=[limiter._entries_key],
             args=[CAP, 1, fake_now, f"prefill-{i}", limiter.WINDOW_SIZE_SECONDS],
         )
 
@@ -73,17 +73,17 @@ def test_scaling_comparison(client):
         for n in N_VALUES:
             # ---- ZSet ----
             zset_redis = fakeredis.FakeRedis()
-            zset = RedisSlidingWindowLogRateLimiter(cap_per_minute=CAP, redis_client=zset_redis)
+            zset = RedisSlidingWindowLogRateLimiter(cap_per_minute=CAP, namespace="test", redis_client=zset_redis)
             _prefill_zset(zset, n)
             zset_us = _time_acquire(zset, REPS)
 
             # ---- Token bucket (Redis hash) ----
             tb_redis = fakeredis.FakeRedis()
-            tb = RedisTokenBucketRateLimiter(cap_per_minute=CAP, redis_client=tb_redis)
+            tb = RedisTokenBucketRateLimiter(cap_per_minute=CAP, namespace="test", redis_client=tb_redis)
             tb_us = _time_acquire(tb, REPS)
 
             # ---- In-memory (deque, process-local baseline) ----
-            mem = InMemoryRateLimiter(cap_per_minute=CAP)
+            mem = InMemoryRateLimiter(cap_per_minute=CAP, namespace="test")
             _prefill_in_memory(mem, n)
             mem_us = _time_acquire(mem, REPS)
 


### PR DESCRIPTION
# Summary | Résumé

Adds a new O(1) Redis-backed rate limiter implementation alongside the existing sliding window log, and cleans up the factory function to accept implementation classes directly.

**New: `RedisTokenBucketRateLimiter`**

Token bucket algorithm backed by a single Redis hash (`tokens`, `last_refill`). All operations are O(1) — admission, rejection, and wait time calculation — regardless of traffic history. Uses an atomic Lua script for thread-safe reads and writes. Exact retry wait times via `deficit / refill_rate`. Supports burst after idle (bucket refills to cap during quiet periods).

**Renamed: `RedisZSetRateLimiter` → `RedisSlidingWindowLogRateLimiter`**

Renamed to reflect the algorithm rather than the data structure, consistent with `RedisTokenBucketRateLimiter` naming convention.

**Improved: `initialize_rate_limiter` factory**

Replaced the `use_redis: bool` parameter with `limiter_class: type[RateLimiter] | None`. Callers can now pass any implementation class directly. When no class is provided, the factory resolves by class name from the `SMS_RATE_LIMITER_BACKEND` config value (e.g. `"RedisTokenBucketRateLimiter"`). Unknown names log a warning and fall back to `InMemoryRateLimiter`. Config default updated from `"memory"` to `"InMemoryRateLimiter"` to match the new naming scheme.

**Performance benchmark: `tests/app/test_rate_limiter_scaling.py`**

New `@pytest.mark.scaling` test (excluded from normal CI runs) that sweeps N prior entries from 1 to 1000 and prints a three-column timing table. Results confirm the O(N) vs O(1) divergence:

```
 N entries   SlidingLog (us)  TokenBucket (us)   InMemory (us)  ratio (Log/TB)
-------------------------------------------------------------------------------
         1             415.8             325.1            42.2            1.28x
        10             361.7             337.5            41.4            1.07x
        50             414.6             290.1            41.8            1.43x
       100             483.3             282.1            41.1            1.71x
       250             739.0             314.5            40.6            2.35x
       500            1004.4             298.3            41.1            3.37x
       750            1355.5             307.2            40.1            4.41x
      1000            1754.5             348.3            43.3            5.04x
```

The sliding window log grows linearly with history size; the token bucket and in-memory implementations remain flat.

## AI disclaimer

Most of the implementation and all test code were generated by AI, and guided / reviewed by the author.

## Related Issues | Cartes liées

* [SMS Rate Limiter](https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/786)

# Test instructions | Instructions pour tester la modification

## Unit tests
```bash
python -m pytest tests/app/test_rate_limiter.py -v
```
Covers all three implementations (`InMemoryRateLimiter`, `RedisSlidingWindowLogRateLimiter`, `RedisTokenBucketRateLimiter`) and the `initialize_rate_limiter` factory. Uses `fakeredis` — no real Redis required.

## Scaling benchmark (optional, not part of CI)
```bash
python -m pytest tests/app/test_rate_limiter_scaling.py -v -s -m scaling --override-ini="addopts="
```
Prints a timing table comparing all three implementations as prior entry count grows from 1 to 1000. Expect the sliding window log to grow linearly and the token bucket / in-memory to remain flat.

## Switching backend via config
Set `SMS_RATE_LIMITER_BACKEND` env var to the class name to test a specific implementation:
```bash
SMS_RATE_LIMITER_BACKEND=RedisTokenBucketRateLimiter
SMS_RATE_LIMITER_BACKEND=RedisSlidingWindowLogRateLimiter
SMS_RATE_LIMITER_BACKEND=InMemoryRateLimiter  # default
```
Unknown values will log a warning and fall back to `InMemoryRateLimiter`.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.