### PR TITLE
Revert "Delete template attachment from scan-files S3 bucket post-verdict receival"

### DIFF
--- a/app/files/rest.py
+++ b/app/files/rest.py
@@ -173,12 +173,6 @@ def update_file_status():
     fetched_file.status = new_status
     dao_update_file(fetched_file)
 
-    try:
-        document_download_client.delete_document(service_id, document_id, "template_attach")
-        current_app.logger.info(f"Deleted scanned file S3 for document_id: {document_id}")
-    except DocumentDownloadError as e:
-        current_app.logger.warning(f"Failed to delete scanned file from S3 for document_id: {document_id}, error: {e.message}")
-
     current_app.logger.info(
         f"Updated file status to {new_status} for file_id: {fetched_file.id} "
         f"template_id: {fetched_file.template_id} document_id: {fetched_file.document_id} "

--- a/tests/app/files/test_rest.py
+++ b/tests/app/files/test_rest.py
@@ -2,7 +2,6 @@ import base64
 import json
 import uuid
 
-import pytest
 from flask import current_app, url_for
 
 from app.dao.permissions_dao import permission_dao
@@ -233,11 +232,7 @@ def _scan_verdict_post(client, data, expected_status=200):
 
 
 class TestUpdateFileStatus:
-    @pytest.fixture(autouse=True)
-    def mock_delete_document(self, mocker):
-        return mocker.patch("app.files.rest.document_download_client.delete_document")
-
-    def test_update_file_status_clean_scan(self, client, sample_file, mock_delete_document):
+    def test_update_file_status_clean_scan(self, client, sample_file):
         data = {
             "scan_status": "COMPLETED",
             "scan_result_status": "NO_THREATS_FOUND",
@@ -248,7 +243,6 @@ class TestUpdateFileStatus:
 
         assert resp["status"] == FILE_STATUS_UPLOADED
         assert sample_file.status == FILE_STATUS_UPLOADED
-        mock_delete_document.assert_called_once_with(str(sample_file.service_id), str(sample_file.document_id), "template_attach")
 
     def test_update_file_status_threat_found(self, client, sample_file):
         data = {


### PR DESCRIPTION
Reverts cds-snc/notification-api#2933

Deleting the file from the scan files bucket too early results in DDAPI failing during [`check_scan_verdict`](https://github.com/cds-snc/notification-document-download-api/blob/main/app/download/views.py#L47) when attempting to download the template attachment.

```
"Failed to get tags from document: {'Code': 'NoSuchKey', 'Message': 'The specified key does not exist.', 'Key': 'notification-canada-ca-staging-document-download-scan-files/template_attachments/70c2d41d-c085-4a10-81dd-17ecf548e389/fd312455-a6c3-400d-839f-76e58db3aa85'}
```