### PR TITLE
Clear the template/template category cache when a template is updated

### DIFF
--- a/app/v2/manage_template/delete_template.py
+++ b/app/v2/manage_template/delete_template.py
@@ -29,6 +29,7 @@ def delete_manage_template(template_id):
     template.folder = None
     templates_dao.dao_update_template(template)
     redis_store.delete(f"service-{str(template.service_id)}-templates")
-    redis_store.delete(f"template-{str(template_id)}-version-{template.version}")
+    redis_store.delete(f"template-{str(template_id)}-version-None")
+    redis_store.delete(f"template-{str(template_id)}-versions")
 
     return jsonify(_serialize_template(template)), 200

--- a/app/v2/manage_template/delete_template.py
+++ b/app/v2/manage_template/delete_template.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from flask import jsonify
+from notifications_utils.clients.redis import template_version_cache_key
 
 from app import api_user, authenticated_service, redis_store
 from app.dao import templates_dao
@@ -29,7 +30,7 @@ def delete_manage_template(template_id):
     template.folder = None
     templates_dao.dao_update_template(template)
     redis_store.delete(f"service-{str(template.service_id)}-templates")
-    redis_store.delete(f"template-{str(template_id)}-version-None")
+    redis_store.delete(template_version_cache_key(template_id))
     redis_store.delete(f"template-{str(template_id)}-versions")
 
     return jsonify(_serialize_template(template)), 200

--- a/app/v2/manage_template/patch_template.py
+++ b/app/v2/manage_template/patch_template.py
@@ -1,5 +1,6 @@
 from flask import jsonify, request
 from jsonschema import ValidationError
+from notifications_utils.clients.redis import template_version_cache_key
 from sqlalchemy.orm.exc import NoResultFound
 
 from app import api_user, authenticated_service, redis_store
@@ -71,7 +72,7 @@ def patch_manage_template(template_id):
 
     templates_dao.dao_update_template(template)
     redis_store.delete(f"service-{str(template.service_id)}-templates")
-    redis_store.delete(f"template-{str(template_id)}-version-None")
+    redis_store.delete(template_version_cache_key(template_id))
     redis_store.delete(f"template-{str(template_id)}-versions")
 
     if "template_category_id" in data:

--- a/app/v2/manage_template/patch_template.py
+++ b/app/v2/manage_template/patch_template.py
@@ -51,6 +51,8 @@ def patch_manage_template(template_id):
                 TemplateCategoryNotFoundError.message,
             )
 
+    old_category_id = str(template.template_category_id) if template.template_category_id else None
+
     if "parent_folder_id" in data:
         parent_folder_id = data.pop("parent_folder_id")
         if parent_folder_id:
@@ -69,6 +71,14 @@ def patch_manage_template(template_id):
 
     templates_dao.dao_update_template(template)
     redis_store.delete(f"service-{str(template.service_id)}-templates")
-    redis_store.delete(f"template-{str(template_id)}-version-{template.version}")
+    redis_store.delete(f"template-{str(template_id)}-version-None")
+    redis_store.delete(f"template-{str(template_id)}-versions")
+
+    if "template_category_id" in data:
+        new_category_id = data["template_category_id"]
+        if old_category_id:
+            redis_store.delete(f"template_category-{old_category_id}")
+        redis_store.delete(f"template_category-{new_category_id}")
+        redis_store.delete("template_categories")
 
     return jsonify(_serialize_template(template)), 200

--- a/tests/app/v2/manage_template/test_patch_template.py
+++ b/tests/app/v2/manage_template/test_patch_template.py
@@ -166,3 +166,45 @@ class TestPatchTemplateV2ManageTemplate:
         assert "created_at" in data
         assert "updated_at" in data
         assert "archived" in data
+
+    def test_patch_template_clears_admin_cache(self, client, sample_service, create_api_key_with_manage_api_perm, mocker):
+        template = create_template(sample_service, template_type=SMS_TYPE)
+        mock_redis_delete = mocker.patch("app.v2.manage_template.patch_template.redis_store.delete")
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_api_perm)
+
+        response = client.patch(
+            f"/v2/manage-template/{template.id}",
+            data=json.dumps({"name": "Cache Bust"}),
+            headers=[("Content-Type", "application/json"), auth_header],
+        )
+
+        assert response.status_code == 200
+        deleted_keys = [call.args[0] for call in mock_redis_delete.call_args_list]
+        assert f"service-{sample_service.id}-templates" in deleted_keys
+        assert f"template-{template.id}-version-None" in deleted_keys
+        assert f"template-{template.id}-versions" in deleted_keys
+
+    def test_patch_template_clears_category_cache_when_category_updated(
+        self,
+        client,
+        sample_service,
+        sample_template_category,
+        sample_template_category_bulk,
+        create_api_key_with_manage_api_perm,
+        mocker,
+    ):
+        template = create_template(sample_service, template_type=SMS_TYPE, template_category=sample_template_category_bulk)
+        mock_redis_delete = mocker.patch("app.v2.manage_template.patch_template.redis_store.delete")
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_api_perm)
+
+        response = client.patch(
+            f"/v2/manage-template/{template.id}",
+            data=json.dumps({"template_category_id": str(sample_template_category.id)}),
+            headers=[("Content-Type", "application/json"), auth_header],
+        )
+
+        assert response.status_code == 200
+        deleted_keys = [call.args[0] for call in mock_redis_delete.call_args_list]
+        assert f"template_category-{sample_template_category_bulk.id}" in deleted_keys
+        assert f"template_category-{sample_template_category.id}" in deleted_keys
+        assert "template_categories" in deleted_keys

--- a/tests/app/v2/manage_template/test_patch_template.py
+++ b/tests/app/v2/manage_template/test_patch_template.py
@@ -1,6 +1,7 @@
 import uuid
 
 from flask import json
+from notifications_utils.clients.redis import template_version_cache_key
 from sqlalchemy.orm.exc import NoResultFound
 from tests import create_authorization_header
 from tests.app.db import create_template
@@ -181,7 +182,7 @@ class TestPatchTemplateV2ManageTemplate:
         assert response.status_code == 200
         deleted_keys = [call.args[0] for call in mock_redis_delete.call_args_list]
         assert f"service-{sample_service.id}-templates" in deleted_keys
-        assert f"template-{template.id}-version-None" in deleted_keys
+        assert template_version_cache_key(template.id) in deleted_keys
         assert f"template-{template.id}-versions" in deleted_keys
 
     def test_patch_template_clears_category_cache_when_category_updated(


### PR DESCRIPTION
# Summary | Résumé

Clear the template/template category cache when a template is updated, so that the changes are visible in notification-admin.

`patch_manage_template` (and `delete_manage_template`) were clearing the wrong Redis key (`template-{id}-version-{version}` using the actual new version number) and missing other keys that notification-admin actually uses.

## Related Issues | Cartes liéesa

* https://github.com/cds-snc/notification-planning/issues/3331
* Support thread: https://gcdigital.slack.com/archives/C03FA4DJCCU/p1783946476371369

# Test instructions | Instructions pour tester la modification

Reproduce the bug on the `main` api branch:
1. run locally
2. get the id for an existing template
3. update the content of that template with a `patch` request to `v2/manage-templates/{template-id}` and `data={"content": "new content"}` in the request
4. reload the template page in your local admin
5. observe that you don't see the new template content

Test the fix on this api branch `fix/template-api-clear-cache`:
redo steps 1-4
5. observe that you do see the new template content

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.