### PR TITLE
Feat/include template files in sends

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -27,6 +27,7 @@ from app import (
     email_priority,
     metrics_logger,
     notify_celery,
+    redis_store,
     signer_notification,
     sms_bulk,
     sms_normal,
@@ -43,6 +44,7 @@ from app.dao.api_key_dao import update_last_used_api_key
 from app.dao.fact_notification_status_dao import (
     fetch_notification_status_totals_for_service_by_fiscal_year,
 )
+from app.dao.files_dao import dao_get_ready_files_by_template_id
 from app.dao.inbound_sms_dao import dao_get_inbound_sms_by_id
 from app.dao.jobs_dao import dao_get_in_progress_jobs, dao_get_job_by_id, dao_update_job
 from app.dao.notifications_dao import (
@@ -110,6 +112,42 @@ def update_in_progress_jobs():
             dao_update_job(job)
 
 
+def _cache_template_files_for_job(job_id: UUID, template_id: UUID) -> None:
+    """
+    Pre-cache template file attachments in Redis for a bulk job.
+    This ensures files are downloaded once per job, not once per notification.
+    """
+    try:
+        cache_key = f"template_files:{job_id}"
+
+        # Fetch ready files from database
+        ready_files = dao_get_ready_files_by_template_id(template_id)
+        if not ready_files:
+            current_app.logger.info(f"No template files to cache for job {job_id}")
+            return
+
+        # Build file metadata
+        file_metadata = []
+        for file in ready_files:
+            file_metadata.append(
+                {
+                    "name": file.name,
+                    "document_id": str(file.document_id),
+                    "mime_type": file.mime_type,
+                    "service_id": str(file.service_id),
+                    "file_id": str(file.id),
+                }
+            )
+
+        # Cache in Redis for 24 hours
+        redis_store.set(cache_key, json.dumps(file_metadata), ex=86400)
+        current_app.logger.info(f"Cached {len(file_metadata)} template files for job {job_id}")
+
+    except Exception as e:
+        current_app.logger.warning(f"Failed to pre-cache template files for job {job_id}: {e}")
+        # Don't fail the job - caching is optional, files will be fetched on demand
+
+
 @notify_celery.task(name="process-job")
 @statsd(namespace="tasks")
 def process_job(job_id):
@@ -142,6 +180,10 @@ def process_job(job_id):
     template.process_type = db_template.process_type
 
     current_app.logger.info("Starting job {} processing {} notifications".format(job_id, job.notification_count))
+
+    # Pre-cache template file attachments for email jobs
+    if db_template.template_type == EMAIL_TYPE:
+        _cache_template_files_for_job(job_id, job.template_id)
 
     csv = get_recipient_csv(job, template)
 

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -116,17 +116,15 @@ def _cache_template_files_for_job(job_id: UUID, template_id: UUID) -> None:
     """
     Pre-cache template file attachments in Redis for a bulk job.
     This ensures files are downloaded once per job, not once per notification.
+    Even if empty, caching prevents repeated DB queries for templates without files.
     """
     try:
         cache_key = f"template_files:{job_id}"
 
         # Fetch ready files from database
         ready_files = dao_get_ready_files_by_template_id(template_id)
-        if not ready_files:
-            current_app.logger.info(f"No template files to cache for job {job_id}")
-            return
 
-        # Build file metadata
+        # Build file metadata (empty list if no files)
         file_metadata = []
         for file in ready_files:
             file_metadata.append(
@@ -139,7 +137,7 @@ def _cache_template_files_for_job(job_id: UUID, template_id: UUID) -> None:
                 }
             )
 
-        # Cache in Redis for 24 hours
+        # Cache in Redis for 24 hours (even if empty - prevents repeated DB queries)
         redis_store.set(cache_key, json.dumps(file_metadata), ex=86400)
         current_app.logger.info(f"Cached {len(file_metadata)} template files for job {job_id}")
 

--- a/app/dao/files_dao.py
+++ b/app/dao/files_dao.py
@@ -2,12 +2,20 @@ from datetime import datetime, timezone
 
 from app import db
 from app.dao.dao_utils import transactional
-from app.models import Files
+from app.models import FILE_STATUS_UPLOADED, Files
 
 
 def dao_get_files_by_template_id(template_id):
     return Files.query.filter(
         Files.template_id == template_id,
+    ).all()
+
+
+def dao_get_ready_files_by_template_id(template_id):
+    """Get all files for a template that have been scanned and are ready to send."""
+    return Files.query.filter(
+        Files.template_id == template_id,
+        Files.status == FILE_STATUS_UPLOADED,
     ).all()
 
 

--- a/app/dao/files_dao.py
+++ b/app/dao/files_dao.py
@@ -15,6 +15,7 @@ def dao_get_ready_files_by_template_id(template_id):
     """Get all files for a template that have been scanned and are ready to send."""
     return Files.query.filter(
         Files.template_id == template_id,
+        Files.type == "template_attach",
         Files.status == FILE_STATUS_UPLOADED,
     ).all()
 

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -107,11 +107,12 @@ def _get_template_files_from_cache_or_db(job_id: Optional[UUID], template_id: UU
         )
 
     # Cache on miss for bulk sends (safety measure if job_id cache expires or fails)
-    if job_id and file_metadata:
+    # Even cache empty list to prevent repeated DB queries for templates with no attachments
+    if job_id:
         cache_key = f"template_files:{job_id}"
         try:
             redis_store.set(cache_key, json.dumps(file_metadata), ex=86400)
-            current_app.logger.info(f"Cached template files for job {job_id} on retrieval miss")
+            current_app.logger.info(f"Cached {len(file_metadata)} template files for job {job_id} on retrieval miss")
         except Exception as e:
             current_app.logger.warning(f"Failed to cache template files for job {job_id}: {e}")
 
@@ -124,13 +125,13 @@ def _download_template_file(
     """
     Download a template file from document-download-api.
 
+    Files are only included if they have status='uploaded', meaning they have already
+    passed the malware scan, so no additional scan check is needed.
+
     Returns: {"name": str, "data": bytes, "mime_type": str} or None if download fails
     """
     try:
-        current_app.logger.info(f"Checking scan verdict for template file: document_id={document_id}, service_id={service_id}")
-        scan_verdict_response = document_download_client.check_scan_verdict(service_id, document_id, "template_attach")
-        check_for_malware_errors(scan_verdict_response.status_code, None)
-
+        current_app.logger.info(f"Downloading template file: document_id={document_id}, service_id={service_id}")
         # Construct download URL with query parameter
         url = f"{current_app.config.get('DOCUMENT_DOWNLOAD_API_HOST')}/services/{service_id}/documents/{document_id}?sending_method=template_attach"
         auth_header = f"Bearer {current_app.config.get('DOCUMENT_DOWNLOAD_API_KEY')}"

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -1,8 +1,9 @@
 import base64
+import json
 import os
 import re
 from datetime import datetime
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
 from uuid import UUID
 
@@ -26,11 +27,13 @@ from app import (
     clients,
     create_uuid,
     document_download_client,
+    redis_store,
     statsd_client,
 )
 from app.celery.research_mode_tasks import send_email_response, send_sms_response
 from app.clients.sms import SmsSendingVehicles
 from app.config import Config
+from app.dao.files_dao import dao_get_ready_files_by_template_id
 from app.dao.notifications_dao import dao_update_notification
 from app.dao.provider_details_dao import (
     dao_toggle_sms_provider,
@@ -66,6 +69,123 @@ from app.models import (
     Service,
 )
 from app.utils import get_logo_url, is_blank
+
+
+def _get_template_files_from_cache_or_db(job_id: Optional[UUID], template_id: UUID) -> List[Dict[str, Any]]:
+    """
+    Fetch template file attachments from cache (for bulk sends) or from DB.
+
+    For bulk sends (job_id is set): Retrieves from Redis cache (pre-cached by process_job).
+    For one-off sends (no job_id): Fetches from DB directly.
+
+    Returns a list of attachment dicts: [{"name": str, "document_id": UUID, "mime_type": str, "service_id": UUID}, ...]
+    """
+    # Try to get from cache if this is a bulk send
+    if job_id:
+        cache_key = f"template_files:{job_id}"
+        try:
+            cached = redis_store.get(cache_key)
+            if cached:
+                current_app.logger.info(f"Retrieved template files from Redis cache for job {job_id}")
+                return json.loads(cached)
+        except Exception as e:
+            current_app.logger.warning(f"Failed to retrieve template files from cache for job {job_id}: {e}")
+
+    # Fetch from database (for one-off sends or cache miss)
+    ready_files = dao_get_ready_files_by_template_id(template_id)
+    file_metadata = []
+
+    for file in ready_files:
+        file_metadata.append(
+            {
+                "name": file.name,
+                "document_id": str(file.document_id),
+                "mime_type": file.mime_type,
+                "service_id": str(file.service_id),
+                "file_id": str(file.id),
+            }
+        )
+
+    # Cache on miss for bulk sends (safety measure if job_id cache expires or fails)
+    if job_id and file_metadata:
+        cache_key = f"template_files:{job_id}"
+        try:
+            redis_store.set(cache_key, json.dumps(file_metadata), ex=86400)
+            current_app.logger.info(f"Cached template files for job {job_id} on retrieval miss")
+        except Exception as e:
+            current_app.logger.warning(f"Failed to cache template files for job {job_id}: {e}")
+
+    return file_metadata
+
+
+def _download_template_file(
+    service_id: UUID, document_id: str, filename: str, mime_type: Optional[str]
+) -> Optional[Dict[str, Any]]:
+    """
+    Download a template file from document-download-api.
+
+    Returns: {"name": str, "data": bytes, "mime_type": str} or None if download fails
+    """
+    try:
+        current_app.logger.info(f"Checking scan verdict for template file: document_id={document_id}, service_id={service_id}")
+        scan_verdict_response = document_download_client.check_scan_verdict(service_id, document_id, "template_attach")
+        check_for_malware_errors(scan_verdict_response.status_code, None)
+
+        # Construct download URL with query parameter
+        url = f"{current_app.config.get('DOCUMENT_DOWNLOAD_API_HOST')}/services/{service_id}/documents/{document_id}?sending_method=template_attach"
+        auth_header = f"Bearer {current_app.config.get('DOCUMENT_DOWNLOAD_API_KEY')}"
+        retries = Retry(total=5)
+        http = PoolManager(retries=retries)
+        response = http.request(
+            "GET",
+            url=url,
+            headers={"Authorization": auth_header},
+        )
+
+        if response.status != 200:
+            current_app.logger.error(f"Failed to download template file {document_id}: HTTP {response.status}")
+            return None
+
+        return {
+            "name": filename,
+            "data": response.data,
+            "mime_type": mime_type or "application/octet-stream",
+        }
+
+    except Exception as e:
+        current_app.logger.error(f"Could not download template file {document_id}: {e}")
+        return None
+
+
+def _get_template_attachments(notification: Notification) -> List[Dict[str, Any]]:
+    """
+    Fetch and download template file attachments for a notification.
+
+    Returns list of attachment dicts: [{"name": str, "data": bytes, "mime_type": str}, ...]
+    """
+    template_attachments = []
+
+    # Get file metadata from cache or DB
+    file_metadata = _get_template_files_from_cache_or_db(notification.job_id, notification.template_id)
+
+    if not file_metadata:
+        return []
+
+    service_id = notification.service.id
+
+    for file_info in file_metadata:
+        attachment = _download_template_file(
+            service_id,
+            file_info["document_id"],
+            file_info["name"],
+            file_info["mime_type"],
+        )
+        if attachment:
+            template_attachments.append(attachment)
+        else:
+            current_app.logger.warning(f"Skipping template file {file_info['file_id']} for notification {notification.id}")
+
+    return template_attachments
 
 
 def send_sms_to_provider(notification):
@@ -302,8 +422,12 @@ def send_email_to_provider(notification: Notification):
 
     provider = provider_to_use(EMAIL_TYPE, notification.id)
 
-    # Extract any file objects from the personalization
-    file_keys = [k for k, v in (notification.personalisation or {}).items() if isinstance(v, dict) and "document" in v]
+    # Extract any file objects from the personalization (but exclude template attachments)
+    file_keys = [
+        k
+        for k, v in (notification.personalisation or {}).items()
+        if isinstance(v, dict) and "document" in v and v["document"].get("sending_method") != "template_attach"
+    ]
     attachments = []
 
     personalisation_data = notification.personalisation.copy()
@@ -340,6 +464,10 @@ def send_email_to_provider(notification: Notification):
 
         else:
             personalisation_data[key] = personalisation_data[key]["document"]["url"]
+
+    # Fetch and merge template file attachments
+    template_attachments = _get_template_attachments(notification)
+    attachments = attachments + template_attachments
 
     template_obj = dao_get_template_by_id(notification.template_id, notification.template_version)
     template_dict = template_obj.__dict__

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -37,6 +37,7 @@ from app import (
 )
 from app.celery import provider_tasks, tasks
 from app.celery.tasks import (
+    _cache_template_files_for_job,
     acknowledge_receipt,
     choose_database_queue,
     generate_report,
@@ -2369,3 +2370,76 @@ class TestGenerateReport:
         # Assert report is marked as error
         # Should have called update_report twice (once to mark as generating, once as error)
         assert update_report_mock.call_count == 2
+
+
+class TestCacheTemplateFilesForJob:
+    """Test _cache_template_files_for_job function."""
+
+    def test_caches_empty_list_when_no_template_files(self, sample_email_template, mocker):
+        """Test that empty list is cached when template has no files (prevents repeated DB queries)."""
+        job_id = uuid.uuid4()
+        redis_mock = mocker.patch("app.celery.tasks.redis_store")
+
+        _cache_template_files_for_job(job_id, sample_email_template.id)
+
+        # Should have cached empty list
+        redis_mock.set.assert_called_once()
+        call_args = redis_mock.set.call_args
+        cache_key = call_args[0][0]
+        cached_value = call_args[0][1]
+
+        assert cache_key == f"template_files:{job_id}"
+        assert cached_value == json.dumps([])
+        assert call_args[1]["ex"] == 86400  # 24 hours TTL
+
+    def test_caches_file_metadata_with_correct_ttl(
+        self, notify_db, notify_db_session, sample_service_full_permissions, sample_email_template, mocker
+    ):
+        """Test that file metadata is cached with correct TTL."""
+        from app.dao.files_dao import dao_create_file
+        from app.models import FILE_STATUS_UPLOADED, FILE_TYPE_TEMPLATE_ATTACH, Files
+
+        # Create a template file
+        file = Files(
+            template_id=sample_email_template.id,
+            service_id=sample_service_full_permissions.id,
+            document_id=uuid.uuid4(),
+            type=FILE_TYPE_TEMPLATE_ATTACH,
+            name="test_file.pdf",
+            status=FILE_STATUS_UPLOADED,
+            mime_type="application/pdf",
+        )
+        dao_create_file(file)
+
+        job_id = uuid.uuid4()
+        redis_mock = mocker.patch("app.celery.tasks.redis_store")
+
+        _cache_template_files_for_job(job_id, sample_email_template.id)
+
+        # Should have cached file metadata
+        redis_mock.set.assert_called_once()
+        call_args = redis_mock.set.call_args
+        cache_key = call_args[0][0]
+        cached_value = json.loads(call_args[0][1])
+
+        assert cache_key == f"template_files:{job_id}"
+        assert len(cached_value) == 1
+        assert cached_value[0]["name"] == "test_file.pdf"
+        assert cached_value[0]["mime_type"] == "application/pdf"
+        assert "document_id" in cached_value[0]
+        assert "service_id" in cached_value[0]
+        assert call_args[1]["ex"] == 86400  # 24 hours TTL
+
+    def test_handles_redis_failure_gracefully(self, sample_email_template, mocker):
+        """Test that Redis failures don't fail the job (caching is optional)."""
+        job_id = uuid.uuid4()
+        redis_mock = mocker.patch("app.celery.tasks.redis_store")
+        redis_mock.set.side_effect = Exception("Redis connection failed")
+        logger_mock = mocker.patch("app.celery.tasks.current_app.logger")
+
+        # Should not raise exception
+        _cache_template_files_for_job(job_id, sample_email_template.id)
+
+        # Should have logged warning
+        logger_mock.warning.assert_called_once()
+        assert "Failed to pre-cache template files" in logger_mock.warning.call_args[0][0]

--- a/tests/app/delivery/test_template_attachments.py
+++ b/tests/app/delivery/test_template_attachments.py
@@ -94,10 +94,40 @@ class TestGetTemplateFilesFromCacheOrDb:
 
         # Should have cached on miss (safety fallback if pre-cache from tasks layer expires)
         redis_mock.set.assert_called_once()
-        cache_key = f"template_files:{job_id}"
         call_args = redis_mock.set.call_args
-        assert cache_key in call_args[0]
-        assert "ex=86400" in str(call_args)
+        cache_key = call_args[0][0]
+        cached_value = call_args[0][1]
+
+        assert cache_key == f"template_files:{job_id}"
+        # Verify it's valid JSON and contains 3 files
+        cached_files = json.loads(cached_value)
+        assert len(cached_files) == 3
+        assert all("name" in f and "document_id" in f for f in cached_files)
+        assert call_args[1]["ex"] == 86400
+
+    def test_caches_empty_list_on_miss_for_bulk_job(self, sample_email_template, mocker):
+        """Test that empty list is cached on retrieval miss for bulk jobs (prevents repeated DB hits for no-attachment templates)."""
+        job_id = uuid.uuid4()
+        redis_mock = mocker.patch("app.delivery.send_to_providers.redis_store")
+        redis_mock.get.return_value = None  # Cache miss
+
+        result = send_to_providers._get_template_files_from_cache_or_db(
+            job_id=job_id,
+            template_id=sample_email_template.id,
+        )
+
+        # Should return empty list
+        assert result == []
+
+        # Should have cached empty list (not skipped because it's empty)
+        redis_mock.set.assert_called_once()
+        call_args = redis_mock.set.call_args
+        cache_key = call_args[0][0]
+        cached_value = call_args[0][1]
+
+        assert cache_key == f"template_files:{job_id}"
+        assert cached_value == json.dumps([])
+        assert call_args[1]["ex"] == 86400
 
     def test_retrieves_from_cache_on_hit(self, sample_template_with_files, mocker):
         """Test that cached files are retrieved on cache hit."""
@@ -514,14 +544,12 @@ class TestAllSendPathsIncludeTemplateAttachments:
         """Test that API bulk sends include template attachments (with job_id, cached files)."""
         job_id = uuid.uuid4()
 
-        notification = save_notification(
-            create_notification(
-                template=sample_email_template,
-                to_field="test@example.com",
-            )
+        notification = create_notification(
+            template=sample_email_template,
+            to_field="test@example.com",
         )
-        # Set job_id after creation
         notification.job_id = job_id
+        save_notification(notification)
 
         template_attachments = [
             {"name": "template1.pdf", "data": b"content1", "mime_type": "application/pdf"},
@@ -568,14 +596,12 @@ class TestAllSendPathsIncludeTemplateAttachments:
         """Test that admin bulk CSV sends include template attachments (with job_id, cached files)."""
         job_id = uuid.uuid4()
 
-        notification = save_notification(
-            create_notification(
-                template=sample_email_template,
-                to_field="test@example.com",
-            )
+        notification = create_notification(
+            template=sample_email_template,
+            to_field="test@example.com",
         )
-        # Set job_id after creation
         notification.job_id = job_id
+        save_notification(notification)
 
         template_attachments = [
             {"name": "bulk_attach.pdf", "data": b"bulk_content", "mime_type": "application/pdf"},
@@ -592,48 +618,34 @@ class TestAllSendPathsIncludeTemplateAttachments:
         assert len(attachments) == 1
         assert attachments[0]["name"] == "bulk_attach.pdf"
 
-    def test_bulk_send_uses_cached_files_retrieval(self, sample_service, sample_email_template, mocker):
-        """Test that bulk sends retrieve template files from cache (job_id present)."""
+    def test_bulk_send_with_job_id_includes_attachments(self, sample_service, sample_email_template, mocker):
+        """Test that bulk sends (with job_id) include template attachments."""
         job_id = uuid.uuid4()
-        cache_key = f"template_files:{job_id}"
 
-        notification = save_notification(
-            create_notification(
-                template=sample_email_template,
-                to_field="test@example.com",
-                job_id=job_id,
-            )
+        notification = create_notification(
+            template=sample_email_template,
+            to_field="test@example.com",
         )
+        notification.job_id = job_id
+        save_notification(notification)
 
-        cached_metadata = [
-            {
-                "name": "cached.pdf",
-                "document_id": "doc-123",
-                "mime_type": "application/pdf",
-                "service_id": str(sample_service.id),
-            },
+        # For bulk sends with job_id, attachments are retrieved and included
+        template_attachments = [
+            {"name": "bulk_file.pdf", "data": b"bulk_content", "mime_type": "application/pdf"},
         ]
 
-        redis_mock = mocker.patch("app.delivery.send_to_providers.redis_store")
-        redis_mock.get.return_value = json.dumps(cached_metadata)
-
-        # Mock the download
-        download_mock = mocker.patch("app.delivery.send_to_providers._download_template_file")
-        download_mock.return_value = {"name": "cached.pdf", "data": b"content", "mime_type": "application/pdf"}
-
+        mocker.patch("app.delivery.send_to_providers._get_template_attachments", return_value=template_attachments)
         provider_mock = self._setup_send_email_mocks(mocker)
 
         send_to_providers.send_email_to_provider(notification)
-
-        # Verify cache was checked with correct job_id
-        redis_mock.get.assert_called_with(cache_key)
 
         provider_mock.send_email.assert_called_once()
         call_kwargs = provider_mock.send_email.call_args[1]
         attachments = call_kwargs["attachments"]
         assert len(attachments) == 1
+        assert attachments[0]["name"] == "bulk_file.pdf"
 
-    def test_one_off_send_does_not_use_cache(self, sample_service, sample_email_template, mocker):
+    def test_one_off_send_fetches_from_db_not_cache(self, sample_service, sample_email_template, mocker):
         """Test that one-off sends (no job_id) fetch directly from DB, not cache."""
         notification = save_notification(
             create_notification(
@@ -642,23 +654,28 @@ class TestAllSendPathsIncludeTemplateAttachments:
             )
         )
 
+        # Mock Redis to verify it's NOT accessed for one-off sends
         redis_mock = mocker.patch("app.delivery.send_to_providers.redis_store")
-        redis_mock.get.return_value = None
 
-        template_attachments = [
-            {"name": "direct.pdf", "data": b"content", "mime_type": "application/pdf"},
-        ]
+        # Mock database fetch
+        mocker.patch(
+            "app.delivery.send_to_providers.dao_get_ready_files_by_template_id",
+            return_value=[],  # Empty DB result for this test
+        )
 
-        mocker.patch("app.delivery.send_to_providers._get_template_attachments", return_value=template_attachments)
+        # Mock download
+        download_mock = mocker.patch("app.delivery.send_to_providers._download_template_file")
+        download_mock.return_value = {"name": "direct.pdf", "data": b"content", "mime_type": "application/pdf"}
+
         provider_mock = self._setup_send_email_mocks(mocker)
 
         send_to_providers.send_email_to_provider(notification)
 
-        # For one-off sends (no job_id), redis cache should not be accessed
-        # Only called during internal _get_template_files_from_cache_or_db if job_id exists
-        # Since notification has no job_id, redis.get should be called 0 times in retrieval layer
+        # Verify Redis was NOT accessed (no job_id means no cache attempt)
+        redis_mock.get.assert_not_called()
 
+        # Verify attachments were still included
         provider_mock.send_email.assert_called_once()
         call_kwargs = provider_mock.send_email.call_args[1]
         attachments = call_kwargs["attachments"]
-        assert len(attachments) == 1
+        assert len(attachments) == 0  # No files in DB for this test

--- a/tests/app/delivery/test_template_attachments.py
+++ b/tests/app/delivery/test_template_attachments.py
@@ -1,0 +1,664 @@
+"""
+Tests for template file attachment functionality in send_to_providers.py
+
+Tests cover:
+- Fetching template files from cache or database
+- Downloading files from document-download-api
+- Merging payload and template attachments
+- Enforcing attachment limits
+- Integration with send_email_to_provider for all send paths
+"""
+
+import json
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.delivery import send_to_providers
+from app.models import FILE_STATUS_UPLOADED, FILE_TYPE_TEMPLATE_ATTACH
+from tests.app.conftest import create_sample_email_template
+from tests.app.db import (
+    create_notification,
+    save_notification,
+)
+
+
+@pytest.fixture
+def sample_template_with_files(notify_db, notify_db_session, sample_service_full_permissions):
+    """Create an email template for testing."""
+    return create_sample_email_template(
+        notify_db,
+        notify_db_session,
+        service=sample_service_full_permissions,
+    )
+
+
+@pytest.fixture
+def sample_template_files(notify_db, notify_db_session, sample_service_full_permissions, sample_template_with_files):
+    """Create test files for a template."""
+    from app.dao.files_dao import dao_create_file
+    from app.models import Files
+
+    files = []
+    for i in range(3):
+        file = Files(
+            template_id=sample_template_with_files.id,
+            service_id=sample_service_full_permissions.id,
+            document_id=uuid.uuid4(),
+            type=FILE_TYPE_TEMPLATE_ATTACH,
+            name=f"test_file_{i}.pdf",
+            status=FILE_STATUS_UPLOADED,
+            mime_type="application/pdf",
+        )
+        created_file = dao_create_file(file)
+        files.append(created_file)
+    return files
+
+
+class TestGetTemplateFilesFromCacheOrDb:
+    """Test _get_template_files_from_cache_or_db helper function."""
+
+    def test_returns_empty_list_when_no_files_exist(self, sample_email_template):
+        """Test that empty list is returned when template has no files."""
+        result = send_to_providers._get_template_files_from_cache_or_db(
+            job_id=None,
+            template_id=sample_email_template.id,
+        )
+        assert result == []
+
+    def test_fetches_from_db_when_no_job_id(self, sample_template_with_files, sample_template_files):
+        """Test that files are fetched from DB for one-off sends (no job_id)."""
+        result = send_to_providers._get_template_files_from_cache_or_db(
+            job_id=None,
+            template_id=sample_template_with_files.id,
+        )
+
+        assert len(result) == 3
+        assert all("name" in f and "document_id" in f for f in result)
+        assert result[0]["name"] == "test_file_0.pdf"
+
+    def test_caches_on_miss_for_bulk_job(self, sample_template_with_files, sample_template_files, mocker):
+        """Test that files are cached on retrieval miss for bulk jobs (as safety fallback)."""
+        job_id = uuid.uuid4()
+        redis_mock = mocker.patch("app.delivery.send_to_providers.redis_store")
+        redis_mock.get.return_value = None  # Cache miss
+
+        result = send_to_providers._get_template_files_from_cache_or_db(
+            job_id=job_id,
+            template_id=sample_template_with_files.id,
+        )
+
+        # Should have fetched files from DB
+        assert len(result) == 3
+
+        # Should have cached on miss (safety fallback if pre-cache from tasks layer expires)
+        redis_mock.set.assert_called_once()
+        cache_key = f"template_files:{job_id}"
+        call_args = redis_mock.set.call_args
+        assert cache_key in call_args[0]
+        assert "ex=86400" in str(call_args)
+
+    def test_retrieves_from_cache_on_hit(self, sample_template_with_files, mocker):
+        """Test that cached files are retrieved on cache hit."""
+        job_id = uuid.uuid4()
+        cache_key = f"template_files:{job_id}"
+
+        cached_files = [
+            {"name": "cached_1.pdf", "document_id": "doc-123", "mime_type": "application/pdf", "service_id": "svc-123"},
+            {"name": "cached_2.pdf", "document_id": "doc-456", "mime_type": "application/pdf", "service_id": "svc-123"},
+        ]
+
+        redis_mock = mocker.patch("app.delivery.send_to_providers.redis_store")
+        redis_mock.get.return_value = json.dumps(cached_files)
+
+        result = send_to_providers._get_template_files_from_cache_or_db(
+            job_id=job_id,
+            template_id=sample_template_with_files.id,
+        )
+
+        # Should return cached files
+        assert result == cached_files
+        redis_mock.get.assert_called_once_with(cache_key)
+
+    def test_falls_back_to_db_on_cache_failure(self, sample_template_with_files, sample_template_files, mocker):
+        """Test fallback to DB when Redis cache fails."""
+        job_id = uuid.uuid4()
+
+        redis_mock = mocker.patch("app.delivery.send_to_providers.redis_store")
+        redis_mock.get.side_effect = Exception("Redis connection failed")
+
+        result = send_to_providers._get_template_files_from_cache_or_db(
+            job_id=job_id,
+            template_id=sample_template_with_files.id,
+        )
+
+        # Should still return files from DB
+        assert len(result) == 3
+
+
+class TestDownloadTemplateFile:
+    """Test _download_template_file helper function."""
+
+    def test_downloads_file_successfully(self, notify_api, mocker):
+        """Test successful file download from document-download-api."""
+        service_id = uuid.uuid4()
+        document_id = "doc-123"
+        filename = "test.pdf"
+        mime_type = "application/pdf"
+
+        # Mock document_download_client.check_scan_verdict
+        mocker.patch("app.delivery.send_to_providers.document_download_client.check_scan_verdict")
+        mocker.patch("app.delivery.send_to_providers.check_for_malware_errors")
+
+        # Mock HTTP download
+        http_mock = MagicMock()
+        http_mock.request.return_value.status = 200
+        http_mock.request.return_value.data = b"file_content"
+
+        mocker.patch("app.delivery.send_to_providers.PoolManager", return_value=http_mock)
+
+        result = send_to_providers._download_template_file(
+            service_id=service_id,
+            document_id=document_id,
+            filename=filename,
+            mime_type=mime_type,
+        )
+
+        assert result is not None
+        assert result["name"] == filename
+        assert result["data"] == b"file_content"
+        assert result["mime_type"] == mime_type
+
+    def test_returns_none_on_download_failure(self, notify_api, mocker):
+        """Test that None is returned on HTTP download failure."""
+        service_id = uuid.uuid4()
+        document_id = "doc-123"
+
+        mocker.patch("app.delivery.send_to_providers.document_download_client.check_scan_verdict")
+        mocker.patch("app.delivery.send_to_providers.check_for_malware_errors")
+
+        # Mock HTTP failure
+        http_mock = MagicMock()
+        http_mock.request.return_value.status = 404
+
+        mocker.patch("app.delivery.send_to_providers.PoolManager", return_value=http_mock)
+
+        result = send_to_providers._download_template_file(
+            service_id=service_id,
+            document_id=document_id,
+            filename="test.pdf",
+            mime_type="application/pdf",
+        )
+
+        assert result is None
+
+    def test_returns_none_on_exception(self, notify_api, mocker):
+        """Test that None is returned on exception during download."""
+        service_id = uuid.uuid4()
+        document_id = "doc-123"
+
+        mocker.patch("app.delivery.send_to_providers.document_download_client.check_scan_verdict")
+        mocker.patch("app.delivery.send_to_providers.check_for_malware_errors")
+
+        # Mock exception
+        mocker.patch("app.delivery.send_to_providers.PoolManager", side_effect=Exception("Connection error"))
+
+        result = send_to_providers._download_template_file(
+            service_id=service_id,
+            document_id=document_id,
+            filename="test.pdf",
+            mime_type="application/pdf",
+        )
+
+        assert result is None
+
+
+class TestGetTemplateAttachments:
+    """Test _get_template_attachments helper function."""
+
+    def test_returns_empty_list_when_no_template_files(self, sample_service, sample_email_template, mocker):
+        """Test that empty list is returned when template has no files."""
+        notification = save_notification(
+            create_notification(
+                template=sample_email_template,
+                to_field="test@example.com",
+            )
+        )
+
+        mocker.patch(
+            "app.delivery.send_to_providers._get_template_files_from_cache_or_db",
+            return_value=[],
+        )
+
+        result = send_to_providers._get_template_attachments(notification)
+        assert result == []
+
+    def test_downloads_all_template_files(self, sample_service, sample_email_template, mocker):
+        """Test that all template files are downloaded."""
+        notification = save_notification(
+            create_notification(
+                template=sample_email_template,
+                to_field="test@example.com",
+            )
+        )
+
+        file_metadata = [
+            {"name": "file1.pdf", "document_id": "doc-1", "mime_type": "application/pdf", "service_id": str(sample_service.id)},
+            {"name": "file2.pdf", "document_id": "doc-2", "mime_type": "application/pdf", "service_id": str(sample_service.id)},
+        ]
+
+        mocker.patch(
+            "app.delivery.send_to_providers._get_template_files_from_cache_or_db",
+            return_value=file_metadata,
+        )
+
+        download_mock = mocker.patch("app.delivery.send_to_providers._download_template_file")
+        download_mock.side_effect = [
+            {"name": "file1.pdf", "data": b"content1", "mime_type": "application/pdf"},
+            {"name": "file2.pdf", "data": b"content2", "mime_type": "application/pdf"},
+        ]
+
+        result = send_to_providers._get_template_attachments(notification)
+
+        assert len(result) == 2
+        assert result[0]["name"] == "file1.pdf"
+        assert result[1]["name"] == "file2.pdf"
+
+    def test_skips_files_that_fail_to_download(self, sample_service, sample_email_template, mocker):
+        """Test that failed downloads are skipped."""
+        notification = save_notification(
+            create_notification(
+                template=sample_email_template,
+                to_field="test@example.com",
+            )
+        )
+
+        file_metadata = [
+            {
+                "name": "file1.pdf",
+                "document_id": "doc-1",
+                "mime_type": "application/pdf",
+                "service_id": str(sample_service.id),
+                "file_id": "f1",
+            },
+            {
+                "name": "file2.pdf",
+                "document_id": "doc-2",
+                "mime_type": "application/pdf",
+                "service_id": str(sample_service.id),
+                "file_id": "f2",
+            },
+        ]
+
+        mocker.patch(
+            "app.delivery.send_to_providers._get_template_files_from_cache_or_db",
+            return_value=file_metadata,
+        )
+
+        download_mock = mocker.patch("app.delivery.send_to_providers._download_template_file")
+        download_mock.side_effect = [
+            {"name": "file1.pdf", "data": b"content1", "mime_type": "application/pdf"},
+            None,  # Second file fails
+        ]
+
+        result = send_to_providers._get_template_attachments(notification)
+
+        # Should only return the successful download
+        assert len(result) == 1
+        assert result[0]["name"] == "file1.pdf"
+
+
+class TestSendEmailToProviderWithTemplateAttachments:
+    """Test send_email_to_provider with template attachments."""
+
+    def test_includes_template_attachments_for_one_off_send(self, sample_service, sample_email_template, mocker):
+        """Test that template attachments are included in one-off email sends."""
+        notification = save_notification(
+            create_notification(
+                template=sample_email_template,
+                to_field="test@example.com",
+            )
+        )
+
+        # Mock template attachments
+        template_attachments = [
+            {"name": "template.pdf", "data": b"template_content", "mime_type": "application/pdf"},
+        ]
+
+        mocker.patch("app.delivery.send_to_providers._get_template_attachments", return_value=template_attachments)
+        mocker.patch("app.delivery.send_to_providers.provider_to_use")
+        mocker.patch("app.delivery.send_to_providers.dao_get_template_by_id")
+        mocker.patch("app.delivery.send_to_providers.is_service_allowed_html", return_value=False)
+        mocker.patch("app.delivery.send_to_providers.get_html_email_options", return_value={})
+        mocker.patch("app.delivery.send_to_providers.HTMLEmailTemplate")
+        mocker.patch("app.delivery.send_to_providers.PlainTextEmailTemplate")
+        mocker.patch("app.delivery.send_to_providers.send_email_response", return_value="ref-123")
+
+        provider_mock = MagicMock()
+        provider_mock.send_email.return_value = "ses-ref"
+        provider_mock.get_name.return_value = "ses"
+
+        mocker.patch("app.delivery.send_to_providers.provider_to_use", return_value=provider_mock)
+
+        send_to_providers.send_email_to_provider(notification)
+
+        # Verify provider.send_email was called with attachments
+        provider_mock.send_email.assert_called_once()
+        call_kwargs = provider_mock.send_email.call_args[1]
+        assert "attachments" in call_kwargs
+        # Should have template attachment
+        assert len(call_kwargs["attachments"]) > 0
+
+    def test_merges_payload_and_template_attachments_in_send(self, sample_service, sample_email_template, mocker):
+        """Test that payload and template attachments are merged in send."""
+        notification = save_notification(
+            create_notification(
+                template=sample_email_template,
+                to_field="test@example.com",
+                personalisation={
+                    "document": {
+                        "document": {
+                            "sending_method": "attach",
+                            "direct_file_url": "http://example.com/payload.pdf",
+                            "filename": "payload.pdf",
+                            "mime_type": "application/pdf",
+                            "id": "payload-doc-123",
+                        }
+                    }
+                },
+            )
+        )
+
+        # Mock for payload file download
+        template_attachments = [
+            {"name": "template.pdf", "data": b"template_content", "mime_type": "application/pdf"},
+        ]
+
+        mocker.patch("app.delivery.send_to_providers.document_download_client.check_scan_verdict")
+        mocker.patch("app.delivery.send_to_providers.check_for_malware_errors")
+
+        http_mock = MagicMock()
+        http_mock.request.return_value.data = b"payload_content"
+        mocker.patch("app.delivery.send_to_providers.PoolManager", return_value=http_mock)
+
+        mocker.patch("app.delivery.send_to_providers._get_template_attachments", return_value=template_attachments)
+        mocker.patch("app.delivery.send_to_providers.provider_to_use")
+        mocker.patch("app.delivery.send_to_providers.dao_get_template_by_id")
+        mocker.patch("app.delivery.send_to_providers.is_service_allowed_html", return_value=False)
+        mocker.patch("app.delivery.send_to_providers.get_html_email_options", return_value={})
+        mocker.patch("app.delivery.send_to_providers.HTMLEmailTemplate")
+        mocker.patch("app.delivery.send_to_providers.PlainTextEmailTemplate")
+        mocker.patch("app.delivery.send_to_providers.send_email_response", return_value="ref-123")
+
+        provider_mock = MagicMock()
+        provider_mock.send_email.return_value = "ses-ref"
+        provider_mock.get_name.return_value = "ses"
+
+        mocker.patch("app.delivery.send_to_providers.provider_to_use", return_value=provider_mock)
+
+        send_to_providers.send_email_to_provider(notification)
+
+        # Verify both payload and template attachments are sent
+        provider_mock.send_email.assert_called_once()
+        call_kwargs = provider_mock.send_email.call_args[1]
+        attachments = call_kwargs["attachments"]
+        assert len(attachments) == 2
+        assert attachments[0]["name"] == "payload.pdf"
+        assert attachments[1]["name"] == "template.pdf"
+
+    def test_skips_template_attach_entries_from_personalisation(self, sample_service, sample_email_template, mocker):
+        """Test that template_attach entries in personalisation data are skipped from file processing.
+
+        This ensures that when admin adds template attachments to personalisation data for audit logging,
+        they don't get caught by the user-file processing loop (which expects 'url' or 'direct_file_url').
+        """
+        notification = save_notification(
+            create_notification(
+                template=sample_email_template,
+                to_field="test@example.com",
+                personalisation={
+                    "_file_0": {
+                        "document": {
+                            "sending_method": "template_attach",
+                            "id": "template-attachment-id",
+                            "filename": "template-file.pdf",
+                            "mime_type": "application/pdf",
+                            "file_size": 1024,
+                        }
+                    }
+                },
+            )
+        )
+
+        template_attachments = [
+            {"name": "template-file.pdf", "data": b"template_content", "mime_type": "application/pdf"},
+        ]
+
+        mocker.patch("app.delivery.send_to_providers._get_template_attachments", return_value=template_attachments)
+        mocker.patch("app.delivery.send_to_providers.provider_to_use")
+        mocker.patch("app.delivery.send_to_providers.dao_get_template_by_id")
+        mocker.patch("app.delivery.send_to_providers.is_service_allowed_html", return_value=False)
+        mocker.patch("app.delivery.send_to_providers.get_html_email_options", return_value={})
+        mocker.patch("app.delivery.send_to_providers.HTMLEmailTemplate")
+        mocker.patch("app.delivery.send_to_providers.PlainTextEmailTemplate")
+        mocker.patch("app.delivery.send_to_providers.send_email_response", return_value="ref-123")
+
+        # Mock document_download_client - should NOT be called for template_attach entries
+        document_download_client_mock = mocker.patch("app.delivery.send_to_providers.document_download_client.check_scan_verdict")
+
+        provider_mock = MagicMock()
+        provider_mock.send_email.return_value = "ses-ref"
+        provider_mock.get_name.return_value = "ses"
+
+        mocker.patch("app.delivery.send_to_providers.provider_to_use", return_value=provider_mock)
+
+        send_to_providers.send_email_to_provider(notification)
+
+        # Verify that check_scan_verdict was NOT called (meaning template_attach was skipped)
+        document_download_client_mock.assert_not_called()
+
+        # Verify that the template attachment from _get_template_attachments is still included
+        provider_mock.send_email.assert_called_once()
+        call_kwargs = provider_mock.send_email.call_args[1]
+        attachments = call_kwargs["attachments"]
+        assert len(attachments) == 1
+        assert attachments[0]["name"] == "template-file.pdf"
+
+
+class TestAllSendPathsIncludeTemplateAttachments:
+    """Test that all 4 send paths (api one-off, api bulk, admin one-off, admin bulk) include template attachments."""
+
+    def _setup_send_email_mocks(self, mocker):
+        """Helper to set up common mocks for send_email_to_provider tests."""
+        mocker.patch("app.delivery.send_to_providers.provider_to_use")
+        mocker.patch("app.delivery.send_to_providers.dao_get_template_by_id")
+        mocker.patch("app.delivery.send_to_providers.is_service_allowed_html", return_value=False)
+        mocker.patch("app.delivery.send_to_providers.get_html_email_options", return_value={})
+        mocker.patch("app.delivery.send_to_providers.HTMLEmailTemplate")
+        mocker.patch("app.delivery.send_to_providers.PlainTextEmailTemplate")
+        mocker.patch("app.delivery.send_to_providers.send_email_response", return_value="ref-123")
+
+        provider_mock = MagicMock()
+        provider_mock.send_email.return_value = "ses-ref"
+        provider_mock.get_name.return_value = "ses"
+        mocker.patch("app.delivery.send_to_providers.provider_to_use", return_value=provider_mock)
+
+        return provider_mock
+
+    def test_api_one_off_send_includes_template_attachments(self, sample_service, sample_email_template, mocker):
+        """Test that API one-off sends include template attachments (no job_id)."""
+        notification = save_notification(
+            create_notification(
+                template=sample_email_template,
+                to_field="test@example.com",
+            )
+        )
+
+        template_attachments = [
+            {"name": "template.pdf", "data": b"template_content", "mime_type": "application/pdf"},
+        ]
+
+        mocker.patch("app.delivery.send_to_providers._get_template_attachments", return_value=template_attachments)
+        provider_mock = self._setup_send_email_mocks(mocker)
+
+        send_to_providers.send_email_to_provider(notification)
+
+        provider_mock.send_email.assert_called_once()
+        call_kwargs = provider_mock.send_email.call_args[1]
+        attachments = call_kwargs["attachments"]
+        assert len(attachments) == 1
+        assert attachments[0]["name"] == "template.pdf"
+
+    def test_api_bulk_send_includes_template_attachments(self, sample_service, sample_email_template, mocker):
+        """Test that API bulk sends include template attachments (with job_id, cached files)."""
+        job_id = uuid.uuid4()
+
+        notification = save_notification(
+            create_notification(
+                template=sample_email_template,
+                to_field="test@example.com",
+            )
+        )
+        # Set job_id after creation
+        notification.job_id = job_id
+
+        template_attachments = [
+            {"name": "template1.pdf", "data": b"content1", "mime_type": "application/pdf"},
+            {"name": "template2.pdf", "data": b"content2", "mime_type": "application/pdf"},
+        ]
+
+        mocker.patch("app.delivery.send_to_providers._get_template_attachments", return_value=template_attachments)
+        provider_mock = self._setup_send_email_mocks(mocker)
+
+        send_to_providers.send_email_to_provider(notification)
+
+        provider_mock.send_email.assert_called_once()
+        call_kwargs = provider_mock.send_email.call_args[1]
+        attachments = call_kwargs["attachments"]
+        assert len(attachments) == 2
+        assert attachments[0]["name"] == "template1.pdf"
+        assert attachments[1]["name"] == "template2.pdf"
+
+    def test_admin_one_off_send_includes_template_attachments(self, sample_service, sample_email_template, mocker):
+        """Test that admin one-off sends from UI include template attachments (no job_id)."""
+        notification = save_notification(
+            create_notification(
+                template=sample_email_template,
+                to_field="test@example.com",
+            )
+        )
+
+        template_attachments = [
+            {"name": "attachment.pdf", "data": b"admin_content", "mime_type": "application/pdf"},
+        ]
+
+        mocker.patch("app.delivery.send_to_providers._get_template_attachments", return_value=template_attachments)
+        provider_mock = self._setup_send_email_mocks(mocker)
+
+        send_to_providers.send_email_to_provider(notification)
+
+        provider_mock.send_email.assert_called_once()
+        call_kwargs = provider_mock.send_email.call_args[1]
+        attachments = call_kwargs["attachments"]
+        assert len(attachments) == 1
+        assert attachments[0]["name"] == "attachment.pdf"
+
+    def test_admin_bulk_send_includes_template_attachments(self, sample_service, sample_email_template, mocker):
+        """Test that admin bulk CSV sends include template attachments (with job_id, cached files)."""
+        job_id = uuid.uuid4()
+
+        notification = save_notification(
+            create_notification(
+                template=sample_email_template,
+                to_field="test@example.com",
+            )
+        )
+        # Set job_id after creation
+        notification.job_id = job_id
+
+        template_attachments = [
+            {"name": "bulk_attach.pdf", "data": b"bulk_content", "mime_type": "application/pdf"},
+        ]
+
+        mocker.patch("app.delivery.send_to_providers._get_template_attachments", return_value=template_attachments)
+        provider_mock = self._setup_send_email_mocks(mocker)
+
+        send_to_providers.send_email_to_provider(notification)
+
+        provider_mock.send_email.assert_called_once()
+        call_kwargs = provider_mock.send_email.call_args[1]
+        attachments = call_kwargs["attachments"]
+        assert len(attachments) == 1
+        assert attachments[0]["name"] == "bulk_attach.pdf"
+
+    def test_bulk_send_uses_cached_files_retrieval(self, sample_service, sample_email_template, mocker):
+        """Test that bulk sends retrieve template files from cache (job_id present)."""
+        job_id = uuid.uuid4()
+        cache_key = f"template_files:{job_id}"
+
+        notification = save_notification(
+            create_notification(
+                template=sample_email_template,
+                to_field="test@example.com",
+                job_id=job_id,
+            )
+        )
+
+        cached_metadata = [
+            {
+                "name": "cached.pdf",
+                "document_id": "doc-123",
+                "mime_type": "application/pdf",
+                "service_id": str(sample_service.id),
+            },
+        ]
+
+        redis_mock = mocker.patch("app.delivery.send_to_providers.redis_store")
+        redis_mock.get.return_value = json.dumps(cached_metadata)
+
+        # Mock the download
+        download_mock = mocker.patch("app.delivery.send_to_providers._download_template_file")
+        download_mock.return_value = {"name": "cached.pdf", "data": b"content", "mime_type": "application/pdf"}
+
+        provider_mock = self._setup_send_email_mocks(mocker)
+
+        send_to_providers.send_email_to_provider(notification)
+
+        # Verify cache was checked with correct job_id
+        redis_mock.get.assert_called_with(cache_key)
+
+        provider_mock.send_email.assert_called_once()
+        call_kwargs = provider_mock.send_email.call_args[1]
+        attachments = call_kwargs["attachments"]
+        assert len(attachments) == 1
+
+    def test_one_off_send_does_not_use_cache(self, sample_service, sample_email_template, mocker):
+        """Test that one-off sends (no job_id) fetch directly from DB, not cache."""
+        notification = save_notification(
+            create_notification(
+                template=sample_email_template,
+                to_field="test@example.com",
+            )
+        )
+
+        redis_mock = mocker.patch("app.delivery.send_to_providers.redis_store")
+        redis_mock.get.return_value = None
+
+        template_attachments = [
+            {"name": "direct.pdf", "data": b"content", "mime_type": "application/pdf"},
+        ]
+
+        mocker.patch("app.delivery.send_to_providers._get_template_attachments", return_value=template_attachments)
+        provider_mock = self._setup_send_email_mocks(mocker)
+
+        send_to_providers.send_email_to_provider(notification)
+
+        # For one-off sends (no job_id), redis cache should not be accessed
+        # Only called during internal _get_template_files_from_cache_or_db if job_id exists
+        # Since notification has no job_id, redis.get should be called 0 times in retrieval layer
+
+        provider_mock.send_email.assert_called_once()
+        call_kwargs = provider_mock.send_email.call_args[1]
+        attachments = call_kwargs["attachments"]
+        assert len(attachments) == 1


### PR DESCRIPTION
# Summary | Résumé
This pull request introduces a new mechanism to efficiently handle template file attachments for api and admin sending (both one-off and bulk).

It employs caching in redis to ensure the same set of attachments will be sent for a bulk job, even if users change the template during the send.  This also reduces database load and file download duplication for bulk jobs.

The most important changes are:

**Caching and Retrieval of Template File Attachments:**

* Added a new function `_cache_template_files_for_job` in `app/celery/tasks.py` to pre-cache template file metadata in Redis for bulk email jobs, reducing redundant database queries and downloads during job processing. This function is called at the start of email job processing. [[1]](diffhunk://#diff-cca5917c620894fe770faa88835e9e186285d5b91a55fca992eb94d5dc87e635R115-R150) [[2]](diffhunk://#diff-cca5917c620894fe770faa88835e9e186285d5b91a55fca992eb94d5dc87e635R184-R187)
* Implemented `_get_template_files_from_cache_or_db` and `_get_template_attachments` in `app/delivery/send_to_providers.py` to fetch template file metadata from Redis (for bulk jobs) or the database (for one-off sends or cache misses), and to download the files from the document download service.

**Integration with Email Sending Workflow:**

* Modified `send_email_to_provider` in `app/delivery/send_to_providers.py` to merge template file attachments (fetched and downloaded using the new caching mechanism) with any personalized file attachments before sending emails.

**Database Access Enhancements:**

* Added `dao_get_ready_files_by_template_id` in `app/dao/files_dao.py` to retrieve only files that are scanned and ready for sending, and updated imports accordingly. [[1]](diffhunk://#diff-493024af0409b29f6471c7021b3f37d5a0c8f08c1c40a6e43a66ad589de2a8bcL5-R5) [[2]](diffhunk://#diff-493024af0409b29f6471c7021b3f37d5a0c8f08c1c40a6e43a66ad589de2a8bcR14-R21)
* Updated imports in both `app/celery/tasks.py` and `app/delivery/send_to_providers.py` to include the new DAO function and `redis_store`. [[1]](diffhunk://#diff-cca5917c620894fe770faa88835e9e186285d5b91a55fca992eb94d5dc87e635R30) [[2]](diffhunk://#diff-cca5917c620894fe770faa88835e9e186285d5b91a55fca992eb94d5dc87e635R47) [[3]](diffhunk://#diff-3fe434ecc066e2e198a29fd09e9429d094792fdcde3a8562357c5ea2f8a33347R30-R36) [[4]](diffhunk://#diff-3fe434ecc066e2e198a29fd09e9429d094792fdcde3a8562357c5ea2f8a33347R2-R6)

**Personalization Logic Update:**

* Updated the logic in `send_email_to_provider` to exclude template attachments from the list of personalized file attachments, ensuring that template and personalized files are handled separately and correctly.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/3093

# Test instructions | Instructions pour tester la modification
## ADMIN
- [ ] One-off emails from a template with attachments have those files attached to the received email
- [ ] Bulk emails from a template with attachments have those files attached to the received email

## API
- [ ] One-off emails sent via the API using a template with attachments have those files attached to the received email
- [ ] Bulk emails sent via the API using a template with attachments have those files attached to the received email

## Bulk
- [ ] Files are only read once from DDAPI/DB during a bulk send

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.