### PR TITLE
Feat/ratelimiter faster slidingwindowimpl

### DIFF
--- a/app/rate_limiter.py
+++ b/app/rate_limiter.py
@@ -57,6 +57,16 @@ class RateLimiter(ABC):
         """
         pass
 
+    @property
+    def max_units_per_acquire(self) -> int:
+        """
+        Maximum units that can be requested in a single acquire_lease() call.
+
+        Defaults to cap_per_minute. Implementations with a tighter per-call
+        ceiling (e.g. RedisTokenBucketRateLimiter) should override this.
+        """
+        return self.cap_per_minute
+
     def buffered(self, size: int) -> BufferedRateLimiter:
         """
         Wrap this rate limiter in a BufferedRateLimiter and register it under
@@ -537,6 +547,11 @@ class RedisTokenBucketRateLimiter(RateLimiter):
         self._lua_scripts: dict[str, object] = {}
 
     @property
+    def max_units_per_acquire(self) -> int:
+        """Per-call ceiling: one second of capacity, minimum 1."""
+        return max(1, self.cap_per_minute // 60)
+
+    @property
     def redis(self):
         # Lazy-load Redis client to avoid circular imports at init time.
         if self.redis_client is not None:
@@ -611,11 +626,10 @@ class RedisTokenBucketRateLimiter(RateLimiter):
         if units <= 0:
             raise ValueError("units must be positive")
 
-        max_tokens = max(1, self.cap_per_minute / 60)
-        if units > max_tokens:
+        if units > self.max_units_per_acquire:
             raise ValueError(
-                f"units ({units}) must be <= {max_tokens:.2f} "
-                f"(cap_per_minute={self.cap_per_minute} / 60). "
+                f"units ({units}) must be <= {self.max_units_per_acquire} "
+                f"(max(1, cap_per_minute={self.cap_per_minute} // 60)). "
                 "The bucket ceiling is one second of capacity to prevent burst."
             )
 
@@ -699,8 +713,11 @@ class BufferedRateLimiter(RateLimiter):
     def __init__(self, rate_limiter: RateLimiter, size: int) -> None:
         if size <= 0:
             raise ValueError("size must be positive")
-        if size > rate_limiter.cap_per_minute:
-            raise ValueError(f"size ({size}) must be <= cap_per_minute ({rate_limiter.cap_per_minute})")
+        if size > rate_limiter.max_units_per_acquire:
+            raise ValueError(
+                f"size ({size}) must be <= max_units_per_acquire ({rate_limiter.max_units_per_acquire}) "
+                f"for {type(rate_limiter).__name__}"
+            )
         super().__init__(rate_limiter.cap_per_minute, rate_limiter.namespace)
         self._rate_limiter = rate_limiter
         self._size = size

--- a/app/rate_limiter.py
+++ b/app/rate_limiter.py
@@ -508,15 +508,15 @@ class RedisTokenBucketRateLimiter(RateLimiter):
     Algorithm:
     - Tokens refill continuously at rate cap_per_minute / 60 per second.
     - On each request, elapsed time since last refill is computed, tokens are
-      topped up (capped at cap_per_minute / 60), and the requested units are
+      topped up (capped at max(1, cap_per_minute / 60)), and the requested units are
       subtracted atomically in Lua.
     - If tokens are insufficient, the exact wait time is returned:
-      deficit / (cap_per_minute / 60) seconds.
+      deficit / (max(1, cap_per_minute / 60)) seconds.
     - No burst after idle: the bucket ceiling is one second of capacity
-      (cap_per_minute / 60), so long idle periods never accumulate more than
+      (max(1, cap_per_minute / 60)), so long idle periods never accumulate more than
       ~1 second worth of tokens. Maximum per-minute throughput cannot exceed
       cap_per_minute regardless of how long the system was idle.
-    - Maximum units per acquire_lease call: cap_per_minute / 60 (one second).
+    - Maximum units per acquire_lease call: max(1, cap_per_minute / 60) (one second).
 
     Complexity: O(1) for all operations.
     """
@@ -552,7 +552,7 @@ class RedisTokenBucketRateLimiter(RateLimiter):
             local cap = tonumber(ARGV[1])
             local units = tonumber(ARGV[2])
             local now = tonumber(ARGV[3])
-            local refill_rate = cap / 60.0
+            local refill_rate = math.max(1, cap / 60.0)
 
             -- Read current state; initialize to one second of tokens on first call.
             -- Using refill_rate (not cap) as the starting value prevents burst-after-idle:
@@ -611,7 +611,7 @@ class RedisTokenBucketRateLimiter(RateLimiter):
         if units <= 0:
             raise ValueError("units must be positive")
 
-        max_tokens = self.cap_per_minute / 60
+        max_tokens = max(1, self.cap_per_minute / 60)
         if units > max_tokens:
             raise ValueError(
                 f"units ({units}) must be <= {max_tokens:.2f} "
@@ -656,7 +656,7 @@ class RedisTokenBucketRateLimiter(RateLimiter):
         last_refill = float(last_refill_str if isinstance(last_refill_str, str) else last_refill_str.decode("utf-8"))
 
         elapsed = now - last_refill
-        refill_rate = self.cap_per_minute / 60.0
+        refill_rate = max(1.0, self.cap_per_minute / 60.0)
         max_tokens = refill_rate  # ceiling matches Lua: one second of capacity
         tokens = min(max_tokens, tokens + elapsed * refill_rate)
 

--- a/app/rate_limiter.py
+++ b/app/rate_limiter.py
@@ -10,6 +10,7 @@ of units that can be acquired per minute.
 
 import logging
 import math
+import uuid
 from abc import ABC, abstractmethod
 from collections import deque
 from time import time
@@ -361,12 +362,15 @@ class RedisSlidingWindowLogRateLimiter(RateLimiter):
             -- 1. Remove expired entries
             redis.call('ZREMRANGEBYSCORE', entries_key, '-inf', '(' .. window_start)
 
-            -- 2. Compute current usage by summing units from members
+            -- 2. Fetch all active entries with scores in a single call.
+            --    Scores are timestamps; members encode units as "entry_id:units".
+            --    This result is reused for both usage summation and wait-time
+            --    calculation, avoiding a second ZRANGE on the denied path.
             local current_usage = 0
-            local entries = redis.call('ZRANGE', entries_key, 0, -1)
+            local entries_with_scores = redis.call('ZRANGE', entries_key, 0, -1, 'WITHSCORES')
 
-            for i = 1, #entries do
-                local member = entries[i]
+            for i = 1, #entries_with_scores, 2 do
+                local member = entries_with_scores[i]
                 local sep = string.find(member, ":")
                 local entry_units = tonumber(string.sub(member, sep + 1)) or 0
                 current_usage = current_usage + entry_units
@@ -381,12 +385,11 @@ class RedisSlidingWindowLogRateLimiter(RateLimiter):
 
                 return {1, 0}
             else
-                -- 4. Calculate wait time
+                -- 4. Calculate wait time by iterating the already-fetched entries_with_scores.
+                --    No second ZRANGE needed.
                 local units_needed = current_usage + units - cap_per_minute
                 local units_freed = 0
                 local last_timestamp_to_wait = nil
-
-                local entries_with_scores = redis.call('ZRANGE', entries_key, 0, -1, 'WITHSCORES')
 
                 for i = 1, #entries_with_scores, 2 do
                     local member = entries_with_scores[i]
@@ -435,8 +438,6 @@ class RedisSlidingWindowLogRateLimiter(RateLimiter):
         if units > self.cap_per_minute:
             raise ValueError("units must be smaller than or equal to the cap_per_minute")
 
-        import uuid
-
         now = time()
         entry_id = str(uuid.uuid4())
 
@@ -469,12 +470,12 @@ class RedisSlidingWindowLogRateLimiter(RateLimiter):
         now = time()
         window_start = now - self.WINDOW_SIZE_SECONDS
 
-        # Remove expired entries
-        self.redis.zremrangebyscore(self._entries_key, "-inf", f"({window_start}")
-
-        # Recalculate usage by summing units from members (encoded as "entry_id:units")
+        # Read only the entries still inside the window without mutating the set.
+        # The Lua acquire script removes entries with score < window_start (exclusive
+        # upper bound), so an entry scored exactly at window_start is still live.
+        # Use an inclusive lower bound here to match that semantics.
         current_usage = 0
-        entries = self.redis.zrange(self._entries_key, 0, -1)
+        entries = self.redis.zrangebyscore(self._entries_key, window_start, "+inf")
         for member in entries:
             # Extract unit count from member string format "entry_id:units"
             if isinstance(member, bytes):

--- a/app/rate_limiter.py
+++ b/app/rate_limiter.py
@@ -507,12 +507,15 @@ class RedisTokenBucketRateLimiter(RateLimiter):
     Algorithm:
     - Tokens refill continuously at rate cap_per_minute / 60 per second.
     - On each request, elapsed time since last refill is computed, tokens are
-      topped up (capped at cap_per_minute), and the requested units are
+      topped up (capped at cap_per_minute / 60), and the requested units are
       subtracted atomically in Lua.
     - If tokens are insufficient, the exact wait time is returned:
       deficit / (cap_per_minute / 60) seconds.
-    - Burst after idle: if the system is idle, the bucket refills to cap,
-      allowing a full cap's worth of units to be acquired immediately.
+    - No burst after idle: the bucket ceiling is one second of capacity
+      (cap_per_minute / 60), so long idle periods never accumulate more than
+      ~1 second worth of tokens. Maximum per-minute throughput cannot exceed
+      cap_per_minute regardless of how long the system was idle.
+    - Maximum units per acquire_lease call: cap_per_minute / 60 (one second).
 
     Complexity: O(1) for all operations.
     """
@@ -550,25 +553,27 @@ class RedisTokenBucketRateLimiter(RateLimiter):
             local now = tonumber(ARGV[3])
             local refill_rate = cap / 60.0
 
-            -- Read current state; default to full bucket on first call
+            -- Read current state; initialize to one second of tokens on first call.
+            -- Using refill_rate (not cap) as the starting value prevents burst-after-idle:
+            -- a newly created or long-idle bucket holds at most one second of capacity.
             local tokens_str = redis.call('HGET', key, 'tokens')
             local last_refill_str = redis.call('HGET', key, 'last_refill')
 
             local tokens
             local last_refill
             if tokens_str == false then
-                tokens = cap
+                tokens = refill_rate
                 last_refill = now
             else
-                -- Default to cap or now if tokens and last refill aren't available
-                -- for defensive programming reasons.
-                tokens = tonumber(tokens_str) or cap
+                -- Default to 0 if tokens can't be parsed (defensive)
+                tokens = tonumber(tokens_str) or 0
                 last_refill = tonumber(last_refill_str) or now
             end
 
-            -- Refill tokens based on elapsed time
+            -- Refill tokens based on elapsed time, capped at one second's worth.
+            -- This keeps the maximum burst to ~1 second regardless of idle duration.
             local elapsed = now - last_refill
-            tokens = math.min(cap, tokens + elapsed * refill_rate)
+            tokens = math.min(refill_rate, tokens + elapsed * refill_rate)
 
             if tokens >= units then
                 -- Admit: subtract units and persist new state
@@ -605,8 +610,13 @@ class RedisTokenBucketRateLimiter(RateLimiter):
         if units <= 0:
             raise ValueError("units must be positive")
 
-        if units > self.cap_per_minute:
-            raise ValueError("units must be smaller than or equal to the cap_per_minute")
+        max_tokens = self.cap_per_minute / 60
+        if units > max_tokens:
+            raise ValueError(
+                f"units ({units}) must be <= {max_tokens:.2f} "
+                f"(cap_per_minute={self.cap_per_minute} / 60). "
+                "The bucket ceiling is one second of capacity to prevent burst."
+            )
 
         now = time()
         script = self._get_acquire_lua_script()
@@ -646,9 +656,10 @@ class RedisTokenBucketRateLimiter(RateLimiter):
 
         elapsed = now - last_refill
         refill_rate = self.cap_per_minute / 60.0
-        tokens = min(self.cap_per_minute, tokens + elapsed * refill_rate)
+        max_tokens = refill_rate  # ceiling matches Lua: one second of capacity
+        tokens = min(max_tokens, tokens + elapsed * refill_rate)
 
-        return max(0, int(self.cap_per_minute - tokens))
+        return max(0, round(max_tokens - tokens))
 
     def reset_limiter(self):
         self.redis.delete(self._key)

--- a/tests/app/test_rate_limiter.py
+++ b/tests/app/test_rate_limiter.py
@@ -354,21 +354,24 @@ class TestRedisTokenBucketRateLimiter:
         return RedisTokenBucketRateLimiter(cap_per_minute=1000, namespace="test", redis_client=redis_client)
 
     def test_acquire_lease_below_capacity_succeeds(self, client, limiter):
+        # max_tokens = 1000/60 ≈ 16.67; requesting 10 fits comfortably
         with client.application.app_context():
-            allow_send, wait_seconds = limiter.acquire_lease(100)
+            allow_send, wait_seconds = limiter.acquire_lease(10)
             assert allow_send is True
             assert wait_seconds == 0
 
     def test_acquire_lease_at_capacity_succeeds(self, client, limiter):
+        # max_tokens ≈ 16.67; requesting 16 fits within the ceiling
         with client.application.app_context():
-            allow_send, wait_seconds = limiter.acquire_lease(1000)
+            allow_send, wait_seconds = limiter.acquire_lease(16)
             assert allow_send is True
             assert wait_seconds == 0
 
     def test_acquire_lease_exceeding_capacity_fails(self, client, limiter):
+        # Fill the bucket then request 1 more — must be denied
         with client.application.app_context():
-            limiter.acquire_lease(1000)
-            allow_send, wait_seconds = limiter.acquire_lease(100)
+            limiter.acquire_lease(16)
+            allow_send, wait_seconds = limiter.acquire_lease(1)
             assert allow_send is False
             assert wait_seconds > 0
 
@@ -388,134 +391,138 @@ class TestRedisTokenBucketRateLimiter:
                 limiter.acquire_lease(limiter.cap_per_minute + 1)
 
     def test_get_current_usage_returns_consumed_parts(self, client, limiter):
+        # max_tokens ≈ 16.67; consume 5+8=13, leaving ~3.67 available
         with client.application.app_context():
             with patch("app.rate_limiter.time") as mock_time:
                 mock_time.return_value = 100.0
-                limiter.acquire_lease(150)
-                limiter.acquire_lease(250)
+                limiter.acquire_lease(5)
+                limiter.acquire_lease(8)
                 # freeze time so no refill occurs during get_current_usage
-                assert limiter.get_current_usage() == 400
+                assert limiter.get_current_usage() == 13
 
     def test_get_current_usage_zero_when_bucket_empty(self, client, limiter):
         with client.application.app_context():
             assert limiter.get_current_usage() == 0
 
     def test_retry_delay_is_precise(self, client, limiter):
-        # Token bucket wait time = ceil(deficit / refill_rate)
-        # refill_rate = 1000 / 60 ≈ 16.67 parts/sec
-        # After consuming 1000/1000, requesting 100 more:
-        # deficit = 100, wait = ceil(100 / 16.67) = ceil(5.999) = 6
+        # refill_rate = 1000/60 ≈ 16.67 tokens/sec
+        # Fill the bucket (16 tokens), then request 1 more:
+        # deficit = 1, wait = ceil(1 / 16.67) = 1 s
         with client.application.app_context():
             with patch("app.rate_limiter.time") as mock_time:
                 mock_time.return_value = 100.0
-                limiter.acquire_lease(1000)
-                allow_send, wait_seconds = limiter.acquire_lease(100)
+                limiter.acquire_lease(16)
+                allow_send, wait_seconds = limiter.acquire_lease(1)
                 assert allow_send is False
                 import math
 
-                expected = math.ceil(100 / (1000 / 60))
+                expected = math.ceil(1 / (1000 / 60))
                 assert wait_seconds == expected
 
     def test_capacity_refills_over_time(self, client, limiter):
+        # Fill bucket, advance 0.12 s: refill = 16.67 * 0.12 = 2.0 tokens
         with client.application.app_context():
             with patch("app.rate_limiter.time") as mock_time:
                 mock_time.return_value = 100.0
-                limiter.acquire_lease(1000)
+                limiter.acquire_lease(16)
 
-                # Advance 30 seconds — should have refilled 1000/60 * 30 = 500 tokens
-                mock_time.return_value = 130.0
-                allow_send, _ = limiter.acquire_lease(500)
+                # 0.12 seconds refills ≈ 2 tokens — enough to acquire 2
+                mock_time.return_value = 100.12
+                allow_send, _ = limiter.acquire_lease(2)
                 assert allow_send is True
 
-    def test_bucket_does_not_exceed_cap_after_idle(self, client, limiter):
+    def test_bucket_does_not_exceed_max_burst_after_idle(self, client, limiter):
+        # Even after 120 s of idle, the bucket holds at most refill_rate ≈ 16.67 tokens.
+        # Requesting 16 must succeed, but 17 must fail.
         with client.application.app_context():
             with patch("app.rate_limiter.time") as mock_time:
                 mock_time.return_value = 100.0
-                limiter.acquire_lease(500)
+                limiter.acquire_lease(10)
 
-                # Advance 120 seconds — bucket should be capped at 1000, not 500 + 1000/60*120
+                # Advance 120 seconds — bucket should be capped at ~16.67, not 10 + 16.67*120
                 mock_time.return_value = 220.0
-                allow_send, _ = limiter.acquire_lease(1000)
+                allow_send, _ = limiter.acquire_lease(16)
                 assert allow_send is True
 
-    def test_burst_after_idle_allows_full_cap(self, client, limiter):
+    def test_no_burst_after_idle(self, client, limiter):
+        # After any amount of idle time the bucket never accumulates more than
+        # one second of tokens (≈16.67). A request for 17 must always be denied.
         with client.application.app_context():
             with patch("app.rate_limiter.time") as mock_time:
                 mock_time.return_value = 100.0
-                # Use up full capacity
-                limiter.acquire_lease(1000)
+                # Drain the bucket first
+                limiter.acquire_lease(16)
 
-                # Advance 60 seconds — bucket fully refilled
+                # Advance 60 seconds — old behaviour would refill to 1000, new caps at ≈16.67
                 mock_time.return_value = 160.0
-                allow_send, _ = limiter.acquire_lease(1000)
-                assert allow_send is True
+                with pytest.raises(ValueError):
+                    limiter.acquire_lease(17)  # still above the ceiling
 
-    def test_full_cap_available_slightly_after_60_seconds(self, client, limiter):
-        # Mirrors test_window_slightly_older_than_60_seconds_is_removed: after
-        # depleting all tokens and waiting 60.1 s the bucket is at full cap and
-        # a full-cap request must be granted.
+    def test_bucket_refills_fully_after_one_second(self, client, limiter):
+        # After draining, exactly 1 second of elapsed time refills the ceiling.
         with client.application.app_context():
             with patch("app.rate_limiter.time") as mock_time:
                 base_time = 100.0
                 mock_time.return_value = base_time
-                limiter.acquire_lease(1000)
+                limiter.acquire_lease(16)
 
-                mock_time.return_value = base_time + 60.1
-                allow_send, _ = limiter.acquire_lease(1000)
+                # After 1 second the bucket is back at ≈16.67 — enough for 16
+                mock_time.return_value = base_time + 1.0
+                allow_send, _ = limiter.acquire_lease(16)
                 assert allow_send is True
 
     def test_reset_clears_bucket(self, client, limiter):
         with client.application.app_context():
             with patch("app.rate_limiter.time") as mock_time:
                 mock_time.return_value = 100.0
-                limiter.acquire_lease(1000)
-                allow_send, _ = limiter.acquire_lease(100)
-                assert allow_send is False
-
-                limiter.reset_limiter()
-                # After reset, bucket is gone; next call initialises fresh full bucket
-                allow_send, _ = limiter.acquire_lease(1000)
-                assert allow_send is True
-
-    def test_multiple_sequential_acquires_deplete_tokens(self, client, limiter):
-        with client.application.app_context():
-            with patch("app.rate_limiter.time") as mock_time:
-                mock_time.return_value = 100.0
-                limiter.acquire_lease(400)
-                limiter.acquire_lease(400)
-                limiter.acquire_lease(200)
-                # Bucket now at 0
+                limiter.acquire_lease(16)
                 allow_send, _ = limiter.acquire_lease(1)
                 assert allow_send is False
 
-    def test_bucket_not_fully_refilled_after_59_9_seconds(self, client, limiter):
-        # After depleting all tokens, 59.9 s of refill restores only
-        # 1000/60 * 59.9 ≈ 998.3 tokens — not enough to grant 1000.
+                limiter.reset_limiter()
+                # After reset, bucket reinitialises with one second of tokens
+                allow_send, _ = limiter.acquire_lease(16)
+                assert allow_send is True
+
+    def test_multiple_sequential_acquires_deplete_tokens(self, client, limiter):
+        # max_tokens ≈ 16.67; acquiring 10 + 6 = 16 leaves < 1 token
+        with client.application.app_context():
+            with patch("app.rate_limiter.time") as mock_time:
+                mock_time.return_value = 100.0
+                limiter.acquire_lease(10)
+                limiter.acquire_lease(6)
+                # Bucket now has ≈ 0.67 tokens — not enough for 1
+                allow_send, _ = limiter.acquire_lease(1)
+                assert allow_send is False
+
+    def test_bucket_not_fully_refilled_after_partial_second(self, client, limiter):
+        # After depleting 16 tokens (leaving ≈0.67 tokens), 0.9 s elapses:
+        # refill = 16.67 * 0.9 ≈ 15.0 tokens, total ≈15.67 < 16.
+        # A second full-ceiling request must therefore fail.
         with client.application.app_context():
             with patch("app.rate_limiter.time") as mock_time:
                 base_time = 100.0
                 mock_time.return_value = base_time
-                limiter.acquire_lease(1000)
+                limiter.acquire_lease(16)
 
-                mock_time.return_value = base_time + 59.9
-                allow_send, _ = limiter.acquire_lease(1000)
+                # 0.9 seconds refills ≈15.67 tokens — not enough for another 16
+                mock_time.return_value = base_time + 0.9
+                allow_send, _ = limiter.acquire_lease(16)
                 assert allow_send is False
 
     def test_retry_delay_with_partial_prior_consumption(self, client, limiter):
-        # Two partial acquires leave 100 tokens remaining; requesting 200 creates
-        # a deficit of 100.  wait = ceil(100 / (1000/60)) = ceil(6.0) = 6 s.
+        # max_tokens ≈ 16.67; acquire 8+5=13 leaving ≈3.67 tokens.
+        # Requesting 5 creates a deficit of ≈1.33.
+        # wait = ceil(1.33 / 16.67) = ceil(0.08) = 1 s.
         with client.application.app_context():
             with patch("app.rate_limiter.time") as mock_time:
-                import math
-
                 mock_time.return_value = 100.0
-                limiter.acquire_lease(500)
-                limiter.acquire_lease(400)
-                # 100 tokens remain; requesting 200 → deficit 100
-                allow_send, wait_seconds = limiter.acquire_lease(200)
+                limiter.acquire_lease(8)
+                limiter.acquire_lease(5)
+                # ≈3.67 tokens remain; requesting 5 → deficit ≈1.33
+                allow_send, wait_seconds = limiter.acquire_lease(5)
                 assert allow_send is False
-                expected = math.ceil(100 / (1000 / 60))
-                assert wait_seconds == expected
+                assert wait_seconds == 1
 
 
 class TestInitializeRateLimiter:

--- a/tests/app/test_rate_limiter.py
+++ b/tests/app/test_rate_limiter.py
@@ -431,6 +431,22 @@ class TestRedisTokenBucketRateLimiter:
                 allow_send, _ = limiter.acquire_lease(2)
                 assert allow_send is True
 
+    def test_capacity_refills_over_more_time(self, client, limiter):
+        # Fill bucket, advance 10s: refill = 16.67 * 10 = 166.7 tokens
+        with client.application.app_context():
+            with patch("app.rate_limiter.time") as mock_time:
+                mock_time.return_value = 100.0
+                limiter.acquire_lease(16)
+
+                # 10 seconds refills ≈ 166.7 tokens — enough to acquire 16 a few times
+                mock_time.return_value = 110.0
+                allow_send, _ = limiter.acquire_lease(16)
+                assert allow_send is True
+
+                # Acquire more but it should fail as internal buckets are 1 second split
+                allow_send, _ = limiter.acquire_lease(16)
+                assert allow_send is False
+
     def test_bucket_does_not_exceed_max_burst_after_idle(self, client, limiter):
         # Even after 120 s of idle, the bucket holds at most refill_rate ≈ 16.67 tokens.
         # Requesting 16 must succeed, but 17 must fail.

--- a/tests/app/test_rate_limiter.py
+++ b/tests/app/test_rate_limiter.py
@@ -612,6 +612,7 @@ class TestBufferedRateLimiter:
     def test_uses_local_tokens_without_calling_rate_limiter(self, client, raw_limiter):
         mock_raw = MagicMock(spec=InMemoryRateLimiter)
         mock_raw.cap_per_minute = 1000
+        mock_raw.max_units_per_acquire = 1000
         mock_raw.namespace = "test"
         buf = BufferedRateLimiter(mock_raw, size=10)
         buf._local_tokens = 5
@@ -647,6 +648,7 @@ class TestBufferedRateLimiter:
     def test_local_tokens_preserved_on_redis_deny(self, client, raw_limiter):
         mock_raw = MagicMock(spec=InMemoryRateLimiter)
         mock_raw.cap_per_minute = 1000
+        mock_raw.max_units_per_acquire = 1000
         mock_raw.namespace = "test"
         mock_raw.acquire_lease.return_value = (False, 30)
         buf = BufferedRateLimiter(mock_raw, size=10)
@@ -662,6 +664,7 @@ class TestBufferedRateLimiter:
     def test_returns_false_with_wait_when_rate_limiter_denies_empty_buffer(self, client, raw_limiter):
         mock_raw = MagicMock(spec=InMemoryRateLimiter)
         mock_raw.cap_per_minute = 1000
+        mock_raw.max_units_per_acquire = 1000
         mock_raw.namespace = "test"
         mock_raw.acquire_lease.return_value = (False, 15)
         buf = BufferedRateLimiter(mock_raw, size=10)
@@ -676,6 +679,7 @@ class TestBufferedRateLimiter:
     def test_deficit_larger_than_size_fetches_exact_deficit(self, client, raw_limiter):
         mock_raw = MagicMock(spec=InMemoryRateLimiter)
         mock_raw.cap_per_minute = 1000
+        mock_raw.max_units_per_acquire = 1000
         mock_raw.namespace = "test"
         mock_raw.acquire_lease.return_value = (True, 0)
         buf = BufferedRateLimiter(mock_raw, size=10)
@@ -702,6 +706,7 @@ class TestBufferedRateLimiter:
     def test_stale_tokens_discarded_after_60_seconds(self, client, raw_limiter):
         mock_raw = MagicMock(spec=InMemoryRateLimiter)
         mock_raw.cap_per_minute = 1000
+        mock_raw.max_units_per_acquire = 1000
         mock_raw.namespace = "test"
         mock_raw.acquire_lease.return_value = (True, 0)
         buf = BufferedRateLimiter(mock_raw, size=10)
@@ -718,6 +723,7 @@ class TestBufferedRateLimiter:
     def test_fresh_tokens_not_discarded_within_60_seconds(self, client, raw_limiter):
         mock_raw = MagicMock(spec=InMemoryRateLimiter)
         mock_raw.cap_per_minute = 1000
+        mock_raw.max_units_per_acquire = 1000
         mock_raw.namespace = "test"
         buf = BufferedRateLimiter(mock_raw, size=10)
         buf._local_tokens = 5
@@ -737,6 +743,7 @@ class TestBufferedRateLimiter:
     def test_get_current_usage_delegates_to_wrapped_limiter(self, client):
         mock_raw = MagicMock(spec=InMemoryRateLimiter)
         mock_raw.cap_per_minute = 1000
+        mock_raw.max_units_per_acquire = 1000
         mock_raw.namespace = "test"
         mock_raw.get_current_usage.return_value = 42
         buf = BufferedRateLimiter(mock_raw, size=10)
@@ -749,6 +756,19 @@ class TestBufferedRateLimiter:
     def test_raises_value_error_when_size_exceeds_cap(self, client, raw_limiter):
         with pytest.raises(ValueError):
             BufferedRateLimiter(raw_limiter, size=raw_limiter.cap_per_minute + 1)
+
+    def test_raises_value_error_when_size_exceeds_token_bucket_per_call_ceiling(self, client):
+        # cap_per_minute=600 → max_units_per_acquire = max(1, 600 // 60) = 10
+        # size=11 fits within cap_per_minute (600) but exceeds the per-call ceiling (10)
+        token_bucket = RedisTokenBucketRateLimiter(
+            cap_per_minute=600, namespace="test-tb", redis_client=fakeredis.FakeRedis()
+        )
+        assert token_bucket.max_units_per_acquire == 10
+        with pytest.raises(ValueError):
+            BufferedRateLimiter(token_bucket, size=11)
+        # boundary: size exactly at the ceiling must be accepted
+        buf = BufferedRateLimiter(token_bucket, size=10)
+        assert buf._size == 10
 
     def test_raises_value_error_when_size_is_zero(self, client, raw_limiter):
         with pytest.raises(ValueError):


### PR DESCRIPTION
# Summary | Résumé

Optimises the Redis sliding-window rate limiter (`RedisSlidingWindowLogRateLimiter`) by eliminating a redundant round-trip to Redis on every rate-limit check.

### What changed

Optimises the Redis sliding-window rate limiter (`RedisSlidingWindowLogRateLimiter`) by eliminating a redundant round-trip to Redis on every rate-limit check.

### What changed

**Lua script — single `ZRANGE WITHSCORES` call instead of two (O(2n) → O(n) on the denied path)**

Previously the Lua script issued two separate `ZRANGE` commands per `acquire`:

1. `ZRANGE … 0 -1` (no scores) — to sum current usage: scans all `n` active entries.
2. `ZRANGE … 0 -1 WITHSCORES` — to calculate the wait time on the denied path: scans all `n` active entries again.

On a denied request this was **O(2n)** in sorted-set scans. The change fetches entries once with `ZRANGE … WITHSCORES` and reuses the result for both usage summation and wait-time calculation, bringing the denied path down to **O(n)**.

**`current_usage` helper — read-only window query**

The Python-side `current_usage` method previously:
- Called `ZREMRANGEBYSCORE` to evict expired entries (a write), then
- Called `ZRANGE 0 -1` to read all members (unbounded scan).

It now calls `ZRANGEBYSCORE window_start +inf`, which:
- Reads only the entries that are still inside the active window (no unbounded scan).
- Does **not** mutate the sorted set — expiry is already handled by the Lua `acquire` script.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1
* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/1

# Test instructions | Instructions pour tester la modification

1. Check out the branch and install dependencies:
   ```bash
   pip install -e ".[test]"
   ```
2. Run the rate-limiter test suite:
   ```bash
   pytest tests/app/test_rate_limiter.py -v
   ```
3. All existing tests should pass without modification — no behaviour changes are expected, only performance improvements.

# Release Instructions | Instructions pour le déploiement

- Requires the env variable `SMS_RATE_LIMITER_BACKEND` to be set on the `RedisSlidingWindowLogRateLimiter` implementation.
- No database migrations required.
- No environment variable or configuration changes required.
- No feature flags required.
- Deploy as a standard rolling release. The change is limited to in-process Redis call patterns and is fully backwards compatible.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.