### PR TITLE
Introducing a buffered proxy rate limiter

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -142,7 +142,7 @@ def create_app(application, config=None):
         salesforce_client.init_app(application)
 
     # Initialize the rate limiter for SMS delivery tasks, then wrap it in a
-    # BufferedRateLimiter to reduce Redis round-trips per Celery worker.
+    # BufferedRateLimiter to reduce network round-trips per Celery worker.
     initialize_rate_limiter(application.config["CELERY_DELIVER_SMS_RATE_LIMIT_PER_MINUTE"], namespace="sms").buffered(
         application.config["SMS_RATE_LIMITER_BATCH"]
     )

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -141,8 +141,11 @@ def create_app(application, config=None):
     if application.config["FF_SALESFORCE_CONTACT"]:
         salesforce_client.init_app(application)
 
-    # Initialize the global rate limiter instance with the configured rate limit for SMS delivery tasks.
-    initialize_rate_limiter(application.config["CELERY_DELIVER_SMS_RATE_LIMIT_PER_MINUTE"], namespace="sms")
+    # Initialize the rate limiter for SMS delivery tasks, then wrap it in a
+    # BufferedRateLimiter to reduce Redis round-trips per Celery worker.
+    initialize_rate_limiter(application.config["CELERY_DELIVER_SMS_RATE_LIMIT_PER_MINUTE"], namespace="sms").buffered(
+        application.config["SMS_RATE_LIMITER_BATCH"]
+    )
 
     flask_redis.init_app(application)
     flask_cache_ops.init_app(application)

--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -74,7 +74,7 @@ def deliver_sms(self, notification_id):
 )
 @statsd(namespace="tasks")
 def deliver_sms_rate_limited(self, notification_id: str, parts_count: int):
-    acquired, seconds_to_wait = get_rate_limiter().acquire_lease(parts_count)
+    acquired, seconds_to_wait = get_rate_limiter("sms").acquire_lease(parts_count)
     if acquired:
         _deliver_sms(self, notification_id)
     else:

--- a/app/config.py
+++ b/app/config.py
@@ -609,6 +609,8 @@ class Config(object):
     # SMS rate limiter backend class name. Must match a key in an implementation class in the rate_limiter module.
     # Options: "InMemoryRateLimiter", "RedisSlidingWindowLogRateLimiter", "RedisTokenBucketRateLimiter"
     SMS_RATE_LIMITER_BACKEND = os.getenv("SMS_RATE_LIMITER_BACKEND", "InMemoryRateLimiter")
+    # Number of tokens to pre-fetch from the underlying rate limiter per Redis call (BufferedRateLimiter batch size).
+    SMS_RATE_LIMITER_BATCH = env.int("SMS_RATE_LIMITER_BATCH", 100)
     AWS_SEND_SMS_BOTO_CALL_LATENCY = os.getenv("AWS_SEND_SMS_BOTO_CALL_LATENCY", 0.06)  # average delay in production
 
     CONTACT_FORM_EMAIL_ADDRESS = os.getenv("CONTACT_FORM_EMAIL_ADDRESS", "helpdesk@cds-snc.ca")

--- a/app/rate_limiter.py
+++ b/app/rate_limiter.py
@@ -1,4 +1,6 @@
 # app/rate_limiter.py
+from __future__ import annotations
+
 """
 Rate Limiting Module
 
@@ -50,6 +52,29 @@ class RateLimiter(ABC):
             int: Number of units used in the current window.
         """
         pass
+
+    def buffered(self, size: int) -> BufferedRateLimiter:
+        """
+        Wrap this rate limiter in a BufferedRateLimiter and register it under
+        the same namespace, replacing the current entry in the registry.
+
+        Args:
+            size (int): Number of tokens to pre-fetch from the underlying
+                limiter per Redis call.
+
+        Returns:
+            BufferedRateLimiter: The new buffered wrapper.
+
+        Raises:
+            TypeError: If called on an already-buffered instance.
+        """
+        if isinstance(self, BufferedRateLimiter):
+            raise TypeError(
+                f"Rate limiter [{self.namespace}] is already a BufferedRateLimiter. " "Double-wrapping is not allowed."
+            )
+        buffered_limiter = BufferedRateLimiter(self, size)
+        _rate_limiter_instances[self.namespace] = buffered_limiter
+        return buffered_limiter
 
 
 class InMemoryRateLimiter(RateLimiter):
