### PR TITLE
Add PATCH to the allowed methods

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -382,7 +382,7 @@ def init_app(app):
         if origin in ALLOWED_ORIGINS:
             response.headers["Access-Control-Allow-Origin"] = origin
         response.headers.add("Access-Control-Allow-Headers", "Content-Type,Authorization")
-        response.headers.add("Access-Control-Allow-Methods", "GET,PUT,POST,DELETE")
+        response.headers.add("Access-Control-Allow-Methods", "GET,PUT,POST,PATCH,DELETE")
         return response
 
     @app.errorhandler(Exception)

--- a/tests/app/authentication/test_authentication.py
+++ b/tests/app/authentication/test_authentication.py
@@ -496,6 +496,11 @@ class TestSwagger:
         assert "Content-Type" in response.headers["Access-Control-Allow-Headers"]
         assert "Authorization" in response.headers["Access-Control-Allow-Headers"]
         assert "Access-Control-Allow-Methods" in response.headers
+        allowed_methods = response.headers["Access-Control-Allow-Methods"]
+        for method in ["GET", "PUT", "POST", "PATCH", "DELETE"]:
+            assert (
+                method in allowed_methods
+            ), "PATCH must be in Access-Control-Allow-Methods for browser-based Swagger UI requests to work"
 
     def test_get_request_to_protected_route_should_require_auth(self, client):
         """Test that GET requests to the same endpoint still require authentication."""

--- a/tests/app/authentication/test_authentication.py
+++ b/tests/app/authentication/test_authentication.py
@@ -496,11 +496,6 @@ class TestSwagger:
         assert "Content-Type" in response.headers["Access-Control-Allow-Headers"]
         assert "Authorization" in response.headers["Access-Control-Allow-Headers"]
         assert "Access-Control-Allow-Methods" in response.headers
-        allowed_methods = response.headers["Access-Control-Allow-Methods"]
-        for method in ["GET", "PUT", "POST", "PATCH", "DELETE"]:
-            assert (
-                method in allowed_methods
-            ), "PATCH must be in Access-Control-Allow-Methods for browser-based Swagger UI requests to work"
 
     def test_get_request_to_protected_route_should_require_auth(self, client):
         """Test that GET requests to the same endpoint still require authentication."""

--- a/tests/app/test_cors_headers.py
+++ b/tests/app/test_cors_headers.py
@@ -5,7 +5,7 @@ def test_cors_headers_set_on_api_request(notify_api):
     with notify_api.test_request_context():
         with notify_api.test_client() as client:
             allow_headers = "Content-Type,Authorization"
-            allow_methods = "GET,PUT,POST,DELETE"
+            allow_methods = "GET,PUT,POST,PATCH,DELETE"
 
             # Making a GET request to healthcheck which should be unrestricted
             response = client.get(
@@ -40,7 +40,7 @@ def test_cors_headers_work_with_options_method(notify_api):
     with notify_api.test_request_context():
         with notify_api.test_client() as client:
             allow_headers = "Content-Type,Authorization"
-            allow_methods = "GET,PUT,POST,DELETE"
+            allow_methods = "GET,PUT,POST,PATCH,DELETE"
 
             # Making an OPTIONS request to healthcheck
             response = client.options(
@@ -60,7 +60,7 @@ def test_cors_headers_with_auth_protected_route(notify_api, sample_service):
     with notify_api.test_request_context():
         with notify_api.test_client() as client:
             allow_headers = "Content-Type,Authorization"
-            allow_methods = "GET,PUT,POST,DELETE"
+            allow_methods = "GET,PUT,POST,PATCH,DELETE"
 
             # Create auth header
             auth_header = create_authorization_header()
@@ -81,7 +81,7 @@ def test_cors_options_with_auth_protected_route(notify_api, sample_service):
     with notify_api.test_request_context():
         with notify_api.test_client() as client:
             allow_headers = "Content-Type,Authorization"
-            allow_methods = "GET,PUT,POST,DELETE"
+            allow_methods = "GET,PUT,POST,PATCH,DELETE"
 
             # Making an OPTIONS request to an auth-protected endpoint
             # Note: OPTIONS requests should work without authentication


### PR DESCRIPTION
# Summary | Résumé

Add PATCH to the allowed methods - this is likely the reason the PATCH endpoint requests are failing on our swagger doc site.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.