### PR TITLE
Fix the expired inflight alarm

### DIFF
--- a/app/aws/metrics.py
+++ b/app/aws/metrics.py
@@ -70,6 +70,9 @@ def put_batch_saving_inflight_processed(metrics_logger: MetricsLogger, queue: Re
             {"acknowledged": "True", "notification_type": queue._suffix, "priority": queue._process_type}
         )
         metrics_logger.flush()
+        metrics_logger.put_metric("batch_saving_inflight", count, "Count")
+        metrics_logger.set_dimensions({"acknowledged": "True", "notification_type": "any", "priority": "any"})
+        metrics_logger.flush()
     except ClientError as e:
         message = "Error sending CloudWatch Metric: {}".format(e)
         current_app.logger.warning(message)

--- a/tests/app/aws/test_metrics.py
+++ b/tests/app/aws/test_metrics.py
@@ -73,10 +73,13 @@ class TestBatchSavingMetricsFunctions:
         redis_queue._suffix = "foo"
         redis_queue._process_type = "bar"
         put_batch_saving_inflight_processed(metrics_logger_mock, redis_queue, 1)
-        metrics_logger_mock.set_dimensions.assert_called_with(
-            {"acknowledged": "True", "notification_type": "foo", "priority": "bar"}
-        )
         metrics_logger_mock.put_metric.assert_called_with("batch_saving_inflight", 1, "Count")
+        metrics_logger_mock.set_dimensions.assert_has_calls(
+            [
+                call({"acknowledged": "True", "notification_type": "foo", "priority": "bar"}),
+                call({"acknowledged": "True", "notification_type": "any", "priority": "any"}),
+            ]
+        )
 
     def test_put_batch_saving_expiry_metric(self, mocker, metrics_logger_mock):
         redis_queue = mocker.MagicMock()


### PR DESCRIPTION
# Summary | Résumé

Fix the expired inflight alarm.  `put_batch_saving_inflight_processed` now emits a second aggregate metric with `notification_type: "any", priority: "any"`, since the expired inflight alarm is looking for an exact match of this and not finding it.

Here is the related TF PR: https://github.com/cds-snc/notification-terraform/pull/2618


# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.