### PR TITLE
Assign a unique id for each bulk notification earlier to avoid duplicates

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -225,6 +225,7 @@ def process_rows(rows: List, template: Template, job: Job, service: Service):
         signed_row = SignedNotification(
             signer_notification.sign(
                 {
+                    "id": create_uuid(),
                     "api_key": job.api_key_id and str(job.api_key_id),  # type: ignore
                     "key_type": job.api_key.key_type if job.api_key else KEY_TYPE_NORMAL,
                     "template": str(template.id),

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -197,6 +197,29 @@ class TestBatchSaving:
         assert persisted_notification[0].status == "created"
         assert persisted_notification[0].notification_type == "email"
 
+    def test_save_emails_is_idempotent_when_same_message_delivered_twice(self, notify_db_session, mocker):
+        # Simulates SQS delivering the same batch twice (or two workers picking up
+        # the same message). Because process_rows now assigns a stable notification
+        # id that is carried in the signed payload, the second delivery must not
+        # create a duplicate notification row or send the email a second time.
+        service = create_service()
+        template = create_template(service=service, template_type="email")
+
+        notification = _notification_json(template, to="dup@test.com")
+        notification["id"] = str(uuid.uuid4())
+        signed = signer_notification.sign(notification)
+
+        deliver_mock = mocker.patch("app.celery.provider_tasks.deliver_email.apply_async")
+
+        # First delivery persists and sends.
+        save_emails(str(template.service_id), [signed], None)
+        # Second (duplicate) delivery must be a no-op.
+        save_emails(str(template.service_id), [signed], None)
+
+        assert Notification.query.count() == 1
+        assert Notification.query.one().id == uuid.UUID(notification["id"])
+        assert deliver_mock.call_count == 1
+
     def test_should_save_smss(self, sample_template_with_placeholders, mocker):
         notification1 = _notification_json(
             sample_template_with_placeholders,
@@ -923,6 +946,7 @@ class TestProcessRows:
         )
         signer_mock.assert_called_once_with(
             {
+                "id": "noti_uuid",
                 "api_key": None if api_key_id is None else str(api_key_id),
                 "key_type": job.api_key.key_type,
                 "template": "template_id",
@@ -1109,6 +1133,7 @@ class TestProcessRows:
         )
         signer_mock.assert_called_once_with(
             {
+                "id": "noti_uuid",
                 "api_key": None if api_key_id is None else str(api_key_id),
                 "key_type": KEY_TYPE_NORMAL,
                 "template": "template_id",


### PR DESCRIPTION
# Summary | Résumé

We have an issue where duplicate notifications are sometimes sent for large bulk jobs. This came up in a recent support ticket here: https://gcdigital.slack.com/archives/C03FA4DJCCU/p1783524265953419

You can see the issue with the following query:

```
select count(id), n.job_row_number
from notifications n 
where n.job_id = '74677119-94f3-4d46-b937-a586c0647e50'
group by n.job_row_number  
order by count(id)
```

Observe that there are 60 rows (out of a 33,169 row job) that have been inserted twice.
 
The issue is that [`process_rows`](https://github.com/cds-snc/notification-api/blob/main/app/celery/tasks.py#L218) batches up the rows from the csv but does not set the id. So it is set later by the celery worker [here](https://github.com/cds-snc/notification-api/blob/main/app/celery/tasks.py#L324): `notification_id = _notification.get("id", create_uuid())`

Which will create duplicates if there are more than one celery worker processing the same set of rows. If we set the notification `id` earlier that should fix the duplicate problem.

This will then trigger a primary-key `IntegrityError` on insert. That exception is caught by the existing except SQLAlchemyError in `save_emails/save_smss`, which calls [tasks.py:537](https://github.com/cds-snc/notification-api/blob/main/app/celery/tasks.py#L537). That function finds the notification already exists via `get_notification_by_id` and does not re-queue or retry. It then acknowledges the SQS receipt and returns cleanly.

The only thing logged is a WARNING message in `handle_batch_error_and_forward` itself: "Batch saving: could not persist notifications". We already have a `duplicate-record` alarm that will trigger if a large number of these errors occur, which is what we want.

## Related Issues | Cartes liées

- https://github.com/cds-snc/notification-planning/issues/3331

# Test instructions | Instructions pour tester la modification

We can't really test that this fixes the bug since there is no reliable way to reproduce it. But we can test that this hasn't broken anything:

1. check out this branch and run locally
2. send a bulk email via csv, using a csv with 100 rows like this:
```
email address
success@simulator.amazonses.com
success@simulator.amazonses.com
...
```
3. verify that the job completes successfully

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.