### PR TITLE
Update with the utils concurrency fix, add tests 

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -46,6 +46,9 @@ ignore_missing_imports = True
 [mypy-pytest_mock.*]
 ignore_missing_imports = True
 
+[mypy-mistune.*]
+ignore_missing_imports = True
+
 [mypy-tests.app.aws.test_s3]
 ignore_missing_imports = True
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2861,7 +2861,7 @@ requests = ">=2.0.0"
 
 [[package]]
 name = "notifications-utils"
-version = "53.2.29"
+version = "53.2.30"
 description = "Shared python code for Notification - Provides logging utils etc."
 optional = false
 python-versions = "~3.12.7"
@@ -2897,8 +2897,8 @@ werkzeug = "3.1.6"
 [package.source]
 type = "git"
 url = "https://github.com/cds-snc/notifier-utils.git"
-reference = "53.2.29"
-resolved_reference = "a58115657654e6037c598fee1e0a592929c37400"
+reference = "fix/mistune-concurrency-issues"
+resolved_reference = "cb751ff3ebf74347be4e15de3dbfb3a9a564a609"
 
 [[package]]
 name = "opentelemetry-api"
@@ -5212,4 +5212,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.12.7"
-content-hash = "8d40c2da7b0dfdbc6a9de22735d1fa721dac5dbbeb2fdbef874534fe685805b0"
+content-hash = "58619e9765a0031e34ba8bac94303018d32679eb48f03c7715d41b3c4afdc8a7"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2897,8 +2897,8 @@ werkzeug = "3.1.6"
 [package.source]
 type = "git"
 url = "https://github.com/cds-snc/notifier-utils.git"
-reference = "fix/mistune-concurrency-issues"
-resolved_reference = "cb751ff3ebf74347be4e15de3dbfb3a9a564a609"
+reference = "53.2.30"
+resolved_reference = "21a241b6697ce07da316bd5c435298d76380ba71"
 
 [[package]]
 name = "opentelemetry-api"
@@ -5212,4 +5212,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.12.7"
-content-hash = "58619e9765a0031e34ba8bac94303018d32679eb48f03c7715d41b3c4afdc8a7"
+content-hash = "c9df9eaa2ffd8164338acd493441c2c2b54a2ced6d6b3c80e0526364b01e9282"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ opentelemetry-instrumentation-celery = "0.55b1"
 opentelemetry-instrumentation-flask = "0.55b1"
 opentelemetry-instrumentation-redis = "0.55b1"
 opentelemetry-instrumentation-sqlalchemy = "0.55b1"
-notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", tag="53.2.29"}
+notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", branch="fix/mistune-concurrency-issues"}
 pre-commit = "^3.7.1"
 psycopg2-binary = "2.9.11"
 pwnedpasswords = "2.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ opentelemetry-instrumentation-celery = "0.55b1"
 opentelemetry-instrumentation-flask = "0.55b1"
 opentelemetry-instrumentation-redis = "0.55b1"
 opentelemetry-instrumentation-sqlalchemy = "0.55b1"
-notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", branch="fix/mistune-concurrency-issues"}
+notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", tag="53.2.30"}
 pre-commit = "^3.7.1"
 psycopg2-binary = "2.9.11"
 pwnedpasswords = "2.0.0"

