### PR TITLE
Fix warning email path

### DIFF
--- a/app/delivery/bounce_rate.py
+++ b/app/delivery/bounce_rate.py
@@ -6,7 +6,7 @@ from notifications_utils.clients.redis import service_cache_key
 from app import bounce_rate_client, notify_celery, redis_store
 from app.config import QueueNames
 from app.dao.service_permissions_dao import dao_remove_service_permission
-from app.models import EMAIL_TYPE, BounceRateStatus
+from app.models import EMAIL_TYPE
 
 TWENTY_FOUR_HOURS_IN_SECONDS = 24 * 60 * 60
 
@@ -28,52 +28,52 @@ def check_service_over_bounce_rate(service_id: str):
         f"Total Notifications: {total_notifications}"
     )
 
-    if bounce_rate_status == BounceRateStatus.CRITICAL.value:
-        min_volume = current_app.config["BR_VOLUME_MINIMUM"]
+    critical_threshold = current_app.config["BR_CRITICAL_PERCENTAGE"]
+    warning_threshold = current_app.config["BR_WARNING_PERCENTAGE"]
+    min_volume = current_app.config["BR_VOLUME_MINIMUM"]
 
-        if total_notifications >= min_volume:
-            # Volume threshold met and bounce rate is critical — remove email permission
-            cache_key = _bounce_rate_suspension_cache_key(service_id)
-            if redis_store.set(cache_key, datetime.utcnow().isoformat(), ex=TWENTY_FOUR_HOURS_IN_SECONDS, nx=True):
-                current_app.logger.warning(
-                    f"Service: {service_id} has had its email permission removed due to exceeding a critical bounce rate threshold of 10%. Bounce rate: {bounce_rate} "
-                    f"with {total_notifications} emails sent."
-                )
-                if current_app.config["NOTIFY_ENVIRONMENT"] != "production":
-                    try:
-                        deleted = dao_remove_service_permission(service_id, EMAIL_TYPE)
-                        redis_store.delete(service_cache_key(service_id))
-                        current_app.logger.info(f"dao_remove_service_permission returned {deleted} for service {service_id}")
-                        notify_celery.send_task(
-                            "send-bounce-rate-suspension-email",
-                            kwargs={"service_id": str(service_id), "bounce_rate": bounce_rate},
-                            queue=QueueNames.NOTIFY,
-                        )
-                    except Exception:
-                        current_app.logger.exception(f"Failed to suspend service {service_id}, clearing cache key to allow retry")
-                        redis_store.delete(cache_key)
-        else:
-            # Volume threshold NOT met — warn only
-            cache_key = _bounce_rate_warning_cache_key(service_id)
-            if redis_store.set(cache_key, datetime.utcnow().isoformat(), ex=TWENTY_FOUR_HOURS_IN_SECONDS, nx=True):
-                current_app.logger.warning(
-                    f"Service: {service_id} has a critical bounce rate of {bounce_rate} but has only sent "
-                    f"{total_notifications} emails (< {min_volume}). Sending warning email."
-                )
-                if current_app.config["NOTIFY_ENVIRONMENT"] != "production":
-                    try:
-                        notify_celery.send_task(
-                            "send-bounce-rate-warning-email",
-                            kwargs={"service_id": str(service_id), "bounce_rate": bounce_rate},
-                            queue=QueueNames.NOTIFY,
-                        )
-                    except Exception:
-                        current_app.logger.exception(
-                            f"Failed to send warning email for service {service_id}, clearing cache key to allow retry"
-                        )
-                        redis_store.delete(cache_key)
+    # Below volume threshold — no action
+    if total_notifications < min_volume:
+        return
 
