### PR TITLE
Classify duplicate-record Celery errors and emit structured log tag

### DIFF
--- a/app/celery/error_registry.py
+++ b/app/celery/error_registry.py
@@ -40,6 +40,9 @@ class CeleryErrorCategory(str, Enum):
     # Notifications that timed out
     TIMEOUT_NOTIFICATION = "CELERY_KNOWN_ERROR::TIMEOUT_NOTIFICATION"
 
+    # Duplicate notification record — SQS redelivery or concurrent worker processed the same row
+    DUPLICATE_RECORD = "CELERY_KNOWN_ERROR::DUPLICATE_RECORD"
+
     # Unknown / unclassified — these should trigger sensitive alarms
     UNKNOWN = "CELERY_UNKNOWN_ERROR"
 
@@ -64,6 +67,7 @@ _EXCEPTION_CLASS_MAP: dict[str, CeleryErrorCategory] = {
 # Some errors don't have a specific exception class, but can be identified
 # by substrings in their message.
 _MESSAGE_SUBSTRING_MAP: dict[str, CeleryErrorCategory] = {
+    "duplicate key value violates unique constraint": CeleryErrorCategory.DUPLICATE_RECORD,
     "notifications not found for SES references": CeleryErrorCategory.NOTIFICATION_NOT_FOUND,
     "SIGKILL": CeleryErrorCategory.SHUTDOWN,
     "Worker exited prematurely": CeleryErrorCategory.SHUTDOWN,

--- a/app/celery/error_registry.py
+++ b/app/celery/error_registry.py
@@ -67,7 +67,7 @@ _EXCEPTION_CLASS_MAP: dict[str, CeleryErrorCategory] = {
 # Some errors don't have a specific exception class, but can be identified
 # by substrings in their message.
 _MESSAGE_SUBSTRING_MAP: dict[str, CeleryErrorCategory] = {
-    "duplicate key value violates unique constraint \"notifications_pkey\"": CeleryErrorCategory.DUPLICATE_RECORD,
+    'duplicate key value violates unique constraint "notifications_pkey"': CeleryErrorCategory.DUPLICATE_RECORD,
     "notifications not found for SES references": CeleryErrorCategory.NOTIFICATION_NOT_FOUND,
     "SIGKILL": CeleryErrorCategory.SHUTDOWN,
     "Worker exited prematurely": CeleryErrorCategory.SHUTDOWN,

--- a/app/celery/error_registry.py
+++ b/app/celery/error_registry.py
@@ -67,7 +67,7 @@ _EXCEPTION_CLASS_MAP: dict[str, CeleryErrorCategory] = {
 # Some errors don't have a specific exception class, but can be identified
 # by substrings in their message.
 _MESSAGE_SUBSTRING_MAP: dict[str, CeleryErrorCategory] = {
-    "duplicate key value violates unique constraint": CeleryErrorCategory.DUPLICATE_RECORD,
+    "duplicate key value violates unique constraint \"notifications_pkey\"": CeleryErrorCategory.DUPLICATE_RECORD,
     "notifications not found for SES references": CeleryErrorCategory.NOTIFICATION_NOT_FOUND,
     "SIGKILL": CeleryErrorCategory.SHUTDOWN,
     "Worker exited prematurely": CeleryErrorCategory.SHUTDOWN,

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -39,6 +39,7 @@ from app.aws.metrics import (
     put_batch_saving_bulk_created,
     put_batch_saving_bulk_processed,
 )
+from app.celery.error_registry import classify_error
 from app.config import Config, Priorities, QueueNames
 from app.dao.api_key_dao import update_last_used_api_key
 from app.dao.fact_notification_status_dao import (
@@ -543,10 +544,13 @@ def handle_batch_error_and_forward(
     receipt: Optional[UUID] = None,
     template: Any = None,
 ):
+    category, _ = classify_error(exception)
     if receipt:
-        current_app.logger.warning(f"Batch saving: could not persist notifications with receipt {receipt}: {str(exception)}")
+        current_app.logger.warning(
+            f"{category.value} Batch saving: could not persist notifications with receipt {receipt}: {str(exception)}"
+        )
     else:
-        current_app.logger.warning(f"Batch saving: could not persist notifications: {str(exception)}")
+        current_app.logger.warning(f"{category.value} Batch saving: could not persist notifications: {str(exception)}")
     process_type = template.process_type if template else None
 
     notifications_in_job: List[str] = []

--- a/tests/app/celery/test_celery_error_classification.py
+++ b/tests/app/celery/test_celery_error_classification.py
@@ -275,6 +275,18 @@ class TestClassifyError:
         assert category == CeleryErrorCategory.TASK_RETRY
         assert root_exc is exc  # Should return the original exception as root
 
+    def test_duplicate_record_by_message(self):
+        """SQLAlchemy IntegrityError wrapping a Postgres unique-constraint violation is classified as DUPLICATE_RECORD."""
+        from sqlalchemy.exc import IntegrityError
+
+        exc = IntegrityError(
+            statement=None,
+            params=None,
+            orig=Exception('duplicate key value violates unique constraint "notifications_pkey"'),
+        )
+        category, root_exc = classify_error(exc)
+        assert category == CeleryErrorCategory.DUPLICATE_RECORD
+
 
 class TestCelerySignalHandlers:
     def test_task_retry_classifies_throttling(self, notify_api):


### PR DESCRIPTION
## What

Adds `DUPLICATE_RECORD` to `CeleryErrorCategory` and the error classifier, and updates `handle_batch_error_and_forward` to emit the structured tag `CELERY_KNOWN_ERROR::DUPLICATE_RECORD` in its warning log.

## Why

The stable-id fix (#2944) made SQS-redelivered batches hit a primary-key conflict on the `notifications` table instead of silently inserting duplicate rows. This is correct behaviour — `handle_batch_error_and_forward` catches the error, finds the existing notification, and skips the resend — but the resulting `IntegrityError` log was only distinguishable from other constraint violations by the raw Postgres error string.

With this change the log line looks like:
```
CELERY_KNOWN_ERROR::DUPLICATE_RECORD Batch saving: could not persist notifications with receipt <uuid>: ...duplicate key value violates unique constraint "notifications_pkey"...
```

This is required by a companion terraform PR which updates the `celery-error-duplicate-record` CloudWatch log filter to match the structured tag instead of the raw Postgres string, and adds a separate alarm for genuinely unexpected constraint violations.

## Testing

- `test_duplicate_record_by_message` — verifies `IntegrityError` wrapping a Postgres unique violation classifies as `DUPLICATE_RECORD`
- All existing classifier and batch-saving tests continue to pass