### PR TITLE
Validate total attachment size

### DIFF
--- a/app/files/rest.py
+++ b/app/files/rest.py
@@ -51,6 +51,8 @@ GUARD_DUTY_STATUS_MAP = {
     "SKIPPED": FILE_STATUS_VIRUS_SCAN_FAILED,
 }
 
+MAX_TOTAL_FILE_SIZE = 6 * 1024 * 1024  # 6MB
+
 
 @files_blueprint.route("", methods=["POST"])
 def create_file(template_id):
@@ -71,6 +73,20 @@ def create_file(template_id):
     service = template.service
     check_service_has_permission(UPLOAD_DOCUMENT, service.permissions)
     validate_template_exists(template_id, service)
+
+    existing_files = dao_get_files_by_template_id(template_id)
+    existing_size = sum(f.file_size or 0 for f in existing_files)
+    total_size = existing_size + data["file_size"]
+    if total_size > MAX_TOTAL_FILE_SIZE:
+        raise InvalidRequest(
+            {
+                "error": "Total file size exceeds the 6MB limit.",
+                "current_usage": existing_size,
+                "requested": data["file_size"],
+                "limit": MAX_TOTAL_FILE_SIZE,
+            },
+            status_code=400,
+        )
 
     filename = data["name"]
     mime_type = data["mime_type"]

--- a/app/files/rest.py
+++ b/app/files/rest.py
@@ -76,25 +76,29 @@ def create_file(template_id):
 
     existing_files = dao_get_files_by_template_id(template_id)
     existing_size = sum(f.file_size or 0 for f in existing_files)
-    total_size = existing_size + data["file_size"]
-    if total_size > MAX_TOTAL_FILE_SIZE:
-        raise InvalidRequest(
-            {
-                "error": "Total file size exceeds the 6MB limit.",
-                "current_usage": existing_size,
-                "requested": data["file_size"],
-                "limit": MAX_TOTAL_FILE_SIZE,
-            },
-            status_code=400,
-        )
 
     filename = data["name"]
     mime_type = data["mime_type"]
     try:
         file_data = base64.b64decode(data["file_data"])
-        uploaded_file = document_download_client.upload_template_attachment(service.id, file_data, filename, mime_type)
     except (binascii.Error, ValueError):
         raise InvalidRequest("file_data is not valid base64", status_code=400)
+
+    actual_file_size = len(file_data)
+    total_size = existing_size + actual_file_size
+    if total_size > MAX_TOTAL_FILE_SIZE:
+        raise InvalidRequest(
+            {
+                "error": "Total file size exceeds the 6MB limit.",
+                "current_usage": existing_size,
+                "requested": actual_file_size,
+                "limit": MAX_TOTAL_FILE_SIZE,
+            },
+            status_code=400,
+        )
+
+    try:
+        uploaded_file = document_download_client.upload_template_attachment(service.id, file_data, filename, mime_type)
     except DocumentDownloadError as e:
         raise InvalidRequest(e.message, status_code=e.status_code)
 

--- a/app/files/rest.py
+++ b/app/files/rest.py
@@ -87,15 +87,14 @@ def create_file(template_id):
     actual_file_size = len(file_data)
     total_size = existing_size + actual_file_size
     if total_size > MAX_TOTAL_FILE_SIZE:
-        raise InvalidRequest(
+        return jsonify(
             {
-                "error": "Total file size exceeds the 6MB limit.",
+                "error": "over_file_limit",
                 "current_usage": existing_size,
                 "requested": actual_file_size,
                 "limit": MAX_TOTAL_FILE_SIZE,
-            },
-            status_code=400,
-        )
+            }
+        ), 400
 
     try:
         uploaded_file = document_download_client.upload_template_attachment(service.id, file_data, filename, mime_type)

--- a/tests/app/files/test_rest.py
+++ b/tests/app/files/test_rest.py
@@ -195,7 +195,7 @@ class TestCreateFile:
         )
 
     def test_create_file_returns_400_when_total_size_exceeds_6mb(
-        self, mocker, notify_db, notify_db_session, admin_request, sample_service_full_permissions
+        self, notify_db, notify_db_session, admin_request, sample_service_full_permissions
     ):
         from app.dao.files_dao import dao_create_file
         from app.files.rest import MAX_TOTAL_FILE_SIZE
