### PR TITLE
Add the `v2/reports/id` GET endpoint

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -341,6 +341,7 @@ def register_v2_blueprints(application):
         v2_notification_blueprint,
     )
     from app.v2.reports import (  # noqa
+        get_reports,
         post_reports,
         v2_reports_blueprint,
     )

--- a/app/dao/reports_dao.py
+++ b/app/dao/reports_dao.py
@@ -49,10 +49,22 @@ def get_paginated_reports_for_service(service_id, older_than=None, page_size=10)
     filters = [Report.service_id == service_id]
 
     if older_than:
-        older_than_requested_at = db.session.query(Report.requested_at).filter(Report.id == older_than).as_scalar()
-        filters.append(Report.requested_at < older_than_requested_at)
+        older_than_row = db.session.query(Report.requested_at, Report.id).filter(Report.id == older_than).subquery()
+        filters.append(
+            db.or_(
+                Report.requested_at < older_than_row.c.requested_at,
+                db.and_(
+                    Report.requested_at == older_than_row.c.requested_at,
+                    Report.id < older_than_row.c.id,
+                ),
+            )
+        )
 
-    return Report.query.filter(*filters).order_by(desc(Report.requested_at)).paginate(per_page=page_size)
+    return (
+        Report.query.filter(*filters)
+        .order_by(desc(Report.requested_at), desc(Report.id))
+        .paginate(per_page=page_size, count=False)
+    )
 
 
 @transactional

--- a/app/dao/reports_dao.py
+++ b/app/dao/reports_dao.py
@@ -1,6 +1,8 @@
 import datetime
 from typing import List
 
+from sqlalchemy import desc
+
 from app import db
 from app.dao.dao_utils import transactional
 from app.models import Report
@@ -41,6 +43,16 @@ def get_reports_for_service(service_id: str, limit_days: int) -> List[Report]:
 
 def get_report_by_id(report_id) -> Report:
     return Report.query.filter_by(id=report_id).one()
+
+
+def get_paginated_reports_for_service(service_id, older_than=None, page_size=10):
+    filters = [Report.service_id == service_id]
+
+    if older_than:
+        older_than_requested_at = db.session.query(Report.requested_at).filter(Report.id == older_than).as_scalar()
+        filters.append(Report.requested_at < older_than_requested_at)
+
+    return Report.query.filter(*filters).order_by(desc(Report.requested_at)).paginate(per_page=page_size).items
 
 
 @transactional

--- a/app/dao/reports_dao.py
+++ b/app/dao/reports_dao.py
@@ -45,6 +45,10 @@ def get_report_by_id(report_id) -> Report:
     return Report.query.filter_by(id=report_id).one()
 
 
+def get_report_by_id_and_service_id(report_id, service_id) -> Report:
+    return Report.query.filter_by(id=report_id, service_id=service_id).one()
+
+
 def get_paginated_reports_for_service(service_id, older_than=None, page_size=10):
     filters = [Report.service_id == service_id]
 

--- a/app/dao/reports_dao.py
+++ b/app/dao/reports_dao.py
@@ -52,7 +52,7 @@ def get_paginated_reports_for_service(service_id, older_than=None, page_size=10)
         older_than_requested_at = db.session.query(Report.requested_at).filter(Report.id == older_than).as_scalar()
         filters.append(Report.requested_at < older_than_requested_at)
 
-    return Report.query.filter(*filters).order_by(desc(Report.requested_at)).paginate(per_page=page_size).items
+    return Report.query.filter(*filters).order_by(desc(Report.requested_at)).paginate(per_page=page_size)
 
 
 @transactional

--- a/app/v2/reports/get_reports.py
+++ b/app/v2/reports/get_reports.py
@@ -3,8 +3,10 @@ from flask import current_app, jsonify, request, url_for
 from app import api_user, authenticated_service
 from app.dao.reports_dao import get_paginated_reports_for_service
 from app.models import ApiKeyPermission
+from app.schema_validation import validate
 from app.v2.errors import ForbiddenError
 from app.v2.reports import v2_reports_blueprint
+from app.v2.reports.report_schemas import get_reports_request
 
 
 @v2_reports_blueprint.route("", methods=["GET"])
@@ -12,7 +14,8 @@ def get_reports():
     if not api_user.has_permission(ApiKeyPermission.MANAGE_REPORTS):
         raise ForbiddenError(message="This API key does not have permission to manage reports.")
 
