### PR TITLE
Adds more concurrent Celery workers feeding on the send-sms-fair SQS queue

### DIFF
--- a/scripts/run_celery_send_sms_ratelimit.sh
+++ b/scripts/run_celery_send_sms_ratelimit.sh
@@ -5,6 +5,6 @@ set -e
 # Placeholder: single-worker SMS control lane for rate-limited flow.
 # Real fair-queue implementation and tuning to follow.
 
-echo "Start celery SMS rate-limit worker (PLACEHOLDER), concurrency: 1"
+echo "Start celery SMS rate-limit worker, concurrency: ${CELERY_CONCURRENCY-4}"
 
 celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency="${CELERY_CONCURRENCY-4}" -Q send-sms-fair

--- a/scripts/run_celery_send_sms_ratelimit.sh
+++ b/scripts/run_celery_send_sms_ratelimit.sh
@@ -7,4 +7,4 @@ set -e
 
 echo "Start celery SMS rate-limit worker (PLACEHOLDER), concurrency: 1"
 
-celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency=1 -Q send-sms-fair
+celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency="${CELERY_CONCURRENCY-4}" -Q send-sms-fair


### PR DESCRIPTION
# Summary | Résumé

Increased the amount of concurrent worker from 1 to 4 and which will send SMS through the rate limiter. Our next steps are to test with more volume and with concurrent instances in STAGING only. 

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/786

# Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.