### PR TITLE
Introduced temporary logger to only activate debug message on rate_limiter module

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -121,6 +121,7 @@ def create_app(application, config=None):
     # for specific loggers.
     if application.config.get("NOTIFY_ENVIRONMENT") == "staging":
         import logging as stdlib_logging
+
         stdlib_logging.getLogger("app.rate_limiter").setLevel(stdlib_logging.DEBUG)
     if application.config.get("OTEL_REQUEST_METRICS_ENABLED", False):
         init_otel_request_metrics(application)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -116,6 +116,12 @@ def create_app(application, config=None):
     zendesk_client.init_app(application)
     statsd_client.init_app(application)
     logging.init_app(application, statsd_client)
+    # Ugly temporary hack to get the rate limiter debug logging to work in staging.
+    # This should be removed when we have a better way of configuring logging levels
+    # for specific loggers.
+    if application.config.get("NOTIFY_ENVIRONMENT") == "staging":
+        import logging as stdlib_logging
+        stdlib_logging.getLogger("app.rate_limiter").setLevel(stdlib_logging.DEBUG)
     if application.config.get("OTEL_REQUEST_METRICS_ENABLED", False):
         init_otel_request_metrics(application)
     aws_sns_client.init_app(application, statsd_client=statsd_client)

--- a/app/rate_limiter.py
+++ b/app/rate_limiter.py
@@ -247,8 +247,6 @@ def initialize_rate_limiter(
     Returns:
         RateLimiter: The initialized rate limiter instance.
     """
-    import logging
-
     logger = logging.getLogger(__name__)
 
     if limiter_class is not None:

--- a/app/rate_limiter.py
+++ b/app/rate_limiter.py
@@ -718,9 +718,7 @@ class BufferedRateLimiter(RateLimiter):
 
         # Discard stale local tokens to prevent cross-window over-consumption.
         if self._local_tokens > 0 and time() - self._acquired_at >= self.TOKEN_WINDOW_SECONDS:
-            _logger.debug(
-                f"BufferedRateLimiter [{self.namespace}]: discarding {self._local_tokens} stale local tokens"
-            )
+            _logger.debug(f"BufferedRateLimiter [{self.namespace}]: discarding {self._local_tokens} stale local tokens")
             self._local_tokens = 0
 
         # Fast path: if the local buffer has enough tokens, spend them without hitting the backend.

--- a/app/rate_limiter.py
+++ b/app/rate_limiter.py
@@ -8,6 +8,7 @@ This module provides a generic rate limiter that enforces a cap on the number
 of units that can be acquired per minute.
 """
 
+import logging
 import math
 from abc import ABC, abstractmethod
 from collections import deque
@@ -15,6 +16,8 @@ from time import time
 from typing import Tuple
 
 from flask import current_app
+
+_logger = logging.getLogger(__name__)
 
 
 class RateLimiter(ABC):
@@ -454,7 +457,7 @@ class RedisSlidingWindowLogRateLimiter(RateLimiter):
         success, wait_seconds = result[0], result[1]
 
         if success:
-            current_app.logger.debug(f"Rate limiter [{self.namespace}]: acquired {units} units. Entry ID: {entry_id}")
+            _logger.debug(f"Rate limiter [{self.namespace}]: acquired {units} units. Entry ID: {entry_id}")
         else:
             current_app.logger.warning(
                 f"Rate limiter [{self.namespace}]: capacity exhausted. Requested {units} units. "
@@ -617,7 +620,7 @@ class RedisTokenBucketRateLimiter(RateLimiter):
         success, wait_seconds = result[0], result[1]
 
         if success:
-            current_app.logger.debug(f"Rate limiter [{self.namespace}]: acquired {units} units.")
+            _logger.debug(f"Rate limiter [{self.namespace}]: acquired {units} units.")
         else:
             current_app.logger.warning(
                 f"Rate limiter [{self.namespace}]: capacity exhausted. Requested {units} units. "
@@ -715,7 +718,7 @@ class BufferedRateLimiter(RateLimiter):
 
         # Discard stale local tokens to prevent cross-window over-consumption.
         if self._local_tokens > 0 and time() - self._acquired_at >= self.TOKEN_WINDOW_SECONDS:
-            current_app.logger.debug(
+            _logger.debug(
                 f"BufferedRateLimiter [{self.namespace}]: discarding {self._local_tokens} stale local tokens"
             )
             self._local_tokens = 0
@@ -723,7 +726,7 @@ class BufferedRateLimiter(RateLimiter):
         # Fast path: if the local buffer has enough tokens, spend them without hitting the backend.
         if self._local_tokens >= units:
             self._local_tokens -= units
-            current_app.logger.debug(
+            _logger.debug(
                 f"BufferedRateLimiter [{self.namespace}]: spent {units} local tokens " f"(remaining: {self._local_tokens})"
             )
             return True, 0
@@ -743,7 +746,7 @@ class BufferedRateLimiter(RateLimiter):
         self._acquired_at = time()
         self._local_tokens += batch
         self._local_tokens -= units
-        current_app.logger.debug(
+        _logger.debug(
             f"BufferedRateLimiter [{self.namespace}]: fetched {batch} tokens from backend, "
             f"spent {units}, local buffer now {self._local_tokens}"
         )


### PR DESCRIPTION
# Summary | Résumé

## feat: enable rate limiter DEBUG logging in Staging

Routes the rate limiter's verbose `debug()` calls through a module-level logger (`app.rate_limiter`) instead of Flask's global `app.logger`, then sets that logger to `DEBUG` only in Staging. All other environments and log levels are unaffected. This is to limit numerous log statements that might overpopulate the logs if we enable the global logger to DEBUG statements.

## Related Issues | Cartes liées

* [SMS Rate Limiter](https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/786)

# Test instructions | Instructions pour tester la modification

1. Run `pytest tests/app/test_rate_limiter.py tests/app/test_rate_limiter_scaling.py`
2. Deploy to Staging with `FF_SMS_RATELIMIT=true` and a Redis-backed `SMS_RATE_LIMITER_BACKEND`; tail Celery worker logs and confirm `DEBUG` entries appear scoped to `app.rate_limiter`
3. Confirm no `DEBUG` entries from `app.rate_limiter` appear in any non-Staging environment

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.