### PR TITLE
Folder session bug

### DIFF
--- a/app/dao/templates_dao.py
+++ b/app/dao/templates_dao.py
@@ -22,9 +22,16 @@ from app.models import (
 
 @transactional
 @version_class(VersionOptions(Template, history_class=TemplateHistory))
-def dao_create_template(template, redact_personalisation=False):
+def dao_create_template(template, redact_personalisation=False, folder=None):
     # must be set now so version history model can use same id
     template.id = uuid.uuid4()
+
+    # Set folder AFTER id is assigned. Setting it before (e.g. in from_json) causes
+    # the folder backref to add the template to the session prematurely; any subsequent
+    # lazy-load query then triggers autoflush, persisting the template before this
+    # function can assign the id — leading to a PK-changing UPDATE that violates FKs.
+    if folder:
+        template.folder = folder
 
     redacted_dict = {
         "template": template,

--- a/app/v2/manage_template/post_template.py
+++ b/app/v2/manage_template/post_template.py
@@ -52,7 +52,6 @@ def post_manage_template():
             "service": authenticated_service.id,
             "created_by": api_user.created_by_id,
         },
-        folder,
     )
 
     if not service_has_permission(template.template_type, authenticated_service.permissions):
@@ -61,7 +60,7 @@ def post_manage_template():
 
     _raise_if_content_or_name_over_limit(template)
 
-    templates_dao.dao_create_template(template)
+    templates_dao.dao_create_template(template, folder=folder)
 
     redis_store.delete(f"service-{authenticated_service.id}-templates")
 

--- a/tests/app/v2/manage_template/test_post_template.py
+++ b/tests/app/v2/manage_template/test_post_template.py
@@ -3,8 +3,10 @@ from types import SimpleNamespace
 
 from flask import json
 from tests import create_authorization_header
+from tests.app.db import create_template_folder
 
-from app.models import EMAIL_TYPE, SMS_TYPE
+from app import db
+from app.models import EMAIL_TYPE, SMS_TYPE, template_folder_map
 
 
 class TestPostTemplateV2ManageTemplate:
@@ -202,3 +204,79 @@ class TestPostTemplateV2ManageTemplate:
 
         assert response.status_code == 201
         mock_redis_delete.assert_called_once_with(f"service-{sample_service.id}-templates")
+
+    def test_post_template_with_parent_folder_id_returns_201(
+        self, client, notify_db_session, sample_service, sample_template_category, create_api_key_with_manage_api_perm
+    ):
+        folder = create_template_folder(sample_service, name="My Folder")
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_api_perm)
+        payload = {
+            "name": "Template In Folder",
+            "template_type": SMS_TYPE,
+            "content": "Hello from folder",
+            "template_category_id": str(sample_template_category.id),
+            "parent_folder_id": str(folder.id),
+        }
+
+        response = client.post(
+            "/v2/manage-template",
+            data=json.dumps(payload),
+            headers=[("Content-Type", "application/json"), auth_header],
+        )
+
+        assert response.status_code == 201
+        data = json.loads(response.get_data(as_text=True))
+        assert data["name"] == payload["name"]
+        assert data["body"] == payload["content"]
+
+        # Verify the template is associated with the folder in the DB
+        template_id = uuid.UUID(data["id"])
+        mapping = db.session.query(template_folder_map).filter_by(template_id=template_id).one()
+        assert mapping.template_folder_id == folder.id
+
+    def test_post_template_with_invalid_parent_folder_id_returns_400(
+        self, client, sample_template_category, create_api_key_with_manage_api_perm
+    ):
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_api_perm)
+        payload = {
+            "name": "Bad Folder Template",
+            "template_type": SMS_TYPE,
+            "content": "Hello",
+            "template_category_id": str(sample_template_category.id),
+            "parent_folder_id": str(uuid.uuid4()),
+        }
+
+        response = client.post(
+            "/v2/manage-template",
+            data=json.dumps(payload),
+            headers=[("Content-Type", "application/json"), auth_header],
+        )
+
+        assert response.status_code == 400
+        data = json.loads(response.get_data(as_text=True))
+        assert "parent_folder_id not found" in data["errors"][0]["message"]
+
+    def test_post_template_without_parent_folder_id_has_no_folder(
+        self, client, sample_service, sample_template_category, create_api_key_with_manage_api_perm
+    ):
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_api_perm)
+        payload = {
+            "name": "No Folder Template",
+            "template_type": SMS_TYPE,
+            "content": "Hello no folder",
+            "template_category_id": str(sample_template_category.id),
+        }
+
+        response = client.post(
+            "/v2/manage-template",
+            data=json.dumps(payload),
+            headers=[("Content-Type", "application/json"), auth_header],
+        )
+
+        assert response.status_code == 201
+        data = json.loads(response.get_data(as_text=True))
+
+        # Verify no folder mapping exists
+        template_id = uuid.UUID(data["id"])
+        mapping = db.session.query(template_folder_map).filter_by(template_id=template_id).first()
+        assert mapping is None


### PR DESCRIPTION
## PR Summary

**Bug:** `POST /v2/manage-template` with `parent_folder_id` fails with `ForeignKeyViolation` on `template_folder_map_template_id_fkey`.

**Root Cause:** Setting `folder` during `Template.from_json()` causes SQLAlchemy's folder backref to implicitly add the template to the session. When `authenticated_service.permissions` is subsequently lazy-loaded, it triggers an autoflush that INSERTs the template (with an auto-generated PK) and the `template_folder_map` row. Then `dao_create_template` reassigns `template.id = uuid.uuid4()`, generating an `UPDATE` to change the PK — which violates the FK constraint from `template_folder_map`.

This never affected the v1/admin endpoint because it pre-loads `permissions` *before* creating the template (the v1 code even has a comment warning about this: *"permissions needs to be placed here otherwise marshmallow will interfere with versioning"*).

**Fix:** Don't pass `folder` to `Template.from_json()`. Instead, pass it to `dao_create_template()` which sets `template.folder` *after* assigning the id — ensuring the template enters the session with the correct, final PK.

**Changes:**
- templates_dao.py — Added optional `folder` param to `dao_create_template`; folder is set after `template.id` is assigned.
- post_template.py — Pass `folder` to `dao_create_template(template, folder=folder)` instead of `Template.from_json()`.
- test_post_template.py — Added tests for create-with-folder, invalid folder, and no-folder cases.

## Test:

1. `main` branch
2. curl --request POST \
  --url http://localhost:6011/v2/manage-template \
  --header 'Authorization:' \
  --header 'Content-Type: application/json' \
  --header 'User-Agent: insomnia/12.6.0' \
  --data '{"name": "Welcome email3",
 "template_type": "email",
 "subject": "Welcome to  notify 3",
 "content": "Hi ((first_name)), welcome!", "template_category_id": "7c16aa95-e2e1-4497-81d6-04c656520fe4",
 "parent_folder_id": "e574f8bb-59c7-4b1f-8b2e-de7ad61e002a"
}'

### you will need to update the parent_folder_id with a folder_id in your service
1. you will see an error similar to this:
```
sqlalchemy.exc.IntegrityError: (raised as a result of Query-invoked autoflush; consider using a session.no_autoflush block if this flush is occurring prematurely)
(psycopg2.errors.ForeignKeyViolation) update or delete on table "templates" violates foreign key constraint "template_folder_map_template_id_fkey" on table "template_folder_map"
DETAIL:  Key (id)=(1b7385fd-8d9b-4930-982e-b705e3ac015d) is still referenced from table "template_folder_map".
```

1. Switch to this branch
1. Send the same curl request. No error