@@ -218,7 +218,8 @@ class TestCreateFile:
         )
         dao_create_file(existing_file)
 
-        # Attempt to add a file that would push us over the limit
+        # file_data decodes to 1001 bytes, which exceeds the remaining 1000 byte budget
+        oversized_content = b"x" * 1001
         response = admin_request.post(
             "files.create_file",
             template_id=str(sample_template.id),
@@ -228,7 +229,7 @@ class TestCreateFile:
                 "name": "too_large.pdf",
                 "mime_type": "application/pdf",
                 "file_size": 1001,
-                "file_data": base64.b64encode(b"test content").decode("utf-8"),
+                "file_data": base64.b64encode(oversized_content).decode("utf-8"),
                 "created_by": current_user_id,
             },
             _expected_status=400,
@@ -263,7 +264,8 @@ class TestCreateFile:
         )
         dao_create_file(existing_file)
 
-        # Adding exactly 1000 bytes should succeed (total == 6MB exactly)
+        # Adding exactly 1000 bytes of actual content should succeed (total == 6MB exactly)
+        exact_content = b"x" * 1000
         admin_request.post(
             "files.create_file",
             template_id=str(sample_template.id),
@@ -273,21 +275,22 @@ class TestCreateFile:
                 "name": "fits.pdf",
                 "mime_type": "application/pdf",
                 "file_size": 1000,
-                "file_data": base64.b64encode(b"test content").decode("utf-8"),
+                "file_data": base64.b64encode(exact_content).decode("utf-8"),
                 "created_by": current_user_id,
             },
             _expected_status=201,
         )
 
     def test_create_file_returns_400_when_single_file_exceeds_6mb(
-        self, mocker, notify_db, notify_db_session, admin_request, sample_service_full_permissions
+        self, notify_db, notify_db_session, admin_request, sample_service_full_permissions
     ):
         from app.files.rest import MAX_TOTAL_FILE_SIZE
 
         sample_template = create_sample_template(notify_db, notify_db_session, service=sample_service_full_permissions)
         current_user_id = str(sample_template.service.users[0].id)
 
-        # A single file larger than 6MB should be rejected even with no existing files
+        # file_data decodes to MAX + 1 bytes, rejected even with no existing files
+        oversized_content = b"x" * (MAX_TOTAL_FILE_SIZE + 1)
         response = admin_request.post(
             "files.create_file",
             template_id=str(sample_template.id),
@@ -297,7 +300,7 @@ class TestCreateFile:
                 "name": "huge.pdf",
                 "mime_type": "application/pdf",
                 "file_size": MAX_TOTAL_FILE_SIZE + 1,
-                "file_data": base64.b64encode(b"test content").decode("utf-8"),
+                "file_data": base64.b64encode(oversized_content).decode("utf-8"),
                 "created_by": current_user_id,
             },
             _expected_status=400,

--- a/tests/app/files/test_rest.py
+++ b/tests/app/files/test_rest.py
@@ -194,6 +194,161 @@ class TestCreateFile:
             _expected_status=403,
         )
 
