### PR TITLE
Add the `POST` `v2/reports` api endpoint behind a feature flag

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -340,6 +340,10 @@ def register_v2_blueprints(application):
         post_notifications,
         v2_notification_blueprint,
     )
+    from app.v2.reports import (  # noqa
+        post_reports,
+        v2_reports_blueprint,
+    )
     from app.v2.template import (  # noqa
         get_template,
         post_template,
@@ -358,6 +362,9 @@ def register_v2_blueprints(application):
     register_notify_blueprint(application, get_inbound_sms, requires_auth)
 
     register_notify_blueprint(application, v2_api_spec_blueprint, requires_no_auth)
+
+    if application.config["FF_REPORT_API"]:
+        register_notify_blueprint(application, v2_reports_blueprint, requires_auth)
 
 
 def init_app(app):

--- a/app/config.py
+++ b/app/config.py
@@ -186,6 +186,8 @@ class Config(object):
     FF_CLOUDWATCH_METRICS_ENABLED = env.bool("FF_CLOUDWATCH_METRICS_ENABLED", False)
     FF_IMPROVE_CELERY_WORKER_ISOLATION = env.bool("FF_IMPROVE_CELERY_WORKER_ISOLATION", False)
     FF_PT_SERVICE_SKIP_FRESHDESK = env.bool("FF_PT_SERVICE_SKIP_FRESHDESK", False)
+    # Enables the /v2/reports API endpoints. Off by default so the feature stays hidden in production until launch.
+    FF_REPORT_API = env.bool("FF_REPORT_API", False)
     FF_SALESFORCE_CONTACT = env.bool("FF_SALESFORCE_CONTACT", False)
     FF_SMS_RATELIMIT = env.bool("FF_SMS_RATELIMIT", False)
     FF_USE_BILLABLE_UNITS = env.bool("FF_USE_BILLABLE_UNITS", False)
@@ -811,6 +813,7 @@ class Test(Development):
     FAILED_LOGIN_LIMIT = 0
     GC_ORGANISATIONS_BUCKET_NAME = "test-gc-organisations"
     FF_USE_BILLABLE_UNITS = True
+    FF_REPORT_API = True
 
 
 class Production(Config):

--- a/app/v2/reports/__init__.py
+++ b/app/v2/reports/__init__.py
@@ -1,0 +1,7 @@
+from flask import Blueprint
+
+from app.v2.errors import register_errors
+
+v2_reports_blueprint = Blueprint("v2_reports", __name__, url_prefix="/v2/reports")
+
+register_errors(v2_reports_blueprint)

--- a/app/v2/reports/post_reports.py
+++ b/app/v2/reports/post_reports.py
@@ -22,6 +22,7 @@ def post_report():
         service_id=authenticated_service.id,
         status=ReportStatus.REQUESTED.value,
         requesting_user_id=None,
+        job_id=data.get("job_id"),
     )
     created_report = create_report(report)
 

--- a/app/v2/reports/post_reports.py
+++ b/app/v2/reports/post_reports.py
@@ -28,8 +28,7 @@ def post_report():
     created_report = create_report(report)
 
     current_app.logger.info(f"Report {created_report.id} requested via API for service {authenticated_service.id}")
-    generate_report.apply_async([created_report.id, []], queue=QueueNames.GENERATE_REPORTS)
-
+    generate_report.apply_async([str(created_report.id), []], queue=QueueNames.GENERATE_REPORTS)
     response = jsonify(report_id=str(created_report.id), status=created_report.status)
     response.status_code = 202
     response.headers["Location"] = f"/v2/reports/{created_report.id}"

--- a/app/v2/reports/post_reports.py
+++ b/app/v2/reports/post_reports.py
@@ -22,6 +22,7 @@ def post_report():
         service_id=authenticated_service.id,
         status=ReportStatus.REQUESTED.value,
         requesting_user_id=None,
+        language=data["language"],
         job_id=data.get("job_id"),
     )
     created_report = create_report(report)

