### PR TITLE
Add `UPLOAD_DOCUMENT` to default service perms

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -29,6 +29,7 @@ from app.models import (
     NHS_ORGANISATION_TYPES,
     NON_CROWN_ORGANISATION_TYPES,
     SMS_TYPE,
+    UPLOAD_DOCUMENT,
     AnnualBilling,
     ApiKey,
     FactBilling,
@@ -61,6 +62,7 @@ DEFAULT_SERVICE_PERMISSIONS = [
     SMS_TYPE,
     EMAIL_TYPE,
     INTERNATIONAL_SMS_TYPE,
+    UPLOAD_DOCUMENT,
 ]
 
 

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -54,6 +54,7 @@ from app.models import (
     KEY_TYPE_TEST,
     LETTER_TYPE,
     SMS_TYPE,
+    UPLOAD_DOCUMENT,
     ApiKey,
     InvitedUser,
     Job,
@@ -646,6 +647,7 @@ def test_create_service_returns_service_with_default_permissions(notify_db_sessi
             SMS_TYPE,
             EMAIL_TYPE,
             INTERNATIONAL_SMS_TYPE,
+            UPLOAD_DOCUMENT,
         ),
     )
 
@@ -658,14 +660,12 @@ def test_create_service_returns_service_with_default_permissions(notify_db_sessi
             (
                 EMAIL_TYPE,
                 INTERNATIONAL_SMS_TYPE,
+                UPLOAD_DOCUMENT,
             ),
         ),
         (
             EMAIL_TYPE,
-            (
-                SMS_TYPE,
-                INTERNATIONAL_SMS_TYPE,
-            ),
+            (SMS_TYPE, INTERNATIONAL_SMS_TYPE, UPLOAD_DOCUMENT),
         ),
     ],
 )
@@ -699,7 +699,7 @@ def test_create_service_by_id_adding_and_removing_letter_returns_service_without
     dao_add_service_permission(service_id=service.id, permission=LETTER_TYPE)
 
     service = dao_fetch_service_by_id(service.id)
-    _assert_service_permissions(service.permissions, (SMS_TYPE, EMAIL_TYPE, INTERNATIONAL_SMS_TYPE, LETTER_TYPE))
+    _assert_service_permissions(service.permissions, (SMS_TYPE, EMAIL_TYPE, INTERNATIONAL_SMS_TYPE, LETTER_TYPE, UPLOAD_DOCUMENT))
 
     dao_remove_service_permission(service_id=service.id, permission=LETTER_TYPE)
     service = dao_fetch_service_by_id(service.id)
@@ -710,6 +710,7 @@ def test_create_service_by_id_adding_and_removing_letter_returns_service_without
             SMS_TYPE,
             EMAIL_TYPE,
             INTERNATIONAL_SMS_TYPE,
+            UPLOAD_DOCUMENT,
         ),
     )
 
@@ -862,6 +863,7 @@ def test_delete_service_and_associated_objects(notify_db_session):
             SMS_TYPE,
             EMAIL_TYPE,
             INTERNATIONAL_SMS_TYPE,
+            UPLOAD_DOCUMENT,
         )
     )
 

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -33,6 +33,7 @@ from app.models import (
     KEY_TYPE_TEST,
     LETTER_TYPE,
     SMS_TYPE,
+    UPLOAD_DOCUMENT,
     EmailBranding,
     InboundNumber,
     Notification,
@@ -295,6 +296,7 @@ def test_get_service_list_has_default_permissions(admin_request, service_factory
                 EMAIL_TYPE,
                 SMS_TYPE,
                 INTERNATIONAL_SMS_TYPE,
+                UPLOAD_DOCUMENT,
             ]
         )
         for json in json_resp["data"]
@@ -309,6 +311,7 @@ def test_get_service_by_id_has_default_service_permissions(admin_request, sample
             EMAIL_TYPE,
             SMS_TYPE,
             INTERNATIONAL_SMS_TYPE,
+            UPLOAD_DOCUMENT,
         ]
     )
 


### PR DESCRIPTION
# Summary | Résumé
This PR adds the `upload_document` setting to the list of default enabled service settings. 

## Related Issues | Cartes liées

* https://docs.google.com/document/d/1m_EzXNJbqjJH-WLzxRKMtO4k5CAHwk51uCXi7xJQR44/edit?pli=1&tab=t.0#task=doULW0OCbF-OneiL

# Test instructions | Instructions pour tester la modification
1. Create a new service
2. Navigate to the service settings
- [ ] Note that the `Send files by email` setting is enabled by default

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.