### PR TITLE
Add the `v2/reports` GET endpoint

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -341,6 +341,7 @@ def register_v2_blueprints(application):
         v2_notification_blueprint,
     )
     from app.v2.reports import (  # noqa
+        get_reports,
         post_reports,
         v2_reports_blueprint,
     )

--- a/app/dao/reports_dao.py
+++ b/app/dao/reports_dao.py
@@ -49,10 +49,22 @@ def get_paginated_reports_for_service(service_id, older_than=None, page_size=10)
     filters = [Report.service_id == service_id]
 
     if older_than:
-        older_than_requested_at = db.session.query(Report.requested_at).filter(Report.id == older_than).as_scalar()
-        filters.append(Report.requested_at < older_than_requested_at)
+        older_than_row = db.session.query(Report.requested_at, Report.id).filter(Report.id == older_than).subquery()
+        filters.append(
+            db.or_(
+                Report.requested_at < older_than_row.c.requested_at,
+                db.and_(
+                    Report.requested_at == older_than_row.c.requested_at,
+                    Report.id < older_than_row.c.id,
+                ),
+            )
+        )
 
-    return Report.query.filter(*filters).order_by(desc(Report.requested_at)).paginate(per_page=page_size)
+    return (
+        Report.query.filter(*filters)
+        .order_by(desc(Report.requested_at), desc(Report.id))
+        .paginate(per_page=page_size, count=False)
+    )
 
 
 @transactional

--- a/app/dao/reports_dao.py
+++ b/app/dao/reports_dao.py
@@ -1,6 +1,8 @@
 import datetime
 from typing import List
 
+from sqlalchemy import desc
+
 from app import db
 from app.dao.dao_utils import transactional
 from app.models import Report
@@ -41,6 +43,16 @@ def get_reports_for_service(service_id: str, limit_days: int) -> List[Report]:
 
 def get_report_by_id(report_id) -> Report:
     return Report.query.filter_by(id=report_id).one()
+
+
+def get_paginated_reports_for_service(service_id, older_than=None, page_size=10):
+    filters = [Report.service_id == service_id]
+
+    if older_than:
+        older_than_requested_at = db.session.query(Report.requested_at).filter(Report.id == older_than).as_scalar()
+        filters.append(Report.requested_at < older_than_requested_at)
+
+    return Report.query.filter(*filters).order_by(desc(Report.requested_at)).paginate(per_page=page_size).items
 
 
 @transactional

--- a/app/dao/reports_dao.py
+++ b/app/dao/reports_dao.py
@@ -52,7 +52,7 @@ def get_paginated_reports_for_service(service_id, older_than=None, page_size=10)
         older_than_requested_at = db.session.query(Report.requested_at).filter(Report.id == older_than).as_scalar()
         filters.append(Report.requested_at < older_than_requested_at)
 
-    return Report.query.filter(*filters).order_by(desc(Report.requested_at)).paginate(per_page=page_size).items
+    return Report.query.filter(*filters).order_by(desc(Report.requested_at)).paginate(per_page=page_size)
 
 
 @transactional

--- a/app/v2/reports/get_reports.py
+++ b/app/v2/reports/get_reports.py
@@ -3,8 +3,10 @@ from flask import current_app, jsonify, request, url_for
 from app import api_user, authenticated_service
 from app.dao.reports_dao import get_paginated_reports_for_service
 from app.models import ApiKeyPermission
+from app.schema_validation import validate
 from app.v2.errors import ForbiddenError
 from app.v2.reports import v2_reports_blueprint
+from app.v2.reports.report_schemas import get_reports_request
 
 
 @v2_reports_blueprint.route("", methods=["GET"])
@@ -12,7 +14,8 @@ def get_reports():
     if not api_user.has_permission(ApiKeyPermission.MANAGE_REPORTS):
         raise ForbiddenError(message="This API key does not have permission to manage reports.")
 
