### PR TITLE
Experiment with fact shards to reduce token usage

### DIFF
--- a/.github/agents/rest-endpoint-builder.agent.md
+++ b/.github/agents/rest-endpoint-builder.agent.md
@@ -16,15 +16,47 @@ Given a description of a resource or endpoint, either **add routes to an existin
 - DO NOT modify authentication functions in `app/authentication/`.
 - DO NOT create database migrations — those are a separate concern.
 - DO NOT add dependencies to `pyproject.toml`.
-- DO NOT deviate from the patterns documented below. Match them exactly.
+- DO NOT deviate from repository facts in `.github/facts/`.
 - ALWAYS use a todo list to track multi-file scaffolding progress.
 - ALWAYS check if existing `app/<module>/` folders are suitable before creating new ones. If an existing module is a good fit, add the new endpoints there instead of creating a new module. This is the **most common case** — most work is adding to existing modules, not creating new ones.
+
+## Mandatory Facts (Load First)
+
+Before proposing code changes, read only the relevant shards from `.github/facts/`. Use **selective loading** to reduce token overhead.
+
+### Always Load (Core REST Patterns)
+
+These shards apply to all endpoint tasks:
+
+- `pattern_api_module_reuse.md` — module structure and reuse patterns
+- `pattern_api_route_shape.md` — Flask route handler structure
+- `pattern_dao_transactional_mutations.md` — DAO mutation conventions
+- `pattern_api_blueprint_registration.md` — Blueprint registration wiring
+- `pattern_api_validation_contract.md` — JSON schema validation
+- `pattern_api_error_contracts_internal_vs_v2.md` — error response formats
+
+### Conditional Load (Conditional on Prompt Content)
+
+Load these shards **only if** the prompt contains relevant keywords or describes the pattern:
+
+| Shard | Load Condition | Trigger Keywords |
+|-------|----------------|------------------|
+| `pattern_api_aggregation_query_patterns.md` | Endpoint groups/summarizes data by dimension | "aggregate", "summary", "breakdown", "by category", "count by", "total per", "group", "usage" |
+| `pattern_api_do_not_explore_list.md` | To minimize exploration scope | "reduce token usage", "minimize scope", "focused exploration", "limit exploration"|
+| `pattern_v2_query_and_pagination.md` | Endpoint is in `app/v2/` or described as "public API" | "v2", "public API", "/v2/" |
+| `pattern_v2_request_parsing_guards.md` | Endpoint is in `app/v2/` or described as "public API" | "v2", "public API", "/v2/" |
+
+### Decision Rule
+
+If the prompt mentions aggregation patterns (group-by, summarize, count by dimension, etc.), load `pattern_api_aggregation_query_patterns.md`. Otherwise, skip it and use the core DAO patterns from `pattern_dao_transactional_mutations.md`.
+
+For benchmark tasks, also load `pattern_api_do_not_explore_list.md` to keep exploration tight.
 
 ## Approach
 
 1. **Gather requirements**: Clarify the entity name, fields, which operations are needed (GET one, GET all, POST create, POST update, DELETE), whether it's scoped under a service (`/service/<uuid:service_id>/...`) or top-level, whether it's an **internal/admin endpoint** or a **v2 public API endpoint**, and which auth type to use.
 2. **Check for existing modules**: Search `app/` and `app/v2/` for modules that already handle the same or related domain. For example, if asked to add a "service callback" endpoint, check `app/service/` first — it likely already has a `rest.py` with a registered Blueprint. If the endpoint is public-facing, check `app/v2/` for an existing module.
-3. **Read the target module** before generating: If adding to an existing module, read its `rest.py`, `*_schema.py`, and corresponding DAO file to understand the existing patterns, imports, and naming conventions in that specific module. If creating a new module, read reference examples including, but not limited to, `app/template_folder/rest.py`, `app/complaint/complaint_rest.py`, and `app/billing/rest.py` to confirm patterns haven't drifted.
+3. **Read facts + target module** before generating: Read relevant files in `.github/facts/` first, then read the target module (`rest.py`, `*_schema.py`, DAO file) to match local naming/import/style conventions.
 4. **Generate or edit files** — see the two workflows below.
 5. **Validate**: Run a syntax check on generated/edited files.
 
