### PR TITLE
Add test option to failure scenario script

### DIFF
--- a/.github/workflows/failure_scenario_performance_tests.yml
+++ b/.github/workflows/failure_scenario_performance_tests.yml
@@ -65,6 +65,30 @@ jobs:
           echo "security_groups=$SECURITY_GROUPS" >> "$GITHUB_OUTPUT"
           echo "assign_public_ip=$ASSIGN_PUBLIC_IP" >> "$GITHUB_OUTPUT"
 
+      - name: Register one-off task definition with failure scenario entrypoint
+        id: register-task-def
+        run: |
+          set -euo pipefail
+
+          # Pull the current task definition, swap the entrypoint, register a new revision.
+          TASK_DEF=$(aws ecs describe-task-definition \
+            --task-definition "${{ env.ECS_TASK_FAMILY }}" \
+            --query 'taskDefinition' \
+            --output json)
+
+          NEW_TASK_DEF=$(echo "$TASK_DEF" | jq '
+            del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy) |
+            .containerDefinitions[0].entryPoint = ["tests_nightly_performance/run_failure_scenarios.sh"]
+          ')
+
+          NEW_TASK_ARN=$(aws ecs register-task-definition \
+            --cli-input-json "$NEW_TASK_DEF" \
+            --query 'taskDefinition.taskDefinitionArn' \
+            --output text)
+
+          echo "task_def_arn=$NEW_TASK_ARN" >> "$GITHUB_OUTPUT"
+          echo "Registered temporary task definition: $NEW_TASK_ARN"
+
       - name: Run failure scenario ECS task
         id: run-task
         run: |
