### PR TITLE
Add patch and delete endpoints

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -310,8 +310,10 @@ def register_v2_blueprints(application):
         v2_inbound_sms_blueprint as get_inbound_sms,
     )
     from app.v2.manage_template import (  # noqa
+        delete_template,
         get_template,
         get_template_categories,
+        patch_template,
         post_template,
         v2_manage_template_blueprint,
     )

--- a/app/v2/errors.py
+++ b/app/v2/errors.py
@@ -134,6 +134,20 @@ class ForbiddenError(InvalidRequest):
         self.fields = fields if fields is not None else []
 
 
+class TemplateCategoryValidationError(BadRequestError):
+    message = "template_category_id must be a valid UUID"
+
+    def __init__(self):
+        super().__init__(message=self.__class__.message)
+
+
+class TemplateCategoryNotFoundError(BadRequestError):
+    message = "template_category_id not found"
+
+    def __init__(self):
+        super().__init__(message=self.__class__.message)
+
+
 class PDFNotReadyError(BadRequestError):
     def __init__(self):
         super().__init__(message="PDF not available yet, try again later", status_code=400)

--- a/app/v2/errors.py
+++ b/app/v2/errors.py
@@ -158,7 +158,7 @@ def register_errors(blueprint):
     def invalid_format(error):
         # Please not that InvalidEmailError is re-raised for InvalidEmail or InvalidPhone,
         # work should be done in the utils app to tidy up these errors.