@@ -171,20 +196,17 @@ class InMemoryRateLimiter(RateLimiter):
 
 
 # ============================================================================
-# Module-level rate limiter instance
+# Module-level rate limiter registry
 # ============================================================================
-# For the in-memory backend, this instance is process-local: it is shared only
-# within the current Python process (for example, one Flask/Celery worker
-# process) and is not coordinated across multiple Celery worker processes,
-# pods, or hosts.
+# Keyed by namespace (e.g. "sms"). Each entry is a RateLimiter instance
+# (possibly a BufferedRateLimiter wrapping a concrete backend).
 #
-# As a result, the in-memory backend does not provide a true global cap unless
-# deployment is constrained so that only a single worker process/pod consumes
-# the relevant queue. A Redis-backed implementation enforces a global
-# cross-process rate limit without changing task code.
+# For the in-memory backend, instances are process-local and not coordinated
+# across multiple Celery worker processes, pods, or hosts.
+# Redis-backed implementations enforce a global cross-process rate limit.
 # ============================================================================
 
-_rate_limiter_instance: RateLimiter | None = None
+_rate_limiter_instances: dict[str, RateLimiter] = {}
 
 
 def _build_limiter_registry() -> dict[str, type[RateLimiter]]:
@@ -200,9 +222,10 @@ def initialize_rate_limiter(
     cap_per_minute: int, limiter_class: type[RateLimiter] | None = None, *, namespace: str
 ) -> RateLimiter:
     """
-    Initialize the global rate limiter instance.
+    Initialize a rate limiter for the given namespace and store it in the registry.
 
-    Called during app initialization (see app/__init__.py).
+    Called during app initialization (see app/__init__.py). Returns the raw
+    limiter instance; chain `.buffered(size)` to wrap it in a BufferedRateLimiter.
 
     The backend is chosen in this order:
     1. limiter_class argument — if provided, instantiated directly.
@@ -216,14 +239,12 @@ def initialize_rate_limiter(
         limiter_class (type[RateLimiter] | None): Implementation class to use.
             If None, the class is resolved from config/default.
         namespace (str): Logical name for this limiter instance (e.g. "sms").
-            Used in Redis key construction and log messages.
+            Used in Redis key construction, log messages, and registry lookup.
 
     Returns:
         RateLimiter: The initialized rate limiter instance.
     """
     import logging
-
-    global _rate_limiter_instance
 
     logger = logging.getLogger(__name__)
 