@@ -75,7 +99,6 @@ jobs:
             "containerOverrides": [
               {
                 "name": "${{ env.CONTAINER_NAME }}",
-                "entryPoint": ["tests_nightly_performance/run_failure_scenarios.sh"],
                 "environment": [
                   {"name": "COOLDOWN",         "value": "${{ inputs.cooldown }}"},
                   {"name": "ERROR_THRESHOLD",  "value": "${{ inputs.error_threshold }}"},
@@ -90,7 +113,7 @@ jobs:
 
           TASK_ARN=$(aws ecs run-task \
             --cluster "${{ env.ECS_CLUSTER }}" \
-            --task-definition "${{ env.ECS_TASK_FAMILY }}" \
+            --task-definition "${{ steps.register-task-def.outputs.task_def_arn }}" \
             --launch-type FARGATE \
             --network-configuration "awsvpcConfiguration={subnets=[${{ steps.network-config.outputs.subnets }}],securityGroups=[${{ steps.network-config.outputs.security_groups }}],assignPublicIp=${{ steps.network-config.outputs.assign_public_ip }}}" \
             --overrides "$OVERRIDES" \
@@ -143,6 +166,12 @@ jobs:
             echo "::error::ECS task failed (exit code $EXIT_CODE): $STOP_REASON"
             exit 1
           fi
+
+      - name: Deregister temporary task definition
+        if: ${{ always() }}
+        run: |
+          aws ecs deregister-task-definition \
+            --task-definition "${{ steps.register-task-def.outputs.task_def_arn }}" > /dev/null
 
       - name: Notify Slack on failure
         if: ${{ failure() }}

--- a/.github/workflows/failure_scenario_performance_tests.yml
+++ b/.github/workflows/failure_scenario_performance_tests.yml
@@ -92,7 +92,7 @@ jobs:
             --cluster "${{ env.ECS_CLUSTER }}" \
             --task-definition "${{ env.ECS_TASK_FAMILY }}" \
             --launch-type FARGATE \
-            --network-configuration "awsvpcConfiguration={subnets=[${{ steps.network-config.outputs.subnets }}],securityGroups=[${{ steps.network-config.outputs.security_groups }}],assignPublicIp=${{ steps.network-config.outputs.assign_public_ip }}" \
+            --network-configuration "awsvpcConfiguration={subnets=[${{ steps.network-config.outputs.subnets }}],securityGroups=[${{ steps.network-config.outputs.security_groups }}],assignPublicIp=${{ steps.network-config.outputs.assign_public_ip }}}" \
             --overrides "$OVERRIDES" \
             --query 'tasks[0].taskArn' \
             --output text)

--- a/.github/workflows/failure_scenario_performance_tests.yml
+++ b/.github/workflows/failure_scenario_performance_tests.yml
@@ -24,7 +24,7 @@ env:
   ACCOUNT_ID: ${{ secrets.STAGING_AWS_ACCOUNT_ID }}
   AWS_DEFAULT_REGION: ca-central-1
   ECS_CLUSTER: performance_test_cluster
-  ECS_TASK_FAMILY: performance_test_cluster
+  ECS_TASK_FAMILY: performance_test_cluster_failure_scenarios
   CONTAINER_NAME: performance-tests-container
 
 permissions:
@@ -65,30 +65,6 @@ jobs:
           echo "security_groups=$SECURITY_GROUPS" >> "$GITHUB_OUTPUT"
           echo "assign_public_ip=$ASSIGN_PUBLIC_IP" >> "$GITHUB_OUTPUT"
 
-      - name: Register one-off task definition with failure scenario entrypoint
-        id: register-task-def
-        run: |
-          set -euo pipefail
-
-          # Pull the current task definition, swap the entrypoint, register a new revision.
-          TASK_DEF=$(aws ecs describe-task-definition \
-            --task-definition "${{ env.ECS_TASK_FAMILY }}" \
-            --query 'taskDefinition' \
-            --output json)
-
-          NEW_TASK_DEF=$(echo "$TASK_DEF" | jq '
-            del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy) |
-            .containerDefinitions[0].entryPoint = ["tests_nightly_performance/run_failure_scenarios.sh"]
-          ')
-
-          NEW_TASK_ARN=$(aws ecs register-task-definition \
-            --cli-input-json "$NEW_TASK_DEF" \
-            --query 'taskDefinition.taskDefinitionArn' \
-            --output text)
-
-          echo "task_def_arn=$NEW_TASK_ARN" >> "$GITHUB_OUTPUT"
-          echo "Registered temporary task definition: $NEW_TASK_ARN"
-
       - name: Run failure scenario ECS task
         id: run-task
         run: |
@@ -113,7 +89,7 @@ jobs:
 
           TASK_ARN=$(aws ecs run-task \
             --cluster "${{ env.ECS_CLUSTER }}" \
-            --task-definition "${{ steps.register-task-def.outputs.task_def_arn }}" \
+            --task-definition "${{ env.ECS_TASK_FAMILY }}" \
             --launch-type FARGATE \
             --network-configuration "awsvpcConfiguration={subnets=[${{ steps.network-config.outputs.subnets }}],securityGroups=[${{ steps.network-config.outputs.security_groups }}],assignPublicIp=${{ steps.network-config.outputs.assign_public_ip }}}" \
             --overrides "$OVERRIDES" \
@@ -166,12 +142,6 @@ jobs:
             echo "::error::ECS task failed (exit code $EXIT_CODE): $STOP_REASON"
             exit 1
           fi
-
-      - name: Deregister temporary task definition
-        if: ${{ always() }}
-        run: |
-          aws ecs deregister-task-definition \
-            --task-definition "${{ steps.register-task-def.outputs.task_def_arn }}" > /dev/null
 
       - name: Notify Slack on failure
         if: ${{ failure() }}

--- a/.github/workflows/failure_scenario_performance_tests.yml
+++ b/.github/workflows/failure_scenario_performance_tests.yml
@@ -1,0 +1,151 @@
+name: Failure Scenario Performance Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      cooldown:
+        description: 'Cool-down between scenarios in seconds (default: 1800 / 30 min)'
+        required: false
+        default: '1800'
+      error_threshold:
+        description: 'Error % that triggers a test stop (default: 3.0)'
+        required: false
+        default: '3.0'
+      min_requests:
+        description: 'Minimum requests before threshold is evaluated (default: 100)'
+        required: false
+        default: '100'
+      spike_users:
+        description: 'Concurrent users for spike scenarios 2 & 4 (default: 500)'
+        required: false
+        default: '500'
+
+env:
+  ACCOUNT_ID: ${{ secrets.STAGING_AWS_ACCOUNT_ID }}
+  AWS_DEFAULT_REGION: ca-central-1
+  ECS_CLUSTER: performance_test_cluster
+  ECS_TASK_FAMILY: performance_test_cluster
+  CONTAINER_NAME: performance-tests-container
+
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
+jobs:
+  run-failure-scenarios:
+    runs-on: ubuntu-latest
+    # Generous timeout: 5 scenarios × (run time + 30 min cooldown) can exceed 3 hours
+    timeout-minutes: 360
+
+    steps:
+      - name: Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          role-to-assume: arn:aws:iam::${{ env.ACCOUNT_ID }}:role/notification-api-apply
+          role-session-name: NotifyApiFailureScenarios
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
+      - name: Fetch network configuration from existing CloudWatch event target
+        id: network-config
+        run: |
+          set -euo pipefail
+
+          # Read the network config straight from the scheduled event target so
+          # we don't duplicate subnet/SG values anywhere else.
+          NETWORK_CONFIG=$(aws events list-targets-by-rule \
+            --rule perf_test_event_rule \
+            --query 'Targets[0].EcsParameters.NetworkConfiguration' \
+            --output json)
+
+          SUBNETS=$(echo "$NETWORK_CONFIG" | jq -r '.awsvpcConfiguration.subnets | join(",")')
+          SECURITY_GROUPS=$(echo "$NETWORK_CONFIG" | jq -r '.awsvpcConfiguration.securityGroups | join(",")')
+          ASSIGN_PUBLIC_IP=$(echo "$NETWORK_CONFIG" | jq -r '.awsvpcConfiguration.assignPublicIp')
+
+          echo "subnets=$SUBNETS"               >> "$GITHUB_OUTPUT"
+          echo "security_groups=$SECURITY_GROUPS" >> "$GITHUB_OUTPUT"
+          echo "assign_public_ip=$ASSIGN_PUBLIC_IP" >> "$GITHUB_OUTPUT"
+
+      - name: Run failure scenario ECS task
+        id: run-task
+        run: |
+          set -euo pipefail
+
+          OVERRIDES=$(cat <<EOF
+          {
+            "containerOverrides": [
+              {
+                "name": "${{ env.CONTAINER_NAME }}",
+                "entryPoint": ["tests_nightly_performance/run_failure_scenarios.sh"],
+                "environment": [
+                  {"name": "COOLDOWN",         "value": "${{ inputs.cooldown }}"},
+                  {"name": "ERROR_THRESHOLD",  "value": "${{ inputs.error_threshold }}"},
+                  {"name": "MIN_REQUESTS",     "value": "${{ inputs.min_requests }}"},
+                  {"name": "SPIKE_USERS",      "value": "${{ inputs.spike_users }}"}
+                ]
+              }
+            ]
+          }
+          EOF
+          )
+
+          TASK_ARN=$(aws ecs run-task \
+            --cluster "${{ env.ECS_CLUSTER }}" \
+            --task-definition "${{ env.ECS_TASK_FAMILY }}" \
+            --launch-type FARGATE \
+            --network-configuration "awsvpcConfiguration={subnets=[${{ steps.network-config.outputs.subnets }}],securityGroups=[${{ steps.network-config.outputs.security_groups }}],assignPublicIp=${{ steps.network-config.outputs.assign_public_ip }}" \
+            --overrides "$OVERRIDES" \
+            --query 'tasks[0].taskArn' \
+            --output text)
+
+          echo "task_arn=$TASK_ARN" >> "$GITHUB_OUTPUT"
+          echo "ECS task started: $TASK_ARN"
+
+      - name: Wait for task to finish
+        run: |
+          set -euo pipefail
+          TASK_ARN="${{ steps.run-task.outputs.task_arn }}"
+
+          echo "Polling task status (checks every 60 s)..."
+          while true; do
+            STATUS=$(aws ecs describe-tasks \
+              --cluster "${{ env.ECS_CLUSTER }}" \
+              --tasks "$TASK_ARN" \
+              --query 'tasks[0].lastStatus' \
+              --output text)
+            echo "  current status: $STATUS"
+            if [ "$STATUS" = "STOPPED" ]; then
+              break
+            fi
+            sleep 60
+          done
+
+      - name: Check container exit code
+        run: |
+          set -euo pipefail
+          TASK_ARN="${{ steps.run-task.outputs.task_arn }}"
+
+          EXIT_CODE=$(aws ecs describe-tasks \
+            --cluster "${{ env.ECS_CLUSTER }}" \
+            --tasks "$TASK_ARN" \
+            --query 'tasks[0].containers[0].exitCode' \
+            --output text)
+
+          STOP_REASON=$(aws ecs describe-tasks \
+            --cluster "${{ env.ECS_CLUSTER }}" \
+            --tasks "$TASK_ARN" \
+            --query 'tasks[0].stoppedReason' \
+            --output text)
+
+          echo "Container exit code : $EXIT_CODE"
+          echo "Stopped reason      : $STOP_REASON"
+
+          if [ "$EXIT_CODE" != "0" ]; then
+            echo "::error::ECS task failed (exit code $EXIT_CODE): $STOP_REASON"
+            exit 1
+          fi
+
+      - name: Notify Slack on failure
+        if: ${{ failure() }}
+        run: |
+          json='{"text":"Failure scenario performance tests failed: <https://github.com/cds-snc/notification-api/actions/runs/${{ github.run_id }}|GitHub Actions>"}'
+          curl -X POST -H 'Content-type: application/json' --data "$json" "${{ secrets.SLACK_WEBHOOK }}"

--- a/.github/workflows/failure_scenario_performance_tests.yml
+++ b/.github/workflows/failure_scenario_performance_tests.yml
@@ -57,9 +57,9 @@ jobs:
             --query 'Targets[0].EcsParameters.NetworkConfiguration' \
             --output json)
 
-          SUBNETS=$(echo "$NETWORK_CONFIG" | jq -r '.awsvpcConfiguration.subnets | join(",")')
-          SECURITY_GROUPS=$(echo "$NETWORK_CONFIG" | jq -r '.awsvpcConfiguration.securityGroups | join(",")')
-          ASSIGN_PUBLIC_IP=$(echo "$NETWORK_CONFIG" | jq -r '.awsvpcConfiguration.assignPublicIp')
+          SUBNETS=$(echo "$NETWORK_CONFIG" | jq -r '.awsvpcConfiguration.Subnets | join(",")')
+          SECURITY_GROUPS=$(echo "$NETWORK_CONFIG" | jq -r '.awsvpcConfiguration.SecurityGroups | join(",")')
+          ASSIGN_PUBLIC_IP=$(echo "$NETWORK_CONFIG" | jq -r '.awsvpcConfiguration.AssignPublicIp')
 
           echo "subnets=$SUBNETS"               >> "$GITHUB_OUTPUT"
           echo "security_groups=$SECURITY_GROUPS" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/failure_scenario_performance_tests.yml
+++ b/.github/workflows/failure_scenario_performance_tests.yml
@@ -19,6 +19,11 @@ on:
         description: 'Concurrent users for spike scenarios 2 & 4 (default: 500)'
         required: false
         default: '500'
+      test_mode:
+        description: 'Run each scenario for 2 minutes with 10s cooldowns to verify the pipeline end-to-end (default: false)'
+        required: false
+        type: boolean
+        default: false
 
 env:
   ACCOUNT_ID: ${{ secrets.STAGING_AWS_ACCOUNT_ID }}
@@ -79,7 +84,8 @@ jobs:
                   {"name": "COOLDOWN",         "value": "${{ inputs.cooldown }}"},
                   {"name": "ERROR_THRESHOLD",  "value": "${{ inputs.error_threshold }}"},
                   {"name": "MIN_REQUESTS",     "value": "${{ inputs.min_requests }}"},
-                  {"name": "SPIKE_USERS",      "value": "${{ inputs.spike_users }}"}
+                  {"name": "SPIKE_USERS",      "value": "${{ inputs.spike_users }}"},
+                  {"name": "TEST_MODE",        "value": "${{ inputs.test_mode }}"}
                 ]
               }
             ]

