### PR TITLE
Make RTE the default editor for all users

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -156,7 +156,7 @@ class User(BaseModel):
         nullable=False,
         default=datetime.datetime.utcnow,
     )
-    default_editor_is_rte = db.Column(db.Boolean, nullable=False, default=False)
+    default_editor_is_rte = db.Column(db.Boolean, nullable=False, default=True)
     updated_at = db.Column(
         db.DateTime,
         index=False,

--- a/migrations/versions/0516_backfill_rte_default.py
+++ b/migrations/versions/0516_backfill_rte_default.py
@@ -1,0 +1,35 @@
+"""
+Revision ID: 0516_backfill_rte_default
+Revises: 0515_add_created_by_id_to_files
+Create Date: 2026-07-06
+
+Backfill all existing users to have default_editor_is_rte = true and change the
+column server default to true so new users also get RTE by default.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0516_backfill_rte_default"
+down_revision = "0515_add_created_by_id_to_files"
+
+
+def upgrade():
+    op.execute("UPDATE users SET default_editor_is_rte = true")
+    op.alter_column(
+        "users",
+        "default_editor_is_rte",
+        existing_type=sa.Boolean(),
+        server_default=sa.true(),
+        existing_nullable=False,
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "users",
+        "default_editor_is_rte",
+        existing_type=sa.Boolean(),
+        server_default=sa.false(),
+        existing_nullable=False,
+    )

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -78,7 +78,7 @@ def test_get_user(admin_request, sample_service, sample_organisation):
     assert fetched["permissions"].keys() == {str(sample_service.id)}
     assert fetched["services"] == [str(sample_service.id)]
     assert fetched["organisations"] == [str(sample_organisation.id)]
-    assert fetched["default_editor_is_rte"] is False
+    assert fetched["default_editor_is_rte"] is True
     assert sorted(fetched["permissions"][str(sample_service.id)]) == sorted(expected_permissions)
 
 


### PR DESCRIPTION
# Summary | Résumé

Make RTE the default editor for all users. This PR:
- changes the default value for `default_editor_is_rte = true` in the db
- adds a migration to set `default_editor_is_rte = true` for all existing users
- updates a test with the new value

It will still be possible for users to toggle back to the markdown editor, which will cause `default_editor_is_rte = false` to be set for them in the db.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/3173

# Test instructions | Instructions pour tester la modification

1. check out the api main branch and run it locally
2. toggle to the markdown editor
3. run `select * from users where email = 'youremail@cds-snc.ca`, verify that `default_editor_is_rte = false`
4. check out this branch `chore/rte-default` and run `flask db upgrade`
5. look in you local db and verify that `default_editor_is_rte = true` for you
6. clear the user cache from the platform admin section of notification-admin
7. create a new template and verify that you see the RTE

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.