-    elif bounce_rate_status == BounceRateStatus.WARNING.value:
-        current_app.logger.warning(
-            f"Service: {service_id} has met or exceeded a warning bounce rate threshold of 5%. Bounce rate: {bounce_rate}"
-        )
+    if bounce_rate >= critical_threshold:
+        # Volume threshold met and bounce rate is critical — remove email permission
+        cache_key = _bounce_rate_suspension_cache_key(service_id)
+        if redis_store.set(cache_key, datetime.utcnow().isoformat(), ex=TWENTY_FOUR_HOURS_IN_SECONDS, nx=True):
+            current_app.logger.warning(
+                f"Service: {service_id} has had its email permission removed due to exceeding a critical bounce rate threshold of 10%. Bounce rate: {bounce_rate} "
+                f"with {total_notifications} emails sent."
+            )
+            if current_app.config["NOTIFY_ENVIRONMENT"] != "production":
+                try:
+                    deleted = dao_remove_service_permission(service_id, EMAIL_TYPE)
+                    redis_store.delete(service_cache_key(service_id))
+                    current_app.logger.info(f"dao_remove_service_permission returned {deleted} for service {service_id}")
+                    notify_celery.send_task(
+                        "send-bounce-rate-suspension-email",
+                        kwargs={"service_id": str(service_id), "bounce_rate": bounce_rate},
+                        queue=QueueNames.NOTIFY,
+                    )
+                except Exception:
+                    current_app.logger.exception(f"Failed to suspend service {service_id}, clearing cache key to allow retry")
+                    redis_store.delete(cache_key)
+
+    elif bounce_rate >= warning_threshold:
+        # Volume threshold met and bounce rate is warning — send warning email
+        cache_key = _bounce_rate_warning_cache_key(service_id)
+        if redis_store.set(cache_key, datetime.utcnow().isoformat(), ex=TWENTY_FOUR_HOURS_IN_SECONDS, nx=True):
+            current_app.logger.warning(
+                f"Service: {service_id} has a warning bounce rate of {bounce_rate} " f"with {total_notifications} emails sent."
+            )
+            if current_app.config["NOTIFY_ENVIRONMENT"] != "production":
+                try:
+                    notify_celery.send_task(
+                        "send-bounce-rate-warning-email",
+                        kwargs={"service_id": str(service_id), "bounce_rate": bounce_rate},
+                        queue=QueueNames.NOTIFY,
+                    )
+                except Exception:
+                    current_app.logger.exception(
+                        f"Failed to send warning email for service {service_id}, clearing cache key to allow retry"
+                    )
+                    redis_store.delete(cache_key)

--- a/tests/app/delivery/test_bounce_rate.py
+++ b/tests/app/delivery/test_bounce_rate.py
@@ -4,21 +4,21 @@ from flask import current_app
 from pytest_mock import MockFixture
 
 from app.delivery import bounce_rate as bounce_rate_module
-from app.models import EMAIL_TYPE, BounceRateStatus
+from app.models import EMAIL_TYPE
 from tests.conftest import set_config_values
 
 
 class TestCheckServiceOverBounceRate:
     def test_critical_high_volume_suspends(self, mocker: MockFixture, notify_api, fake_uuid):
+        """>=1000 messages, bounce rate >=10% → suspend sending"""
         with notify_api.app_context():
-            mocker.patch("app.bounce_rate_client.check_bounce_rate_status", return_value=BounceRateStatus.CRITICAL.value)
+            mocker.patch("app.bounce_rate_client.check_bounce_rate_status", return_value="critical")
             mocker.patch("app.bounce_rate_client.get_bounce_rate", return_value=current_app.config["BR_CRITICAL_PERCENTAGE"])
             mocker.patch("app.bounce_rate_client.get_total_notifications", return_value=1500)
             mocker.patch("app.delivery.bounce_rate.redis_store")
-            bounce_rate_module.redis_store.set.return_value = True  # nx=True succeeds
+            bounce_rate_module.redis_store.set.return_value = True
             mock_remove_perm = mocker.patch("app.delivery.bounce_rate.dao_remove_service_permission")
             mock_send_task = mocker.patch("app.delivery.bounce_rate.notify_celery.send_task")
-            mock_logger = mocker.patch("app.delivery.bounce_rate.current_app.logger.warning")
 
             bounce_rate_module.check_service_over_bounce_rate(fake_uuid)
 
@@ -28,16 +28,15 @@ class TestCheckServiceOverBounceRate:
                 kwargs={"service_id": fake_uuid, "bounce_rate": current_app.config["BR_CRITICAL_PERCENTAGE"]},
                 queue=ANY,
             )
-            bounce_rate_module.redis_store.set.assert_called_once()
-            mock_logger.assert_called_once()
 
     def test_critical_high_volume_already_sent(self, mocker: MockFixture, notify_api, fake_uuid):
+        """>=1000 messages, bounce rate >=10%, but suspension email already sent → no duplicate"""
         with notify_api.app_context():
