### PR TITLE
fix: set html lang on outbound emails based on service branding

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -509,6 +509,7 @@ def get_html_email_options(service: Service):
                 "logo_with_background_colour": False,
                 "alt_text_en": None,
                 "alt_text_fr": None,
+                "lang": "fr",
             }
         else:
             return {
@@ -517,6 +518,7 @@ def get_html_email_options(service: Service):
                 "logo_with_background_colour": False,
                 "alt_text_en": None,
                 "alt_text_fr": None,
+                "lang": "en",
             }
 
     logo_url = get_logo_url(service.email_branding.logo) if service.email_branding.logo else None
@@ -531,6 +533,7 @@ def get_html_email_options(service: Service):
         "brand_name": service.email_branding.name,
         "alt_text_en": service.email_branding.alt_text_en,
         "alt_text_fr": service.email_branding.alt_text_fr,
+        "lang": "fr" if service.email_branding.brand_type == BRANDING_BOTH_FR else "en",
     }
 
 

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -799,16 +799,16 @@ def test_get_html_email_renderer_should_return_for_normal_service(sample_service
 
 
 @pytest.mark.parametrize(
-    "branding_type, fip_banner_english, fip_banner_french",
+    "branding_type, fip_banner_english, fip_banner_french, expected_lang",
     [
-        (BRANDING_ORG_NEW, False, False),
-        (BRANDING_BOTH_EN, True, False),
-        (BRANDING_BOTH_FR, False, True),
-        (BRANDING_ORG_BANNER_NEW, False, False),
+        (BRANDING_ORG_NEW, False, False, "en"),
+        (BRANDING_BOTH_EN, True, False, "en"),
+        (BRANDING_BOTH_FR, False, True, "fr"),
+        (BRANDING_ORG_BANNER_NEW, False, False, "en"),
     ],
 )
 def test_get_html_email_renderer_with_branding_details(
-    branding_type, fip_banner_english, fip_banner_french, notify_db, sample_service
+    branding_type, fip_banner_english, fip_banner_french, expected_lang, notify_db, sample_service
 ):
     email_branding = EmailBranding(
         brand_type=branding_type,
@@ -829,6 +829,7 @@ def test_get_html_email_renderer_with_branding_details(
     assert options["brand_colour"] == "#000000"
     assert options["brand_text"] == "League of Justice"
     assert options["brand_name"] == "Justice League"
+    assert options["lang"] == expected_lang
 
     if branding_type == BRANDING_ORG_BANNER_NEW:
         assert options["logo_with_background_colour"] is True
@@ -848,6 +849,7 @@ def test_get_html_email_renderer_with_branding_details_and_render_fip_banner_eng
         "logo_with_background_colour": False,
         "alt_text_en": None,
         "alt_text_fr": None,
+        "lang": "en",
     }
 
 


### PR DESCRIPTION
# Summary | Résumé

Pair with notification-utils PR https://github.com/cds-snc/notification-utils/pull/415.

`get_html_email_options` now returns a `lang` value that is splatted into
`HTMLEmailTemplate(**…)`:

- `"fr"` when the service uses `BRANDING_BOTH_FR` or has
  `default_branding_is_french=True` and no email_branding.
- `"en"` otherwise.

Existing `get_html_email_options` tests updated to assert the new key.
Requires notifications-utils bump that adds the `lang` kwarg.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/3309

# Test instructions | Instructions pour tester la modification

TBD 

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.