--- a/tests_nightly_performance/run_failure_scenarios.sh
+++ b/tests_nightly_performance/run_failure_scenarios.sh
@@ -194,6 +194,6 @@ log "========================================================"
 log "All scenarios complete."
 log "Results: $OUTPUT_DIR"
 log "S3 path : ${S3_BASE}/"
-log "========================================================" 
+log "========================================================"
 
 notify_slack ":white_check_mark: Blast API failure scenario suite complete — ${S3_BASE}/ :rotating-light-blue:"

--- a/tests_nightly_performance/run_failure_scenarios.sh
+++ b/tests_nightly_performance/run_failure_scenarios.sh
@@ -32,11 +32,21 @@ set -uo pipefail
 # ---------------------------------------------------------------------------
 # Configurable defaults
 # ---------------------------------------------------------------------------
+TEST_MODE="${TEST_MODE:-false}"          # Set TEST_MODE=true for a fast CI smoke-run
 COOLDOWN="${COOLDOWN:-1800}"
 ERROR_THRESHOLD="${ERROR_THRESHOLD:-3.0}"
 MIN_REQUESTS="${MIN_REQUESTS:-100}"
 SPIKE_USERS="${SPIKE_USERS:-500}"
 PERF_TEST_AWS_S3_BUCKET="${PERF_TEST_AWS_S3_BUCKET:-notify-performance-test-results-staging}"