-        current_app.logger.info(error)
+        current_app.logger.info(str(error))
         return (
             jsonify(
                 status_code=400,
@@ -169,13 +169,13 @@ def register_errors(blueprint):
 
     @blueprint.errorhandler(InvalidRequest)
     def invalid_data(error):
-        current_app.logger.info(error)
+        current_app.logger.info(str(error))
         response = jsonify(error.to_dict_v2()), error.status_code
         return response
 
     @blueprint.errorhandler(ValidationError)
     def validation_error(error):
-        current_app.logger.info(error)
+        current_app.logger.info(str(error.message))
         return jsonify(json.loads(error.message)), 400
 
     @blueprint.errorhandler(JobIncompleteError)
@@ -185,7 +185,7 @@ def register_errors(blueprint):
     @blueprint.errorhandler(NoResultFound)
     @blueprint.errorhandler(DataError)
     def no_result_found(e):
-        current_app.logger.info(e)
+        current_app.logger.info(str(e))
         return (
             jsonify(
                 status_code=404,

--- a/app/v2/errors.py
+++ b/app/v2/errors.py
@@ -118,10 +118,20 @@ class RateLimitError(InvalidRequest):
 class BadRequestError(InvalidRequest):
     message = "An error occurred"
 
-    def __init__(self, fields=[], message=None, status_code=400):
-        self.status_code = status_code
-        self.fields = fields
-        self.message = message if message else self.message
+    def __init__(self, fields=None, message=None, status_code=400):
+        resolved_message = message if message else self.message
+        super().__init__(message=resolved_message, status_code=status_code)
+        self.fields = fields if fields is not None else []
+
+
+class ForbiddenError(InvalidRequest):
+    status_code = 403
+    message = "You do not have permission to perform this action."
+
+    def __init__(self, fields=None, message=None):
+        resolved_message = message if message else self.__class__.message
+        super().__init__(message=resolved_message, status_code=self.__class__.status_code)
+        self.fields = fields if fields is not None else []
 
 
 class PDFNotReadyError(BadRequestError):

--- a/app/v2/manage_template/delete_template.py
+++ b/app/v2/manage_template/delete_template.py
@@ -26,6 +26,7 @@ def delete_manage_template(template_id):
 
     template.archived = True
     template.updated_at = datetime.utcnow()
+    template.folder = None
     templates_dao.dao_update_template(template)
     redis_store.delete(f"service-{str(template.service_id)}-templates")
     redis_store.delete(f"template-{str(template_id)}-version-{template.version}")

--- a/app/v2/manage_template/delete_template.py
+++ b/app/v2/manage_template/delete_template.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from flask import jsonify
 
-from app import api_user, authenticated_service
+from app import api_user, authenticated_service, redis_store
 from app.dao import templates_dao
 from app.models import ApiKeyPermission
 from app.schema_validation import validate
@@ -27,5 +27,6 @@ def delete_manage_template(template_id):
     template.archived = True
     template.updated_at = datetime.utcnow()
     templates_dao.dao_update_template(template)
+    redis_store.delete(f"service-{authenticated_service.id}-templates")
 
     return jsonify(_serialize_template(template)), 200

--- a/app/v2/manage_template/delete_template.py
+++ b/app/v2/manage_template/delete_template.py
@@ -27,6 +27,7 @@ def delete_manage_template(template_id):
     template.archived = True
     template.updated_at = datetime.utcnow()
     templates_dao.dao_update_template(template)
-    redis_store.delete(f"service-{authenticated_service.id}-templates")
+    redis_store.delete(f"service-{str(template.service_id)}-templates")
+    redis_store.delete(f"template-{str(template_id)}-version-{template.version}")
 
     return jsonify(_serialize_template(template)), 200

--- a/app/v2/manage_template/delete_template.py
+++ b/app/v2/manage_template/delete_template.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+
+from flask import jsonify
+
+from app import api_user, authenticated_service
+from app.dao import templates_dao
+from app.models import ApiKeyPermission
+from app.schema_validation import validate
+from app.v2.errors import BadRequestError, ForbiddenError
+from app.v2.manage_template import v2_manage_template_blueprint
+from app.v2.manage_template.get_template import _serialize_template
+from app.v2.template.template_schemas import get_template_by_id_request
+
+
+@v2_manage_template_blueprint.route("/<template_id>", methods=["DELETE"])
+def delete_manage_template(template_id):
+    if not api_user.has_permission(ApiKeyPermission.MANAGE_TEMPLATES):
+        raise ForbiddenError(message="This API key does not have permission to manage templates.")
+
+    validate({"id": template_id}, get_template_by_id_request)
+
+    template = templates_dao.dao_get_template_by_id_and_service_id(template_id, authenticated_service.id)
+
+    if template.archived:
+        raise BadRequestError(message="Template is already archived.")
+
+    template.archived = True
+    template.updated_at = datetime.utcnow()
+    templates_dao.dao_update_template(template)
+
+    return jsonify(_serialize_template(template)), 200

--- a/app/v2/manage_template/get_template.py
+++ b/app/v2/manage_template/get_template.py
@@ -2,9 +2,9 @@ from flask import jsonify
 
 from app import DATETIME_FORMAT, api_user, authenticated_service
 from app.dao import templates_dao
-from app.errors import InvalidRequest
 from app.models import ApiKeyPermission
 from app.schema_validation import validate
+from app.v2.errors import ForbiddenError
 from app.v2.manage_template import v2_manage_template_blueprint
 from app.v2.template.template_schemas import get_template_by_id_request
 
@@ -12,7 +12,7 @@ from app.v2.template.template_schemas import get_template_by_id_request
 @v2_manage_template_blueprint.route("/<template_id>", methods=["GET"])
 def get_template_by_id_enhanced(template_id):
     if not api_user.has_permission(ApiKeyPermission.MANAGE_TEMPLATES):
-        raise InvalidRequest("This API key does not have permission to manage templates.", status_code=403)
+        raise ForbiddenError(message="This API key does not have permission to manage templates.")
 
     validate({"id": template_id}, get_template_by_id_request)
 

--- a/app/v2/manage_template/get_template_categories.py
+++ b/app/v2/manage_template/get_template_categories.py
@@ -2,15 +2,15 @@ from flask import jsonify
 
 from app import api_user
 from app.dao.template_categories_dao import dao_get_all_template_categories
-from app.errors import InvalidRequest
 from app.models import ApiKeyPermission
+from app.v2.errors import ForbiddenError
 from app.v2.manage_template import v2_manage_template_blueprint
 
 
 @v2_manage_template_blueprint.route("/template-categories", methods=["GET"])
 def get_template_categories():
     if not api_user.has_permission(ApiKeyPermission.MANAGE_TEMPLATES):
-        raise InvalidRequest("This API key does not have permission to manage templates.", status_code=403)
+        raise ForbiddenError(message="This API key does not have permission to manage templates.")
 
     template_categories = dao_get_all_template_categories(hidden=False)
 

--- a/app/v2/manage_template/patch_template.py
+++ b/app/v2/manage_template/patch_template.py
@@ -8,11 +8,15 @@ from app.dao.template_categories_dao import dao_get_template_category_by_id
 from app.dao.template_folder_dao import dao_get_template_folder_by_id_and_service_id
 from app.models import ApiKeyPermission
 from app.schema_validation import validate
-from app.v2.errors import BadRequestError, ForbiddenError
+from app.v2.errors import (
+    BadRequestError,
+    ForbiddenError,
+    TemplateCategoryNotFoundError,
+    TemplateCategoryValidationError,
+)
 from app.v2.manage_template import v2_manage_template_blueprint
 from app.v2.manage_template.get_template import _serialize_template
 from app.v2.manage_template.post_template import (
-    _get_validation_message,
     _raise_if_content_or_name_over_limit,
     _template_category_error_response,
 )
@@ -31,7 +35,10 @@ def patch_manage_template(template_id):
         data = validate(request.get_json() or {}, patch_manage_template_request)
     except ValidationError as e:
         if "template_category_id" in str(e):
-            return _template_category_error_response("ValidationError", _get_validation_message(e))
+            return _template_category_error_response(
+                TemplateCategoryValidationError.__name__,
+                TemplateCategoryValidationError.message,
+            )
         raise
 
     template = templates_dao.dao_get_template_by_id_and_service_id(template_id, authenticated_service.id)
@@ -40,7 +47,10 @@ def patch_manage_template(template_id):
         try:
             dao_get_template_category_by_id(data["template_category_id"])
         except NoResultFound:
-            return _template_category_error_response("InvalidRequest", "template_category_id not found")
+            return _template_category_error_response(
+                TemplateCategoryNotFoundError.__name__,
+                TemplateCategoryNotFoundError.message,
+            )
 
     if "parent_folder_id" in data:
         parent_folder_id = data.pop("parent_folder_id")

--- a/app/v2/manage_template/patch_template.py
+++ b/app/v2/manage_template/patch_template.py
@@ -1,0 +1,63 @@
+from flask import jsonify, request
+from jsonschema import ValidationError
+from sqlalchemy.orm.exc import NoResultFound
+
+from app import api_user, authenticated_service
+from app.dao import templates_dao
+from app.dao.template_categories_dao import dao_get_template_category_by_id
+from app.dao.template_folder_dao import dao_get_template_folder_by_id_and_service_id
+from app.models import ApiKeyPermission
+from app.schema_validation import validate
+from app.v2.errors import BadRequestError, ForbiddenError
+from app.v2.manage_template import v2_manage_template_blueprint
+from app.v2.manage_template.get_template import _serialize_template
+from app.v2.manage_template.post_template import (
+    _get_validation_message,
+    _raise_if_content_or_name_over_limit,
+    _template_category_error_response,
+)
+from app.v2.manage_template.template_schemas import patch_manage_template_request
+from app.v2.template.template_schemas import get_template_by_id_request
+
+
+@v2_manage_template_blueprint.route("/<template_id>", methods=["PATCH"])
+def patch_manage_template(template_id):
+    if not api_user.has_permission(ApiKeyPermission.MANAGE_TEMPLATES):
+        raise ForbiddenError(message="This API key does not have permission to manage templates.")
+
+    validate({"id": template_id}, get_template_by_id_request)
+
+    try:
+        data = validate(request.get_json() or {}, patch_manage_template_request)
+    except ValidationError as e:
+        if "template_category_id" in str(e):
+            return _template_category_error_response("ValidationError", _get_validation_message(e))
+        raise
+
+    template = templates_dao.dao_get_template_by_id_and_service_id(template_id, authenticated_service.id)
+
+    if "template_category_id" in data:
+        try:
+            dao_get_template_category_by_id(data["template_category_id"])
+        except NoResultFound:
+            return _template_category_error_response("InvalidRequest", "template_category_id not found")
+
+    if "parent_folder_id" in data:
+        parent_folder_id = data.pop("parent_folder_id")
+        if parent_folder_id:
+            try:
+                template.folder = dao_get_template_folder_by_id_and_service_id(parent_folder_id, authenticated_service.id)
+            except NoResultFound:
+                raise BadRequestError(message="parent_folder_id not found")
+        else:
+            template.folder = None
+
+    for field in ("name", "content", "subject", "template_category_id"):
+        if field in data:
+            setattr(template, field, data[field])
+
+    _raise_if_content_or_name_over_limit(template)
+
+    templates_dao.dao_update_template(template)
+
+    return jsonify(_serialize_template(template)), 200

--- a/app/v2/manage_template/patch_template.py
+++ b/app/v2/manage_template/patch_template.py
@@ -2,7 +2,7 @@ from flask import jsonify, request
 from jsonschema import ValidationError
 from sqlalchemy.orm.exc import NoResultFound
 
-from app import api_user, authenticated_service
+from app import api_user, authenticated_service, redis_store
 from app.dao import templates_dao
 from app.dao.template_categories_dao import dao_get_template_category_by_id
 from app.dao.template_folder_dao import dao_get_template_folder_by_id_and_service_id
@@ -69,5 +69,6 @@ def patch_manage_template(template_id):
     _raise_if_content_or_name_over_limit(template)
 
     templates_dao.dao_update_template(template)
+    redis_store.delete(f"service-{authenticated_service.id}-templates")
 
     return jsonify(_serialize_template(template)), 200

--- a/app/v2/manage_template/patch_template.py
+++ b/app/v2/manage_template/patch_template.py
@@ -40,7 +40,6 @@ def patch_manage_template(template_id):
                 TemplateCategoryValidationError.message,
             )
         raise
-
     template = templates_dao.dao_get_template_by_id_and_service_id(template_id, authenticated_service.id)
 
     if "template_category_id" in data:
@@ -69,6 +68,7 @@ def patch_manage_template(template_id):
     _raise_if_content_or_name_over_limit(template)
 
     templates_dao.dao_update_template(template)
-    redis_store.delete(f"service-{authenticated_service.id}-templates")
+    redis_store.delete(f"service-{str(template.service_id)}-templates")
+    redis_store.delete(f"template-{str(template_id)}-version-{template.version}")
 
     return jsonify(_serialize_template(template)), 200

--- a/app/v2/manage_template/post_template.py
+++ b/app/v2/manage_template/post_template.py
@@ -10,11 +10,11 @@ from app import api_user, authenticated_service, redis_store
 from app.dao import templates_dao
 from app.dao.template_categories_dao import dao_get_all_template_categories, dao_get_template_category_by_id
 from app.dao.template_folder_dao import dao_get_template_folder_by_id_and_service_id
-from app.errors import InvalidRequest
 from app.models import EMAIL_TYPE, SMS_TYPE, ApiKeyPermission, Template
 from app.notifications.validators import service_has_permission
 from app.schema_validation import validate
 from app.utils import get_public_notify_type_text
+from app.v2.errors import BadRequestError, ForbiddenError
 from app.v2.manage_template import v2_manage_template_blueprint
 from app.v2.manage_template.get_template import _serialize_template
 from app.v2.manage_template.template_schemas import post_manage_template_request
@@ -23,7 +23,7 @@ from app.v2.manage_template.template_schemas import post_manage_template_request
 @v2_manage_template_blueprint.route("", methods=["POST"])
 def post_manage_template():
     if not api_user.has_permission(ApiKeyPermission.MANAGE_TEMPLATES):
-        raise InvalidRequest("This API key does not have permission to manage templates.", status_code=403)
+        raise ForbiddenError(message="This API key does not have permission to manage templates.")
 
     try:
         data = validate(request.get_json() or {}, post_manage_template_request)
@@ -34,7 +34,7 @@ def post_manage_template():
 
     try:
         _validate_template_category_id(data["template_category_id"])
-    except InvalidRequest as e:
+    except BadRequestError as e:
         if e.message == "template_category_id not found":
             return _template_category_error_response("InvalidRequest", e.message)
         raise
@@ -51,7 +51,7 @@ def post_manage_template():
 
     if not service_has_permission(template.template_type, authenticated_service.permissions):
         message = "Creating {} templates is not allowed".format(get_public_notify_type_text(template.template_type))
-        raise InvalidRequest(message, status_code=403)
+        raise ForbiddenError(message=message)
 
     _raise_if_content_or_name_over_limit(template)
 
@@ -66,7 +66,7 @@ def _validate_template_category_id(template_category_id):
     try:
         dao_get_template_category_by_id(template_category_id)
     except NoResultFound:
-        raise InvalidRequest("template_category_id not found", status_code=400)
+        raise BadRequestError(message="template_category_id not found")
 
 
 def _validate_parent_folder(data):
@@ -75,7 +75,7 @@ def _validate_parent_folder(data):
         try:
             return dao_get_template_folder_by_id_and_service_id(parent_folder_id, authenticated_service.id)
         except NoResultFound:
-            raise InvalidRequest("parent_folder_id not found", status_code=400)
+            raise BadRequestError(message="parent_folder_id not found")
     return None
 
 
@@ -83,11 +83,11 @@ def _raise_if_content_or_name_over_limit(template):
     if _content_count_greater_than_limit(template.content, template.template_type):
         char_limit = SMS_CHAR_COUNT_LIMIT if template.template_type == SMS_TYPE else EMAIL_CHAR_COUNT_LIMIT
         message = "Content has a character count greater than the limit of {}".format(char_limit)
-        raise InvalidRequest(message, status_code=400)
+        raise BadRequestError(message=message)
 
     if _template_name_over_char_limit(template.name, template.content, template.template_type):
         message = "Template name must be less than {} characters".format(TEMPLATE_NAME_CHAR_COUNT_LIMIT)
-        raise InvalidRequest(message, status_code=400)
+        raise BadRequestError(message=message)
 
 
 def _content_count_greater_than_limit(content, template_type):

--- a/app/v2/manage_template/post_template.py
+++ b/app/v2/manage_template/post_template.py
@@ -1,5 +1,3 @@
-import json
-
 from flask import jsonify, request
 from jsonschema import ValidationError
 from notifications_utils import EMAIL_CHAR_COUNT_LIMIT, SMS_CHAR_COUNT_LIMIT, TEMPLATE_NAME_CHAR_COUNT_LIMIT
@@ -14,7 +12,12 @@ from app.models import EMAIL_TYPE, SMS_TYPE, ApiKeyPermission, Template
 from app.notifications.validators import service_has_permission
 from app.schema_validation import validate
 from app.utils import get_public_notify_type_text
-from app.v2.errors import BadRequestError, ForbiddenError
+from app.v2.errors import (
+    BadRequestError,
+    ForbiddenError,
+    TemplateCategoryNotFoundError,
+    TemplateCategoryValidationError,
+)
 from app.v2.manage_template import v2_manage_template_blueprint
 from app.v2.manage_template.get_template import _serialize_template
 from app.v2.manage_template.template_schemas import post_manage_template_request
@@ -29,14 +32,17 @@ def post_manage_template():
         data = validate(request.get_json() or {}, post_manage_template_request)
     except ValidationError as e:
         if "template_category_id" in str(e):
-            return _template_category_error_response("ValidationError", _get_validation_message(e))
+            return _template_category_error_response(
+                TemplateCategoryValidationError.__name__,
+                _template_category_validation_message(e),
+            )
         raise
 
     try:
         _validate_template_category_id(data["template_category_id"])
-    except BadRequestError as e:
-        if e.message == "template_category_id not found":
-            return _template_category_error_response("InvalidRequest", e.message)
+    except TemplateCategoryNotFoundError as e:
+        if e.message == TemplateCategoryNotFoundError.message:
+            return _template_category_error_response(TemplateCategoryNotFoundError.__name__, e.message)
         raise
 
     folder = _validate_parent_folder(data)
@@ -66,7 +72,7 @@ def _validate_template_category_id(template_category_id):
     try:
         dao_get_template_category_by_id(template_category_id)
     except NoResultFound:
-        raise BadRequestError(message="template_category_id not found")
+        raise TemplateCategoryNotFoundError()
 
 
 def _validate_parent_folder(data):
@@ -131,17 +137,7 @@ def _template_category_error_response(error_type, message):
     )
 
 
-def _get_validation_message(error):
-    if isinstance(error.message, str):
-        try:
-            parsed_error = json.loads(error.message)
-        except ValueError:
-            return error.message
-
-        errors = parsed_error.get("errors") if isinstance(parsed_error, dict) else None
-        if isinstance(errors, list) and errors:
-            first_error = errors[0]
-            if isinstance(first_error, dict) and "message" in first_error:
-                return first_error["message"]
-
-    return str(error)
+def _template_category_validation_message(error):
+    if "required property" in str(error):
+        return "template_category_id is a required property"
+    return TemplateCategoryValidationError.message

--- a/app/v2/manage_template/template_schemas.py
+++ b/app/v2/manage_template/template_schemas.py
@@ -1,5 +1,19 @@
 from app.models import EMAIL_TYPE, SMS_TYPE
-from app.schema_validation.definitions import uuid
+from app.schema_validation.definitions import nullable_uuid, uuid
+
+patch_manage_template_request = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "PATCH schema for updating a manage template",
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "content": {"type": "string"},
+        "subject": {"type": "string"},
+        "template_category_id": uuid,
+        "parent_folder_id": nullable_uuid,
+    },
+    "additionalProperties": False,
+}
 
 post_manage_template_request = {
     "$schema": "http://json-schema.org/draft-04/schema#",

--- a/tests/app/v2/manage_template/test_delete_template.py
+++ b/tests/app/v2/manage_template/test_delete_template.py
@@ -1,0 +1,98 @@
+import uuid
+
+from flask import json
+from tests import create_authorization_header
+from tests.app.db import create_service, create_template
+
+from app.models import EMAIL_TYPE, SMS_TYPE
+
+
+class TestDeleteTemplateV2ManageTemplate:
+    def test_delete_template_archives_and_returns_200(self, client, sample_service, create_api_key_with_manage_api_perm):
+        template = create_template(sample_service, template_type=SMS_TYPE)
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_api_perm)
+
+        response = client.delete(
+            f"/v2/manage-template/{template.id}",
+            headers=[("Content-Type", "application/json"), auth_header],
+        )
+
+        assert response.status_code == 200
+        data = json.loads(response.get_data(as_text=True))
+        assert data["id"] == str(template.id)
+        assert data["archived"] is True
+
+    def test_delete_template_returns_serialized_body(self, client, sample_service, create_api_key_with_manage_api_perm):
+        template = create_template(sample_service, template_type=EMAIL_TYPE, subject="Subject")
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_api_perm)
+
+        response = client.delete(
+            f"/v2/manage-template/{template.id}",
+            headers=[("Content-Type", "application/json"), auth_header],
+        )
+
+        assert response.status_code == 200
+        data = json.loads(response.get_data(as_text=True))
+        assert "id" in data
+        assert "service_id" in data
+        assert "service_name" in data
+        assert "name" in data
+        assert "type" in data
+        assert "body" in data
+        assert "archived" in data
+        assert data["archived"] is True
+
+    def test_delete_already_archived_template_returns_400(self, client, sample_service, create_api_key_with_manage_api_perm):
+        template = create_template(sample_service, template_type=SMS_TYPE, archived=True)
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_api_perm)
+
+        response = client.delete(
+            f"/v2/manage-template/{template.id}",
+            headers=[("Content-Type", "application/json"), auth_header],
+        )
+
+        assert response.status_code == 400
+        data = json.loads(response.get_data(as_text=True))
+        assert "already archived" in data["errors"][0]["message"].lower()
+
+    def test_delete_template_returns_403_without_manage_templates_permission(
+        self, client, sample_service, create_api_key_no_perm
+    ):
+        template = create_template(sample_service, template_type=SMS_TYPE)
+        auth_header = create_authorization_header(api_key=create_api_key_no_perm)
+
+        response = client.delete(
+            f"/v2/manage-template/{template.id}",
+            headers=[("Content-Type", "application/json"), auth_header],
+        )
+
+        assert response.status_code == 403
+        data = json.loads(response.get_data(as_text=True))
+        assert "manage templates" in data["errors"][0]["message"].lower()
+
+    def test_delete_template_returns_404_for_nonexistent_template(
+        self, client, sample_service, create_api_key_with_manage_api_perm
+    ):
+        nonexistent_id = uuid.uuid4()
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_api_perm)
+
+        response = client.delete(
+            f"/v2/manage-template/{nonexistent_id}",
+            headers=[("Content-Type", "application/json"), auth_header],
+        )
+
+        assert response.status_code == 404
+
+    def test_delete_template_returns_404_for_template_belonging_to_other_service(
+        self, client, sample_service, create_api_key_with_manage_api_perm
+    ):
+        other_service = create_service(service_name=f"other service {uuid.uuid4()}")
+        other_template = create_template(other_service, template_type=SMS_TYPE)
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_api_perm)
+
+        response = client.delete(
+            f"/v2/manage-template/{other_template.id}",
+            headers=[("Content-Type", "application/json"), auth_header],
+        )
+
+        assert response.status_code == 404