@@ -253,29 +274,35 @@ def initialize_rate_limiter(
             resolved_class = registry[class_name]
 
     logger.info("Rate limiter [%s]: initializing with %s", namespace, resolved_class.__name__)
-    _rate_limiter_instance = resolved_class(cap_per_minute, namespace)
+    instance = resolved_class(cap_per_minute, namespace)
+    _rate_limiter_instances[namespace] = instance
 
-    return _rate_limiter_instance
+    return instance
 
 
-def get_rate_limiter() -> RateLimiter:
+def get_rate_limiter(namespace: str) -> RateLimiter:
     """
-    Get the global rate limiter instance.
+    Get the rate limiter registered under the given namespace.
 
-    Call this from tasks to access the rate limiter.
-    Raises RuntimeError if initialize_rate_limiter() hasn't been called.
+    If a BufferedRateLimiter was installed via `.buffered()`, that is returned
+    transparently — callers need no awareness of buffering.
+
+    Args:
+        namespace (str): The namespace used during initialization (e.g. "sms").
 
     Returns:
-        RateLimiter: The global rate limiter instance.
+        RateLimiter: The registered rate limiter instance.
 
     Raises:
-        RuntimeError: If the rate limiter hasn't been initialized.
+        RuntimeError: If no limiter has been registered for this namespace.
     """
-    if _rate_limiter_instance is None:
+    instance = _rate_limiter_instances.get(namespace)
+    if instance is None:
         raise RuntimeError(
-            "Rate limiter not initialized. " "Call initialize_rate_limiter() during app startup (app/__init__.py)."
+            f"Rate limiter [{namespace!r}] not initialized. "
+            "Call initialize_rate_limiter() during app startup (app/__init__.py)."
         )
-    return _rate_limiter_instance
+    return instance
 
 
 class RedisSlidingWindowLogRateLimiter(RateLimiter):
@@ -625,3 +652,102 @@ class RedisTokenBucketRateLimiter(RateLimiter):
     def reset_limiter(self):
         self.redis.delete(self._key)
         current_app.logger.info(f"Rate limiter [{self.namespace}]: reset (token bucket)")
+
+
+class BufferedRateLimiter(RateLimiter):
+    """
+    A buffering proxy that wraps any RateLimiter and pre-fetches tokens in
+    configurable batches to reduce calls to the underlying backend (e.g. Redis).
+
+    Each Celery worker process maintains its own local token counter. Tokens are
+    spent locally without hitting the backend; the underlying limiter is only
+    called when the local buffer runs dry.
+
+    Token expiry:
+    Each batch is stamped with ``_acquired_at``. Before spending local tokens,
+    the buffer is checked for staleness: tokens older than 60 seconds are
+    discarded. This prevents tokens from a previous rate-limit window from being
+    consumed after the backend (especially a token bucket) has refilled, which
+    would allow over-consumption up to ``size * num_workers`` beyond the cap.
+
+    Top-up on partial buffer:
+    When ``_local_tokens < units``, the buffer is topped up (not replaced).
+    The underlying limiter is called for ``max(units - _local_tokens, size)``
+    additional tokens. The existing local tokens are combined with the new
+    batch, so already-claimed tokens are never wasted.
+
+    Thread safety:
+    Not needed — Celery prefork runs one task at a time per process, and each
+    worker process owns its own ``BufferedRateLimiter`` instance independently.
+    """
+
+    TOKEN_WINDOW_SECONDS = 60
+
+    def __init__(self, rate_limiter: RateLimiter, size: int) -> None:
+        if size <= 0:
+            raise ValueError("size must be positive")
+        if size > rate_limiter.cap_per_minute:
+            raise ValueError(f"size ({size}) must be <= cap_per_minute ({rate_limiter.cap_per_minute})")
+        super().__init__(rate_limiter.cap_per_minute, rate_limiter.namespace)
+        self._rate_limiter = rate_limiter
+        self._size = size
+        self._local_tokens: int = 0
+        self._acquired_at: float = 0.0
+
+    def acquire_lease(self, units: int) -> Tuple[bool, int]:
+        """
+        Attempt to acquire a lease for the given number of units.
+
+        Spends from the local buffer when possible. Tops up from the underlying
+        rate limiter when the buffer is insufficient, fetching at least ``_size``
+        tokens per Redis call.
+
+        Args:
+            units (int): Number of units to acquire.
+
+        Returns:
+            Tuple[bool, int]:
+                - (True, 0) if units were acquired (locally or via the backend).
+                - (False, seconds_to_wait) if the backend denied the request.
+        """
+        if units <= 0:
+            raise ValueError("units must be positive")
+
+        # Discard stale local tokens to prevent cross-window over-consumption.
+        if self._local_tokens > 0 and time() - self._acquired_at >= self.TOKEN_WINDOW_SECONDS:
+            current_app.logger.debug(
+                f"BufferedRateLimiter [{self.namespace}]: discarding {self._local_tokens} stale local tokens"
+            )
+            self._local_tokens = 0
+
+        if self._local_tokens >= units:
+            self._local_tokens -= units
+            current_app.logger.debug(
+                f"BufferedRateLimiter [{self.namespace}]: spent {units} local tokens " f"(remaining: {self._local_tokens})"
+            )
+            return True, 0
+
+        # Top-up: fetch enough to cover the deficit, at least _size tokens.
+        deficit = units - self._local_tokens
+        batch = max(deficit, self._size)
+
+        acquired, seconds_to_wait = self._rate_limiter.acquire_lease(batch)
+        if not acquired:
+            current_app.logger.warning(
+                f"BufferedRateLimiter [{self.namespace}]: backend denied {batch} token batch. "
+                f"Retry in {seconds_to_wait}s. Local buffer unchanged ({self._local_tokens} tokens)."
+            )
+            return False, seconds_to_wait
+
+        self._acquired_at = time()
+        self._local_tokens += batch
+        self._local_tokens -= units
+        current_app.logger.debug(
+            f"BufferedRateLimiter [{self.namespace}]: fetched {batch} tokens from backend, "
+            f"spent {units}, local buffer now {self._local_tokens}"
+        )
+        return True, 0
+
+    def get_current_usage(self) -> int:
+        """Delegates to the wrapped rate limiter (reflects global consumed capacity)."""
+        return self._rate_limiter.get_current_usage()

--- a/app/rate_limiter.py
+++ b/app/rate_limiter.py
@@ -720,6 +720,7 @@ class BufferedRateLimiter(RateLimiter):
             )
             self._local_tokens = 0
 