+
+# In test mode: cap each scenario to 2 minutes and cool-down to 10 seconds
+# so the entire suite finishes in ~20 minutes, suitable for a GitHub Actions job.
+if [[ "$TEST_MODE" == "true" ]]; then
+    RUN_TIME="${RUN_TIME:-2m}"
+    COOLDOWN="${COOLDOWN:-10}"
+else
+    RUN_TIME="${RUN_TIME:-1h}"
+fi
 
 current_time=$(date "+%Y.%m.%d-%H.%M.%S")
 OUTPUT_DIR="${OUTPUT_DIR:-/tmp/blast_scenarios/$current_time}"
@@ -52,11 +62,13 @@ mkdir -p "$OUTPUT_DIR"
 
 # Base locust invocation — overrides run-time from locust.conf so each test
 # runs until the error threshold (or manual interrupt), not a fixed duration.
+# In TEST_MODE the run-time is capped short so the full suite can be validated
+# quickly in CI without waiting for natural failure thresholds.
 LOCUST_BASE=(
     locust
     --config locust.conf
     --locustfile src/blast_api.py
-    --run-time 1h
+    --run-time "$RUN_TIME"
     --error-threshold "$ERROR_THRESHOLD"
     --min-requests "$MIN_REQUESTS"
     --wait-min 0
@@ -105,11 +117,13 @@ cooldown() {
 # ---------------------------------------------------------------------------
 log "========================================================"
 log "Blast API Failure Scenario Suite"
+[[ "$TEST_MODE" == "true" ]] && log "*** TEST MODE — run-time capped at ${RUN_TIME} per scenario ***"
 log "Output directory : $OUTPUT_DIR"
 log "S3 destination   : ${S3_BASE}/<scenario>/"
 log "Error threshold  : ${ERROR_THRESHOLD}%  (min requests: $MIN_REQUESTS)"
 log "Spike user count : $SPIKE_USERS"
 log "Cool-down        : ${COOLDOWN}s between scenarios"
+log "Per-scenario cap : ${RUN_TIME}"
 log "========================================================"
 echo ""
 

--- a/tests_nightly_performance/run_failure_scenarios.sh
+++ b/tests_nightly_performance/run_failure_scenarios.sh
@@ -104,7 +104,7 @@ run_scenario() {
 notify_slack() {
     local message="$1"
     if [[ -n "${PERF_TEST_SLACK_WEBHOOK:-}" ]]; then
-        curl -s -X POST -H 'Content-type: application/json' \
+        curl -fsS --max-time 10 -X POST -H 'Content-type: application/json' \
             --data "{\"text\":\"$message\"}" \
             "$PERF_TEST_SLACK_WEBHOOK" || log "WARNING: Slack notification failed"
     else

--- a/tests_nightly_performance/run_failure_scenarios.sh
+++ b/tests_nightly_performance/run_failure_scenarios.sh
@@ -101,6 +101,17 @@ run_scenario() {
         --include "${slug}*" || log "WARNING: S3 upload failed for scenario $number"
 }
 
+notify_slack() {
+    local message="$1"
+    if [[ -n "${PERF_TEST_SLACK_WEBHOOK:-}" ]]; then
+        curl -s -X POST -H 'Content-type: application/json' \
+            --data "{\"text\":\"$message\"}" \
+            "$PERF_TEST_SLACK_WEBHOOK" || log "WARNING: Slack notification failed"
+    else
+        log "PERF_TEST_SLACK_WEBHOOK not set — skipping Slack notification"
+    fi
+}
+
 cooldown() {
     local next="$1"
     log "Cooling down for ${COOLDOWN}s before scenario $next... (Ctrl-C to skip cool-down)"
@@ -126,7 +137,7 @@ log "Cool-down        : ${COOLDOWN}s between scenarios"
 log "Per-scenario cap : ${RUN_TIME}"
 log "========================================================"
 echo ""
-
+notify_slack ":warning: Blast API failure scenario suite starting — ${S3_BASE}/ :rotating-light-blue:"
 # ---------------------------------------------------------------------------
 # Scenario 1 — Gradual ramp-up of individual sends
 #   Starts at 10 users, steps up by 50 every 120 s until error threshold.
@@ -183,4 +194,6 @@ log "========================================================"
 log "All scenarios complete."
 log "Results: $OUTPUT_DIR"
 log "S3 path : ${S3_BASE}/"
-log "========================================================"
+log "========================================================" 
+
+notify_slack ":white_check_mark: Blast API failure scenario suite complete — ${S3_BASE}/ :rotating-light-blue:"

--- a/tests_nightly_performance/src/blast_api.py
+++ b/tests_nightly_performance/src/blast_api.py
@@ -87,14 +87,13 @@ def on_init(environment, **kwargs):
 
 @events.test_start.add_listener
 def configure_user_classes(environment, **kwargs):
-    """Zero out the weight of whichever user class isn't active so Locust
-    doesn't split spawns between NotifyApiUser and BulkBurstUser."""
+    """Remove whichever user class isn't active so Locust only dispatches to
+    the relevant class. Setting weight=0 causes a math domain error in
+    locust's _kl_generator (log2(0)), so we filter the list instead."""
     if environment.parsed_options.bulk_burst:
-        NotifyApiUser.weight = 0
-        BulkBurstUser.weight = 1
+        environment.user_classes = [BulkBurstUser]
     else:
-        NotifyApiUser.weight = 1
-        BulkBurstUser.weight = 0
+        environment.user_classes = [NotifyApiUser]
 
 
 @events.quitting.add_listener


### PR DESCRIPTION
# Summary | Résumé

Adding a test option so that I can verify the whole failure test scenario script without waiting 5 hours to run all of the tests.

Also adding a notification to staging-ops that the tests are starting and finishing.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/761

# Test instructions | Instructions pour tester la modification

Run the failure scenarios with the test button checked.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.