@@ -56,293 +88,12 @@ When no existing module fits:
 5. Register blueprint in `app/__init__.py`
 6. `tests/app/<module>/__init__.py` (empty) + `tests/app/<module>/test_rest.py` (test stubs)
 
-## File Patterns
-
-### 1. Module `__init__.py`
-
-Always an empty file:
-
-```python
-
-```
-
-### 2. JSON Schema File (`app/<module>/<module>_schema.py`)
-
-Use JSON Schema dicts for **request validation** in module-specific schema files. This is the pattern used by all module-level `*_schema.py` files in the codebase (templates, billing, users, complaints, organisations, etc.). Import shared definitions from `app.schema_validation.definitions`.
-
-Note: Marshmallow `SQLAlchemyAutoSchema` classes exist in the central `app/schemas.py` for **model serialization** (`.load()` / `.dump()`). If the new endpoint needs custom serialization beyond the model's `.serialize()` method, add a Marshmallow schema there. But for input validation, use JSON Schema dicts as shown below.
-
-```python
-from app.schema_validation.definitions import uuid, nullable_uuid
-
-post_create_<entity>_schema = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "description": "POST schema for creating <entity>",
-    "type": "object",
-    "properties": {
-        "name": {"type": "string", "minLength": 1},
-        "parent_id": nullable_uuid,
-    },
-    "required": ["name"],
-}
-
-post_update_<entity>_schema = {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "description": "POST schema for updating <entity>",
-    "type": "object",
-    "properties": {
-        "name": {"type": "string", "minLength": 1},
-    },
-    "required": ["name"],
-}
-```
-
-Available shared definitions: `uuid`, `nullable_uuid`, `personalisation`, `https_url`.
-
-### 3. DAO File (`app/dao/<entity>_dao.py`)
-
-```python
-from flask import current_app
-from sqlalchemy import desc
-
-from app import db
-from app.dao.dao_utils import transactional
-from app.models import <Model>
-
-
-def dao_get_<entity>_by_id(<entity>_id):
-    return <Model>.query.filter_by(id=<entity>_id).one()
-
-
-def dao_get_<entity>_by_id_and_service_id(<entity>_id, service_id):
-    return <Model>.query.filter(
-        <Model>.id == <entity>_id,
-        <Model>.service_id == service_id,
-    ).one()
-
-
-def dao_fetch_<entities>_for_service(service_id):
-    return <Model>.query.filter_by(service_id=service_id).order_by(desc(<Model>.created_at)).all()
-
-
-def dao_fetch_paginated_<entities>(page=1):
-    return <Model>.query.order_by(desc(<Model>.created_at)).paginate(
-        page=page,
-        per_page=current_app.config["PAGE_SIZE"],
-    )
-
-
-@transactional
-def dao_create_<entity>(<entity>):
-    db.session.add(<entity>)
-
-
-@transactional
-def dao_update_<entity>(<entity>):
-    db.session.add(<entity>)
-
-
-@transactional
-def dao_delete_<entity>(<entity>):
-    db.session.delete(<entity>)
-```
-
-Key rules:
-- `@transactional` decorator on any function that mutates state.
-- Query functions do NOT get `@transactional`.
-- Use `.one()` when exactly one result is expected (raises `NoResultFound` → caught by `register_errors` as 404).
-- Use `.all()` for collections, `.paginate()` for paginated collections.
-- Import from `app.dao.dao_utils` for `transactional`.
-
-### 4. Blueprint REST File (`app/<module>/rest.py`)
-
-```python
-from flask import Blueprint, current_app, jsonify, request
-
-from app.dao.<entity>_dao import (
-    dao_create_<entity>,
-    dao_delete_<entity>,
-    dao_fetch_<entities>_for_service,
-    dao_get_<entity>_by_id_and_service_id,
-    dao_update_<entity>,
-)
-from app.errors import InvalidRequest, register_errors
-from app.models import <Model>
-from app.schema_validation import validate
-from app.<module>.<module>_schema import (
-    post_create_<entity>_schema,
-    post_update_<entity>_schema,
-)
-from app.utils import pagination_links
-
-<entity>_blueprint = Blueprint("<entity>", __name__, url_prefix="/service/<uuid:service_id>/<entity-kebab>")
-register_errors(<entity>_blueprint)
-
-
-@<entity>_blueprint.route("", methods=["GET"])
-def get_<entities>_for_service(service_id):
-    <entities> = dao_fetch_<entities>_for_service(service_id)
-    return jsonify([x.serialize() for x in <entities>]), 200
-
-
-@<entity>_blueprint.route("/<uuid:<entity>_id>", methods=["GET"])
-def get_<entity>_by_id(service_id, <entity>_id):
-    <entity> = dao_get_<entity>_by_id_and_service_id(<entity>_id, service_id)
-    return jsonify(<entity>.serialize()), 200
-
-
-@<entity>_blueprint.route("", methods=["POST"])
-def create_<entity>(service_id):
-    data = request.get_json()
-    validate(data, post_create_<entity>_schema)
-    <entity> = <Model>(**data, service_id=service_id)
-    dao_create_<entity>(<entity>)
-    return jsonify(<entity>.serialize()), 201
-
-
-@<entity>_blueprint.route("/<uuid:<entity>_id>", methods=["POST"])
-def update_<entity>(service_id, <entity>_id):
-    data = request.get_json()
-    validate(data, post_update_<entity>_schema)
-    <entity> = dao_get_<entity>_by_id_and_service_id(<entity>_id, service_id)
-    # Update fields from data
-    for key, value in data.items():
-        setattr(<entity>, key, value)
-    dao_update_<entity>(<entity>)
-    return jsonify(<entity>.serialize()), 200
-
-
-@<entity>_blueprint.route("/<uuid:<entity>_id>", methods=["DELETE"])
-def delete_<entity>(service_id, <entity>_id):
-    <entity> = dao_get_<entity>_by_id_and_service_id(<entity>_id, service_id)
-    dao_delete_<entity>(<entity>)
-    return "", 204
-```
-
-Key rules:
-- `register_errors(<blueprint>)` is MANDATORY — it registers all standard error handlers (404, 400, 401, 403, 500, `InvalidRequest`, `NoResultFound`, `ValidationError`, etc.).
-- Blueprint variable name: `<entity>_blueprint`.
-- Use `validate(data, schema)` from `app.schema_validation` for input validation.
-- Response format: `jsonify(data)` with appropriate status code (200, 201, 204).
-- Use `InvalidRequest(message, status_code)` for custom errors.
-- For paginated GET endpoints, use `pagination_links()` from `app.utils`.
-- Routes use `<uuid:id>` for UUID path parameters.
-- POST is used for both create (on collection) and update (on resource) — NOT PUT/PATCH.
-
-### 5. Blueprint Registration in `app/__init__.py`
-
-Add the import and registration call inside the `register_blueprint()` function:
-
-```python
-from app.<module>.rest import <entity>_blueprint
-
-# Inside register_blueprint() function, add:
-register_notify_blueprint(application, <entity>_blueprint, requires_admin_auth)
-```
-
-Auth function options:
-- `requires_admin_auth` — Admin/internal endpoints (most common for management APIs)
-- `requires_auth` — External API user endpoints (service API key auth)
-- `requires_no_auth` — Public endpoints (rare)
-- `requires_sre_auth` — SRE-only endpoints
-
-### 6. Test File Stubs (`tests/app/<module>/`)
-
-Create `tests/app/<module>/__init__.py` (empty) and `tests/app/<module>/test_rest.py`:
-
-```python
-import pytest
-from flask import url_for
-
-from app.models import <Model>
-from tests.app.db import create_service
-
-
-class TestGet<Entity>:
-    def test_get_<entities>_for_service(self, admin_request, sample_service):
-        response = admin_request.get(
-            "<entity>.get_<entities>_for_service",
-            service_id=sample_service.id,
-        )
-        assert response.status_code == 200
-
-    def test_get_<entity>_by_id(self, admin_request, sample_service):
-        # Setup: create the entity
-        response = admin_request.get(
-            "<entity>.get_<entity>_by_id",
-            service_id=sample_service.id,
-            <entity>_id=str(<entity>.id),
-        )
-        assert response.status_code == 200
-
-
-class TestCreate<Entity>:
-    def test_create_<entity>(self, admin_request, sample_service):
-        response = admin_request.post(
-            "<entity>.create_<entity>",
-            service_id=sample_service.id,
-            _data={
-                # ... required fields ...
-            },
-        )
-        assert response.status_code == 201
-
-    def test_create_<entity>_missing_required_field(self, admin_request, sample_service):
-        response = admin_request.post(
-            "<entity>.create_<entity>",
-            service_id=sample_service.id,
-            _data={},
-            _expected_status=400,
-        )
-        assert response.status_code == 400
-
-
-class TestUpdate<Entity>:
-    def test_update_<entity>(self, admin_request, sample_service):
-        # Setup: create the entity first
-        response = admin_request.post(
-            "<entity>.update_<entity>",
-            service_id=sample_service.id,
-            <entity>_id=str(<entity>.id),
-            _data={
-                # ... updated fields ...
-            },
-        )
-        assert response.status_code == 200
-
-
-class TestDelete<Entity>:
-    def test_delete_<entity>(self, admin_request, sample_service):
-        # Setup: create the entity first
-        response = admin_request.delete(
-            "<entity>.delete_<entity>",
-            service_id=sample_service.id,
-            <entity>_id=str(<entity>.id),
-        )
-        assert response.status_code == 204
-```
-
-Key test conventions:
-- Class-based grouping: `TestGet*`, `TestCreate*`, `TestUpdate*`, `TestDelete*`
-- Test naming: `test_<action>_<entity>_<condition>`
-- Use `admin_request` fixture for admin-authed endpoints
-- Use `sample_service` fixture for service-scoped resources
-- Factory functions from `tests/app/db.py` (e.g., `create_service()`, `create_template()`)
-- Test both happy path and validation errors
-
-### Top-Level vs Service-Scoped Endpoints
-
-**Service-scoped** (most common):
-```python
-url_prefix="/service/<uuid:service_id>/<entity-kebab>"
-```
-All route handlers receive `service_id` as first parameter.
-
-**Top-level** (for platform-wide resources like complaints):
-```python
-url_prefix="/<entity-kebab>"
-```
-Route handlers do NOT receive `service_id`.
+## Lean Implementation Notes
+
+- Keep `app/<module>/__init__.py` empty for internal modules.
+- Use JSON Schema dict files (`*_schema.py` or `*_schemas.py`) for request validation; reserve Marshmallow `app/schemas.py` changes for custom serialization needs.
+- Add or update tests in existing `tests/app/<module>/test_rest.py` when extending a module.
+- Service-scoped endpoints usually use `/service/<uuid:service_id>/...`; top-level endpoints do not include `service_id`.
 
 ## V2 Public API Endpoints (`app/v2/`)
 
