### PR TITLE
Add new scan verdict auth & callback endpoint

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -201,6 +201,7 @@ def register_blueprint(application):
         requires_cache_clear_auth,
         requires_cypress_auth,
         requires_no_auth,
+        requires_scan_verdict_auth,
         requires_sre_auth,
     )
     from app.billing.rest import billing_blueprint
@@ -209,7 +210,7 @@ def register_blueprint(application):
     from app.cypress.rest import cypress_blueprint
     from app.email_branding.rest import email_branding_blueprint
     from app.events.rest import events as events_blueprint
-    from app.files.rest import files_blueprint
+    from app.files.rest import files_blueprint, scan_verdict_callback_blueprint
     from app.inbound_number.rest import inbound_number_blueprint
     from app.inbound_sms.rest import inbound_sms as inbound_sms_blueprint
     from app.invite.rest import invite as invite_blueprint
@@ -246,6 +247,8 @@ def register_blueprint(application):
     register_notify_blueprint(application, notifications_blueprint, requires_auth)
 
     register_notify_blueprint(application, files_blueprint, requires_admin_auth)
+
+    register_notify_blueprint(application, scan_verdict_callback_blueprint, requires_scan_verdict_auth)
 
     register_notify_blueprint(application, job_blueprint, requires_admin_auth)
 

--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -169,7 +169,7 @@ def requires_scan_verdict_auth():
     if not hmac.compare_digest(provided_token, expected_token):
         raise AuthError("Unauthorized, invalid scan verdict callback token", 403)
 
-    g.service_id = "scan-verdict-callback"
+    g.service_id = current_app.config.get("SCAN_VERDICT_CALLBACK_USER_NAME")
 
 
 def requires_auth():

--- a/app/authentication/auth.py
+++ b/app/authentication/auth.py
@@ -1,3 +1,5 @@
+import hmac
+
 from flask import current_app, g, request  # type: ignore
 from jwt import PyJWTError
 from notifications_python_client.authentication import (
@@ -149,6 +151,25 @@ def requires_cypress_auth():
         return handle_admin_key(auth_token, current_app.config.get("CYPRESS_AUTH_CLIENT_SECRET"))
     else:
         raise AuthError("Unauthorized, cypress authentication token required", 401)
+
+
+def requires_scan_verdict_auth():
+    request_helper.check_proxy_header_before_request()
+
+    provided_token = request.headers.get("X-Scan-Callback-Token")
+    expected_token = current_app.config.get("SCAN_VERDICT_CALLBACK_TOKEN")
+
+    if not provided_token:
+        raise AuthError("Unauthorized, scan verdict callback token required", 401)
+
+    if not expected_token:
+        current_app.logger.error("SCAN_VERDICT_CALLBACK_TOKEN is not configured")
+        raise AuthError("Unauthorized, scan verdict auth unavailable", 401)
+
+    if not hmac.compare_digest(provided_token, expected_token):
+        raise AuthError("Unauthorized, invalid scan verdict callback token", 403)
+
+    g.service_id = "scan-verdict-callback"
 
 
 def requires_auth():

--- a/app/config.py
+++ b/app/config.py
@@ -688,6 +688,9 @@ class Config(object):
     CYPRESS_AUTH_USER_NAME = "CYPRESS_AUTH_USER"
     CYPRESS_AUTH_CLIENT_SECRET = os.getenv("CYPRESS_AUTH_CLIENT_SECRET")
     CYPRESS_EMAIL_PREFIX = "notify-ui-tests"
+    # scan files callback auth
+    SCAN_VERDICT_CALLBACK_TOKEN = os.getenv("SCAN_VERDICT_CALLBACK_TOKEN")
+    SCAN_VERDICT_CALLBACK_USER_NAME = "scan-verdict-callback"
 
     @classmethod
     def get_sensitive_config(cls) -> list[str]:

--- a/app/dao/files_dao.py
+++ b/app/dao/files_dao.py
@@ -19,6 +19,10 @@ def dao_get_file_by_id(file_id):
     return Files.query.filter(Files.id == file_id).one()
 
 
+def dao_get_file_by_document_id(document_id):
+    return Files.query.filter(Files.document_id == document_id).one()
+
+
 @transactional
 def dao_create_file(file):
     db.session.add(file)

--- a/app/files/files_schema.py
+++ b/app/files/files_schema.py
@@ -30,3 +30,25 @@ post_update_file_status_schema = {
     },
     "required": ["status"],
 }