-            mocker.patch("app.bounce_rate_client.check_bounce_rate_status", return_value=BounceRateStatus.CRITICAL.value)
+            mocker.patch("app.bounce_rate_client.check_bounce_rate_status", return_value="critical")
             mocker.patch("app.bounce_rate_client.get_bounce_rate", return_value=current_app.config["BR_CRITICAL_PERCENTAGE"])
             mocker.patch("app.bounce_rate_client.get_total_notifications", return_value=1500)
             mocker.patch("app.delivery.bounce_rate.redis_store")
-            bounce_rate_module.redis_store.set.return_value = None  # nx=True fails (already set)
+            bounce_rate_module.redis_store.set.return_value = None  # nx=True fails
             mock_remove_perm = mocker.patch("app.delivery.bounce_rate.dao_remove_service_permission")
             mock_send_task = mocker.patch("app.delivery.bounce_rate.notify_celery.send_task")
 
@@ -46,61 +45,62 @@ class TestCheckServiceOverBounceRate:
             mock_remove_perm.assert_not_called()
             mock_send_task.assert_not_called()
 
-    def test_critical_low_volume_warns(self, mocker: MockFixture, notify_api, fake_uuid):
-        with notify_api.app_context(), set_config_values(notify_api, {"BR_VOLUME_MINIMUM": 1000}):
-            mocker.patch("app.bounce_rate_client.check_bounce_rate_status", return_value=BounceRateStatus.CRITICAL.value)
-            mocker.patch("app.bounce_rate_client.get_bounce_rate", return_value=current_app.config["BR_CRITICAL_PERCENTAGE"])
-            mocker.patch("app.bounce_rate_client.get_total_notifications", return_value=500)
+    def test_warning_high_volume_sends_warning_email(self, mocker: MockFixture, notify_api, fake_uuid):
+        """>=1000 messages, bounce rate >=5% <10% → warning email"""
+        with notify_api.app_context():
+            mocker.patch("app.bounce_rate_client.check_bounce_rate_status", return_value="warning")
+            mocker.patch("app.bounce_rate_client.get_bounce_rate", return_value=current_app.config["BR_WARNING_PERCENTAGE"])
+            mocker.patch("app.bounce_rate_client.get_total_notifications", return_value=1500)
             mocker.patch("app.delivery.bounce_rate.redis_store")
-            bounce_rate_module.redis_store.set.return_value = True  # nx=True succeeds
+            bounce_rate_module.redis_store.set.return_value = True
             mock_remove_perm = mocker.patch("app.delivery.bounce_rate.dao_remove_service_permission")
             mock_send_task = mocker.patch("app.delivery.bounce_rate.notify_celery.send_task")
-            mock_logger = mocker.patch("app.delivery.bounce_rate.current_app.logger.warning")
 
             bounce_rate_module.check_service_over_bounce_rate(fake_uuid)
 
             mock_remove_perm.assert_not_called()
             mock_send_task.assert_called_once_with(
                 "send-bounce-rate-warning-email",
-                kwargs={"service_id": fake_uuid, "bounce_rate": current_app.config["BR_CRITICAL_PERCENTAGE"]},
+                kwargs={"service_id": fake_uuid, "bounce_rate": current_app.config["BR_WARNING_PERCENTAGE"]},
                 queue=ANY,
             )
-            bounce_rate_module.redis_store.set.assert_called_once()
-            mock_logger.assert_called_once()
 
-    def test_critical_low_volume_already_warned(self, mocker: MockFixture, notify_api, fake_uuid):
-        with notify_api.app_context(), set_config_values(notify_api, {"BR_VOLUME_MINIMUM": 1000}):
-            mocker.patch("app.bounce_rate_client.check_bounce_rate_status", return_value=BounceRateStatus.CRITICAL.value)
-            mocker.patch("app.bounce_rate_client.get_bounce_rate", return_value=current_app.config["BR_CRITICAL_PERCENTAGE"])
-            mocker.patch("app.bounce_rate_client.get_total_notifications", return_value=500)
+    def test_warning_high_volume_already_warned(self, mocker: MockFixture, notify_api, fake_uuid):
+        """>=1000 messages, bounce rate >=5% <10%, but warning already sent → no duplicate"""
+        with notify_api.app_context():
+            mocker.patch("app.bounce_rate_client.check_bounce_rate_status", return_value="warning")
+            mocker.patch("app.bounce_rate_client.get_bounce_rate", return_value=current_app.config["BR_WARNING_PERCENTAGE"])
+            mocker.patch("app.bounce_rate_client.get_total_notifications", return_value=1500)
             mocker.patch("app.delivery.bounce_rate.redis_store")
