### PR TITLE
Block localhost urls when configuring callbacks

### DIFF
--- a/app/service/callback_rest.py
+++ b/app/service/callback_rest.py
@@ -192,6 +192,8 @@ def _validate_not_localhost(url):
                 try:
                     is_loopback = ipaddress.ip_address(hostname).is_loopback
                 except ValueError:
+                    # Hostname is not an IP literal (for example, a normal DNS name);
+                    # keep `is_loopback` as determined by localhost-name checks above.
                     pass
             if is_loopback:
                 raise InvalidRequest("Callback URL must not point to localhost", status_code=400)

--- a/app/service/callback_rest.py
+++ b/app/service/callback_rest.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlparse
+
 from flask import Blueprint, jsonify, request
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -36,6 +38,7 @@ register_errors(service_callback_blueprint)
 def create_service_inbound_api(service_id):
     data = request.get_json()
     validate(data, create_service_callback_api_schema)
+    _validate_not_localhost(data.get("url"))
     data["service_id"] = service_id
     inbound_api = ServiceInboundApi(**data)
     try:
@@ -50,6 +53,7 @@ def create_service_inbound_api(service_id):
 def update_service_inbound_api(service_id, inbound_api_id):
     data = request.get_json()
     validate(data, update_service_callback_api_schema)
+    _validate_not_localhost(data.get("url"))
 
     to_update = get_service_inbound_api(inbound_api_id, service_id)
 
@@ -85,6 +89,7 @@ def remove_service_inbound_api(service_id, inbound_api_id):
 def create_service_callback_api(service_id):
     data = request.get_json()
     validate(data, create_service_callback_api_schema)
+    _validate_not_localhost(data.get("url"))
     data["service_id"] = service_id
     data["callback_type"] = DELIVERY_STATUS_CALLBACK_TYPE
     callback_api = ServiceCallbackApi(**data)
@@ -100,6 +105,7 @@ def create_service_callback_api(service_id):
 def update_service_callback_api(service_id, callback_api_id):
     data = request.get_json()
     validate(data, update_service_callback_api_schema)
+    _validate_not_localhost(data.get("url"))
 
     to_update = get_service_callback_api(callback_api_id, service_id)
 
@@ -172,3 +178,17 @@ def handle_sql_error(e, table_name):
         return jsonify(result="error", message="No result found"), 404
     else:
         raise e
+
+
+def _validate_not_localhost(url):
+    """Reject callback URLs that reference localhost or loopback addresses."""
+    if url:
+        try:
+            parsed = urlparse(url)
+            hostname = parsed.hostname or ""
+            if hostname in ("localhost", "127.0.0.1", "::1") or hostname.endswith(".localhost"):
+                raise InvalidRequest("Callback URL must not point to localhost", status_code=400)
+        except InvalidRequest:
+            raise
+        except Exception:
+            pass

--- a/app/service/callback_rest.py
+++ b/app/service/callback_rest.py
@@ -190,5 +190,5 @@ def _validate_not_localhost(url):
                 raise InvalidRequest("Callback URL must not point to localhost", status_code=400)
         except InvalidRequest:
             raise
-        except Exception:
-            pass
+        except Exception as e:
+            raise InvalidRequest("Invalid callback URL", status_code=400) from e

--- a/app/service/callback_rest.py
+++ b/app/service/callback_rest.py
@@ -1,3 +1,4 @@
+import ipaddress
 from urllib.parse import urlparse
 
 from flask import Blueprint, jsonify, request
@@ -185,8 +186,14 @@ def _validate_not_localhost(url):
     if url:
         try:
             parsed = urlparse(url)
-            hostname = parsed.hostname or ""
-            if hostname in ("localhost", "127.0.0.1", "::1") or hostname.endswith(".localhost"):
+            hostname = (parsed.hostname or "").rstrip(".")
+            is_loopback = hostname == "localhost" or hostname.endswith(".localhost")
+            if not is_loopback:
+                try:
+                    is_loopback = ipaddress.ip_address(hostname).is_loopback
+                except ValueError:
+                    pass
+            if is_loopback:
                 raise InvalidRequest("Callback URL must not point to localhost", status_code=400)
         except InvalidRequest:
             raise