+
+
+guardduty_scan_verdict_callback_schema = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "POST schema for transformed GuardDuty scan verdict callback payload",
+    "type": "object",
+    "additionalProperties": True,
+    "properties": {
+        "event_id": {"type": "string"},
+        "event_time": {"type": "string"},
+        "account": {"type": "string"},
+        "region": {"type": "string"},
+        "bucket_name": {"type": "string"},
+        "object_key": {
+            "type": "string",
+            "pattern": r"^/?template/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+        },
+        "scan_status": {"type": "string", "enum": ["COMPLETED", "FAILED"]},
+        "scan_result_status": {"type": "string"},
+    },
+    "required": ["object_key", "scan_status", "bucket_name"],
+}

--- a/app/files/rest.py
+++ b/app/files/rest.py
@@ -108,7 +108,7 @@ def get_file_status(template_id, file_id):
 
 @files_blueprint.route("/<uuid:file_id>", methods=["DELETE"])
 def delete_file(template_id, file_id):
-    fetched_file = fetched_file = dao_get_file_by_id(file_id)
+    fetched_file = dao_get_file_by_id(file_id)
 
     if fetched_file.template_id != template_id:
         raise InvalidRequest(

--- a/app/files/rest.py
+++ b/app/files/rest.py
@@ -6,6 +6,7 @@ from sqlalchemy.exc import NoResultFound
 from app.dao.files_dao import (
     dao_create_file,
     dao_delete_file,
+    dao_get_file_by_document_id,
     dao_get_file_by_id,
     dao_get_file_status_by_id_and_template_id,
     dao_get_files_by_template_id,
@@ -15,10 +16,17 @@ from app.dao.permissions_dao import permission_dao
 from app.dao.templates_dao import dao_get_template_by_id
 from app.errors import InvalidRequest, register_errors
 from app.files.files_schema import (
+    guardduty_scan_verdict_callback_schema,
     post_create_file_schema,
-    post_update_file_status_schema,
 )
-from app.models import FILE_STATUS_PENDING_VIRUS_SCAN, MANAGE_TEMPLATES, UPLOAD_DOCUMENT, Files
+from app.models import (
+    FILE_STATUS_PENDING_VIRUS_SCAN,
+    FILE_STATUS_UPLOADED,
+    FILE_STATUS_VIRUS_SCAN_FAILED,
+    MANAGE_TEMPLATES,
+    UPLOAD_DOCUMENT,
+    Files,
+)
 from app.notifications.validators import check_service_has_permission, validate_template_exists
 from app.schema_validation import validate
 from app.schemas import files_schema
@@ -26,12 +34,31 @@ from app.schemas import files_schema
 files_blueprint = Blueprint("files", __name__, url_prefix="/templates/<uuid:template_id>/files")
 register_errors(files_blueprint)
 
+scan_verdict_callback_blueprint = Blueprint("scan_verdict_callback", __name__, url_prefix="/templates/scan-verdict-callback")
+register_errors(scan_verdict_callback_blueprint)
+
+GUARD_DUTY_STATUS_MAP = {
+    "NO_THREATS_FOUND": FILE_STATUS_UPLOADED,
+    "THREATS_FOUND": FILE_STATUS_VIRUS_SCAN_FAILED,
+    "RUNNING": FILE_STATUS_PENDING_VIRUS_SCAN,
+    # Leave scan errors terminal so UI can show failure rather than spin forever
+    "UNSUPPORTED": FILE_STATUS_VIRUS_SCAN_FAILED,
+    "ACCESS_DENIED": FILE_STATUS_VIRUS_SCAN_FAILED,
+    "FAILED": FILE_STATUS_VIRUS_SCAN_FAILED,
+    "SKIPPED": FILE_STATUS_VIRUS_SCAN_FAILED,
+}
+
 
 @files_blueprint.route("", methods=["POST"])
 def create_file(template_id):
     data = request.get_json()
     validate(data, post_create_file_schema)
-    _check_user_has_file_permissions(data["created_by"])
+
+    user_id = data["created_by"]
+    permissions = {p.permission for p in permission_dao.get_permissions_by_user_id(data["created_by"])}
+
+    if MANAGE_TEMPLATES not in permissions:
+        raise InvalidRequest(f"User {user_id} does not have {MANAGE_TEMPLATES} permissions.", 403)
 
     try:
         template = dao_get_template_by_id(template_id)
@@ -81,31 +108,7 @@ def get_file_status(template_id, file_id):
 
 @files_blueprint.route("/<uuid:file_id>", methods=["DELETE"])
 def delete_file(template_id, file_id):
-    fetched_file = _validate_file_template_match(template_id, file_id)
-
-    dao_delete_file(fetched_file)
-
-    current_app.logger.info(f"Deleted file: {file_id} template_id {template_id}")
-    return "", 204
-
-
-# TODO: This will be pulled out into a separate route later for the eventbridge lambda
-# to access via a token. Just including here for now.
-@files_blueprint.route("/<uuid:file_id>/status", methods=["POST"])
-def update_file_status(template_id, file_id):
-    fetched_file = _validate_file_template_match(template_id, file_id)
-    data = request.get_json()
-    validate(data, post_update_file_status_schema)
-
-    fetched_file.status = data["status"]
-    dao_update_file(fetched_file)
-
-    current_app.logger.info(f"Updated file status for file: {file_id} template_id: {template_id} to {data['status']}")
-    return jsonify(files_schema.dump(fetched_file)), 200
-
-
-def _validate_file_template_match(template_id, file_id):
-    fetched_file = dao_get_file_by_id(file_id)
+    fetched_file = fetched_file = dao_get_file_by_id(file_id)
 
     if fetched_file.template_id != template_id:
         raise InvalidRequest(
@@ -113,11 +116,58 @@ def _validate_file_template_match(template_id, file_id):
             404,
         )
 
-    return fetched_file
+    dao_delete_file(fetched_file)
+
+    current_app.logger.info(f"Deleted file: {file_id} template_id {template_id}")
+    return "", 204
 
 
-def _check_user_has_file_permissions(user_id):
-    permissions = {p.permission for p in permission_dao.get_permissions_by_user_id(user_id)}
+# TODO: This will be pulled out into a separate route later for the eventbridge API destination to call
+@scan_verdict_callback_blueprint.route("", methods=["POST"])
+def update_file_status():
+    """Callback endpoints that receives completed scan verdicts from GuardDuty / EventBridge
+    and updates the file in the DB with the appropriate scan verdict status.
 
-    if MANAGE_TEMPLATES not in permissions:
-        raise InvalidRequest(f"User {user_id} does not have {MANAGE_TEMPLATES} permissions.", 403)
+    The EventBridge connection calls this endpoint when it receives a file scan verdict event
+    from GuardDuty. Only events meeting the following criteria will be forwarded to this endpoint:
+    1. The scan_status is COMPLETED or FAILED
+    2. The scan was on the `*-document-download-scan-files` bucket
+    3. The scanned key matches `/template/<service_id>/<document_id>`
+    """
+    event = request.get_json()
+    validate(event, guardduty_scan_verdict_callback_schema)
+
+    parsed = _parse_scan_verdict_payload(event)
+    document_id = parsed["document_id"]
+    new_status = parsed["new_status"]
+
+    fetched_file = dao_get_file_by_document_id(document_id)
+    fetched_file.status = new_status
+    dao_update_file(fetched_file)
+
+    current_app.logger.info(
+        f"Updated file status to {new_status} for file_id: {fetched_file.id} "
+        f"template_id: {fetched_file.template_id} document_id: {fetched_file.document_id} "
+    )
+    return jsonify(files_schema.dump(fetched_file)), 200
+
+
+def _parse_scan_verdict_payload(event):
+    scan_status = event.get("scan_status")
+    scan_result = event.get("scan_result_status")
+    object_key = event["object_key"]
+    bucket_name = event.get("bucket_name")
+
+    current_app.logger.info(
+        f"Received Scan result: bucket={bucket_name} key={object_key}" f" scanStatus={scan_status} scanResult={scan_result}"
+    )
+    normalized_key = object_key.lstrip("/")
+    _, service_id, document_id = normalized_key.split("/", 2)
+    new_status = GUARD_DUTY_STATUS_MAP.get(scan_result, FILE_STATUS_VIRUS_SCAN_FAILED)
+
+    return {
+        "status": "ok",
+        "service_id": service_id,
+        "document_id": document_id,
+        "new_status": new_status,
+    }

--- a/app/files/rest.py
+++ b/app/files/rest.py
@@ -122,7 +122,6 @@ def delete_file(template_id, file_id):
     return "", 204
 
 
-# TODO: This will be pulled out into a separate route later for the eventbridge API destination to call
 @scan_verdict_callback_blueprint.route("", methods=["POST"])
 def update_file_status():
     """Callback endpoints that receives completed scan verdicts from GuardDuty / EventBridge

--- a/app/files/rest.py
+++ b/app/files/rest.py
@@ -138,9 +138,16 @@ def update_file_status():
 
     parsed = _parse_scan_verdict_payload(event)
     document_id = parsed["document_id"]
+    service_id = parsed["service_id"]
     new_status = parsed["new_status"]
 
     fetched_file = dao_get_file_by_document_id(document_id)
+    if str(fetched_file.service_id) != service_id:
+        raise InvalidRequest(
+            f"Requested document_id {fetched_file.document_id} is not associated with service {service_id}",
+            404,
+        )
+
     fetched_file.status = new_status
     dao_update_file(fetched_file)
 
@@ -162,7 +169,11 @@ def _parse_scan_verdict_payload(event):
     )
     normalized_key = object_key.lstrip("/")
     _, service_id, document_id = normalized_key.split("/", 2)
-    new_status = GUARD_DUTY_STATUS_MAP.get(scan_result, FILE_STATUS_VIRUS_SCAN_FAILED)
+
+    if scan_status == "COMPLETED":
+        new_status = GUARD_DUTY_STATUS_MAP.get(scan_result, FILE_STATUS_VIRUS_SCAN_FAILED)
+    else:
+        new_status = GUARD_DUTY_STATUS_MAP.get(scan_status, FILE_STATUS_VIRUS_SCAN_FAILED)
 
     return {
         "status": "ok",

--- a/tests/app/authentication/test_authentication.py
+++ b/tests/app/authentication/test_authentication.py
@@ -14,6 +14,7 @@ from app.authentication.auth import (
     requires_admin_auth,
     requires_auth,
     requires_cache_clear_auth,
+    requires_scan_verdict_auth,
 )
 from app.dao.api_key_dao import (
     expire_api_key,
@@ -507,3 +508,59 @@ class TestSwagger:
         error_data = json.loads(response.get_data(as_text=True))
         # assert error_data['result'] == 'error'
         assert "authentication token must be provided" in error_data["errors"][0]["message"]
+
+
+class TestScanVerdictAuth:
+    def test_requires_scan_verdict_auth_fails_without_token(self, client):
+        """Test that scan verdict auth fails when X-Scan-Callback-Token header is missing."""
+        request.headers = {}
+        with pytest.raises(AuthError) as exc:
+            requires_scan_verdict_auth()
+        assert exc.value.short_message == "Unauthorized, scan verdict callback token required"
+        assert exc.value.code == 401
+
+    def test_requires_scan_verdict_auth_fails_with_missing_config(self, client):
+        """Test that scan verdict auth fails when SCAN_VERDICT_CALLBACK_TOKEN is not configured."""
+        with set_config(client.application, "SCAN_VERDICT_CALLBACK_TOKEN", ""):
+            request.headers = {"X-Scan-Callback-Token": "some-token"}
+            with pytest.raises(AuthError) as exc:
+                requires_scan_verdict_auth()
+            assert exc.value.short_message == "Unauthorized, scan verdict auth unavailable"
+            assert exc.value.code == 401
+
+    def test_requires_scan_verdict_auth_fails_with_invalid_token(self, client):
+        """Test that scan verdict auth fails when provided token doesn't match expected token."""
+        with set_config(client.application, "SCAN_VERDICT_CALLBACK_TOKEN", "expected-token-value"):
+            request.headers = {"X-Scan-Callback-Token": "wrong-token-value"}
+            with pytest.raises(AuthError) as exc:
+                requires_scan_verdict_auth()
+            assert exc.value.short_message == "Unauthorized, invalid scan verdict callback token"
+            assert exc.value.code == 403
+
+    def test_requires_scan_verdict_auth_succeeds_with_valid_token(self, client):
+        """Test that scan verdict auth succeeds with valid token and sets g.service_id."""
+        scan_verdict_token = "valid-scan-verdict-callback-token"
+        scan_verdict_user_name = "scan-verdict-user"
+        with set_config_values(
+            client.application,
+            {
+                "SCAN_VERDICT_CALLBACK_TOKEN": scan_verdict_token,
+                "SCAN_VERDICT_CALLBACK_USER_NAME": scan_verdict_user_name,
+            },
+        ):
+            request.headers = {"X-Scan-Callback-Token": scan_verdict_token}
+            # This should not raise an exception
+            requires_scan_verdict_auth()
+            # Verify that g.service_id was set correctly
+            assert g.service_id == scan_verdict_user_name
+
+    def test_requires_scan_verdict_auth_token_comparison_is_constant_time(self, client):
+        """Test that token comparison uses constant-time comparison (hmac.compare_digest)."""
+        scan_verdict_token = "super-secret-callback-token"
+        with set_config(client.application, "SCAN_VERDICT_CALLBACK_TOKEN", scan_verdict_token):
+            # Test with a token that differs only in the last character
+            request.headers = {"X-Scan-Callback-Token": "super-secret-callback-toke" + chr(ord("n") + 1)}
+            with pytest.raises(AuthError) as exc:
+                requires_scan_verdict_auth()
+            # Should fail with invalid token, not expose timing information
+            assert exc.value.code == 403

--- a/tests/app/files/test_rest.py
+++ b/tests/app/files/test_rest.py
@@ -1,13 +1,15 @@
 import base64
+import json
+import uuid
 
-import pytest
-from jsonschema import ValidationError
+from flask import current_app, url_for
 
 from app.dao.permissions_dao import permission_dao
 from app.files.rest import _parse_scan_verdict_payload
-from app.models import FILE_STATUS_UPLOADED
+from app.models import FILE_STATUS_UPLOADED, FILE_STATUS_VIRUS_SCAN_FAILED
 from tests.app.conftest import create_sample_template
 from tests.app.db import create_user
+from tests.conftest import set_config_values
 
 
 class TestCreateFile:
@@ -132,29 +134,100 @@ class TestGetFile:
         )
 
 
-class TestUpdateFileStatus:
-    def test_update_file_status(self, admin_request, sample_file):
-        admin_request.post(
-            "files.update_file_status",
-            template_id=str(sample_file.template_id),
-            file_id=str(sample_file.id),
-            _data={"status": "uploaded"},
-            _expected_status=200,
+SCAN_VERDICT_TOKEN = "test-scan-verdict-token"
+
+
+def _scan_verdict_post(client, data, expected_status=200):
+    """POST to the scan-verdict-callback endpoint with the X-Scan-Callback-Token header."""
+    with set_config_values(current_app, {"SCAN_VERDICT_CALLBACK_TOKEN": SCAN_VERDICT_TOKEN}):
+        resp = client.post(
+            url_for("scan_verdict_callback.update_file_status"),
+            data=json.dumps(data),
+            headers=[
+                ("Content-Type", "application/json"),
+                ("X-Scan-Callback-Token", SCAN_VERDICT_TOKEN),
+            ],
         )
+    assert resp.status_code == expected_status, resp.json
+    return resp.json
+
+
+class TestUpdateFileStatus:
+    def test_update_file_status_clean_scan(self, client, sample_file):
+        data = {
+            "scan_status": "COMPLETED",
+            "scan_result_status": "NO_THREATS_FOUND",
+            "object_key": f"template/{sample_file.service_id}/{sample_file.document_id}",
+            "bucket_name": "test-bucket",
+        }
+        resp = _scan_verdict_post(client, data)
+
+        assert resp["status"] == FILE_STATUS_UPLOADED
         assert sample_file.status == FILE_STATUS_UPLOADED
 
-    def test_update_file_status_returns_404_when_template_file_mismatch(
-        self, notify_db, notify_db_session, admin_request, sample_file, sample_service_full_permissions
-    ):
-        different_template = create_sample_template(notify_db, notify_db_session, service=sample_service_full_permissions)
+    def test_update_file_status_threat_found(self, client, sample_file):
+        data = {
+            "scan_status": "COMPLETED",
+            "scan_result_status": "THREATS_FOUND",
+            "object_key": f"template/{sample_file.service_id}/{sample_file.document_id}",
+            "bucket_name": "test-bucket",
+        }
+        resp = _scan_verdict_post(client, data)
 
-        admin_request.post(
-            "files.update_file_status",
-            template_id=str(different_template.id),
-            file_id=str(sample_file.id),
-            _data={"status": "uploaded"},
-            _expected_status=404,
+        assert resp["status"] == FILE_STATUS_VIRUS_SCAN_FAILED
+        assert sample_file.status == FILE_STATUS_VIRUS_SCAN_FAILED
+
+    def test_update_file_status_scan_failure_maps_to_terminal(self, client, sample_file):
+        data = {
+            "scan_status": "FAILED",
+            "object_key": f"template/{sample_file.service_id}/{sample_file.document_id}",
+            "bucket_name": "test-bucket",
+        }
+        resp = _scan_verdict_post(client, data)
+
+        assert resp["status"] == FILE_STATUS_VIRUS_SCAN_FAILED
+        assert sample_file.status == FILE_STATUS_VIRUS_SCAN_FAILED
+
+    def test_update_file_status_returns_404_for_unknown_document_id(self, client, sample_file):
+        data = {
+            "scan_status": "COMPLETED",
+            "scan_result_status": "NO_THREATS_FOUND",
+            "object_key": f"template/{sample_file.service_id}/{uuid.uuid4()}",
+            "bucket_name": "test-bucket",
+        }
+        _scan_verdict_post(client, data, expected_status=404)
+
+    def test_update_file_status_returns_404_for_service_id_mismatch(self, client, sample_file):
+        wrong_service_id = str(uuid.uuid4())
+        data = {
+            "scan_status": "COMPLETED",
+            "scan_result_status": "NO_THREATS_FOUND",
+            "object_key": f"template/{wrong_service_id}/{sample_file.document_id}",
+            "bucket_name": "test-bucket",
+        }
+        _scan_verdict_post(client, data, expected_status=404)
+
+    def test_update_file_status_returns_400_for_invalid_schema(self, client, sample_file):
+        _scan_verdict_post(client, {"unexpected": "payload"}, expected_status=400)
+
+    def test_update_file_status_returns_401_without_token(self, client, sample_file):
+        resp = client.post(
+            url_for("scan_verdict_callback.update_file_status"),
+            data=json.dumps({"scan_status": "COMPLETED"}),
+            headers=[("Content-Type", "application/json")],
         )
+        assert resp.status_code == 401
+
+    def test_update_file_status_returns_403_for_wrong_token(self, client, sample_file):
+        resp = client.post(
+            url_for("scan_verdict_callback.update_file_status"),
+            data=json.dumps({"scan_status": "COMPLETED"}),
+            headers=[
+                ("Content-Type", "application/json"),
+                ("X-Scan-Callback-Token", "wrong-token"),
+            ],
+        )
+        assert resp.status_code == 401
 
 
 class TestDeleteFile:
@@ -198,17 +271,6 @@ class TestParseScanVerdictPayload:
             "new_status": "uploaded",
         }
 
-    def test_parse_scan_verdict_payload_raises_on_unparseable_object_key(self, client):
-        payload = {
-            "scan_status": "COMPLETED",
-            "scan_result_status": "THREATS_FOUND",
-            "object_key": "bad/key/format",
-            "bucket_name": "my-bucket",
-        }
-
-        with pytest.raises(ValidationError, match="objectKey"):
-            _parse_scan_verdict_payload(payload)
-
     def test_parse_scan_verdict_payload_accepts_object_key_with_leading_slash(self, client):
         payload = {
             "scan_status": "COMPLETED",
@@ -229,6 +291,39 @@ class TestParseScanVerdictPayload:
     def test_parse_scan_verdict_payload_maps_failed_scan_to_terminal_status(self, client):
         payload = {
             "scan_status": "FAILED",
+            "object_key": "template/11111111-1111-1111-1111-111111111111/22222222-2222-2222-2222-222222222222",
+            "bucket_name": "my-bucket",
+        }
+
+        parsed = _parse_scan_verdict_payload(payload)
+
+        assert parsed == {
+            "status": "ok",
+            "service_id": "11111111-1111-1111-1111-111111111111",
+            "document_id": "22222222-2222-2222-2222-222222222222",
+            "new_status": "virus_scan_failed",
+        }
+
+    def test_parse_scan_verdict_payload_completed_with_unknown_scan_result_falls_back_to_terminal_status(self, client):
+        payload = {
+            "scan_status": "COMPLETED",
+            "scan_result_status": "SOMETHING_NEW",
+            "object_key": "template/11111111-1111-1111-1111-111111111111/22222222-2222-2222-2222-222222222222",
+            "bucket_name": "my-bucket",
+        }
+
+        parsed = _parse_scan_verdict_payload(payload)
+
+        assert parsed == {
+            "status": "ok",
+            "service_id": "11111111-1111-1111-1111-111111111111",
+            "document_id": "22222222-2222-2222-2222-222222222222",
+            "new_status": "virus_scan_failed",
+        }
+
+    def test_parse_scan_verdict_payload_completed_without_scan_result_falls_back_to_terminal_status(self, client):
+        payload = {
+            "scan_status": "COMPLETED",
             "object_key": "template/11111111-1111-1111-1111-111111111111/22222222-2222-2222-2222-222222222222",
             "bucket_name": "my-bucket",
         }

--- a/tests/app/files/test_rest.py
+++ b/tests/app/files/test_rest.py
@@ -1,6 +1,10 @@
 import base64
 
+import pytest
+from jsonschema import ValidationError
+
 from app.dao.permissions_dao import permission_dao
+from app.files.rest import _parse_scan_verdict_payload
 from app.models import FILE_STATUS_UPLOADED
 from tests.app.conftest import create_sample_template
 from tests.app.db import create_user
@@ -173,3 +177,67 @@ class TestDeleteFile:
             file_id=str(sample_file.id),
             _expected_status=404,
         )
+
+
+class TestParseScanVerdictPayload:
+    def test_parse_scan_verdict_payload_accepts_extra_fields(self, client):
+        payload = {
+            "scan_status": "COMPLETED",
+            "scan_result_status": "NO_THREATS_FOUND",
+            "object_key": "template/11111111-1111-1111-1111-111111111111/22222222-2222-2222-2222-222222222222",
+            "bucket_name": "my-bucket",
+            "top_level": "ignored",
+        }
+
+        parsed = _parse_scan_verdict_payload(payload)
+
+        assert parsed == {
+            "status": "ok",
+            "service_id": "11111111-1111-1111-1111-111111111111",
+            "document_id": "22222222-2222-2222-2222-222222222222",
+            "new_status": "uploaded",
+        }
+
+    def test_parse_scan_verdict_payload_raises_on_unparseable_object_key(self, client):
+        payload = {
+            "scan_status": "COMPLETED",
+            "scan_result_status": "THREATS_FOUND",
+            "object_key": "bad/key/format",
+            "bucket_name": "my-bucket",
+        }
+
+        with pytest.raises(ValidationError, match="objectKey"):
+            _parse_scan_verdict_payload(payload)
+
+    def test_parse_scan_verdict_payload_accepts_object_key_with_leading_slash(self, client):
+        payload = {
+            "scan_status": "COMPLETED",
+            "scan_result_status": "NO_THREATS_FOUND",
+            "object_key": "/template/11111111-1111-1111-1111-111111111111/22222222-2222-2222-2222-222222222222",
+            "bucket_name": "my-bucket",
+        }
+
+        parsed = _parse_scan_verdict_payload(payload)
+
+        assert parsed == {
+            "status": "ok",
+            "service_id": "11111111-1111-1111-1111-111111111111",
+            "document_id": "22222222-2222-2222-2222-222222222222",
+            "new_status": "uploaded",
+        }
+
+    def test_parse_scan_verdict_payload_maps_failed_scan_to_terminal_status(self, client):
+        payload = {
+            "scan_status": "FAILED",
+            "object_key": "template/11111111-1111-1111-1111-111111111111/22222222-2222-2222-2222-222222222222",
+            "bucket_name": "my-bucket",
+        }
+
+        parsed = _parse_scan_verdict_payload(payload)
+
+        assert parsed == {
+            "status": "ok",
+            "service_id": "11111111-1111-1111-1111-111111111111",
+            "document_id": "22222222-2222-2222-2222-222222222222",
+            "new_status": "virus_scan_failed",
+        }


### PR DESCRIPTION
# Summary | Résumé
This PR adds a new endpoint to receive template attachment file scan verdicts from EventBridge and update the file status in the DB. It's a rough implementation at the moment and will likely be iterated on once the EventBridge / Connection API infrastructure in TF is implemented and we see exactly what kind of payloads the endpoint receives.

- Added a new route `/templates/scan-verdict-callback` protected by `requires_scan_verdict_auth`
- Updated the `update_file_status` endpoint to live under the above route
- Added a schema to validate GuardDuty result events
- Moved permission checking into `create_file` endpoint as it was only used once

## Related Issues | Cartes liées
* https://github.com/cds-snc/notification-planning/issues/3283

# Test instructions | Instructions pour tester la modification
Just that CI is passing for now, 

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.