-    older_than = request.args.get("older_than")
+    data = validate(request.args.to_dict(), get_reports_request)
+    older_than = data.get("older_than")
 
     paginated_reports = get_paginated_reports_for_service(
         service_id=authenticated_service.id,

--- a/app/v2/reports/get_reports.py
+++ b/app/v2/reports/get_reports.py
@@ -1,0 +1,48 @@
+from flask import current_app, jsonify, request, url_for
+
+from app import api_user, authenticated_service
+from app.dao.reports_dao import get_paginated_reports_for_service
+from app.models import ApiKeyPermission
+from app.v2.errors import ForbiddenError
+from app.v2.reports import v2_reports_blueprint
+
+
+@v2_reports_blueprint.route("", methods=["GET"])
+def get_reports():
+    if not api_user.has_permission(ApiKeyPermission.MANAGE_REPORTS):
+        raise ForbiddenError(message="This API key does not have permission to manage reports.")
+
+    older_than = request.args.get("older_than")
+
+    paginated_reports = get_paginated_reports_for_service(
+        service_id=authenticated_service.id,
+        older_than=older_than,
+        page_size=current_app.config.get("API_PAGE_SIZE"),
+    )
+
+    return (
+        jsonify(
+            reports=[report.serialize() for report in paginated_reports],
+            links=_build_links(paginated_reports, older_than),
+        ),
+        200,
+    )
+
+
+def _build_links(reports_list, older_than=None):
+    _links = {
+        "current": url_for(
+            "v2_reports.get_reports",
+            _external=True,
+            **{"older_than": older_than} if older_than else {},
+        ),
+    }
+
+    if reports_list:
+        _links["next"] = url_for(
+            "v2_reports.get_reports",
+            older_than=reports_list[-1].id,
+            _external=True,
+        )
+
+    return _links

--- a/app/v2/reports/get_reports.py
+++ b/app/v2/reports/get_reports.py
@@ -8,6 +8,8 @@ from app.v2.errors import ForbiddenError
 from app.v2.reports import v2_reports_blueprint
 from app.v2.reports.report_schemas import get_report_by_id_request, get_reports_request
 
+EXCLUDED_FIELDS = {"url"}
+
 
 @v2_reports_blueprint.route("", methods=["GET"])
 def get_reports():
@@ -23,12 +25,10 @@ def get_reports():
         page_size=current_app.config.get("API_PAGE_SIZE"),
     )
 
-    excluded_fields = {"url"}
-
     return (
         jsonify(
             reports=[
-                {k: v for k, v in report.serialize().items() if k not in excluded_fields} for report in paginated_reports.items
+                {k: v for k, v in report.serialize().items() if k not in EXCLUDED_FIELDS} for report in paginated_reports.items
             ],
             links=_build_links(paginated_reports.items, older_than),
         ),
@@ -45,7 +45,7 @@ def get_report(report_id):
 
     report = get_report_by_id_and_service_id(report_id=report_id, service_id=authenticated_service.id)
 
-    serialized = {k: v for k, v in report.serialize().items() if k != "url"}
+    serialized = {k: v for k, v in report.serialize().items() if k not in EXCLUDED_FIELDS}
     return jsonify(serialized), 200
 
 

--- a/app/v2/reports/get_reports.py
+++ b/app/v2/reports/get_reports.py
@@ -24,8 +24,10 @@ def get_reports():
 
     return (
         jsonify(
-            reports=[{k: v for k, v in report.serialize().items() if k not in excluded_fields} for report in paginated_reports],
-            links=_build_links(paginated_reports, older_than),
+            reports=[
+                {k: v for k, v in report.serialize().items() if k not in excluded_fields} for report in paginated_reports.items
+            ],
+            links=_build_links(paginated_reports.items, older_than),
         ),
         200,
     )

--- a/app/v2/reports/get_reports.py
+++ b/app/v2/reports/get_reports.py
@@ -1,12 +1,12 @@
 from flask import current_app, jsonify, request, url_for
 
 from app import api_user, authenticated_service
-from app.dao.reports_dao import get_paginated_reports_for_service
+from app.dao.reports_dao import get_paginated_reports_for_service, get_report_by_id_and_service_id
 from app.models import ApiKeyPermission
 from app.schema_validation import validate
 from app.v2.errors import ForbiddenError
 from app.v2.reports import v2_reports_blueprint
-from app.v2.reports.report_schemas import get_reports_request
+from app.v2.reports.report_schemas import get_report_by_id_request, get_reports_request
 
 
 @v2_reports_blueprint.route("", methods=["GET"])
@@ -34,6 +34,19 @@ def get_reports():
         ),
         200,
     )