--- a/tests/app/service/test_callback_rest.py
+++ b/tests/app/service/test_callback_rest.py
@@ -224,12 +224,12 @@ class TestSuspendCallbackApi:
     "url",
     [
         "https://localhost/callback",
-        "https://localhost:8080/callback",
         "https://localhost./callback",
+        "https://localhost:8080/callback",
         "https://127.0.0.1/callback",
-        "https://127.0.0.1:443/callback",
         "https://127.0.0.2/callback",
         "https://127.255.255.255/callback",
+        "https://127.0.0.1:443/callback",
         "https://[::1]/callback",
         "https://[0:0:0:0:0:0:0:1]/callback",
         "https://sub.localhost/callback",
@@ -259,6 +259,8 @@ def test_validate_not_localhost_allows_valid_urls(url):
     [
         "https://localhost/callback",
         "https://127.0.0.1/callback",
+        "https://127.0.0.2/callback",
+        "https://[::1]/callback",
     ],
 )
 def test_create_inbound_api_rejects_localhost(admin_request, sample_service, url):
@@ -281,6 +283,8 @@ def test_create_inbound_api_rejects_localhost(admin_request, sample_service, url
     [
         "https://localhost/callback",
         "https://127.0.0.1/callback",
+        "https://127.0.0.2/callback",
+        "https://[::1]/callback",
     ],
 )
 def test_create_callback_api_rejects_localhost(admin_request, sample_service, url):

--- a/tests/app/service/test_callback_rest.py
+++ b/tests/app/service/test_callback_rest.py
@@ -3,6 +3,7 @@ import uuid
 import pytest
 
 from app.models import ServiceCallbackApi, ServiceInboundApi
+from app.service.callback_rest import _validate_not_localhost
 from tests.app.db import create_service_callback_api, create_service_inbound_api
 
 
@@ -217,3 +218,77 @@ class TestSuspendCallbackApi:
         callback = ServiceCallbackApi.query.get(service_callback_api.id)
         assert callback.is_suspended is suspend_unsuspend
         assert callback.updated_by_id == sample_service.users[0].id
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://localhost/callback",
+        "https://localhost:8080/callback",
+        "https://127.0.0.1/callback",
+        "https://127.0.0.1:443/callback",
+        "https://[::1]/callback",
+        "https://sub.localhost/callback",
+    ],
+)
+def test_validate_not_localhost_rejects_localhost_urls(url):
+    from app.errors import InvalidRequest
+
+    with pytest.raises(InvalidRequest):
+        _validate_not_localhost(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://example.com/callback",
+        "https://my-service.gc.ca/callback",
+        None,
+    ],
+)
+def test_validate_not_localhost_allows_valid_urls(url):
+    _validate_not_localhost(url)  # should not raise
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://localhost/callback",
+        "https://127.0.0.1/callback",
+    ],
+)
+def test_create_inbound_api_rejects_localhost(admin_request, sample_service, url):
+    data = {
+        "url": url,
+        "bearer_token": "some-unique-string",
+        "updated_by_id": str(sample_service.users[0].id),
+    }
+    resp_json = admin_request.post(
+        "service_callback.create_service_inbound_api",
+        service_id=sample_service.id,
+        _data=data,
+        _expected_status=400,
+    )
+    assert "localhost" in resp_json["message"].lower()
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://localhost/callback",
+        "https://127.0.0.1/callback",
+    ],
+)
+def test_create_callback_api_rejects_localhost(admin_request, sample_service, url):
+    data = {
+        "url": url,
+        "bearer_token": "some-unique-string",
+        "updated_by_id": str(sample_service.users[0].id),
+    }
+    resp_json = admin_request.post(
+        "service_callback.create_service_callback_api",
+        service_id=sample_service.id,
+        _data=data,
+        _expected_status=400,
+    )
+    assert "localhost" in resp_json["message"].lower()

--- a/tests/app/service/test_callback_rest.py
+++ b/tests/app/service/test_callback_rest.py
@@ -225,9 +225,13 @@ class TestSuspendCallbackApi:
     [
         "https://localhost/callback",
         "https://localhost:8080/callback",
+        "https://localhost./callback",
         "https://127.0.0.1/callback",
         "https://127.0.0.1:443/callback",
+        "https://127.0.0.2/callback",
+        "https://127.255.255.255/callback",
         "https://[::1]/callback",
+        "https://[0:0:0:0:0:0:0:1]/callback",
         "https://sub.localhost/callback",
     ],
 )


### PR DESCRIPTION
# Summary | Résumé
This PR adds validation to prevent `localhost`, `127.0.0.1/8`,  and `.localhost` subdomains (that loopback to localhost) from being used when configuration notification callbacks.

# Test instructions | Instructions pour tester la modification
- [ ] CI is passing
- [ ] The related [admin PR](https://github.com/cds-snc/notification-admin/pull/2730) was tested and merged.