+    def test_create_file_returns_400_when_total_size_exceeds_6mb(
+        self, mocker, notify_db, notify_db_session, admin_request, sample_service_full_permissions
+    ):
+        from app.dao.files_dao import dao_create_file
+        from app.files.rest import MAX_TOTAL_FILE_SIZE
+        from app.models import FILE_STATUS_PENDING_VIRUS_SCAN, Files
+
+        sample_template = create_sample_template(notify_db, notify_db_session, service=sample_service_full_permissions)
+        current_user_id = str(sample_template.service.users[0].id)
+
+        # Create an existing file that uses most of the 6MB budget
+        existing_file = Files(
+            template_id=sample_template.id,
+            service_id=sample_service_full_permissions.id,
+            document_id=uuid.uuid4(),
+            type="attach",
+            name="existing.pdf",
+            mime_type="application/pdf",
+            file_size=MAX_TOTAL_FILE_SIZE - 1000,
+            status=FILE_STATUS_PENDING_VIRUS_SCAN,
+            created_by_id=current_user_id,
+        )
+        dao_create_file(existing_file)
+
+        # Attempt to add a file that would push us over the limit
+        response = admin_request.post(
+            "files.create_file",
+            template_id=str(sample_template.id),
+            _data={
+                "template_id": str(sample_template.id),
+                "type": "attach",
+                "name": "too_large.pdf",
+                "mime_type": "application/pdf",
+                "file_size": 1001,
+                "file_data": base64.b64encode(b"test content").decode("utf-8"),
+                "created_by": current_user_id,
+            },
+            _expected_status=400,
+        )
+        assert response["message"]["error"] == "Total file size exceeds the 6MB limit."
+        assert response["message"]["current_usage"] == MAX_TOTAL_FILE_SIZE - 1000
+        assert response["message"]["requested"] == 1001
+        assert response["message"]["limit"] == MAX_TOTAL_FILE_SIZE
+
+    def test_create_file_succeeds_when_total_size_exactly_at_6mb(
+        self, mocker, notify_db, notify_db_session, admin_request, sample_service_full_permissions
+    ):
+        from app.dao.files_dao import dao_create_file
+        from app.files.rest import MAX_TOTAL_FILE_SIZE
+        from app.models import FILE_STATUS_PENDING_VIRUS_SCAN, Files
+
+        _mock_upload_template_attachment(mocker)
+        sample_template = create_sample_template(notify_db, notify_db_session, service=sample_service_full_permissions)
+        current_user_id = str(sample_template.service.users[0].id)
+
+        # Create an existing file
+        existing_file = Files(
+            template_id=sample_template.id,
+            service_id=sample_service_full_permissions.id,
+            document_id=uuid.uuid4(),
+            type="attach",
+            name="existing.pdf",
+            mime_type="application/pdf",
+            file_size=MAX_TOTAL_FILE_SIZE - 1000,
+            status=FILE_STATUS_PENDING_VIRUS_SCAN,
+            created_by_id=current_user_id,
+        )
+        dao_create_file(existing_file)
+
+        # Adding exactly 1000 bytes should succeed (total == 6MB exactly)
+        admin_request.post(
+            "files.create_file",
+            template_id=str(sample_template.id),
+            _data={
+                "template_id": str(sample_template.id),
+                "type": "attach",
+                "name": "fits.pdf",
+                "mime_type": "application/pdf",
+                "file_size": 1000,
+                "file_data": base64.b64encode(b"test content").decode("utf-8"),
+                "created_by": current_user_id,
+            },
+            _expected_status=201,
+        )
+
+    def test_create_file_returns_400_when_single_file_exceeds_6mb(
+        self, mocker, notify_db, notify_db_session, admin_request, sample_service_full_permissions
+    ):
+        from app.files.rest import MAX_TOTAL_FILE_SIZE
+
+        sample_template = create_sample_template(notify_db, notify_db_session, service=sample_service_full_permissions)
+        current_user_id = str(sample_template.service.users[0].id)
+
+        # A single file larger than 6MB should be rejected even with no existing files
+        response = admin_request.post(
+            "files.create_file",
+            template_id=str(sample_template.id),
+            _data={
+                "template_id": str(sample_template.id),
+                "type": "attach",
+                "name": "huge.pdf",
+                "mime_type": "application/pdf",
+                "file_size": MAX_TOTAL_FILE_SIZE + 1,
+                "file_data": base64.b64encode(b"test content").decode("utf-8"),
+                "created_by": current_user_id,
+            },
+            _expected_status=400,
+        )
+        assert response["message"]["error"] == "Total file size exceeds the 6MB limit."
+        assert response["message"]["current_usage"] == 0
+        assert response["message"]["requested"] == MAX_TOTAL_FILE_SIZE + 1
+        assert response["message"]["limit"] == MAX_TOTAL_FILE_SIZE
+
+    def test_create_file_ignores_archived_files_in_size_calculation(
+        self, mocker, notify_db, notify_db_session, admin_request, sample_service_full_permissions
+    ):
+        from app.dao.files_dao import dao_archive_file, dao_create_file
+        from app.files.rest import MAX_TOTAL_FILE_SIZE
+        from app.models import FILE_STATUS_PENDING_VIRUS_SCAN, Files
+
+        _mock_upload_template_attachment(mocker)
+        sample_template = create_sample_template(notify_db, notify_db_session, service=sample_service_full_permissions)
+        current_user_id = str(sample_template.service.users[0].id)
+
+        # Create a large file and archive it
+        archived_file = Files(
+            template_id=sample_template.id,
+            service_id=sample_service_full_permissions.id,
+            document_id=uuid.uuid4(),
+            type="attach",
+            name="archived.pdf",
+            mime_type="application/pdf",
+            file_size=MAX_TOTAL_FILE_SIZE,
+            status=FILE_STATUS_PENDING_VIRUS_SCAN,
+            created_by_id=current_user_id,
+        )
+        dao_create_file(archived_file)
+        dao_archive_file(archived_file)
+
+        # Should succeed because archived files don't count toward the limit
+        admin_request.post(
+            "files.create_file",
+            template_id=str(sample_template.id),
+            _data={
+                "template_id": str(sample_template.id),
+                "type": "attach",
+                "name": "new.pdf",
+                "mime_type": "application/pdf",
+                "file_size": 1000,
+                "file_data": base64.b64encode(b"test content").decode("utf-8"),
+                "created_by": current_user_id,
+            },
+            _expected_status=201,
+        )
+
 
 class TestGetFile:
     def test_get_file_status(self, admin_request, sample_file):

