### PR TITLE
Long git commit SHA for our API Version screen

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -45,7 +45,7 @@ jobs:
         docker pull $DOCKER_SLUG:latest
         docker build \
         --cache-from $DOCKER_SLUG:latest \
-        --build-arg GIT_SHA=${GITHUB_SHA::7} \
+        --build-arg GIT_SHA=${GITHUB_SHA} \
         -t $DOCKER_SLUG:${GITHUB_SHA::7} \
         -t $DOCKER_SLUG:latest \
         -f ci/Dockerfile .


### PR DESCRIPTION
# Summary | Résumé

This pull request makes a minor update to the Docker build process in the GitHub Actions workflow. The change ensures that the full Git SHA is passed as a build argument, rather than just the first seven characters.

- Updated the `GIT_SHA` build argument in `.github/workflows/docker.yaml` to use the full commit SHA instead of a shortened version.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.