@@ -374,61 +125,14 @@ app/v2/<module>/
 └── post_<entity>.py     # POST route handlers
 ```
 
-### V2 Blueprint Definition (`app/v2/<module>/__init__.py`)
+### V2 Snippet Sources
 
-Unlike internal modules (where `__init__.py` is empty), v2 modules define their Blueprint in `__init__.py`:
+For V2 code examples, use facts shards instead of inline examples in this agent file:
 
-```python
-from flask import Blueprint
-from app.v2.errors import register_errors
-
-v2_<entity>_blueprint = Blueprint("v2_<entity>", __name__, url_prefix="/v2/<entity-kebab>")
-register_errors(v2_<entity>_blueprint)
-```
-
-Key differences:
-- Import `register_errors` from `app.v2.errors` (NOT `app.errors`).
-- Blueprint name prefixed with `v2_`.
-- URL prefix starts with `/v2/`.
-
-### V2 Route File (`app/v2/<module>/get_<entity>.py`)
-
-```python
-from flask import current_app, jsonify, request
-
-from app.authentication.auth import AuthError
-from app.dao.<entity>_dao import dao_get_<entity>_by_id
-from app.schema_validation import validate
-from app.v2.<module> import v2_<entity>_blueprint
-from app.v2.<module>.<module>_schemas import get_<entity>_by_id_request
-
-
-@v2_<entity>_blueprint.route("/<entity_id>", methods=["GET"])
-def get_<entity>_by_id(<entity>_id):
-    _data = {"<entity>_id": <entity>_id}
-    validate(_data, get_<entity>_by_id_request)
-    <entity> = dao_get_<entity>_by_id(<entity>_id)
-    return jsonify(<entity>.serialize()), 200
-```
-
-Key differences from internal routes:
-- Import the Blueprint from the module's `__init__.py` (not defined in the route file).
-- Use `authenticated_service` (set by `requires_auth`) to scope queries to the calling service.
-- Return `model.serialize()` directly — no Marshmallow `.dump()`, no `data=` wrapper.
-
-### V2 Blueprint Registration in `app/__init__.py`
-
-V2 blueprints are registered in the separate `register_v2_blueprints()` function:
-
-```python
-# Inside register_v2_blueprints() function:
-from app.v2.<module> import v2_<entity>_blueprint
-from app.v2.<module> import get_<entity>, post_<entity>  # Import route modules to register routes
-
-register_notify_blueprint(application, v2_<entity>_blueprint, requires_auth)
-```
-
-Note: The route modules (`get_<entity>.py`, `post_<entity>.py`) must be imported so their `@blueprint.route()` decorators execute and register with the Blueprint.
+- `pattern_api_route_shape.md` (includes V2 route skeleton)
+- `pattern_api_blueprint_registration.md` (includes V2 registration wiring)
+- `pattern_v2_query_and_pagination.md` (query normalization + cursor links)
+- `pattern_v2_request_parsing_guards.md` (request decoding/media-type guard pattern)
 
 ## Output Format
 

--- a/.github/facts/pattern_api_aggregation_query_patterns.md
+++ b/.github/facts/pattern_api_aggregation_query_patterns.md
@@ -1,0 +1,65 @@
+# API Aggregation Query Patterns
+
+- Prefer DAO-level aggregation helpers for analytics endpoints; keep route handlers thin.
+- Scope all aggregation queries by `service_id` first, then apply optional date filters.
+- Use SQLAlchemy `func` expressions (`count`, `sum`, `avg`) and explicit `group_by` fields.
+- For categorical breakdowns, aggregate in SQL and return deterministic key order in Python.
+- Use `Notification` for live/current data and `NotificationHistory` only when explicitly required by endpoint contract.
+- Include only billable/terminal statuses if the endpoint contract requires it; otherwise aggregate over the explicit status set requested.
+- Keep date filtering consistent: `created_at >= start_date` and `created_at < end_date` (half-open range).
+- Return zeros for missing categories to keep response shape stable.
+
+## Snippets
+
+### DAO aggregation skeleton
+
+```python
+from sqlalchemy import case, func
+
+from app.models import Notification
+
+
+def get_<metric>_by_category(service_id, start_date=None, end_date=None):
+    query = Notification.query.filter(Notification.service_id == service_id)
+
+    if start_date is not None:
+        query = query.filter(Notification.created_at >= start_date)
+    if end_date is not None:
+        query = query.filter(Notification.created_at < end_date)
+
+    rows = (
+        query.with_entities(
+            Notification.notification_type,
+            func.count(Notification.id).label("total"),
+            func.sum(case((Notification.status == "delivered", 1), else_=0)).label("delivered"),
+            func.sum(case((Notification.status == "failed", 1), else_=0)).label("failed"),
+        )
+        .group_by(Notification.notification_type)
+        .all()
+    )
+
+    return rows
+```
+
+### Stable response shaping
+
+```python
+def build_breakdown(rows):
+    breakdown = {"sms": 0, "email": 0, "letter": 0}
+    for r in rows:
+        breakdown[r.notification_type] = int(r.total or 0)
+    return breakdown
+```
+
+### Date range schema pattern
+
+```python
+get_<metric>_request = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+        "start_date": {"type": "string", "format": "date-time"},
+        "end_date": {"type": "string", "format": "date-time"},
+    },
+}
+```

--- a/.github/facts/pattern_api_blueprint_registration.md
+++ b/.github/facts/pattern_api_blueprint_registration.md
@@ -1,0 +1,30 @@
+# API Blueprint Registration
+
+- New API blueprints require import wiring in app bootstrap.
+- Register with register_notify_blueprint(application, blueprint, auth_function, prefix_optional).
+- Use auth function and prefix style that matches adjacent registrations.
+- If only adding routes to an already-registered blueprint, do not touch registration.
+- Keep registration order and grouping consistent with file conventions.
+
+## Snippets
+
+### Internal module registration
+
+```python
+# app/__init__.py -> register_blueprint()
+from app.<module>.rest import <module>_blueprint
+from app.authentication.auth import requires_admin_auth
+
+register_notify_blueprint(application, <module>_blueprint, requires_admin_auth)
+```
+
+### V2 module registration
+
+```python
+# app/__init__.py -> register_v2_blueprints()
+from app.v2.<module> import v2_<module>_blueprint
+from app.v2.<module> import get_<entity>, post_<entity>
+from app.authentication.auth import requires_auth
+
+register_notify_blueprint(application, v2_<module>_blueprint, requires_auth)
+```

--- a/.github/facts/pattern_api_do_not_explore_list.md
+++ b/.github/facts/pattern_api_do_not_explore_list.md
@@ -1,0 +1,42 @@
+# API Do-Not-Explore Execution Rules
+
+- Do not broad-scan unrelated modules when the prompt names exact target files.
+- Do not create new modules/tables/migrations unless the prompt explicitly requires them.
+- Do not create new test files if an existing module-level test file already covers the target area.
+- Do not inspect fixtures beyond the minimum required to mirror an existing local test pattern.
+- Do not change route registration when editing an already-registered module.
+- Do not refactor nearby code during benchmark tasks; implement the smallest valid delta.
+
+## Search Budget
+
+- Read at most:
+  - target route file
+  - target schema file
+  - target DAO file
+  - one existing test file in same module
+  - one existing DAO test file (if needed)
+- If requirements are still ambiguous after these reads, ask one clarifying question instead of continuing exploration.
+
+## Snippets
+
+### Minimal-file checklist
+
+```text
+1) Read target schema + DAO
+2) Read local route in same module
+3) Read nearest existing tests
+4) Implement smallest patch
+5) Run focused errors/tests on touched files only
+```
+
+### Benchmark-safe scope guard
+
+```python
+ALLOWED_FILES = {
+    "app/<module>/rest.py",
+    "app/<module>/<module>_schema.py",
+    "app/dao/<module>_dao.py",
+    "tests/app/<module>/test_rest.py",
+}
+# If a file is outside this set, skip unless prompt explicitly asks for it.
+```

--- a/.github/facts/pattern_api_error_contracts_internal_vs_v2.md
+++ b/.github/facts/pattern_api_error_contracts_internal_vs_v2.md
@@ -1,0 +1,26 @@
+# API Error Contracts: Internal vs V2
+
+- Internal API (`app/errors.py`) typically responds with `{"result": "error", "message": "..."}`.
+- V2 API (`app/v2/errors.py`) responds with `{"status_code": <int>, "errors": [{"error": "...", "message": "..."}]}`.
+- `register_errors(...)` must match stack: internal routes use `app.errors.register_errors`, V2 routes use `app.v2.errors.register_errors`.
+- `NoResultFound` maps to 404 in both stacks, but payload shape differs.
+
+## Snippets
+
+### Internal API error shape
+
+```python
+return jsonify(result="error", message="No result found"), 404
+```
+
+### V2 API error shape
+
+```python
+return (
+    jsonify(
+        status_code=404,
+        errors=[{"error": "NoResultFound", "message": "No result found"}],
+    ),
+    404,
+)
+```

--- a/.github/facts/pattern_api_module_reuse.md
+++ b/.github/facts/pattern_api_module_reuse.md
@@ -1,0 +1,34 @@
+# Prefer Existing Modules
+
+- Default behavior is to extend an existing domain module or client before creating a new one.
+- In API work, check existing app domain folders first.
+- In Admin work, check existing notify_client and main view modules first.
+- Create a new module only when no existing domain fit is reasonable.
+- When extending existing modules, match local naming, imports, and file conventions.
+
+## Snippets
+
+### Extend existing module
+
+```python
+# app/<module>/rest.py
+@<module>_blueprint.route("/<uuid:<entity>_id>", methods=["POST"])
+def update_<entity>(service_id, <entity>_id):
+	data = request.get_json()
+	validate(data, post_update_<entity>_schema)
+	item = dao_get_<entity>_by_id_and_service_id(<entity>_id, service_id)
+	for key, value in data.items():
+		setattr(item, key, value)
+	dao_update_<entity>(item)
+	return jsonify(item.serialize()), 200
+```
+
+### New module scaffold (only if no fit)
+
+```text
+app/<module>/__init__.py
+app/<module>/<module>_schema.py
+app/dao/<module>_dao.py
+app/<module>/rest.py
+tests/app/<module>/test_rest.py
+```

--- a/.github/facts/pattern_api_route_shape.md
+++ b/.github/facts/pattern_api_route_shape.md
@@ -1,0 +1,47 @@
+# API Route Shape
+
+- Use Blueprint with explicit url_prefix.
+- Register errors on the blueprint via register_errors(...).
+- For write operations, parse request JSON and validate payload with schema validation.
+- Return jsonify payloads with explicit status codes.
+- Use UUID path parameter conventions consistent with existing routes.
+- Keep route naming and placement aligned with module conventions.
+
+## Snippets
+
+### Internal API route skeleton (app/<module>/rest.py)
+
+```python
+from flask import Blueprint, jsonify, request
+
+from app.errors import register_errors
+from app.schema_validation import validate
+
+<module>_blueprint = Blueprint("<module>", __name__, url_prefix="/service/<uuid:service_id>/<module-kebab>")
+register_errors(<module>_blueprint)
+
+
+@<module>_blueprint.route("", methods=["POST"])
+def create_<entity>(service_id):
+	data = request.get_json()
+	validate(data, post_create_<entity>_schema)
+	item = <Model>(**data, service_id=service_id)
+	dao_create_<entity>(item)
+	return jsonify(item.serialize()), 201
+```
+
+### V2 route skeleton (app/v2/<module>/post_<entity>.py)
+
+```python
+from flask import jsonify, request
+
+from app.schema_validation import validate
+from app.v2.<module> import v2_<module>_blueprint
+
+
+@v2_<module>_blueprint.route("", methods=["POST"])
+def post_<entity>():
+	data = validate(request.get_json() or {}, post_<entity>_request)
+	item = create_<entity>(authenticated_service.id, data)
+	return jsonify(item.serialize()), 201
+```

--- a/.github/facts/pattern_api_validation_contract.md
+++ b/.github/facts/pattern_api_validation_contract.md
@@ -1,0 +1,27 @@
+# API Validation Contract
+
+- Use `validate(payload, schema)` from `app.schema_validation` for request validation.
+- Validation failures produce a 400 response envelope with `status_code` and `errors`.
+- Error entries use `{"error": "ValidationError", "message": "..."}` shape.
+- Deduplicate repeated validation errors before returning.
+- If `personalisation` is present, validation may include personalisation/file decoding checks.
+
+## Snippets
+
+### Validate incoming body
+
+```python
+data = request.get_json() or {}
+validated = validate(data, post_<entity>_request)
+```
+
+### Expected validation error envelope
+
+```json
+{
+  "status_code": 400,
+  "errors": [
+    {"error": "ValidationError", "message": "template_id is a required property"}
+  ]
+}
+```

--- a/.github/facts/pattern_dao_transactional_mutations.md
+++ b/.github/facts/pattern_dao_transactional_mutations.md
@@ -1,0 +1,38 @@
+# DAO Transaction Pattern
+
+- Mutating DAO functions use the transactional decorator.
+- Mutations use db session add, update, or delete operations.
+- Commit and rollback behavior is delegated to decorator flow.
+- Keep guard clauses and domain validation near mutation logic.
+- Follow existing DAO naming conventions for get, fetch, create, update, and archive operations.
+
+## Snippets
+
+### Query patterns (no @transactional)
+
+```python
+def dao_get_<entity>_by_id(<entity>_id):
+	return <Model>.query.filter_by(id=<entity>_id).one()
+
+
+def dao_fetch_<entities>_for_service(service_id):
+	return <Model>.query.filter_by(service_id=service_id).all()
+```
+
+### Mutation patterns (@transactional)
+
+```python
+from app import db
+from app.dao.dao_utils import transactional
+
+
+@transactional
+def dao_create_<entity>(item):
+	db.session.add(item)
+
+
+@transactional
+def dao_archive_<entity>(item):
+	item.archived = True
+	db.session.add(item)
+```

--- a/.github/facts/pattern_v2_query_and_pagination.md
+++ b/.github/facts/pattern_v2_query_and_pagination.md
@@ -1,0 +1,32 @@
+# V2 Query and Pagination Pattern
+
+- Normalize query params from `request.args.to_dict(flat=False)` before schema validation.
+- Flatten single-value fields (for example `older_than`, `reference`, `include_jobs`) from list to scalar.
+- Validate normalized params with V2 schema.
+- Use cursor-style pagination in V2 (`older_than`) instead of internal page/total pagination.
+- Return `_links.current` and optional `_links.next` based on last item ID.
+
+## Snippets
+
+### Normalize + validate query args
+
+```python
+_data = request.args.to_dict(flat=False)
+if "older_than" in _data:
+    _data["older_than"] = _data["older_than"][0]
+if "reference" in _data:
+    _data["reference"] = _data["reference"][0]
+if "include_jobs" in _data:
+    _data["include_jobs"] = _data["include_jobs"][0]
+
+data = validate(_data, get_<entity>_request)
+```
+
+### Build V2 cursor links
+
+```python
+_links = {"current": url_for(".get_<entities>", _external=True, **data)}
+if len(items):
+    next_query = dict(data, older_than=items[-1].id)
+    _links["next"] = url_for(".get_<entities>", _external=True, **next_query)
+```


### PR DESCRIPTION
# Summary | Résumé

This PR experiments with "fact shards" in an attempt to reduce token usage for the `api-endpoint-builder` agent. Patterns and code examples were pulled out of the base agent file and placed into individual fact shard files that are then referenced by that agent.md file. 

Since the entire agent.md file is loaded into context with each new chat, a small amount of [conditional loading](https://github.com/cds-snc/notification-api/pull/2919/changes#diff-58ce6c6cfc9a320b343b05add2c0b18a7179f8538fdc57f639f4eabe2c88ebf5R38) was put in place to help guide the agent when it decides what shards to pull into context when responding to a prompt.

A full breakdown with 4 test cases can be read here: https://github.com/cds-snc/notification-api/wiki/Fact-shards-experiment-results. In short:

✅ When a prompt maps well to documented patterns / fact shards token usage seems to be significantly reduced
🔴 When the AI loads fact shards + has to perform it's own exploration of the codebase for patterns - token usage is negatively impacted
⚠️ When constraints are placed on exploration depth token usage is decreased - unclear how output quality is affected by exploration constraints

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1
* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/1

# Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.