--- a/app/v2/reports/post_reports.py
+++ b/app/v2/reports/post_reports.py
@@ -1,0 +1,34 @@
+import uuid
+
+from flask import current_app, jsonify, request
+
+from app import authenticated_service
+from app.celery.tasks import generate_report
+from app.config import QueueNames
+from app.dao.reports_dao import create_report
+from app.models import Report, ReportStatus
+from app.schema_validation import validate
+from app.v2.reports import v2_reports_blueprint
+from app.v2.reports.report_schemas import post_report_request
+
+
+@v2_reports_blueprint.route("", methods=["POST"])
+def post_report():
+    data = validate(request.get_json(), post_report_request)
+
+    report = Report(
+        id=uuid.uuid4(),
+        report_type=data["report_type"],
+        service_id=authenticated_service.id,
+        status=ReportStatus.REQUESTED.value,
+        requesting_user_id=None,
+    )
+    created_report = create_report(report)
+
+    current_app.logger.info(f"Report {created_report.id} requested via API for service {authenticated_service.id}")
+    generate_report.apply_async([created_report.id, []], queue=QueueNames.GENERATE_REPORTS)
+
+    response = jsonify(report_id=str(created_report.id), status=created_report.status)
+    response.status_code = 202
+    response.headers["Location"] = f"/v2/reports/{created_report.id}"
+    return response