--- a/tests/app/v2/manage_template/test_patch_template.py
+++ b/tests/app/v2/manage_template/test_patch_template.py
@@ -1,0 +1,168 @@
+import uuid
+
+from flask import json
+from sqlalchemy.orm.exc import NoResultFound
+from tests import create_authorization_header
+from tests.app.db import create_template
+
+from app.models import EMAIL_TYPE, SMS_TYPE
+
+
+class TestPatchTemplateV2ManageTemplate:
+    def test_patch_template_updates_name(self, client, sample_service, create_api_key_with_manage_api_perm):
+        template = create_template(sample_service, template_type=SMS_TYPE)
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_api_perm)
+
+        response = client.patch(
+            f"/v2/manage-template/{template.id}",
+            data=json.dumps({"name": "Updated Name"}),
+            headers=[("Content-Type", "application/json"), auth_header],
+        )
+
+        assert response.status_code == 200
+        data = json.loads(response.get_data(as_text=True))
+        assert data["name"] == "Updated Name"
+
+    def test_patch_template_updates_content(self, client, sample_service, create_api_key_with_manage_api_perm):
+        template = create_template(sample_service, template_type=SMS_TYPE)
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_api_perm)
+
+        response = client.patch(
+            f"/v2/manage-template/{template.id}",
+            data=json.dumps({"content": "New content body"}),
+            headers=[("Content-Type", "application/json"), auth_header],
+        )
+
+        assert response.status_code == 200
+        data = json.loads(response.get_data(as_text=True))
+        assert data["body"] == "New content body"
+
+    def test_patch_template_updates_subject_for_email(self, client, sample_service, create_api_key_with_manage_api_perm):
+        template = create_template(sample_service, template_type=EMAIL_TYPE, subject="Old subject")
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_api_perm)
+
+        response = client.patch(
+            f"/v2/manage-template/{template.id}",
+            data=json.dumps({"subject": "New subject"}),
+            headers=[("Content-Type", "application/json"), auth_header],
+        )
+
+        assert response.status_code == 200
+        data = json.loads(response.get_data(as_text=True))
+        assert data["subject"] == "New subject"
+
+    def test_patch_template_updates_template_category(
+        self, client, sample_service, sample_template_category, create_api_key_with_manage_api_perm
+    ):
+        template = create_template(sample_service, template_type=SMS_TYPE)
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_api_perm)
+
+        response = client.patch(
+            f"/v2/manage-template/{template.id}",
+            data=json.dumps({"template_category_id": str(sample_template_category.id)}),
+            headers=[("Content-Type", "application/json"), auth_header],
+        )
+
+        assert response.status_code == 200
+        data = json.loads(response.get_data(as_text=True))
+        assert data["template_category_id"] == str(sample_template_category.id)
+
+    def test_patch_template_returns_400_for_invalid_template_category_id(
+        self, client, sample_service, create_api_key_with_manage_api_perm, mocker
+    ):
+        mocker.patch(
+            "app.v2.manage_template.patch_template.dao_get_template_category_by_id",
+            side_effect=NoResultFound,
+        )
+        template = create_template(sample_service, template_type=SMS_TYPE)
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_api_perm)
+
+        response = client.patch(
+            f"/v2/manage-template/{template.id}",
+            data=json.dumps({"template_category_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}),
+            headers=[("Content-Type", "application/json"), auth_header],
+        )
+
+        assert response.status_code == 400
+        data = json.loads(response.get_data(as_text=True))
+        assert data["errors"][0]["message"] == "template_category_id not found"
+
+    def test_patch_template_returns_400_for_invalid_parent_folder_id(
+        self, client, sample_service, create_api_key_with_manage_api_perm
+    ):
+        template = create_template(sample_service, template_type=SMS_TYPE)
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_api_perm)
+
+        response = client.patch(
+            f"/v2/manage-template/{template.id}",
+            data=json.dumps({"parent_folder_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}),
+            headers=[("Content-Type", "application/json"), auth_header],
+        )
+
+        assert response.status_code == 400
+        data = json.loads(response.get_data(as_text=True))
+        assert "parent_folder_id not found" in data["errors"][0]["message"]
+
+    def test_patch_template_returns_403_without_manage_templates_permission(self, client, sample_service, create_api_key_no_perm):
+        template = create_template(sample_service, template_type=SMS_TYPE)
+        auth_header = create_authorization_header(api_key=create_api_key_no_perm)
+
+        response = client.patch(
+            f"/v2/manage-template/{template.id}",
+            data=json.dumps({"name": "Should fail"}),
+            headers=[("Content-Type", "application/json"), auth_header],
+        )
+
+        assert response.status_code == 403
+        data = json.loads(response.get_data(as_text=True))
+        assert "manage templates" in data["errors"][0]["message"].lower()
+
+    def test_patch_template_returns_404_for_nonexistent_template(
+        self, client, sample_service, create_api_key_with_manage_api_perm
+    ):
+        nonexistent_id = uuid.uuid4()
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_api_perm)
+
+        response = client.patch(
+            f"/v2/manage-template/{nonexistent_id}",
+            data=json.dumps({"name": "Should not exist"}),
+            headers=[("Content-Type", "application/json"), auth_header],
+        )
+
+        assert response.status_code == 404
+
+    def test_patch_template_returns_400_for_additional_properties(
+        self, client, sample_service, create_api_key_with_manage_api_perm
+    ):
+        template = create_template(sample_service, template_type=SMS_TYPE)
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_api_perm)
+
+        response = client.patch(
+            f"/v2/manage-template/{template.id}",
+            data=json.dumps({"template_type": SMS_TYPE}),
+            headers=[("Content-Type", "application/json"), auth_header],
+        )
+
+        assert response.status_code == 400
+
+    def test_patch_template_returns_serialized_template(self, client, sample_service, create_api_key_with_manage_api_perm):
+        template = create_template(sample_service, template_type=SMS_TYPE)
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_api_perm)
+
+        response = client.patch(
+            f"/v2/manage-template/{template.id}",
+            data=json.dumps({"name": "Patched Template"}),
+            headers=[("Content-Type", "application/json"), auth_header],
+        )
+
+        assert response.status_code == 200
+        data = json.loads(response.get_data(as_text=True))
+        assert "id" in data
+        assert "service_id" in data
+        assert "service_name" in data
+        assert "name" in data
+        assert "type" in data
+        assert "body" in data
+        assert "created_at" in data
+        assert "updated_at" in data
+        assert "archived" in data

