### PR TITLE
Fixed bugs with suspension email flow

### DIFF
--- a/app/delivery/bounce_rate.py
+++ b/app/delivery/bounce_rate.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from flask import current_app
+from notifications_utils.clients.redis import service_cache_key
 
 from app import bounce_rate_client, notify_celery, redis_store
 from app.config import QueueNames
@@ -31,25 +32,26 @@ def check_service_over_bounce_rate(service_id: str):
         min_volume = current_app.config["BR_VOLUME_MINIMUM"]
 
         if total_notifications >= min_volume:
-            # Volume threshold met and bounce rate is critical — suspend the service
+            # Volume threshold met and bounce rate is critical — remove email permission
             cache_key = _bounce_rate_suspension_cache_key(service_id)
-            if not redis_store.get(cache_key):
+            if redis_store.set(cache_key, datetime.utcnow().isoformat(), ex=TWENTY_FOUR_HOURS_IN_SECONDS, nx=True):
                 current_app.logger.warning(
                     f"Service: {service_id} has had its email permission removed due to exceeding a critical bounce rate threshold of 10%. Bounce rate: {bounce_rate} "
                     f"with {total_notifications} emails sent."
                 )
                 if current_app.config["NOTIFY_ENVIRONMENT"] != "production":
-                    dao_remove_service_permission(service_id, EMAIL_TYPE)
+                    deleted = dao_remove_service_permission(service_id, EMAIL_TYPE)
+                    redis_store.delete(service_cache_key(service_id))
+                    current_app.logger.info(f"dao_remove_service_permission returned {deleted} for service {service_id}")
                     notify_celery.send_task(
                         "send-bounce-rate-suspension-email",
                         kwargs={"service_id": str(service_id), "bounce_rate": bounce_rate},
                         queue=QueueNames.NOTIFY,
                     )
-                redis_store.set(cache_key, datetime.utcnow().isoformat(), ex=TWENTY_FOUR_HOURS_IN_SECONDS)
         else:
             # Volume threshold NOT met — warn only
             cache_key = _bounce_rate_warning_cache_key(service_id)
-            if not redis_store.get(cache_key):
+            if redis_store.set(cache_key, datetime.utcnow().isoformat(), ex=TWENTY_FOUR_HOURS_IN_SECONDS, nx=True):
                 current_app.logger.warning(
                     f"Service: {service_id} has a critical bounce rate of {bounce_rate} but has only sent "
                     f"{total_notifications} emails (< {min_volume}). Sending warning email."
@@ -60,7 +62,6 @@ def check_service_over_bounce_rate(service_id: str):
                         kwargs={"service_id": str(service_id), "bounce_rate": bounce_rate},
                         queue=QueueNames.NOTIFY,
                     )
-                    redis_store.set(cache_key, datetime.utcnow().isoformat(), ex=TWENTY_FOUR_HOURS_IN_SECONDS)
 
     elif bounce_rate_status == BounceRateStatus.WARNING.value:
         current_app.logger.warning(

--- a/app/delivery/bounce_rate.py
+++ b/app/delivery/bounce_rate.py
@@ -40,14 +40,18 @@ def check_service_over_bounce_rate(service_id: str):
                     f"with {total_notifications} emails sent."
                 )
                 if current_app.config["NOTIFY_ENVIRONMENT"] != "production":
-                    deleted = dao_remove_service_permission(service_id, EMAIL_TYPE)
-                    redis_store.delete(service_cache_key(service_id))
-                    current_app.logger.info(f"dao_remove_service_permission returned {deleted} for service {service_id}")
-                    notify_celery.send_task(
-                        "send-bounce-rate-suspension-email",
-                        kwargs={"service_id": str(service_id), "bounce_rate": bounce_rate},
-                        queue=QueueNames.NOTIFY,
-                    )
+                    try:
+                        deleted = dao_remove_service_permission(service_id, EMAIL_TYPE)
+                        redis_store.delete(service_cache_key(service_id))
+                        current_app.logger.info(f"dao_remove_service_permission returned {deleted} for service {service_id}")
+                        notify_celery.send_task(
+                            "send-bounce-rate-suspension-email",
+                            kwargs={"service_id": str(service_id), "bounce_rate": bounce_rate},
+                            queue=QueueNames.NOTIFY,
+                        )
+                    except Exception:
+                        current_app.logger.exception(f"Failed to suspend service {service_id}, clearing cache key to allow retry")
+                        redis_store.delete(cache_key)
         else:
             # Volume threshold NOT met — warn only
             cache_key = _bounce_rate_warning_cache_key(service_id)
