### PR TITLE
Add created_by_id to the files table

### DIFF
--- a/app/files/rest.py
+++ b/app/files/rest.py
@@ -60,6 +60,7 @@ def create_file(template_id):
         mime_type=data["mime_type"],
         file_size=data["file_size"],
         status=FILE_STATUS_PENDING_VIRUS_SCAN,
+        created_by_id=data["created_by"],
     )
     dao_create_file(file)
 

--- a/app/models.py
+++ b/app/models.py
@@ -1456,11 +1456,13 @@ class Files(BaseModel):
     mime_type = db.Column(db.Text, nullable=True)
     file_size = db.Column(db.Integer, nullable=True)
     status = db.Column(db.Enum(*FILE_STATUSES, name="notify_file_status_enum"), nullable=False)
+    created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), index=True, nullable=True)
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
     updated_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow)
 
     template = db.relationship("Template")
     service = db.relationship("Service")
+    created_by = db.relationship("User", foreign_keys=[created_by_id], lazy="select")
 
     @property
     def file_size_mib(self):

--- a/migrations/versions/0515_add_created_by_id_to_files.py
+++ b/migrations/versions/0515_add_created_by_id_to_files.py
@@ -1,0 +1,25 @@
+"""
+Revision ID: 0515_add_created_by_id_to_files
+Revises: 0514_add_files_table
+Create Date: 2026-06-10
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0515_add_created_by_id_to_files"
+down_revision = "0514_add_files_table"
+
+
+def upgrade():
+    op.add_column("files", sa.Column("created_by_id", postgresql.UUID(as_uuid=True), nullable=True))
+    op.create_foreign_key("files_created_by_id_fkey", "files", "users", ["created_by_id"], ["id"])
+    op.create_index("ix_files_created_by_id", "files", ["created_by_id"])
+
+
+def downgrade():
+    op.drop_index("ix_files_created_by_id", table_name="files")
+    op.drop_constraint("files_created_by_id_fkey", "files", type_="foreignkey")
+    op.drop_column("files", "created_by_id")

--- a/migrations/versions/0515_add_created_by_id_to_files.py
+++ b/migrations/versions/0515_add_created_by_id_to_files.py
@@ -16,10 +16,10 @@ down_revision = "0514_add_files_table"
 def upgrade():
     op.add_column("files", sa.Column("created_by_id", postgresql.UUID(as_uuid=True), nullable=True))
     op.create_foreign_key("files_created_by_id_fkey", "files", "users", ["created_by_id"], ["id"])
-    op.create_index("ix_files_created_by_id", "files", ["created_by_id"])
+    op.create_index(op.f("ix_files_created_by_id"), "files", ["created_by_id"])
 
 
 def downgrade():
-    op.drop_index("ix_files_created_by_id", table_name="files")
+    op.drop_index(op.f("ix_files_created_by_id"), table_name="files")
     op.drop_constraint("files_created_by_id_fkey", "files", type_="foreignkey")
     op.drop_column("files", "created_by_id")


### PR DESCRIPTION
# Summary | Résumé
This PR adds a `created_by_id` column to the files table per [discussions here](https://github.com/cds-snc/notification-admin/pull/2702#discussion_r3383585631) 

# Test instructions | Instructions pour tester la modification
- [ ] `flask db upgrade/downgrade` work as expected
- [ ] CI is passing

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.