-            bounce_rate_module.redis_store.set.return_value = None  # nx=True fails (already set)
+            bounce_rate_module.redis_store.set.return_value = None  # nx=True fails
             mock_send_task = mocker.patch("app.delivery.bounce_rate.notify_celery.send_task")
 
             bounce_rate_module.check_service_over_bounce_rate(fake_uuid)
 
             mock_send_task.assert_not_called()
 
-    def test_warning_status_logs_only(self, mocker: MockFixture, notify_api, fake_uuid):
-        with notify_api.app_context():
-            mocker.patch("app.bounce_rate_client.check_bounce_rate_status", return_value=BounceRateStatus.WARNING.value)
-            mocker.patch("app.bounce_rate_client.get_bounce_rate", return_value=current_app.config["BR_WARNING_PERCENTAGE"])
-            mocker.patch("app.bounce_rate_client.get_total_notifications", return_value=5000)
-            mock_logger = mocker.patch("app.delivery.bounce_rate.current_app.logger.warning")
+    def test_low_volume_no_action(self, mocker: MockFixture, notify_api, fake_uuid):
+        """<1000 messages → no email sent regardless of bounce rate"""
+        with notify_api.app_context(), set_config_values(notify_api, {"BR_VOLUME_MINIMUM": 1000}):
+            mocker.patch("app.bounce_rate_client.check_bounce_rate_status", return_value="critical")
+            mocker.patch("app.bounce_rate_client.get_bounce_rate", return_value=0.87)
+            mocker.patch("app.bounce_rate_client.get_total_notifications", return_value=100)
+            mock_remove_perm = mocker.patch("app.delivery.bounce_rate.dao_remove_service_permission")
+            mock_send_task = mocker.patch("app.delivery.bounce_rate.notify_celery.send_task")
 
             bounce_rate_module.check_service_over_bounce_rate(fake_uuid)
 
-            mock_logger.assert_called_once_with(
-                f"Service: {fake_uuid} has met or exceeded a warning bounce rate threshold of 5%. "
-                f"Bounce rate: {current_app.config['BR_WARNING_PERCENTAGE']}"
-            )
+            mock_remove_perm.assert_not_called()
+            mock_send_task.assert_not_called()
 
-    def test_normal_status_no_action(self, mocker: MockFixture, notify_api, fake_uuid):
+    def test_normal_bounce_rate_no_action(self, mocker: MockFixture, notify_api, fake_uuid):
+        """>=1000 messages but bounce rate <5% → no action"""
         with notify_api.app_context():
-            mocker.patch("app.bounce_rate_client.check_bounce_rate_status", return_value=BounceRateStatus.NORMAL.value)
-            mocker.patch("app.bounce_rate_client.get_bounce_rate", return_value=0.0)
-            mocker.patch("app.bounce_rate_client.get_total_notifications", return_value=100)
-            mock_logger = mocker.patch("app.delivery.bounce_rate.current_app.logger.warning")
+            mocker.patch("app.bounce_rate_client.check_bounce_rate_status", return_value="normal")
+            mocker.patch("app.bounce_rate_client.get_bounce_rate", return_value=0.02)
+            mocker.patch("app.bounce_rate_client.get_total_notifications", return_value=5000)
+            mock_send_task = mocker.patch("app.delivery.bounce_rate.notify_celery.send_task")
 
-            assert bounce_rate_module.check_service_over_bounce_rate(fake_uuid) is None
-            mock_logger.assert_not_called()
+            bounce_rate_module.check_service_over_bounce_rate(fake_uuid)
+
+            mock_send_task.assert_not_called()


### PR DESCRIPTION
# Summary | Résumé
Two key differences from the previous version:

1. Warning email now actually sends: Previously, when bounce rate was 5-10% with >=1000 emails, the code hit [elif bounce_rate_status == BounceRateStatus.WARNING.value m  which only logged — no email was sent. Now it sends the warning email.

2. Low volume = silence: Previously there was a low-volume warning path (critical rate but <1000 emails → send warning). Now <1000 messages is an early return with no action at all. The **old path was also unreachable** anyway because the library's [check_bounce_rate_status()] returns "normal" for anything under the volume threshold, so the code never entered the [CRITICAL] branch for low-volume services.

In short: the warning email moved from "high bounce rate + low volume" (broken/unreachable) to "moderate bounce rate + high volume" (the actual desired behavior).


## testing
will test on staging