+        # Fast path: if the local buffer has enough tokens, spend them without hitting the backend.
         if self._local_tokens >= units:
             self._local_tokens -= units
             current_app.logger.debug(

--- a/tests/app/test_rate_limiter.py
+++ b/tests/app/test_rate_limiter.py
@@ -1,13 +1,16 @@
-from unittest.mock import patch
+from time import time
+from unittest.mock import MagicMock, patch
 
 import fakeredis
 import pytest
 
 from app import rate_limiter
 from app.rate_limiter import (
+    BufferedRateLimiter,
     InMemoryRateLimiter,
     RedisSlidingWindowLogRateLimiter,
     RedisTokenBucketRateLimiter,
+    get_rate_limiter,
     initialize_rate_limiter,
 )
 
@@ -517,9 +520,8 @@ class TestRedisTokenBucketRateLimiter:
 
 class TestInitializeRateLimiter:
     def teardown_method(self):
-        # Reset global singleton between tests
-        with patch.object(rate_limiter, "_rate_limiter_instance", None):
-            pass
+        # Reset registry between tests
+        rate_limiter._rate_limiter_instances.clear()
 
     def test_explicit_class_arg_takes_precedence(self, client):
         with client.application.app_context():
@@ -573,3 +575,174 @@ class TestInitializeRateLimiter:
             with patch("app.config.Config.SMS_RATE_LIMITER_BACKEND", "InMemoryRateLimiter", create=True):
                 instance = initialize_rate_limiter(1000, namespace="test")
                 assert isinstance(instance, InMemoryRateLimiter)
+
+
+class TestBufferedRateLimiter:
+    @pytest.fixture
+    def raw_limiter(self):
+        return InMemoryRateLimiter(cap_per_minute=1000, namespace="test")
+
+    @pytest.fixture
+    def buffered(self, raw_limiter):
+        return BufferedRateLimiter(raw_limiter, size=10)
+
+    def test_uses_local_tokens_without_calling_rate_limiter(self, client, raw_limiter):
+        mock_raw = MagicMock(spec=InMemoryRateLimiter)
+        mock_raw.cap_per_minute = 1000
+        mock_raw.namespace = "test"
+        buf = BufferedRateLimiter(mock_raw, size=10)
+        buf._local_tokens = 5
+        buf._acquired_at = time()
+
+        acquired, wait = buf.acquire_lease(3)
+
+        assert acquired is True
+        assert wait == 0
+        assert buf._local_tokens == 2
+        mock_raw.acquire_lease.assert_not_called()
+
+    def test_fetches_batch_when_local_tokens_empty(self, client, buffered):
+        with client.application.app_context():
+            buffered._local_tokens = 0
+            acquired, wait = buffered.acquire_lease(2)
+            assert acquired is True
+            assert wait == 0
+            # fetched batch of 10 (size), spent 2 → 8 remain
+            assert buffered._local_tokens == 8
+
+    def test_tops_up_partial_buffer(self, client, buffered):
+        with client.application.app_context():
+            buffered._local_tokens = 3
+            buffered._acquired_at = time()
+            acquired, wait = buffered.acquire_lease(6)
+            assert acquired is True
+            assert wait == 0
+            # deficit=3, batch=max(3,10)=10 fetched from backend
+            # local = 3 + 10 - 6 = 7
+            assert buffered._local_tokens == 7
+
+    def test_local_tokens_preserved_on_redis_deny(self, client, raw_limiter):
+        mock_raw = MagicMock(spec=InMemoryRateLimiter)
+        mock_raw.cap_per_minute = 1000
+        mock_raw.namespace = "test"
+        mock_raw.acquire_lease.return_value = (False, 30)
+        buf = BufferedRateLimiter(mock_raw, size=10)
+        buf._local_tokens = 3
+        buf._acquired_at = time()
+
+        acquired, wait = buf.acquire_lease(6)
+
+        assert acquired is False
+        assert wait == 30
+        assert buf._local_tokens == 3  # unchanged
+
+    def test_returns_false_with_wait_when_rate_limiter_denies_empty_buffer(self, client, raw_limiter):
+        mock_raw = MagicMock(spec=InMemoryRateLimiter)
+        mock_raw.cap_per_minute = 1000
+        mock_raw.namespace = "test"
+        mock_raw.acquire_lease.return_value = (False, 15)
+        buf = BufferedRateLimiter(mock_raw, size=10)
+
+        with client.application.app_context():
+            acquired, wait = buf.acquire_lease(5)
+
+        assert acquired is False
+        assert wait == 15
+        assert buf._local_tokens == 0
+
+    def test_deficit_larger_than_size_fetches_exact_deficit(self, client, raw_limiter):
+        mock_raw = MagicMock(spec=InMemoryRateLimiter)
+        mock_raw.cap_per_minute = 1000
+        mock_raw.namespace = "test"
+        mock_raw.acquire_lease.return_value = (True, 0)
+        buf = BufferedRateLimiter(mock_raw, size=10)
+        buf._local_tokens = 2
+        buf._acquired_at = time()
+
+        with client.application.app_context():
+            acquired, wait = buf.acquire_lease(20)  # deficit=18 > size=10
+
+        assert acquired is True
+        mock_raw.acquire_lease.assert_called_once_with(18)  # max(18, 10) = 18
+        assert buf._local_tokens == 0  # 2 + 18 - 20 = 0
+
+    def test_remainder_decrements_on_successive_calls(self, client, buffered):
+        with client.application.app_context():
+            buffered._local_tokens = 0
+            # First call fetches batch of 10, spends 3 → 7 remain
+            buffered.acquire_lease(3)
+            assert buffered._local_tokens == 7
+            # Second call spends 4 locally → 3 remain
+            buffered.acquire_lease(4)
+            assert buffered._local_tokens == 3
+
+    def test_stale_tokens_discarded_after_60_seconds(self, client, raw_limiter):
+        mock_raw = MagicMock(spec=InMemoryRateLimiter)
+        mock_raw.cap_per_minute = 1000
+        mock_raw.namespace = "test"
+        mock_raw.acquire_lease.return_value = (True, 0)
+        buf = BufferedRateLimiter(mock_raw, size=10)
+        buf._local_tokens = 50
+        buf._acquired_at = time() - 61  # stale
+
+        with client.application.app_context():
+            buf.acquire_lease(3)
+
+        # Stale tokens discarded; backend called for a fresh batch
+        mock_raw.acquire_lease.assert_called_once()
+        assert buf._local_tokens == 7  # 0 + 10 - 3
+
+    def test_fresh_tokens_not_discarded_within_60_seconds(self, client, raw_limiter):
+        mock_raw = MagicMock(spec=InMemoryRateLimiter)
+        mock_raw.cap_per_minute = 1000
+        mock_raw.namespace = "test"
+        buf = BufferedRateLimiter(mock_raw, size=10)
+        buf._local_tokens = 5
+        buf._acquired_at = time() - 30  # still fresh
+
+        buf.acquire_lease(2)
+
+        mock_raw.acquire_lease.assert_not_called()
+        assert buf._local_tokens == 3
+
+    def test_acquired_at_updated_on_each_redis_fetch(self, client, buffered):
+        with client.application.app_context():
+            before = time()
+            buffered.acquire_lease(1)
+            assert buffered._acquired_at >= before
+
+    def test_get_current_usage_delegates_to_wrapped_limiter(self, client):
+        mock_raw = MagicMock(spec=InMemoryRateLimiter)
+        mock_raw.cap_per_minute = 1000
+        mock_raw.namespace = "test"
+        mock_raw.get_current_usage.return_value = 42
+        buf = BufferedRateLimiter(mock_raw, size=10)
+
+        result = buf.get_current_usage()
+
+        assert result == 42
+        mock_raw.get_current_usage.assert_called_once()
+
+    def test_raises_value_error_when_size_exceeds_cap(self, client, raw_limiter):
+        with pytest.raises(ValueError):
+            BufferedRateLimiter(raw_limiter, size=raw_limiter.cap_per_minute + 1)
+
+    def test_raises_value_error_when_size_is_zero(self, client, raw_limiter):
+        with pytest.raises(ValueError):
+            BufferedRateLimiter(raw_limiter, size=0)
+
+    def test_raises_type_error_on_double_wrapping(self, client, raw_limiter):
+        with client.application.app_context():
+            # First register the raw limiter so .buffered() can find the registry
+            rate_limiter._rate_limiter_instances["test"] = raw_limiter
+            buf = raw_limiter.buffered(10)
+            with pytest.raises(TypeError):
+                buf.buffered(10)
+            rate_limiter._rate_limiter_instances.pop("test", None)
+
+    def test_buffered_factory_self_registers_in_registry(self, client, raw_limiter):
+        with client.application.app_context():
+            rate_limiter._rate_limiter_instances["test"] = raw_limiter
+            buf = raw_limiter.buffered(10)
+            assert get_rate_limiter("test") is buf
+            rate_limiter._rate_limiter_instances.pop("test", None)

--- a/tests/app/test_rate_limiter.py
+++ b/tests/app/test_rate_limiter.py
@@ -733,7 +733,7 @@ class TestBufferedRateLimiter:
 
     def test_raises_type_error_on_double_wrapping(self, client, raw_limiter):
         with client.application.app_context():
-            # First register the raw limiter so .buffered() can find the registry
+            # Seed the registry so `.buffered()` replaces the existing entry for this namespace
             rate_limiter._rate_limiter_instances["test"] = raw_limiter
             buf = raw_limiter.buffered(10)
             with pytest.raises(TypeError):


### PR DESCRIPTION
# Summary | Résumé

Introduces `BufferedRateLimiter`, a batching proxy that wraps any `RateLimiter` backend and pre-fetches tokens in configurable batches. Each Celery worker process spends tokens from a local counter without hitting Redis on every SMS; the underlying rate limiter is only called when the local buffer runs dry. This reduces Redis round-trips per `deliver_sms_rate_limited` task and allows the next SMS in the same worker to be dispatched faster.

The `BufferedRateLimiter` is a true `RateLimiter` subclass and is installed transparently via a new `.buffered(size)` factory method on the `RateLimiter` ABC, so existing callers of `get_rate_limiter("sms")` work without changes. The buffer includes a 60-second staleness check to discard tokens acquired in a previous rate-limit window, preventing cross-window over-consumption.

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/786

# Test instructions | Instructions pour tester la modification

1. Run the rate limiter unit tests:
   ```
   pytest tests/app/test_rate_limiter.py -v
   ```

   All `TestBufferedRateLimiter` tests (15 cases) should pass, covering: local token consumption without Redis calls, top-up on partial buffer, stale token expiry after 60 s, Redis deny propagation, and the `.buffered()` factory self-registration.

2. Run the provider task tests:

   ```
   pytest tests/app/celery/test_provider_tasks.py::TestDeliverSmsRateLimited -v
   ```

3. To tune the batch size, set the `SMS_RATE_LIMITER_BATCH` environment variable (default: `100`). A higher value reduces Redis calls further; a lower value reduces over-claiming when workers are idle.

4. To disable buffering and revert to direct Redis calls, set `SMS_RATE_LIMITER_BATCH=1`.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.