+
+
+@v2_reports_blueprint.route("/<report_id>", methods=["GET"])
+def get_report(report_id):
+    if not api_user.has_permission(ApiKeyPermission.MANAGE_REPORTS):
+        raise ForbiddenError(message="This API key does not have permission to manage reports.")
+
+    validate({"report_id": report_id}, get_report_by_id_request)
+
+    report = get_report_by_id_and_service_id(report_id=report_id, service_id=authenticated_service.id)
+
+    serialized = {k: v for k, v in report.serialize().items() if k != "url"}
+    return jsonify(serialized), 200
 
 
 def _build_links(reports_list, older_than=None):

--- a/app/v2/reports/get_reports.py
+++ b/app/v2/reports/get_reports.py
@@ -20,9 +20,11 @@ def get_reports():
         page_size=current_app.config.get("API_PAGE_SIZE"),
     )
 
+    excluded_fields = {"url"}
+
     return (
         jsonify(
-            reports=[report.serialize() for report in paginated_reports],
+            reports=[{k: v for k, v in report.serialize().items() if k not in excluded_fields} for report in paginated_reports],
             links=_build_links(paginated_reports, older_than),
         ),
         200,

--- a/app/v2/reports/report_schemas.py
+++ b/app/v2/reports/report_schemas.py
@@ -2,6 +2,17 @@ from app.models import ReportType
 from app.schema_validation.definitions import nullable_uuid
 from app.schema_validation.definitions import uuid as uuid_schema
 
+get_report_by_id_request = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "schema for path parameters when getting a single report by id",
+    "type": "object",
+    "properties": {
+        "report_id": uuid_schema,
+    },
+    "required": ["report_id"],
+    "additionalProperties": False,
+}
+
 get_reports_request = {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "schema for query parameters allowed when getting list of reports",

--- a/app/v2/reports/report_schemas.py
+++ b/app/v2/reports/report_schemas.py
@@ -2,6 +2,16 @@ from app.models import ReportType
 from app.schema_validation.definitions import nullable_uuid
 from app.schema_validation.definitions import uuid as uuid_schema
 
+get_reports_request = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "schema for query parameters allowed when getting list of reports",
+    "type": "object",
+    "properties": {
+        "older_than": uuid_schema,
+    },
+    "additionalProperties": False,
+}
+
 post_report_request = {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "POST v2 report request schema",

--- a/tests/app/v2/reports/test_get_reports.py
+++ b/tests/app/v2/reports/test_get_reports.py
@@ -1,0 +1,154 @@
+import json
+import uuid
+
+from app.dao.reports_dao import create_report
+from app.models import Report, ReportStatus, ReportType
+from tests import create_authorization_header
+
+
+def _make_report(
+    service_id, report_type=ReportType.EMAIL.value, status=ReportStatus.READY.value, url="https://s3.example.com/report.csv"
+):
+    return Report(
+        id=uuid.uuid4(),
+        report_type=report_type,
+        service_id=service_id,
+        status=status,
+        requesting_user_id=None,
+        language="en",
+        url=url,
+    )
+
+
+def test_get_reports_returns_200(client, sample_service, create_api_key_with_manage_reports_perm):
+    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+    create_report(_make_report(sample_service.id))
+
+    response = client.get(
+        path="/v2/reports",
+        headers=[auth_header],
+    )
+
+    assert response.status_code == 200
+
+
+def test_get_reports_returns_list_of_reports(client, sample_service, create_api_key_with_manage_reports_perm):
+    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+    report = _make_report(sample_service.id)
+    create_report(report)
+
+    response = client.get(
+        path="/v2/reports",
+        headers=[auth_header],
+    )
+
+    data = json.loads(response.get_data(as_text=True))
+    assert len(data["reports"]) == 1
+    assert data["reports"][0]["id"] == str(report.id)
+    assert data["reports"][0]["report_type"] == report.report_type
+    assert data["reports"][0]["status"] == report.status
+
+
+def test_get_reports_does_not_include_url(client, sample_service, create_api_key_with_manage_reports_perm):
+    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+    create_report(_make_report(sample_service.id))
+
+    response = client.get(
+        path="/v2/reports",
+        headers=[auth_header],
+    )
+
+    data = json.loads(response.get_data(as_text=True))
+    assert "url" not in data["reports"][0]
+
+
+def test_get_reports_returns_only_reports_for_service(
+    client, sample_service, notify_db_session, create_api_key_with_manage_reports_perm
+):
+    from tests.app.db import create_service
+
+    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+    other_service = create_service(service_name="other service")
+
+    create_report(_make_report(sample_service.id))
+    create_report(_make_report(other_service.id))
+
+    response = client.get(
+        path="/v2/reports",
+        headers=[auth_header],
+    )
+
+    data = json.loads(response.get_data(as_text=True))
+    assert len(data["reports"]) == 1
+    assert data["reports"][0]["service_id"] == str(sample_service.id)
+
+
+def test_get_reports_returns_links(client, sample_service, create_api_key_with_manage_reports_perm):
+    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+    create_report(_make_report(sample_service.id))
+
+    response = client.get(
+        path="/v2/reports",
+        headers=[auth_header],
+    )
+
+    data = json.loads(response.get_data(as_text=True))
+    assert "links" in data
+    assert "current" in data["links"]
+    assert "next" in data["links"]
+
+
+def test_get_reports_empty_list_has_no_next_link(client, sample_service, create_api_key_with_manage_reports_perm):
+    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+
+    response = client.get(
+        path="/v2/reports",
+        headers=[auth_header],
+    )
+
+    data = json.loads(response.get_data(as_text=True))
+    assert data["reports"] == []
+    assert "next" not in data["links"]
+
+
+def test_get_reports_returns_403_without_manage_reports_permission(client, create_api_key_no_perm):
+    auth_header = create_authorization_header(api_key=create_api_key_no_perm)
+
+    response = client.get(
+        path="/v2/reports",
+        headers=[auth_header],
+    )
+
+    assert response.status_code == 403
+    data = json.loads(response.get_data(as_text=True))
+    assert "manage reports" in data["errors"][0]["message"].lower()
+
+
+def test_get_reports_requires_authentication(client):
+    response = client.get(path="/v2/reports")
+
+    assert response.status_code == 401
+
+
+def test_get_reports_pagination_with_older_than(
+    client, sample_service, notify_db_session, create_api_key_with_manage_reports_perm, mocker
+):
+    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+    mocker.patch.dict("app.v2.reports.get_reports.current_app.config", {"API_PAGE_SIZE": 1})
+
+    report1 = _make_report(sample_service.id)
+    report2 = _make_report(sample_service.id)
+    create_report(report1)
+    create_report(report2)
+
+    # Fetch first page
+    response = client.get(path="/v2/reports", headers=[auth_header])
+    data = json.loads(response.get_data(as_text=True))
+    assert len(data["reports"]) == 1
+    first_id = data["reports"][0]["id"]
+
+    # Fetch next page using older_than
+    response2 = client.get(path=f"/v2/reports?older_than={first_id}", headers=[auth_header])
+    data2 = json.loads(response2.get_data(as_text=True))
+    assert len(data2["reports"]) == 1
+    assert data2["reports"][0]["id"] != first_id

--- a/tests/app/v2/reports/test_get_reports.py
+++ b/tests/app/v2/reports/test_get_reports.py
@@ -160,3 +160,88 @@ def test_get_reports_returns_400_for_invalid_older_than(client, sample_service, 
     response = client.get(path="/v2/reports?older_than=not-a-uuid", headers=[auth_header])
 
     assert response.status_code == 400
+
+
+# ---- GET /v2/reports/<report_id> tests ----
+
+
+def test_get_report_by_id_returns_200(client, sample_service, create_api_key_with_manage_reports_perm):
+    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+    report = _make_report(sample_service.id)
+    create_report(report)
+
+    response = client.get(path=f"/v2/reports/{report.id}", headers=[auth_header])
+
+    assert response.status_code == 200
+
+
+def test_get_report_by_id_returns_report_fields(client, sample_service, create_api_key_with_manage_reports_perm):
+    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+    report = _make_report(sample_service.id)
+    create_report(report)
+
+    response = client.get(path=f"/v2/reports/{report.id}", headers=[auth_header])
+
+    data = json.loads(response.get_data(as_text=True))
+    assert data["id"] == str(report.id)
+    assert data["report_type"] == report.report_type
+    assert data["status"] == report.status
+    assert data["service_id"] == str(sample_service.id)
+
+
+def test_get_report_by_id_does_not_include_url(client, sample_service, create_api_key_with_manage_reports_perm):
+    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+    report = _make_report(sample_service.id)
+    create_report(report)
+
+    response = client.get(path=f"/v2/reports/{report.id}", headers=[auth_header])
+
+    data = json.loads(response.get_data(as_text=True))
+    assert "url" not in data
+
+
+def test_get_report_by_id_returns_404_for_nonexistent_id(client, sample_service, create_api_key_with_manage_reports_perm):
+    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+
+    response = client.get(path=f"/v2/reports/{uuid.uuid4()}", headers=[auth_header])
+
+    assert response.status_code == 404
+
+
+def test_get_report_by_id_returns_404_for_other_services_report(
+    client, sample_service, notify_db_session, create_api_key_with_manage_reports_perm
+):
+    from tests.app.db import create_service
+
+    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+    other_service = create_service(service_name="other service")
+    other_report = _make_report(other_service.id)
+    create_report(other_report)
+
+    response = client.get(path=f"/v2/reports/{other_report.id}", headers=[auth_header])
+
+    assert response.status_code == 404
+
+
+def test_get_report_by_id_returns_403_without_manage_reports_permission(client, sample_service, create_api_key_no_perm):
+    auth_header = create_authorization_header(api_key=create_api_key_no_perm)
+
+    response = client.get(path=f"/v2/reports/{uuid.uuid4()}", headers=[auth_header])
+
+    assert response.status_code == 403
+    data = json.loads(response.get_data(as_text=True))
+    assert "manage reports" in data["errors"][0]["message"].lower()
+
+
+def test_get_report_by_id_requires_authentication(client):
+    response = client.get(path=f"/v2/reports/{uuid.uuid4()}")
+
+    assert response.status_code == 401
+
+
+def test_get_report_by_id_returns_400_for_invalid_id(client, sample_service, create_api_key_with_manage_reports_perm):
+    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+
+    response = client.get(path="/v2/reports/not-a-uuid", headers=[auth_header])
+
+    assert response.status_code == 400

--- a/tests/app/v2/reports/test_get_reports.py
+++ b/tests/app/v2/reports/test_get_reports.py
@@ -4,6 +4,7 @@ import uuid
 from app.dao.reports_dao import create_report
 from app.models import Report, ReportStatus, ReportType
 from tests import create_authorization_header
+from tests.app.db import create_service
 
 
 def _make_report(
@@ -211,8 +212,6 @@ def test_get_report_by_id_returns_404_for_nonexistent_id(client, sample_service,
 def test_get_report_by_id_returns_404_for_other_services_report(
     client, sample_service, notify_db_session, create_api_key_with_manage_reports_perm
 ):
-    from tests.app.db import create_service
-
     auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
     other_service = create_service(service_name="other service")
     other_report = _make_report(other_service.id)

--- a/tests/app/v2/reports/test_get_reports.py
+++ b/tests/app/v2/reports/test_get_reports.py
@@ -21,226 +21,207 @@ def _make_report(
     )
 
 
-def test_get_reports_returns_200(client, sample_service, create_api_key_with_manage_reports_perm):
-    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
-    create_report(_make_report(sample_service.id))
+class TestGetReports:
+    def test_returns_200(self, client, sample_service, create_api_key_with_manage_reports_perm):
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+        create_report(_make_report(sample_service.id))
+
+        response = client.get(
+            path="/v2/reports",
+            headers=[auth_header],
+        )
+
+        assert response.status_code == 200
+
+    def test_returns_list_of_reports(self, client, sample_service, create_api_key_with_manage_reports_perm):
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+        report = _make_report(sample_service.id)
+        create_report(report)
+
+        response = client.get(
+            path="/v2/reports",
+            headers=[auth_header],
+        )
+
+        data = json.loads(response.get_data(as_text=True))
+        assert len(data["reports"]) == 1
+        assert data["reports"][0]["id"] == str(report.id)
+        assert data["reports"][0]["report_type"] == report.report_type
+        assert data["reports"][0]["status"] == report.status
+
+    def test_does_not_include_url(self, client, sample_service, create_api_key_with_manage_reports_perm):
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+        create_report(_make_report(sample_service.id))
+
+        response = client.get(
+            path="/v2/reports",
+            headers=[auth_header],
+        )
+
+        data = json.loads(response.get_data(as_text=True))
+        assert "url" not in data["reports"][0]
+
+    def test_returns_only_reports_for_service(
+        self, client, sample_service, notify_db_session, create_api_key_with_manage_reports_perm
+    ):
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+        other_service = create_service(service_name="other service")
+
+        create_report(_make_report(sample_service.id))
+        create_report(_make_report(other_service.id))
+
+        response = client.get(
+            path="/v2/reports",
+            headers=[auth_header],
+        )
+
+        data = json.loads(response.get_data(as_text=True))
+        assert len(data["reports"]) == 1
+        assert data["reports"][0]["service_id"] == str(sample_service.id)
+
+    def test_returns_links(self, client, sample_service, create_api_key_with_manage_reports_perm):
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+        create_report(_make_report(sample_service.id))
+
+        response = client.get(
+            path="/v2/reports",
+            headers=[auth_header],
+        )
+
+        data = json.loads(response.get_data(as_text=True))
+        assert "links" in data
+        assert "current" in data["links"]
+        assert "next" in data["links"]
 
-    response = client.get(
-        path="/v2/reports",
-        headers=[auth_header],
-    )
+    def test_empty_list_has_no_next_link(self, client, sample_service, create_api_key_with_manage_reports_perm):
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
 
-    assert response.status_code == 200
+        response = client.get(
+            path="/v2/reports",
+            headers=[auth_header],
+        )
+
+        data = json.loads(response.get_data(as_text=True))
+        assert data["reports"] == []
+        assert "next" not in data["links"]
 
+    def test_returns_403_without_manage_reports_permission(self, client, create_api_key_no_perm):
+        auth_header = create_authorization_header(api_key=create_api_key_no_perm)
 
-def test_get_reports_returns_list_of_reports(client, sample_service, create_api_key_with_manage_reports_perm):
-    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
-    report = _make_report(sample_service.id)
-    create_report(report)
+        response = client.get(
+            path="/v2/reports",
+            headers=[auth_header],
+        )
 
-    response = client.get(
-        path="/v2/reports",
-        headers=[auth_header],
-    )
+        assert response.status_code == 403
+        data = json.loads(response.get_data(as_text=True))
+        assert "manage reports" in data["errors"][0]["message"].lower()
 
-    data = json.loads(response.get_data(as_text=True))
-    assert len(data["reports"]) == 1
-    assert data["reports"][0]["id"] == str(report.id)
-    assert data["reports"][0]["report_type"] == report.report_type
-    assert data["reports"][0]["status"] == report.status
+    def test_requires_authentication(self, client):
+        response = client.get(path="/v2/reports")
 
+        assert response.status_code == 401
 
-def test_get_reports_does_not_include_url(client, sample_service, create_api_key_with_manage_reports_perm):
-    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
-    create_report(_make_report(sample_service.id))
+    def test_pagination_with_older_than(
+        self, client, sample_service, notify_db_session, create_api_key_with_manage_reports_perm, mocker
+    ):
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+        mocker.patch.dict("app.v2.reports.get_reports.current_app.config", {"API_PAGE_SIZE": 1})
 
-    response = client.get(
-        path="/v2/reports",
-        headers=[auth_header],
-    )
+        report1 = _make_report(sample_service.id)
+        report2 = _make_report(sample_service.id)
+        create_report(report1)
+        create_report(report2)
 
-    data = json.loads(response.get_data(as_text=True))
-    assert "url" not in data["reports"][0]
+        # Fetch first page
+        response = client.get(path="/v2/reports", headers=[auth_header])
+        data = json.loads(response.get_data(as_text=True))
+        assert len(data["reports"]) == 1
+        first_id = data["reports"][0]["id"]
 
+        # Fetch next page using older_than
+        response2 = client.get(path=f"/v2/reports?older_than={first_id}", headers=[auth_header])
+        data2 = json.loads(response2.get_data(as_text=True))
+        assert len(data2["reports"]) == 1
+        assert data2["reports"][0]["id"] != first_id
 
-def test_get_reports_returns_only_reports_for_service(
-    client, sample_service, notify_db_session, create_api_key_with_manage_reports_perm
-):
-    from tests.app.db import create_service
+    def test_returns_400_for_invalid_older_than(self, client, sample_service, create_api_key_with_manage_reports_perm):
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
 
-    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
-    other_service = create_service(service_name="other service")
+        response = client.get(path="/v2/reports?older_than=not-a-uuid", headers=[auth_header])
 
-    create_report(_make_report(sample_service.id))
-    create_report(_make_report(other_service.id))
+        assert response.status_code == 400
 
-    response = client.get(
-        path="/v2/reports",
-        headers=[auth_header],
-    )
 
-    data = json.loads(response.get_data(as_text=True))
-    assert len(data["reports"]) == 1
-    assert data["reports"][0]["service_id"] == str(sample_service.id)
+class TestGetReportById:
+    def test_returns_200(self, client, sample_service, create_api_key_with_manage_reports_perm):
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+        report = _make_report(sample_service.id)
+        create_report(report)
 
+        response = client.get(path=f"/v2/reports/{report.id}", headers=[auth_header])
 
-def test_get_reports_returns_links(client, sample_service, create_api_key_with_manage_reports_perm):
-    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
-    create_report(_make_report(sample_service.id))
+        assert response.status_code == 200
 
-    response = client.get(
-        path="/v2/reports",
-        headers=[auth_header],
-    )
+    def test_returns_report_fields(self, client, sample_service, create_api_key_with_manage_reports_perm):
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+        report = _make_report(sample_service.id)
+        create_report(report)
 
-    data = json.loads(response.get_data(as_text=True))
-    assert "links" in data
-    assert "current" in data["links"]
-    assert "next" in data["links"]
+        response = client.get(path=f"/v2/reports/{report.id}", headers=[auth_header])
 
+        data = json.loads(response.get_data(as_text=True))
+        assert data["id"] == str(report.id)
+        assert data["report_type"] == report.report_type
+        assert data["status"] == report.status
+        assert data["service_id"] == str(sample_service.id)
 
-def test_get_reports_empty_list_has_no_next_link(client, sample_service, create_api_key_with_manage_reports_perm):
-    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+    def test_does_not_include_url(self, client, sample_service, create_api_key_with_manage_reports_perm):
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+        report = _make_report(sample_service.id)
+        create_report(report)
 
-    response = client.get(
-        path="/v2/reports",
-        headers=[auth_header],
-    )
+        response = client.get(path=f"/v2/reports/{report.id}", headers=[auth_header])
 
-    data = json.loads(response.get_data(as_text=True))
-    assert data["reports"] == []
-    assert "next" not in data["links"]
+        data = json.loads(response.get_data(as_text=True))
+        assert "url" not in data
 
+    def test_returns_404_for_nonexistent_id(self, client, sample_service, create_api_key_with_manage_reports_perm):
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
 
-def test_get_reports_returns_403_without_manage_reports_permission(client, create_api_key_no_perm):
-    auth_header = create_authorization_header(api_key=create_api_key_no_perm)
+        response = client.get(path=f"/v2/reports/{uuid.uuid4()}", headers=[auth_header])
 
-    response = client.get(
-        path="/v2/reports",
-        headers=[auth_header],
-    )
+        assert response.status_code == 404
 
-    assert response.status_code == 403
-    data = json.loads(response.get_data(as_text=True))
-    assert "manage reports" in data["errors"][0]["message"].lower()
+    def test_returns_404_for_other_services_report(
+        self, client, sample_service, notify_db_session, create_api_key_with_manage_reports_perm
+    ):
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+        other_service = create_service(service_name="other service")
+        other_report = _make_report(other_service.id)
+        create_report(other_report)
 
+        response = client.get(path=f"/v2/reports/{other_report.id}", headers=[auth_header])
 
-def test_get_reports_requires_authentication(client):
-    response = client.get(path="/v2/reports")
+        assert response.status_code == 404
 
-    assert response.status_code == 401
+    def test_returns_403_without_manage_reports_permission(self, client, sample_service, create_api_key_no_perm):
+        auth_header = create_authorization_header(api_key=create_api_key_no_perm)
 
+        response = client.get(path=f"/v2/reports/{uuid.uuid4()}", headers=[auth_header])
 
-def test_get_reports_pagination_with_older_than(
-    client, sample_service, notify_db_session, create_api_key_with_manage_reports_perm, mocker
-):
-    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
-    mocker.patch.dict("app.v2.reports.get_reports.current_app.config", {"API_PAGE_SIZE": 1})
+        assert response.status_code == 403
+        data = json.loads(response.get_data(as_text=True))
+        assert "manage reports" in data["errors"][0]["message"].lower()
 
-    report1 = _make_report(sample_service.id)
-    report2 = _make_report(sample_service.id)
-    create_report(report1)
-    create_report(report2)
+    def test_requires_authentication(self, client):
+        response = client.get(path=f"/v2/reports/{uuid.uuid4()}")
 
-    # Fetch first page
-    response = client.get(path="/v2/reports", headers=[auth_header])
-    data = json.loads(response.get_data(as_text=True))
-    assert len(data["reports"]) == 1
-    first_id = data["reports"][0]["id"]
+        assert response.status_code == 401
 
-    # Fetch next page using older_than
-    response2 = client.get(path=f"/v2/reports?older_than={first_id}", headers=[auth_header])
-    data2 = json.loads(response2.get_data(as_text=True))
-    assert len(data2["reports"]) == 1
-    assert data2["reports"][0]["id"] != first_id
+    def test_returns_400_for_invalid_id(self, client, sample_service, create_api_key_with_manage_reports_perm):
+        auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
 
+        response = client.get(path="/v2/reports/not-a-uuid", headers=[auth_header])
 
-def test_get_reports_returns_400_for_invalid_older_than(client, sample_service, create_api_key_with_manage_reports_perm):
-    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
-
-    response = client.get(path="/v2/reports?older_than=not-a-uuid", headers=[auth_header])
-
-    assert response.status_code == 400
-
-
-# ---- GET /v2/reports/<report_id> tests ----
-
-
-def test_get_report_by_id_returns_200(client, sample_service, create_api_key_with_manage_reports_perm):
-    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
-    report = _make_report(sample_service.id)
-    create_report(report)
-
-    response = client.get(path=f"/v2/reports/{report.id}", headers=[auth_header])
-
-    assert response.status_code == 200
-
-
-def test_get_report_by_id_returns_report_fields(client, sample_service, create_api_key_with_manage_reports_perm):
-    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
-    report = _make_report(sample_service.id)
-    create_report(report)
-
-    response = client.get(path=f"/v2/reports/{report.id}", headers=[auth_header])
-
-    data = json.loads(response.get_data(as_text=True))
-    assert data["id"] == str(report.id)
-    assert data["report_type"] == report.report_type
-    assert data["status"] == report.status
-    assert data["service_id"] == str(sample_service.id)
-
-
-def test_get_report_by_id_does_not_include_url(client, sample_service, create_api_key_with_manage_reports_perm):
-    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
-    report = _make_report(sample_service.id)
-    create_report(report)
-
-    response = client.get(path=f"/v2/reports/{report.id}", headers=[auth_header])
-
-    data = json.loads(response.get_data(as_text=True))
-    assert "url" not in data
-
-
-def test_get_report_by_id_returns_404_for_nonexistent_id(client, sample_service, create_api_key_with_manage_reports_perm):
-    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
-
-    response = client.get(path=f"/v2/reports/{uuid.uuid4()}", headers=[auth_header])
-
-    assert response.status_code == 404
-
-
-def test_get_report_by_id_returns_404_for_other_services_report(
-    client, sample_service, notify_db_session, create_api_key_with_manage_reports_perm
-):
-    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
-    other_service = create_service(service_name="other service")
-    other_report = _make_report(other_service.id)
-    create_report(other_report)
-
-    response = client.get(path=f"/v2/reports/{other_report.id}", headers=[auth_header])
-
-    assert response.status_code == 404
-
-
-def test_get_report_by_id_returns_403_without_manage_reports_permission(client, sample_service, create_api_key_no_perm):
-    auth_header = create_authorization_header(api_key=create_api_key_no_perm)
-
-    response = client.get(path=f"/v2/reports/{uuid.uuid4()}", headers=[auth_header])
-
-    assert response.status_code == 403
-    data = json.loads(response.get_data(as_text=True))
-    assert "manage reports" in data["errors"][0]["message"].lower()
-
-
-def test_get_report_by_id_requires_authentication(client):
-    response = client.get(path=f"/v2/reports/{uuid.uuid4()}")
-
-    assert response.status_code == 401
-
-
-def test_get_report_by_id_returns_400_for_invalid_id(client, sample_service, create_api_key_with_manage_reports_perm):
-    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
-
-    response = client.get(path="/v2/reports/not-a-uuid", headers=[auth_header])
-
-    assert response.status_code == 400
+        assert response.status_code == 400

--- a/tests/app/v2/reports/test_get_reports.py
+++ b/tests/app/v2/reports/test_get_reports.py
@@ -152,3 +152,11 @@ def test_get_reports_pagination_with_older_than(
     data2 = json.loads(response2.get_data(as_text=True))
     assert len(data2["reports"]) == 1
     assert data2["reports"][0]["id"] != first_id
+
+
+def test_get_reports_returns_400_for_invalid_older_than(client, sample_service, create_api_key_with_manage_reports_perm):
+    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+
+    response = client.get(path="/v2/reports?older_than=not-a-uuid", headers=[auth_header])
+
+    assert response.status_code == 400


### PR DESCRIPTION
# Summary | Résumé

This PR adds the `v2/reports/id` GET endpoint. This returns the metadata for a single report. I've also added tests and  some data validation for the api requests.

## Related Issues | Cartes liées

- https://github.com/cds-snc/notification-planning/issues/3371

# Test instructions | Instructions pour tester la modification

1. check out branch and run locally
2. try requesting a report and note the id using the following:
```
curl -X POST "http://localhost:6011/v2/reports" \
  -H "Authorization: ApiKey-v1 YOUR_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"report_type": "email", "language": "en"}'
```
4. test the new endpoint using the report id you recieved in the previous step:
```
curl -X GET "http://localhost:6011/v2/reports/YOUR_REPORT_ID" \
  -H "Authorization: ApiKey-v1 YOUR_API_KEY" \
  -H "Content-Type: application/json" 
```

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.