### PR TITLE
attempting to fix our missing SHA 

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -48,7 +48,7 @@ ENV GIT_SHA ${GIT_SHA}
 
 RUN . ${APP_VENV}/bin/activate \
     && git config --global --add safe.directory /app \
-    && make generate-version-file
+    && make generate-version-file GIT_COMMIT=${GIT_SHA:-$(git rev-parse HEAD)}
 
 RUN chown app:app /app /app/app/version.py
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -43,15 +43,16 @@ RUN python -m venv ${APP_VENV} \
 
 COPY --chown=app:app . /app/
 
+ARG GIT_SHA
+ENV GIT_SHA ${GIT_SHA}
+
 RUN . ${APP_VENV}/bin/activate \
+    && git config --global --add safe.directory /app \
     && make generate-version-file
 
 RUN chown app:app /app /app/app/version.py
 
 ENV PORT=6011
-
-ARG GIT_SHA
-ENV GIT_SHA ${GIT_SHA}
 
 USER app
 

--- a/ci/Dockerfile.test
+++ b/ci/Dockerfile.test
@@ -36,19 +36,20 @@ RUN python -m venv ${POETRY_HOME} \
 
 COPY --chown=app:app . /app/
 
+ARG GIT_SHA
+ENV GIT_SHA ${GIT_SHA}
+
 RUN python -m venv ${APP_VENV} \
     && . ${APP_VENV}/bin/activate \
     && poetry install \
     && poetry add wheel
 
-RUN make generate-version-file
+RUN git config --global --add safe.directory /app \
+    && make generate-version-file
 
 RUN chown app:app /app /app/app/version.py
 
 ENV PORT=6011
-
-ARG GIT_SHA
-ENV GIT_SHA ${GIT_SHA}
 
 USER app
 

--- a/ci/Dockerfile.test
+++ b/ci/Dockerfile.test
@@ -36,16 +36,16 @@ RUN python -m venv ${POETRY_HOME} \
 
 COPY --chown=app:app . /app/
 
-ARG GIT_SHA
-ENV GIT_SHA ${GIT_SHA}
-
 RUN python -m venv ${APP_VENV} \
     && . ${APP_VENV}/bin/activate \
     && poetry install \
     && poetry add wheel
 
+ARG GIT_SHA
+ENV GIT_SHA ${GIT_SHA}
+
 RUN git config --global --add safe.directory /app \
-    && make generate-version-file
+    && make generate-version-file GIT_COMMIT=${GIT_SHA:-$(git rev-parse HEAD)}
 
 RUN chown app:app /app /app/app/version.py
 


### PR DESCRIPTION
# Summary | Résumé

This pull request updates the Docker build process for both the main and test images to improve reliability and ensure correct versioning. The main changes involve setting up the `GIT_SHA` environment variable earlier and configuring Git to recognize `/app` as a safe directory before running version generation scripts.

**Dockerfile improvements:**

- Set the `GIT_SHA` build argument and environment variable earlier in both `ci/Dockerfile` and `ci/Dockerfile.test` to ensure it's available for subsequent steps. [[1]](diffhunk://#diff-3e80aab0c5827bd91cc241afb47e7d83cf0c2dad29dd29c6be31d7ed46d7adecR46-L55) [[2]](diffhunk://#diff-041f69d34224f03bda4a0119ace08d704810822315809e08f8f1e50f72223234R39-L52)
- Add `git config --global --add safe.directory /app` before running `make generate-version-file` to avoid Git safety errors during version file generation. [[1]](diffhunk://#diff-3e80aab0c5827bd91cc241afb47e7d83cf0c2dad29dd29c6be31d7ed46d7adecR46-L55) [[2]](diffhunk://#diff-041f69d34224f03bda4a0119ace08d704810822315809e08f8f1e50f72223234R39-L52)


# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.