--- a/app/v2/reports/report_schemas.py
+++ b/app/v2/reports/report_schemas.py
@@ -8,9 +8,10 @@ post_report_request = {
     "title": "POST v2/reports request",
     "properties": {
         "report_type": {"type": "string", "enum": [rt.value for rt in ReportType]},
+        "language": {"type": "string", "enum": ["en", "fr"]},
         "job_id": nullable_uuid,
     },
-    "required": ["report_type"],
+    "required": ["report_type", "language"],
     "additionalProperties": False,
     "if": {"properties": {"report_type": {"const": "job"}}},
     "then": {"required": ["job_id"]},

--- a/app/v2/reports/report_schemas.py
+++ b/app/v2/reports/report_schemas.py
@@ -1,4 +1,5 @@
 from app.models import ReportType
+from app.schema_validation.definitions import nullable_uuid
 
 post_report_request = {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -7,7 +8,10 @@ post_report_request = {
     "title": "POST v2/reports request",
     "properties": {
         "report_type": {"type": "string", "enum": [rt.value for rt in ReportType]},
+        "job_id": nullable_uuid,
     },
     "required": ["report_type"],
     "additionalProperties": False,
+    "if": {"properties": {"report_type": {"const": "job"}}},
+    "then": {"required": ["job_id"]},
 }

--- a/app/v2/reports/report_schemas.py
+++ b/app/v2/reports/report_schemas.py
@@ -1,5 +1,6 @@
 from app.models import ReportType
-from app.schema_validation.definitions import nullable_uuid, uuid as uuid_schema
+from app.schema_validation.definitions import nullable_uuid
+from app.schema_validation.definitions import uuid as uuid_schema
 
 post_report_request = {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/app/v2/reports/report_schemas.py
+++ b/app/v2/reports/report_schemas.py
@@ -1,5 +1,5 @@
 from app.models import ReportType
-from app.schema_validation.definitions import nullable_uuid
+from app.schema_validation.definitions import nullable_uuid, uuid as uuid_schema
 
 post_report_request = {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -13,6 +13,6 @@ post_report_request = {
     },
     "required": ["report_type", "language"],
     "additionalProperties": False,
-    "if": {"properties": {"report_type": {"const": "job"}}},
-    "then": {"required": ["job_id"]},
+    "if": {"properties": {"report_type": {"const": "job"}}, "required": ["report_type"]},
+    "then": {"properties": {"job_id": uuid_schema}, "required": ["job_id"]},
 }

--- a/app/v2/reports/report_schemas.py
+++ b/app/v2/reports/report_schemas.py
@@ -1,0 +1,13 @@
+from app.models import ReportType
+
+post_report_request = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "POST v2 report request schema",
+    "type": "object",
+    "title": "POST v2/reports request",
+    "properties": {
+        "report_type": {"type": "string", "enum": [rt.value for rt in ReportType]},
+    },
+    "required": ["report_type"],
+    "additionalProperties": False,
+}

--- a/tests/app/v2/reports/test_post_reports.py
+++ b/tests/app/v2/reports/test_post_reports.py
@@ -31,6 +31,34 @@ def test_post_report_returns_202(client, sample_service, mocker):
     mock_task.assert_called_once()
 
 
+def test_post_job_report_requires_job_id(client, sample_service, mocker):
+    mocker.patch("app.v2.reports.post_reports.generate_report.apply_async")
+    auth_header = create_authorization_header(service_id=sample_service.id)
+
+    response = client.post(
+        path="/v2/reports",
+        data=json.dumps({"report_type": "job"}),
+        headers=[("Content-Type", "application/json"), auth_header],
+    )
+
+    assert response.status_code == 400
+
+
+def test_post_job_report_with_job_id_returns_202(client, sample_job, mocker):
+    mocker.patch("app.v2.reports.post_reports.generate_report.apply_async")
+    auth_header = create_authorization_header(service_id=sample_job.service_id)
+
+    response = client.post(
+        path="/v2/reports",
+        data=json.dumps({"report_type": "job", "job_id": str(sample_job.id)}),
+        headers=[("Content-Type", "application/json"), auth_header],
+    )
+
+    assert response.status_code == 202
+    report = get_report_by_id(json.loads(response.get_data(as_text=True))["report_id"])
+    assert str(report.job_id) == str(sample_job.id)
+
+
 def test_post_report_rejects_invalid_report_type(client, sample_service, mocker):
     mocker.patch("app.v2.reports.post_reports.generate_report.apply_async")
     auth_header = create_authorization_header(service_id=sample_service.id)

--- a/tests/app/v2/reports/test_post_reports.py
+++ b/tests/app/v2/reports/test_post_reports.py
@@ -1,0 +1,54 @@
+import json
+
+from app.config import configs
+from app.dao.reports_dao import get_report_by_id
+from app.models import ReportStatus
+from tests import create_authorization_header
+
+
+def test_report_api_disabled_by_default_in_production():
+    # The feature must stay hidden in production unless FF_REPORT_API is explicitly enabled.
+    assert configs["production"].FF_REPORT_API is False
+
+
+def test_post_report_returns_202(client, sample_service, mocker):
+    mock_task = mocker.patch("app.v2.reports.post_reports.generate_report.apply_async")
+    auth_header = create_authorization_header(service_id=sample_service.id)
+
+    response = client.post(
+        path="/v2/reports",
+        data=json.dumps({"report_type": "email"}),
+        headers=[("Content-Type", "application/json"), auth_header],
+    )
+
+    assert response.status_code == 202
+    resp_json = json.loads(response.get_data(as_text=True))
+    report = get_report_by_id(resp_json["report_id"])
+    assert str(report.service_id) == str(sample_service.id)
+    assert report.status == ReportStatus.REQUESTED.value
+    assert report.requesting_user_id is None
+    assert response.headers["Location"] == f"/v2/reports/{report.id}"
+    mock_task.assert_called_once()
+
+
+def test_post_report_rejects_invalid_report_type(client, sample_service, mocker):
+    mocker.patch("app.v2.reports.post_reports.generate_report.apply_async")
+    auth_header = create_authorization_header(service_id=sample_service.id)
+
+    response = client.post(
+        path="/v2/reports",
+        data=json.dumps({"report_type": "invalid"}),
+        headers=[("Content-Type", "application/json"), auth_header],
+    )
+
+    assert response.status_code == 400
+
+
+def test_post_report_requires_authentication(client):
+    response = client.post(
+        path="/v2/reports",
+        data=json.dumps({"report_type": "email"}),
+        headers=[("Content-Type", "application/json")],
+    )
+
+    assert response.status_code == 401

--- a/tests/app/v2/reports/test_post_reports.py
+++ b/tests/app/v2/reports/test_post_reports.py
@@ -29,7 +29,7 @@ def test_post_report_returns_202(client, sample_service, mocker):
     assert report.requesting_user_id is None
     assert report.language == "en"
     assert response.headers["Location"] == f"/v2/reports/{report.id}"
-    mock_task.assert_called_once()
+    mock_task.assert_called_once_with([str(report.id), []], queue="generate-reports")
 
 
 def test_post_report_requires_language(client, sample_service, mocker):

--- a/tests/app/v2/reports/test_post_reports.py
+++ b/tests/app/v2/reports/test_post_reports.py
@@ -17,7 +17,7 @@ def test_post_report_returns_202(client, sample_service, mocker):
 
     response = client.post(
         path="/v2/reports",
-        data=json.dumps({"report_type": "email"}),
+        data=json.dumps({"report_type": "email", "language": "en"}),
         headers=[("Content-Type", "application/json"), auth_header],
     )
 
@@ -27,8 +27,35 @@ def test_post_report_returns_202(client, sample_service, mocker):
     assert str(report.service_id) == str(sample_service.id)
     assert report.status == ReportStatus.REQUESTED.value
     assert report.requesting_user_id is None
+    assert report.language == "en"
     assert response.headers["Location"] == f"/v2/reports/{report.id}"
     mock_task.assert_called_once()
+
+
+def test_post_report_requires_language(client, sample_service, mocker):
+    mocker.patch("app.v2.reports.post_reports.generate_report.apply_async")
+    auth_header = create_authorization_header(service_id=sample_service.id)
+
+    response = client.post(
+        path="/v2/reports",
+        data=json.dumps({"report_type": "email"}),
+        headers=[("Content-Type", "application/json"), auth_header],
+    )
+
+    assert response.status_code == 400
+
+
+def test_post_report_rejects_invalid_language(client, sample_service, mocker):
+    mocker.patch("app.v2.reports.post_reports.generate_report.apply_async")
+    auth_header = create_authorization_header(service_id=sample_service.id)
+
+    response = client.post(
+        path="/v2/reports",
+        data=json.dumps({"report_type": "email", "language": "es"}),
+        headers=[("Content-Type", "application/json"), auth_header],
+    )
+
+    assert response.status_code == 400
 
 
 def test_post_job_report_requires_job_id(client, sample_service, mocker):
@@ -37,7 +64,7 @@ def test_post_job_report_requires_job_id(client, sample_service, mocker):
 
     response = client.post(
         path="/v2/reports",
-        data=json.dumps({"report_type": "job"}),
+        data=json.dumps({"report_type": "job", "language": "en"}),
         headers=[("Content-Type", "application/json"), auth_header],
     )
 
@@ -50,7 +77,7 @@ def test_post_job_report_with_job_id_returns_202(client, sample_job, mocker):
 
     response = client.post(
         path="/v2/reports",
-        data=json.dumps({"report_type": "job", "job_id": str(sample_job.id)}),
+        data=json.dumps({"report_type": "job", "language": "en", "job_id": str(sample_job.id)}),
         headers=[("Content-Type", "application/json"), auth_header],
     )
 
@@ -65,7 +92,7 @@ def test_post_report_rejects_invalid_report_type(client, sample_service, mocker)
 
     response = client.post(
         path="/v2/reports",
-        data=json.dumps({"report_type": "invalid"}),
+        data=json.dumps({"report_type": "invalid", "language": "en"}),
         headers=[("Content-Type", "application/json"), auth_header],
     )
 


### PR DESCRIPTION
# Summary | Résumé

Add the `POST` `v2/reports` api endpoint behind a new feature flag `FF_REPORT_API`. This is the endpoint for creating/requesting reports, both for the last 7 days and for jobs. The PR also adds a schema to validate the posted data: language, job_id, and report_type.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/3371

# Test instructions | Instructions pour tester la modification

1. check out branch
2. add `FF_REPORT_API=true` to your .env file
3. `make run`
4. test out the new endpoint with the following curl request:
```
curl -X POST "http://localhost:6011/v2/reports" \
  -H "Authorization: ApiKey-v1 YOUR_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"report_type": "email", "language": "en"}'
```
5. verify that you see a new report created on your reports page: `http://localhost:6012/services/your-service-id/reports`

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.