### PR TITLE
Fix bug with suspension flow

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -44,21 +44,22 @@
             "name": "Python: Celery",
             "type": "debugpy",
             "request": "launch",
+            "python": "/home/vscode/.venv/workspace/bin/python",
             "module": "celery",
             "console": "integratedTerminal",
             "justMyCode": false,
             "args": [
-                "--app",
-                "run_celery",
+                "-A",
+                "run_celery.notify_celery",
                 "worker",
+                "--beat",
                 "--pidfile",
                 "/tmp/celery.pid",
+                "--loglevel=INFO",
+                "--pool=prefork",
                 "--concurrency=1",
-                "-l",
-                "DEBUG",
                 "-Q",
-                "database-tasks,-priority-database-tasks.fifo,-normal-database-tasks,-bulk-database-tasks,job-tasks,notify-internal-tasks,periodic-tasks,priority-tasks,normal-tasks,bulk-tasks,reporting-tasks,research-mode-tasks,retry-tasks,service-callbacks-retry,send-sms-tasks,send-sms-high,send-sms-medium,send-sms-low,send-throttled-sms-tasks,send-sms-fair,send-email-high,send-email-medium,send-email-low,send-email-tasks,service-callbacks,delivery-receipts",
-                "--beat",
+                "-priority-database-tasks.fifo,-normal-database-tasks,-bulk-database-tasks,job-tasks,notify-internal-tasks,periodic-tasks,priority-tasks,normal-tasks,bulk-tasks,reporting-tasks,research-mode-tasks,retry-tasks,send-sms-high,send-sms-medium,send-sms-low,send-throttled-sms-tasks,send-email-high,send-email-medium,send-email-low,send-sms-fair,service-callbacks,service-callbacks-retry,delivery-receipts,generate-reports"
             ]
         },
         {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -44,7 +44,7 @@
             "name": "Python: Celery",
             "type": "debugpy",
             "request": "launch",
-            "python": "/home/vscode/.venv/workspace/bin/python",
+            "python": "${command:python.interpreterPath}",
             "module": "celery",
             "console": "integratedTerminal",
             "justMyCode": false,

--- a/app/delivery/bounce_rate.py
+++ b/app/delivery/bounce_rate.py
@@ -39,7 +39,7 @@ def check_service_over_bounce_rate(service_id: str):
     if bounce_rate >= critical_threshold:
         # Volume threshold met and bounce rate is critical — remove email permission
         cache_key = _bounce_rate_suspension_cache_key(service_id)
-        if redis_store.set(cache_key, datetime.utcnow().isoformat(), ex=TWENTY_FOUR_HOURS_IN_SECONDS, nx=True):
+        if redis_store.redis_store.set(cache_key, datetime.utcnow().isoformat(), ex=TWENTY_FOUR_HOURS_IN_SECONDS, nx=True):
             current_app.logger.warning(
                 f"Service: {service_id} has had its email permission removed due to exceeding a critical bounce rate threshold of 10%. Bounce rate: {bounce_rate} "
                 f"with {total_notifications} emails sent."
@@ -61,7 +61,7 @@ def check_service_over_bounce_rate(service_id: str):
     elif bounce_rate >= warning_threshold:
         # Volume threshold met and bounce rate is warning — send warning email
         cache_key = _bounce_rate_warning_cache_key(service_id)
-        if redis_store.set(cache_key, datetime.utcnow().isoformat(), ex=TWENTY_FOUR_HOURS_IN_SECONDS, nx=True):
+        if redis_store.redis_store.set(cache_key, datetime.utcnow().isoformat(), ex=TWENTY_FOUR_HOURS_IN_SECONDS, nx=True):
             current_app.logger.warning(
                 f"Service: {service_id} has a warning bounce rate of {bounce_rate} " f"with {total_notifications} emails sent."
             )

--- a/app/delivery/bounce_rate.py
+++ b/app/delivery/bounce_rate.py
@@ -39,9 +39,8 @@ def check_service_over_bounce_rate(service_id: str):
     if bounce_rate >= critical_threshold:
         # Volume threshold met and bounce rate is critical — remove email permission
         cache_key = _bounce_rate_suspension_cache_key(service_id)
-        # The RedisClient.set method calls self.redis_store.set(...) but doesn't return the result,
-        # redis-py set returns True when nx=True succeeds, but the wrapper discards it and implicitly returns None.
-        # Note the below method will return True ONLY the first time it is called, the next time it will return Null.
+        # NOTE: RedisClient.set() does not currently return the underlying redis-py result.
+        # redis-py returns True when `nx=True` succeeds (i.e., the key did not already exist), otherwise None.
         if redis_store.redis_store.set(cache_key, datetime.utcnow().isoformat(), ex=TWENTY_FOUR_HOURS_IN_SECONDS, nx=True):
             current_app.logger.warning(
                 f"Service: {service_id} has had its email permission removed due to exceeding a critical bounce rate threshold of 10%. Bounce rate: {bounce_rate} "

--- a/app/delivery/bounce_rate.py
+++ b/app/delivery/bounce_rate.py
@@ -39,6 +39,9 @@ def check_service_over_bounce_rate(service_id: str):
     if bounce_rate >= critical_threshold:
         # Volume threshold met and bounce rate is critical — remove email permission
         cache_key = _bounce_rate_suspension_cache_key(service_id)
+        # The RedisClient.set method calls self.redis_store.set(...) but doesn't return the result,
+        # redis-py set returns True when nx=True succeeds, but the wrapper discards it and implicitly returns None.
+        # Note the below method will return True ONLY the first time it is called, the next time it will return Null.
         if redis_store.redis_store.set(cache_key, datetime.utcnow().isoformat(), ex=TWENTY_FOUR_HOURS_IN_SECONDS, nx=True):
             current_app.logger.warning(
                 f"Service: {service_id} has had its email permission removed due to exceeding a critical bounce rate threshold of 10%. Bounce rate: {bounce_rate} "
@@ -53,6 +56,11 @@ def check_service_over_bounce_rate(service_id: str):
                         "send-bounce-rate-suspension-email",
                         kwargs={"service_id": str(service_id), "bounce_rate": bounce_rate},
                         queue=QueueNames.NOTIFY,
+                    )
+                    # Also set warning key so a warning email won't be sent if bounce rate drops to 5-10%
+                    warning_cache_key = _bounce_rate_warning_cache_key(service_id)
+                    redis_store.redis_store.set(
+                        warning_cache_key, datetime.utcnow().isoformat(), ex=TWENTY_FOUR_HOURS_IN_SECONDS, nx=True
                     )
                 except Exception:
                     current_app.logger.exception(f"Failed to suspend service {service_id}, clearing cache key to allow retry")

--- a/tests/app/delivery/test_bounce_rate.py
+++ b/tests/app/delivery/test_bounce_rate.py
@@ -28,6 +28,8 @@ class TestCheckServiceOverBounceRate:
                 kwargs={"service_id": fake_uuid, "bounce_rate": current_app.config["BR_CRITICAL_PERCENTAGE"]},
                 queue=ANY,
             )
+            # Warning key should also be set to prevent a follow-up warning email
+            assert bounce_rate_module.redis_store.redis_store.set.call_count == 2
 
     def test_critical_high_volume_already_sent(self, mocker: MockFixture, notify_api, fake_uuid):
         """>=1000 messages, bounce rate >=10%, but suspension email already sent → no duplicate"""

--- a/tests/app/delivery/test_bounce_rate.py
+++ b/tests/app/delivery/test_bounce_rate.py
@@ -16,7 +16,7 @@ class TestCheckServiceOverBounceRate:
             mocker.patch("app.bounce_rate_client.get_bounce_rate", return_value=current_app.config["BR_CRITICAL_PERCENTAGE"])
             mocker.patch("app.bounce_rate_client.get_total_notifications", return_value=1500)
             mocker.patch("app.delivery.bounce_rate.redis_store")
-            bounce_rate_module.redis_store.set.return_value = True
+            bounce_rate_module.redis_store.redis_store.set.return_value = True
             mock_remove_perm = mocker.patch("app.delivery.bounce_rate.dao_remove_service_permission")
             mock_send_task = mocker.patch("app.delivery.bounce_rate.notify_celery.send_task")
 
@@ -36,7 +36,7 @@ class TestCheckServiceOverBounceRate:
             mocker.patch("app.bounce_rate_client.get_bounce_rate", return_value=current_app.config["BR_CRITICAL_PERCENTAGE"])
             mocker.patch("app.bounce_rate_client.get_total_notifications", return_value=1500)
             mocker.patch("app.delivery.bounce_rate.redis_store")
-            bounce_rate_module.redis_store.set.return_value = None  # nx=True fails
+            bounce_rate_module.redis_store.redis_store.set.return_value = None  # nx=True fails
             mock_remove_perm = mocker.patch("app.delivery.bounce_rate.dao_remove_service_permission")
             mock_send_task = mocker.patch("app.delivery.bounce_rate.notify_celery.send_task")
 
@@ -52,7 +52,7 @@ class TestCheckServiceOverBounceRate:
             mocker.patch("app.bounce_rate_client.get_bounce_rate", return_value=current_app.config["BR_WARNING_PERCENTAGE"])
             mocker.patch("app.bounce_rate_client.get_total_notifications", return_value=1500)
             mocker.patch("app.delivery.bounce_rate.redis_store")
-            bounce_rate_module.redis_store.set.return_value = True
+            bounce_rate_module.redis_store.redis_store.set.return_value = True
             mock_remove_perm = mocker.patch("app.delivery.bounce_rate.dao_remove_service_permission")
             mock_send_task = mocker.patch("app.delivery.bounce_rate.notify_celery.send_task")
 
@@ -72,7 +72,7 @@ class TestCheckServiceOverBounceRate:
             mocker.patch("app.bounce_rate_client.get_bounce_rate", return_value=current_app.config["BR_WARNING_PERCENTAGE"])
             mocker.patch("app.bounce_rate_client.get_total_notifications", return_value=1500)
             mocker.patch("app.delivery.bounce_rate.redis_store")
-            bounce_rate_module.redis_store.set.return_value = None  # nx=True fails
+            bounce_rate_module.redis_store.redis_store.set.return_value = None  # nx=True fails
             mock_send_task = mocker.patch("app.delivery.bounce_rate.notify_celery.send_task")
 
             bounce_rate_module.check_service_over_bounce_rate(fake_uuid)


### PR DESCRIPTION
1. Fix redis_store.set() not returning a value (nx=True always None)

The RedisClient.set() wrapper calls self.redis_store.set(...) but doesn't return the result — it implicitly returns None
This meant the if redis_store.set(..., nx=True) gate never evaluated to True, so suspension/warning actions were silently skipped
Fixed by calling redis_store.redis_store.set(...) directly (the underlying redis-py client), which correctly returns True on first set and None on subsequent calls

2. Prevent warning email after suspension email

When a service is suspended (≥10% bounce rate), also set the warning cache key
This prevents a follow-up warning email if the bounce rate later drops to the 5–10% range within the same 24h window

## Testing
I tested this by manupilating my DB and updating redis, but I will retest once on staging