### PR TITLE
Changed the product type to be a list

### DIFF
--- a/app/clients/airtable/models.py
+++ b/app/clients/airtable/models.py
@@ -232,18 +232,18 @@ class GrowthNewsletterSubscriber(AirtableTableMixin, Model):
     This mirrors NewsletterSubscriber and includes an additional Product field.
     """
 
-    DEFAULT_PRODUCT_NAME = "GC Notify"
+    DEFAULT_PRODUCT_NAME = "Notify"
 
     def __init__(self, **fields):
         """Initialize a growth newsletter subscriber with default values."""
         fields.setdefault("language", self.Languages.EN.value)
         fields.setdefault("status", self.Statuses.UNCONFIRMED.value)
-        fields.setdefault("product", self.DEFAULT_PRODUCT_NAME)
+        fields.setdefault("product", [self.DEFAULT_PRODUCT_NAME])
 
         super().__init__(**fields)
 
     email = F.RequiredTextField("Email")
-    product = F.RequiredTextField("Product")
+    product = F.MultipleSelectField("Product")
     language = F.RequiredSelectField("Language")
     status = F.RequiredSelectField("Status")
     created_at = F.DatetimeField("Created At")
@@ -331,7 +331,15 @@ class GrowthNewsletterSubscriber(AirtableTableMixin, Model):
             "name": table_name,
             "fields": [
                 {"name": "Email", "type": "singleLineText"},
-                {"name": "Product", "type": "singleLineText"},
+                {
+                    "name": "Product",
+                    "type": "multipleSelects",
+                    "options": {
+                        "choices": [
+                            {"name": cls.DEFAULT_PRODUCT_NAME},
+                        ]
+                    },
+                },
                 {
                     "name": "Language",
                     "type": "singleSelect",

--- a/app/newsletter/rest.py
+++ b/app/newsletter/rest.py
@@ -334,7 +334,7 @@ def _upsert_growth_subscriber(subscriber):
     growth_subscriber.has_resubscribed = subscriber.has_resubscribed
 
     if is_new_record and not getattr(growth_subscriber, "product", None):
-        growth_subscriber.product = GrowthNewsletterSubscriber.DEFAULT_PRODUCT_NAME
+        growth_subscriber.product = [GrowthNewsletterSubscriber.DEFAULT_PRODUCT_NAME]
 
     return growth_subscriber.save()
 

--- a/tests/app/clients/test_airtable.py
+++ b/tests/app/clients/test_airtable.py
@@ -381,7 +381,7 @@ class TestGrowthNewsletterSubscriber:
 
         assert subscriber.language == GrowthNewsletterSubscriber.Languages.EN.value
         assert subscriber.status == GrowthNewsletterSubscriber.Statuses.UNCONFIRMED.value
-        assert subscriber.product == GrowthNewsletterSubscriber.DEFAULT_PRODUCT_NAME
+        assert subscriber.product == [GrowthNewsletterSubscriber.DEFAULT_PRODUCT_NAME]
 
     def test_get_table_schema_structure(self, notify_api):
         schema = GrowthNewsletterSubscriber.get_table_schema()


### PR DESCRIPTION
# Summary | Résumé

Airtable column heading had a mismatch from what we were sending through the API. The model sent a Single text field, but the Product field was a drop down. Made the change to send Notify as a value for the drop down