--- a/tests/app/v2/manage_template/test_post_template.py
+++ b/tests/app/v2/manage_template/test_post_template.py
@@ -122,7 +122,7 @@ class TestPostTemplateV2ManageTemplate:
 
         assert response.status_code == 400
         data = json.loads(response.get_data(as_text=True))
-        assert data["errors"][0]["error"] == "ValidationError"
+        assert data["errors"][0]["error"] == "TemplateCategoryValidationError"
         assert data["errors"][0]["message"] == "template_category_id is a required property"
         assert "template_categories" in data
         assert len(data["template_categories"]) > 0
@@ -177,7 +177,7 @@ class TestPostTemplateV2ManageTemplate:
 
         assert response.status_code == 400
         data = json.loads(response.get_data(as_text=True))
-        assert data["errors"][0]["error"] == "ValidationError"
+        assert data["errors"][0]["error"] == "TemplateCategoryValidationError"
         assert "template_category_id" in data["errors"][0]["message"]
         assert "template_categories" in data
         assert len(data["template_categories"]) > 0


### PR DESCRIPTION
# Summary | Résumé

Added patch and delete endpoints for Templates

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/3139
# Test instructions | Instructions pour tester la modification

1. Create a new template:
```
POST http://localhost:6011/v2/manage-template
{"name": "Welcome email1",
 "template_type": "email",
 "subject": "Welcome to  notify 3",
 "content": "Hi ((first_name)), welcome!", 
 "template_category_id": "7c16aa95-e2e1-4497-81d6-04c656520fe4"
}
```

2. Patch the above Template
```
PATCH http://localhost:6011/v2/manage-template/<template_id_from_above>
{"name": "Welcome email1",
 "template_type": "email",
 "subject": "Welcome to  notify 3",
 "content": "Hi ((first_name)), welcome!", 
 "template_category_id": "7c16aa95-e2e1-4497-81d6-04c656520fe4"
}
```
^ Ifyou posted the above with template_type, you will get an error
Remove the template_type and when you send the PATCH, you should see the version gets updated

3. Delete the above template
4. Check admin to see that the template doesn't exist