--- a/tests/app/files/test_rest.py
+++ b/tests/app/files/test_rest.py
@@ -234,10 +234,10 @@ class TestCreateFile:
             },
             _expected_status=400,
         )
-        assert response["message"]["error"] == "Total file size exceeds the 6MB limit."
-        assert response["message"]["current_usage"] == MAX_TOTAL_FILE_SIZE - 1000
-        assert response["message"]["requested"] == 1001
-        assert response["message"]["limit"] == MAX_TOTAL_FILE_SIZE
+        assert response["error"] == "over_file_limit"
+        assert response["current_usage"] == MAX_TOTAL_FILE_SIZE - 1000
+        assert response["requested"] == 1001
+        assert response["limit"] == MAX_TOTAL_FILE_SIZE
 
     def test_create_file_succeeds_when_total_size_exactly_at_6mb(
         self, mocker, notify_db, notify_db_session, admin_request, sample_service_full_permissions
@@ -305,10 +305,10 @@ class TestCreateFile:
             },
             _expected_status=400,
         )
-        assert response["message"]["error"] == "Total file size exceeds the 6MB limit."
-        assert response["message"]["current_usage"] == 0
-        assert response["message"]["requested"] == MAX_TOTAL_FILE_SIZE + 1
-        assert response["message"]["limit"] == MAX_TOTAL_FILE_SIZE
+        assert response["error"] == "over_file_limit"
+        assert response["current_usage"] == 0
+        assert response["requested"] == MAX_TOTAL_FILE_SIZE + 1
+        assert response["limit"] == MAX_TOTAL_FILE_SIZE
 
     def test_create_file_ignores_archived_files_in_size_calculation(
         self, mocker, notify_db, notify_db_session, admin_request, sample_service_full_permissions


### PR DESCRIPTION
# Summary | Résumé

This PR adds additional defensive validation to `files/rest.py::create_file` that ensures total file attachment size does not exceed 6MB. It takes the size of the newly requested file + existing file attachments into account. The `InvalidRequest` raised returns data to aid in constructing an appropriate error message on the front end.

```
{
  "error": "Total file size exceeds the 6MB limit.",
  "current_usage": existing_size,
  "requested": data["file_size"],
  "limit": MAX_TOTAL_FILE_SIZE,
}
```

## Related Issues | Cartes liées

Bug bash issue: https://docs.google.com/document/d/1m_EzXNJbqjJH-WLzxRKMtO4k5CAHwk51uCXi7xJQR44/edit?tab=t.0#task=NbqwOoo-dIWUUrb0

# Test instructions | Instructions pour tester la modification
1. Hook your local up to staging
2. Add a few files to a template eventually adding one that would put you over the 6Mb limit
3. Note that the file isn't attached (currently nothing will happen, no error message yet as it needs to be caught in the front end and displayed)

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.