@@ -57,11 +61,17 @@ def check_service_over_bounce_rate(service_id: str):
                     f"{total_notifications} emails (< {min_volume}). Sending warning email."
                 )
                 if current_app.config["NOTIFY_ENVIRONMENT"] != "production":
-                    notify_celery.send_task(
-                        "send-bounce-rate-warning-email",
-                        kwargs={"service_id": str(service_id), "bounce_rate": bounce_rate},
-                        queue=QueueNames.NOTIFY,
-                    )
+                    try:
+                        notify_celery.send_task(
+                            "send-bounce-rate-warning-email",
+                            kwargs={"service_id": str(service_id), "bounce_rate": bounce_rate},
+                            queue=QueueNames.NOTIFY,
+                        )
+                    except Exception:
+                        current_app.logger.exception(
+                            f"Failed to send warning email for service {service_id}, clearing cache key to allow retry"
+                        )
+                        redis_store.delete(cache_key)
 
     elif bounce_rate_status == BounceRateStatus.WARNING.value:
         current_app.logger.warning(

--- a/tests/app/delivery/test_bounce_rate.py
+++ b/tests/app/delivery/test_bounce_rate.py
@@ -15,7 +15,7 @@ class TestCheckServiceOverBounceRate:
             mocker.patch("app.bounce_rate_client.get_bounce_rate", return_value=current_app.config["BR_CRITICAL_PERCENTAGE"])
             mocker.patch("app.bounce_rate_client.get_total_notifications", return_value=1500)
             mocker.patch("app.delivery.bounce_rate.redis_store")
-            bounce_rate_module.redis_store.get.return_value = None
+            bounce_rate_module.redis_store.set.return_value = True  # nx=True succeeds
             mock_remove_perm = mocker.patch("app.delivery.bounce_rate.dao_remove_service_permission")
             mock_send_task = mocker.patch("app.delivery.bounce_rate.notify_celery.send_task")
             mock_logger = mocker.patch("app.delivery.bounce_rate.current_app.logger.warning")
@@ -37,7 +37,7 @@ class TestCheckServiceOverBounceRate:
             mocker.patch("app.bounce_rate_client.get_bounce_rate", return_value=current_app.config["BR_CRITICAL_PERCENTAGE"])
             mocker.patch("app.bounce_rate_client.get_total_notifications", return_value=1500)
             mocker.patch("app.delivery.bounce_rate.redis_store")
-            bounce_rate_module.redis_store.get.return_value = b"2026-07-15T00:00:00"
+            bounce_rate_module.redis_store.set.return_value = None  # nx=True fails (already set)
             mock_remove_perm = mocker.patch("app.delivery.bounce_rate.dao_remove_service_permission")
             mock_send_task = mocker.patch("app.delivery.bounce_rate.notify_celery.send_task")
 
@@ -52,7 +52,7 @@ class TestCheckServiceOverBounceRate:
             mocker.patch("app.bounce_rate_client.get_bounce_rate", return_value=current_app.config["BR_CRITICAL_PERCENTAGE"])
             mocker.patch("app.bounce_rate_client.get_total_notifications", return_value=500)
             mocker.patch("app.delivery.bounce_rate.redis_store")
-            bounce_rate_module.redis_store.get.return_value = None
+            bounce_rate_module.redis_store.set.return_value = True  # nx=True succeeds
             mock_remove_perm = mocker.patch("app.delivery.bounce_rate.dao_remove_service_permission")
             mock_send_task = mocker.patch("app.delivery.bounce_rate.notify_celery.send_task")
             mock_logger = mocker.patch("app.delivery.bounce_rate.current_app.logger.warning")
@@ -74,7 +74,7 @@ class TestCheckServiceOverBounceRate:
             mocker.patch("app.bounce_rate_client.get_bounce_rate", return_value=current_app.config["BR_CRITICAL_PERCENTAGE"])
             mocker.patch("app.bounce_rate_client.get_total_notifications", return_value=500)
             mocker.patch("app.delivery.bounce_rate.redis_store")
-            bounce_rate_module.redis_store.get.return_value = b"2026-07-15T00:00:00"
+            bounce_rate_module.redis_store.set.return_value = None  # nx=True fails (already set)
             mock_send_task = mocker.patch("app.delivery.bounce_rate.notify_celery.send_task")
 
             bounce_rate_module.check_service_over_bounce_rate(fake_uuid)


### PR DESCRIPTION
# Summary | Résumé

When sending an email on staging that would trigger the suspension work flow: We are getting multiple emails due to all celery workers reading and writing to the same key. Made a fix so only the first worker will write to the key, everyone else will get a No-op. 

Also needed to clear the service cache key.

# Test instructions | Instructions pour tester la modification

Will test the fixed on staging