--- a/tests/app/test_markdown_concurrency.py
+++ b/tests/app/test_markdown_concurrency.py
@@ -1,0 +1,104 @@
+"""
+Regression tests for the mistune concurrency bug.
+
+Mistune 0.8.x Markdown instances hold mutable parse state and are not thread-safe.
+The fix in notification-utils uses threading.local so each thread gets its own
+parser instance. These tests verify that rendering email templates concurrently
+(as Celery workers do) does not produce corrupted output or raise exceptions.
+
+See: fix/mistune-concurrency-issues in notification-utils
+"""
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import pytest
+from notifications_utils.template import HTMLEmailTemplate, PlainTextEmailTemplate
+
+TEMPLATE_SAMPLES = [
+    {
+        "content": "Hello there",
+        "subject": "Simple subject",
+    },
+    {
+        "content": "# Heading\n\nA paragraph with **bold** text.",
+        "subject": "Markdown subject",
+    },
+    {
+        "content": "Here is a list:\n\n* item one\n* item two\n* item three\n",
+        "subject": "List email",
+    },
+    {
+        "content": "Line one\n\nLine two\n\nLine three",
+        "subject": "Multi paragraph",
+    },
+    {
+        "content": "Visit https://example.com for more info.\n\nThanks.",
+        "subject": "Link email",
+    },
+]
+
+
+def _render_html(i):
+    template_dict = TEMPLATE_SAMPLES[i % len(TEMPLATE_SAMPLES)]
+    return str(HTMLEmailTemplate({"content": template_dict["content"], "subject": template_dict["subject"]}))
+
+
+def _render_plain_text(i):
+    template_dict = TEMPLATE_SAMPLES[i % len(TEMPLATE_SAMPLES)]
+    return str(PlainTextEmailTemplate({"content": template_dict["content"], "subject": template_dict["subject"]}))
+
+
+@pytest.mark.parametrize(
+    "render_fn, expected_count",
+    [
+        (_render_html, 200),
+        (_render_plain_text, 200),
+    ],
+    ids=["HTMLEmailTemplate", "PlainTextEmailTemplate"],
+)
+def test_email_template_rendering_is_safe_under_concurrency(render_fn, expected_count):
+    """
+    Verify that rendering email templates from multiple threads concurrently does
+    not raise exceptions or produce corrupted results.
+
+    Before the fix, shared Mistune Markdown instances caused token-mismatch errors
+    under concurrent load (e.g. from Celery workers).
+    """
+    with ThreadPoolExecutor(max_workers=16) as executor:
+        futures = [executor.submit(render_fn, i) for i in range(expected_count)]
+        results = [f.result() for f in as_completed(futures)]
+
+    assert len(results) == expected_count
+    assert all(isinstance(r, str) and len(r) > 0 for r in results)
+
+
+def test_html_email_template_concurrent_output_is_deterministic():
+    """
+    The same input must always produce the same HTML output regardless of
+    which thread renders it.
+    """
+    template_dict = {"content": "# Hello\n\nThis is **important**.", "subject": "Test"}
+
+    def render(_):
+        return str(HTMLEmailTemplate(template_dict))
+
+    with ThreadPoolExecutor(max_workers=16) as executor:
+        results = list(executor.map(render, range(100)))
+
+    assert len(set(results)) == 1, "Concurrent renders produced different HTML outputs"
+
+
+def test_plain_text_email_template_concurrent_output_is_deterministic():
+    """
+    The same input must always produce the same plain-text output regardless of
+    which thread renders it.
+    """
+    template_dict = {"content": "# Hello\n\nThis is **important**.", "subject": "Test"}
+
+    def render(_):
+        return str(PlainTextEmailTemplate(template_dict))
+
+    with ThreadPoolExecutor(max_workers=16) as executor:
+        results = list(executor.map(render, range(100)))
+
+    assert len(set(results)) == 1, "Concurrent renders produced different plain-text outputs"

--- a/tests/app/test_markdown_concurrency.py
+++ b/tests/app/test_markdown_concurrency.py
@@ -2,103 +2,97 @@
 Regression tests for the mistune concurrency bug.
 
 Mistune 0.8.x Markdown instances hold mutable parse state and are not thread-safe.
-The fix in notification-utils uses threading.local so each thread gets its own
-parser instance. These tests verify that rendering email templates concurrently
-(as Celery workers do) does not produce corrupted output or raise exceptions.
+The fix in notification-utils wraps each renderer in a thread-local factory so
+each thread gets its own parser instance.
+
+The root cause: the old code created module-level mistune.Markdown singletons
+(e.g. `notify_email_markdown = mistune.Markdown(...)`). Under concurrent Celery
+thread-pool workers those shared instances had their parse state overwritten by
+other threads, producing token-mismatch errors in production.
+
+The fix: each renderer is now a plain Python function that lazily creates a
+per-thread mistune.Markdown instance via threading.local.
+
+These tests verify the fix is in place. Note: simply rendering templates
+concurrently is NOT a reliable way to detect this bug — Python's GIL prevents
+true parallelism for pure-Python code, so the race condition rarely triggers in
+tests even with the broken code. Instead we assert properties of the fix
+itself: that the formatters are functions (not shared objects) and that they
+hand each thread an isolated parser instance.
 
 See: fix/mistune-concurrency-issues in notification-utils
 """
 
-from concurrent.futures import ThreadPoolExecutor, as_completed
+import inspect
+import threading
 
+import mistune
 import pytest
-from notifications_utils.template import HTMLEmailTemplate, PlainTextEmailTemplate
+from notifications_utils import formatters
 
-TEMPLATE_SAMPLES = [
-    {
-        "content": "Hello there",
-        "subject": "Simple subject",
-    },
-    {
-        "content": "# Heading\n\nA paragraph with **bold** text.",
-        "subject": "Markdown subject",
-    },
-    {
-        "content": "Here is a list:\n\n* item one\n* item two\n* item three\n",
-        "subject": "List email",
-    },
-    {
-        "content": "Line one\n\nLine two\n\nLine three",
-        "subject": "Multi paragraph",
-    },
-    {
-        "content": "Visit https://example.com for more info.\n\nThanks.",
-        "subject": "Link email",
-    },
+# The four rendering functions that were previously shared Markdown singletons.
+FORMATTER_NAMES = [
+    "notify_email_markdown",
+    "notify_plain_text_email_markdown",
+    "notify_email_preheader_markdown",
+    "notify_letter_preview_markdown",
 ]
 
 
-def _render_html(i):
-    template_dict = TEMPLATE_SAMPLES[i % len(TEMPLATE_SAMPLES)]
-    return str(HTMLEmailTemplate({"content": template_dict["content"], "subject": template_dict["subject"]}))
-
-
-def _render_plain_text(i):
-    template_dict = TEMPLATE_SAMPLES[i % len(TEMPLATE_SAMPLES)]
-    return str(PlainTextEmailTemplate({"content": template_dict["content"], "subject": template_dict["subject"]}))
-
-
-@pytest.mark.parametrize(
-    "render_fn, expected_count",
-    [
-        (_render_html, 200),
-        (_render_plain_text, 200),
-    ],
-    ids=["HTMLEmailTemplate", "PlainTextEmailTemplate"],
-)
-def test_email_template_rendering_is_safe_under_concurrency(render_fn, expected_count):
+@pytest.mark.parametrize("name", FORMATTER_NAMES)
+def test_markdown_formatter_is_a_function_not_a_shared_instance(name):
     """