-    older_than = request.args.get("older_than")
+    data = validate(request.args.to_dict(), get_reports_request)
+    older_than = data.get("older_than")
 
     paginated_reports = get_paginated_reports_for_service(
         service_id=authenticated_service.id,

--- a/app/v2/reports/get_reports.py
+++ b/app/v2/reports/get_reports.py
@@ -1,0 +1,48 @@
+from flask import current_app, jsonify, request, url_for
+
+from app import api_user, authenticated_service
+from app.dao.reports_dao import get_paginated_reports_for_service
+from app.models import ApiKeyPermission
+from app.v2.errors import ForbiddenError
+from app.v2.reports import v2_reports_blueprint
+
+
+@v2_reports_blueprint.route("", methods=["GET"])
+def get_reports():
+    if not api_user.has_permission(ApiKeyPermission.MANAGE_REPORTS):
+        raise ForbiddenError(message="This API key does not have permission to manage reports.")
+
+    older_than = request.args.get("older_than")
+
+    paginated_reports = get_paginated_reports_for_service(
+        service_id=authenticated_service.id,
+        older_than=older_than,
+        page_size=current_app.config.get("API_PAGE_SIZE"),
+    )
+
+    return (
+        jsonify(
+            reports=[report.serialize() for report in paginated_reports],
+            links=_build_links(paginated_reports, older_than),
+        ),
+        200,
+    )
+
+
+def _build_links(reports_list, older_than=None):
+    _links = {
+        "current": url_for(
+            "v2_reports.get_reports",
+            _external=True,
+            **{"older_than": older_than} if older_than else {},
+        ),
+    }
+
+    if reports_list:
+        _links["next"] = url_for(
+            "v2_reports.get_reports",
+            older_than=reports_list[-1].id,
+            _external=True,
+        )
+
+    return _links

--- a/app/v2/reports/get_reports.py
+++ b/app/v2/reports/get_reports.py
@@ -24,8 +24,10 @@ def get_reports():
 
     return (
         jsonify(
-            reports=[{k: v for k, v in report.serialize().items() if k not in excluded_fields} for report in paginated_reports],
-            links=_build_links(paginated_reports, older_than),
+            reports=[
+                {k: v for k, v in report.serialize().items() if k not in excluded_fields} for report in paginated_reports.items
+            ],
+            links=_build_links(paginated_reports.items, older_than),
         ),
         200,
     )

--- a/app/v2/reports/get_reports.py
+++ b/app/v2/reports/get_reports.py
@@ -20,9 +20,11 @@ def get_reports():
         page_size=current_app.config.get("API_PAGE_SIZE"),
     )
 
