### PR TITLE
fixed messaging on failure scenario slack post

### DIFF
--- a/tests_nightly_performance/run_failure_scenarios.sh
+++ b/tests_nightly_performance/run_failure_scenarios.sh
@@ -137,7 +137,7 @@ log "Cool-down        : ${COOLDOWN}s between scenarios"
 log "Per-scenario cap : ${RUN_TIME}"
 log "========================================================"
 echo ""
-notify_slack ":warning: Blast API failure scenario suite starting — ${S3_BASE}/ :rotating-light-blue:"
+notify_slack ":rotating-light-blue: Blast API Failure Scenario Started :rotating-light-blue:"
 # ---------------------------------------------------------------------------
 # Scenario 1 — Gradual ramp-up of individual sends
 #   Starts at 10 users, steps up by 50 every 120 s until error threshold.
@@ -196,4 +196,4 @@ log "Results: $OUTPUT_DIR"
 log "S3 path : ${S3_BASE}/"
 log "========================================================"
 
-notify_slack ":white_check_mark: Blast API failure scenario suite complete — ${S3_BASE}/ :rotating-light-blue:"
+notify_slack ":rotating-light-blue: Blast API Failure Scenario Complete :rotating-light-blue:"


### PR DESCRIPTION
# Summary | Résumé

Simplified the slack post messaging on failure scenario testing.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/761

# Test instructions | Instructions pour tester la modification

Run the test manually

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.