### PR TITLE
Add migration and db model change to add an `archived` column to the `files` table

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1456,6 +1456,7 @@ class Files(BaseModel):
     mime_type = db.Column(db.Text, nullable=True)
     file_size = db.Column(db.Integer, nullable=True)
     status = db.Column(db.Enum(*FILE_STATUSES, name="notify_file_status_enum"), nullable=False)
+    archived = db.Column(db.Boolean, nullable=False, default=False)
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), index=True, nullable=True)
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
     updated_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow)

--- a/migrations/versions/0517_add_archived_to_files.py
+++ b/migrations/versions/0517_add_archived_to_files.py
@@ -1,0 +1,22 @@
+"""
+Revision ID: 0517_add_archived_to_files
+Revises: 0516_backfill_rte_default
+Create Date: 2026-07-08
+
+Add archived column to files table.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0517_add_archived_to_files"
+down_revision = "0516_backfill_rte_default"
+
+
+def upgrade():
+    op.add_column("files", sa.Column("archived", sa.Boolean(), nullable=False, server_default=sa.false()))
+    op.alter_column("files", "archived", server_default=None)
+
+
+def downgrade():
+    op.drop_column("files", "archived")

--- a/migrations/versions/0517_add_archived_to_files.py
+++ b/migrations/versions/0517_add_archived_to_files.py
@@ -15,7 +15,6 @@ down_revision = "0516_backfill_rte_default"
 
 def upgrade():
     op.add_column("files", sa.Column("archived", sa.Boolean(), nullable=False, server_default=sa.false()))
-    op.alter_column("files", "archived", server_default=None)
 
 
 def downgrade():


### PR DESCRIPTION
# Summary | Résumé

This PR adds a migration and db model change to add an `archived` column to the `files` table. This shouldn't affect any of the test suite.

# Test instructions | Instructions pour tester la modification

1. check out the branch locally
2. run `flask db upgrade`
3. look in your local db and verify that the new column is there

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.