### PR TITLE
Fix Redis rate limiter `register_script` by switching to `flask_cache_ops`

### DIFF
--- a/app/rate_limiter.py
+++ b/app/rate_limiter.py
@@ -383,7 +383,7 @@ class RedisSlidingWindowLogRateLimiter(RateLimiter):
                 return {0, seconds_to_wait}
             end
             """
-            self._lua_scripts["acquire"] = self.redis.register_script(lua_code)
+            self._lua_scripts["acquire"] = self.redis.redis_store.register_script(lua_code)
 
         return self._lua_scripts["acquire"]
 
@@ -557,7 +557,7 @@ class RedisTokenBucketRateLimiter(RateLimiter):
                 return {0, seconds_to_wait}
             end
             """
-            self._lua_scripts["acquire"] = self.redis.register_script(lua_code)
+            self._lua_scripts["acquire"] = self.redis.redis_store.register_script(lua_code)
 
         return self._lua_scripts["acquire"]
 

--- a/app/rate_limiter.py
+++ b/app/rate_limiter.py
@@ -301,7 +301,7 @@ class RedisSlidingWindowLogRateLimiter(RateLimiter):
             cap_per_minute (int): Maximum units allowed per minute.
             namespace (str): Logical name for this limiter instance (e.g. "sms").
                 Used to construct the Redis key: app.rate_limit:{namespace}:entries.
-            redis_client: Redis client instance. If None, uses app's redis_store.
+            redis_client: Redis client instance. If None, uses app's flask_cache_ops.
         """
         super().__init__(cap_per_minute, namespace)
         self._entries_key = f"app.rate_limit:{namespace}:entries"
@@ -313,9 +313,9 @@ class RedisSlidingWindowLogRateLimiter(RateLimiter):
         # Lazy-load Redis client to avoid circular imports at init time.
         if self.redis_client is not None:
             return self.redis_client
-        from app import redis_store
+        from app import flask_cache_ops
 
-        return redis_store
+        return flask_cache_ops
 
     def _get_acquire_lua_script(self):
         if "acquire" not in self._lua_scripts:
@@ -383,7 +383,7 @@ class RedisSlidingWindowLogRateLimiter(RateLimiter):
                 return {0, seconds_to_wait}
             end
             """
-            self._lua_scripts["acquire"] = self.redis.redis_store.register_script(lua_code)
+            self._lua_scripts["acquire"] = self.redis.register_script(lua_code)
 
         return self._lua_scripts["acquire"]
 
@@ -497,7 +497,7 @@ class RedisTokenBucketRateLimiter(RateLimiter):
             cap_per_minute (int): Maximum units allowed per minute.
             namespace (str): Logical name for this limiter instance (e.g. "sms").
                 Used to construct the Redis key: app.rate_limit:{namespace}:token_bucket.
-            redis_client: Redis client instance. If None, uses app's redis_store.
+            redis_client: Redis client instance. If None, uses app's flask_cache_ops.
         """
         super().__init__(cap_per_minute, namespace)
         self._key = f"app.rate_limit:{namespace}:token_bucket"
@@ -509,9 +509,9 @@ class RedisTokenBucketRateLimiter(RateLimiter):
         # Lazy-load Redis client to avoid circular imports at init time.
         if self.redis_client is not None:
             return self.redis_client
-        from app import redis_store
+        from app import flask_cache_ops
 
-        return redis_store
+        return flask_cache_ops
 
     def _get_acquire_lua_script(self):
         if "acquire" not in self._lua_scripts:
@@ -557,7 +557,7 @@ class RedisTokenBucketRateLimiter(RateLimiter):
                 return {0, seconds_to_wait}
             end
             """
-            self._lua_scripts["acquire"] = self.redis.redis_store.register_script(lua_code)
+            self._lua_scripts["acquire"] = self.redis.register_script(lua_code)
 
         return self._lua_scripts["acquire"]
 


### PR DESCRIPTION
# Summary | Résumé

## Problem

The new Redis-backed rate limiter implementations (`RedisSlidingWindowLogRateLimiter` and `RedisTokenBucketRateLimiter`) were calling `register_script` on the wrong Redis client, causing a runtime `AttributeError` in production:

```
AttributeError: 'RedisClient' object has no attribute 'register_script'
```

The `redis` property on both classes was lazy-loading `redis_store` — a `RedisClient` wrapper from `notifications_utils` that does not expose `register_script` directly (it wraps a `FlaskRedis` instance internally).

## Fix

Replaced the fallback client in both `redis` properties from `redis_store` to `flask_cache_ops`.

`flask_cache_ops` is a `FlaskRedis` instance (a direct proxy to the underlying `StrictRedis` client), which exposes `register_script` natively. This also removes the need to unwrap `.redis_store` to reach the raw client.

Beyond fixing the immediate error, this is the semantically correct choice:

- `flask_cache_ops` is intended for vital, operational Redis operations — which rate limiting absolutely is.
- `redis_store` is the `RedisClient` wrapper intended for application-level caching and operational data constructs.

## Changes

- `RedisSlidingWindowLogRateLimiter.redis` and `RedisTokenBucketRateLimiter.redis`: lazy-load `flask_cache_ops` instead of `redis_store`
- Both `_get_acquire_lua_script` methods: call `self.redis.register_script(...)` directly (no `.redis_store` unwrapping)
- Updated inline docstrings to reference `flask_cache_ops`

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1
* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/1

# Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.