### PR TITLE
Add `manage_reports` API key permission

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1081,6 +1081,7 @@ class ApiKeyPermission(StrEnum):
     """
 
     MANAGE_TEMPLATES = "manage_templates"
+    MANAGE_REPORTS = "manage_reports"
 
 
 API_KEY_PERMISSION_TYPES: frozenset[str] = frozenset(p.value for p in ApiKeyPermission)

--- a/tests/app/dao/test_api_key_dao.py
+++ b/tests/app/dao/test_api_key_dao.py
@@ -286,6 +286,15 @@ class TestApiKeyPermissions:
         fetched = ApiKey.query.get(api_key.id)
         assert fetched.permissions == ["manage_templates"]
 
+    def test_can_persist_and_round_trip_manage_reports_permission(self, sample_service):
+        from app.models import API_KEY_PERMISSION_TYPES, ApiKeyPermission
+
+        assert "manage_reports" in API_KEY_PERMISSION_TYPES
+        api_key = self._make_key(sample_service, permissions=[ApiKeyPermission.MANAGE_REPORTS])
+        fetched = ApiKey.query.get(api_key.id)
+        assert fetched.permissions == ["manage_reports"]
+        assert fetched.has_permission("manage_reports") is True
+
     def test_unknown_permission_is_rejected(self, sample_service):
         with pytest.raises(ValueError, match="Invalid api key permission"):
             self._make_key(sample_service, permissions=["not_a_real_permission"])

--- a/tests/app/dao/test_api_key_dao.py
+++ b/tests/app/dao/test_api_key_dao.py
@@ -16,7 +16,7 @@ from app.dao.api_key_dao import (
     update_compromised_api_key_info,
     update_last_used_api_key,
 )
-from app.models import KEY_TYPE_NORMAL, ApiKey
+from app.models import API_KEY_PERMISSION_TYPES, KEY_TYPE_NORMAL, ApiKey, ApiKeyPermission
 from tests.app.db import create_api_key
 from tests.conftest import set_signer_secret_key
 
@@ -287,8 +287,6 @@ class TestApiKeyPermissions:
         assert fetched.permissions == ["manage_templates"]
 
     def test_can_persist_and_round_trip_manage_reports_permission(self, sample_service):
-        from app.models import API_KEY_PERMISSION_TYPES, ApiKeyPermission
-
         assert "manage_reports" in API_KEY_PERMISSION_TYPES
         api_key = self._make_key(sample_service, permissions=[ApiKeyPermission.MANAGE_REPORTS])
         fetched = ApiKey.query.get(api_key.id)


### PR DESCRIPTION
# Summary | Résumé

Add `MANAGE_REPORTS` to the `ApiKeyPermission` enum so it flows into API_KEY_PERMISSION_TYPES and the ApiKey.permissions validator, making 'manage_reports' a grantable key permission.

## Related Issues | Cartes liées

* Ref: cds-snc/notification-planning#3371

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.