+    excluded_fields = {"url"}
+
     return (
         jsonify(
-            reports=[report.serialize() for report in paginated_reports],
+            reports=[{k: v for k, v in report.serialize().items() if k not in excluded_fields} for report in paginated_reports],
             links=_build_links(paginated_reports, older_than),
         ),
         200,

--- a/app/v2/reports/report_schemas.py
+++ b/app/v2/reports/report_schemas.py
@@ -2,6 +2,16 @@ from app.models import ReportType
 from app.schema_validation.definitions import nullable_uuid
 from app.schema_validation.definitions import uuid as uuid_schema
 
+get_reports_request = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "schema for query parameters allowed when getting list of reports",
+    "type": "object",
+    "properties": {
+        "older_than": uuid_schema,
+    },
+    "additionalProperties": False,
+}
+
 post_report_request = {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST v2 report request schema",

--- a/tests/app/v2/reports/test_get_reports.py
+++ b/tests/app/v2/reports/test_get_reports.py
@@ -1,0 +1,154 @@
+import json
+import uuid
+
+from app.dao.reports_dao import create_report
+from app.models import Report, ReportStatus, ReportType
+from tests import create_authorization_header
+
+
+def _make_report(
+    service_id, report_type=ReportType.EMAIL.value, status=ReportStatus.READY.value, url="https://s3.example.com/report.csv"
+):
+    return Report(
+        id=uuid.uuid4(),
+        report_type=report_type,
+        service_id=service_id,
+        status=status,
+        requesting_user_id=None,
+        language="en",
+        url=url,
+    )
+
+
+def test_get_reports_returns_200(client, sample_service, create_api_key_with_manage_reports_perm):
+    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+    create_report(_make_report(sample_service.id))
+
+    response = client.get(
+        path="/v2/reports",
+        headers=[auth_header],
+    )
+
+    assert response.status_code == 200
+
+
+def test_get_reports_returns_list_of_reports(client, sample_service, create_api_key_with_manage_reports_perm):
+    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+    report = _make_report(sample_service.id)
+    create_report(report)
+
+    response = client.get(
+        path="/v2/reports",
+        headers=[auth_header],
+    )
+
+    data = json.loads(response.get_data(as_text=True))
+    assert len(data["reports"]) == 1
+    assert data["reports"][0]["id"] == str(report.id)
+    assert data["reports"][0]["report_type"] == report.report_type
+    assert data["reports"][0]["status"] == report.status
+
+
+def test_get_reports_does_not_include_url(client, sample_service, create_api_key_with_manage_reports_perm):
+    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+    create_report(_make_report(sample_service.id))
+
+    response = client.get(
+        path="/v2/reports",
+        headers=[auth_header],
+    )
+
+    data = json.loads(response.get_data(as_text=True))
+    assert "url" not in data["reports"][0]
+
+
+def test_get_reports_returns_only_reports_for_service(
+    client, sample_service, notify_db_session, create_api_key_with_manage_reports_perm
+):
+    from tests.app.db import create_service
+
+    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+    other_service = create_service(service_name="other service")
+
+    create_report(_make_report(sample_service.id))
+    create_report(_make_report(other_service.id))
+
+    response = client.get(
+        path="/v2/reports",
+        headers=[auth_header],
+    )
+
+    data = json.loads(response.get_data(as_text=True))
+    assert len(data["reports"]) == 1
+    assert data["reports"][0]["service_id"] == str(sample_service.id)
+
+
+def test_get_reports_returns_links(client, sample_service, create_api_key_with_manage_reports_perm):
+    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+    create_report(_make_report(sample_service.id))
+
+    response = client.get(
+        path="/v2/reports",
+        headers=[auth_header],
+    )
+
+    data = json.loads(response.get_data(as_text=True))
+    assert "links" in data
+    assert "current" in data["links"]
+    assert "next" in data["links"]
+
+
+def test_get_reports_empty_list_has_no_next_link(client, sample_service, create_api_key_with_manage_reports_perm):
+    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+
+    response = client.get(
+        path="/v2/reports",
+        headers=[auth_header],
+    )
+
+    data = json.loads(response.get_data(as_text=True))
+    assert data["reports"] == []
+    assert "next" not in data["links"]
+
+
+def test_get_reports_returns_403_without_manage_reports_permission(client, create_api_key_no_perm):
+    auth_header = create_authorization_header(api_key=create_api_key_no_perm)
+
+    response = client.get(
+        path="/v2/reports",
+        headers=[auth_header],
+    )
+
+    assert response.status_code == 403
+    data = json.loads(response.get_data(as_text=True))
+    assert "manage reports" in data["errors"][0]["message"].lower()
+
+
+def test_get_reports_requires_authentication(client):
+    response = client.get(path="/v2/reports")
+
+    assert response.status_code == 401
+
+
+def test_get_reports_pagination_with_older_than(
+    client, sample_service, notify_db_session, create_api_key_with_manage_reports_perm, mocker
+):
+    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+    mocker.patch.dict("app.v2.reports.get_reports.current_app.config", {"API_PAGE_SIZE": 1})
+
+    report1 = _make_report(sample_service.id)
+    report2 = _make_report(sample_service.id)
+    create_report(report1)
+    create_report(report2)
+
+    # Fetch first page
+    response = client.get(path="/v2/reports", headers=[auth_header])
+    data = json.loads(response.get_data(as_text=True))
+    assert len(data["reports"]) == 1
+    first_id = data["reports"][0]["id"]
+
+    # Fetch next page using older_than
+    response2 = client.get(path=f"/v2/reports?older_than={first_id}", headers=[auth_header])
+    data2 = json.loads(response2.get_data(as_text=True))
+    assert len(data2["reports"]) == 1
+    assert data2["reports"][0]["id"] != first_id

--- a/tests/app/v2/reports/test_get_reports.py
+++ b/tests/app/v2/reports/test_get_reports.py
@@ -152,3 +152,11 @@ def test_get_reports_pagination_with_older_than(
     data2 = json.loads(response2.get_data(as_text=True))
     assert len(data2["reports"]) == 1
     assert data2["reports"][0]["id"] != first_id
+
+
+def test_get_reports_returns_400_for_invalid_older_than(client, sample_service, create_api_key_with_manage_reports_perm):
+    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+
+    response = client.get(path="/v2/reports?older_than=not-a-uuid", headers=[auth_header])
+
+    assert response.status_code == 400


### PR DESCRIPTION
# Summary | Résumé

This PR adds the `v2/reports` GET endpoint and tests. The new endpoint uses cursor-based pagination with an optional `older_than` argument, the same as with the `v2/notifications` GET endpoing.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/3371

# Test instructions | Instructions pour tester la modification

1. check out branch and run locally
2. create an api key with the "manage_reports" permission if you haven't already
3. try the following curl request:
```
curl -X GET "http://localhost:6011/v2/reports" \
  -H "Authorization: ApiKey-v1 YOUR_API_KEY" \
  -H "Content-Type: application/json" 
```
4. verify that you get back data that matches up with what you see on your service's reports page: `http://localhost:6012/services/your-service-id/reports`

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.