### PR TITLE
Set get notification to use DB reader

### DIFF
--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -339,7 +339,7 @@ def get_notification_with_personalisation(service_id, notification_id, key_type)
         filter_dict["key_type"] = key_type
 
     try:
-        return Notification.query.filter_by(**filter_dict).options(joinedload("template")).one()
+        return db.on_reader().query(Notification).filter_by(**filter_dict).options(joinedload("template")).one()
     except NoResultFound:
         current_app.logger.warning(f"Failed to get notification with filter: {filter_dict}")
         return None

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -526,6 +526,26 @@ def test_get_notification_with_personalisation_by_id_no_result(sample_template, 
     assert mock_logger.called
 
 
+def test_get_notification_with_personalisation_uses_reader_bind(mocker, fake_uuid):
+    reader = mocker.Mock()
+    query = mocker.Mock()
+    query_with_filters = mocker.Mock()
+    query_with_template = mocker.Mock()
+
+    mocker.patch("app.dao.notifications_dao.db.on_reader", return_value=reader)
+    reader.query.return_value = query
+    query.filter_by.return_value = query_with_filters
+    query_with_filters.options.return_value = query_with_template
+    query_with_template.one.return_value = mocker.sentinel.notification
+
+    result = get_notification_with_personalisation(fake_uuid, fake_uuid, key_type=None)
+
+    reader.query.assert_called_once_with(Notification)
+    query.filter_by.assert_called_once_with(service_id=fake_uuid, id=fake_uuid)
+    query_with_filters.options.assert_called_once()
+    assert result == mocker.sentinel.notification
+
+
 def test_get_notification_by_id_when_notification_exists(sample_notification):
     notification_from_db = get_notification_by_id(sample_notification.id)
 


### PR DESCRIPTION
# Summary | Résumé

_TODO: 1-3 sentence description of the changed you're proposing._

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1
* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/1

# Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.