-    Verify that rendering email templates from multiple threads concurrently does
-    not raise exceptions or produce corrupted results.
+    Before the fix each formatter was a module-level mistune.Markdown object.
+    After the fix each formatter must be a plain Python function that wraps a
+    thread-local Markdown instance.
 
-    Before the fix, shared Mistune Markdown instances caused token-mismatch errors
-    under concurrent load (e.g. from Celery workers).
+    This test FAILS on notification-utils <= 53.2.29 (the buggy release) and
+    PASSES on the fixed release.
     """
-    with ThreadPoolExecutor(max_workers=16) as executor:
-        futures = [executor.submit(render_fn, i) for i in range(expected_count)]
-        results = [f.result() for f in as_completed(futures)]
+    fn = getattr(formatters, name)
+    assert inspect.isfunction(fn), (
+        f"notifications_utils.formatters.{name} is a {type(fn).__name__}, not a function. "
+        "This means a shared mistune.Markdown instance is being used across threads "
+        "(the concurrency bug). Upgrade notification-utils to the version that introduces "
+        "thread-local markdown renderers."
+    )
 
-    assert len(results) == expected_count
-    assert all(isinstance(r, str) and len(r) > 0 for r in results)
 
-
-def test_html_email_template_concurrent_output_is_deterministic():
+@pytest.mark.parametrize("name", FORMATTER_NAMES)
+def test_each_thread_gets_an_isolated_markdown_instance(name):
     """
-    The same input must always produce the same HTML output regardless of
-    which thread renders it.
+    The fix stores a separate mistune.Markdown object per thread in threading.local.
+    Verify that two threads calling the same formatter function never share the
+    same underlying Markdown parser object.
+
+    This test FAILS on the buggy release (there is only one shared instance so
+    both threads see the same id()) and PASSES on the fixed release.
     """
-    template_dict = {"content": "# Hello\n\nThis is **important**.", "subject": "Test"}
+    fn = getattr(formatters, name)
+    collected = {}
+    barrier = threading.Barrier(2)
 
-    def render(_):
-        return str(HTMLEmailTemplate(template_dict))
+    def capture(thread_id):
+        # Warm up the thread-local so the instance is created.
+        fn("hello")
+        barrier.wait()  # ensure both threads are alive at the same time
+        # Read back the instance that was stored for this thread.
+        collected[thread_id] = getattr(formatters._markdown_local, name, None)
 
-    with ThreadPoolExecutor(max_workers=16) as executor:
-        results = list(executor.map(render, range(100)))
+    t1 = threading.Thread(target=capture, args=(1,))
+    t2 = threading.Thread(target=capture, args=(2,))
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
 
-    assert len(set(results)) == 1, "Concurrent renders produced different HTML outputs"
+    instance_1 = collected[1]
+    instance_2 = collected[2]
 
-
-def test_plain_text_email_template_concurrent_output_is_deterministic():
-    """
-    The same input must always produce the same plain-text output regardless of
-    which thread renders it.
-    """
-    template_dict = {"content": "# Hello\n\nThis is **important**.", "subject": "Test"}
-
-    def render(_):
-        return str(PlainTextEmailTemplate(template_dict))
-
-    with ThreadPoolExecutor(max_workers=16) as executor:
-        results = list(executor.map(render, range(100)))
-
-    assert len(set(results)) == 1, "Concurrent renders produced different plain-text outputs"
+    assert instance_1 is not None, f"Thread 1 did not create a {name} instance"
+    assert instance_2 is not None, f"Thread 2 did not create a {name} instance"
+    assert isinstance(instance_1, mistune.Markdown)
+    assert isinstance(instance_2, mistune.Markdown)
+    assert instance_1 is not instance_2, (
+        f"Both threads share the same mistune.Markdown instance for {name}. " "The thread-safety fix is not in place."
+    )


### PR DESCRIPTION
~I will update this PR with the new version number for utils once that is merged.~ Done

Update to the latest utils. I added some tests. `test_each_thread_gets_an_isolated_markdown_instance` uses a `threading.Barrier` to ensure two threads are alive simultaneously, then checks that `formatters._markdown_local` (which doesn't exist in the old version) stores different Markdown objects for each thread. 

These tests fail for the old version of utils.