### PR TITLE
Add archived_by_id & archived_at columns

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -239,7 +239,7 @@ def dao_fetch_all_services_by_user(user_id, only_active=False):
 
 
 @transactional
-def dao_archive_service(service_id):
+def dao_archive_service(service_id, user_id=None):
     """
     Archive a service and commit the change.
 
@@ -252,7 +252,7 @@ def dao_archive_service(service_id):
     atomicity.
     """
 
-    return dao_archive_service_no_transaction(service_id)
+    return dao_archive_service_no_transaction(service_id, user_id)
 
 
 @version_class(
@@ -260,7 +260,7 @@ def dao_archive_service(service_id):
     VersionOptions(Service),
     VersionOptions(Template, history_class=TemplateHistory, must_write_history=False),
 )
-def dao_archive_service_no_transaction(service_id):
+def dao_archive_service_no_transaction(service_id, user_id=None):
     """
     Core archive implementation that DOES NOT commit the session.
 
@@ -291,6 +291,9 @@ def dao_archive_service_no_transaction(service_id):
     service.active = False
     service.name = "_archived_" + time + "_" + service.name
     service.email_from = "_archived_" + time + "_" + service.email_from
+    service.archived_at = datetime.now(tz=pytz.UTC)
+    if user_id is not None:
+        service.archived_by_id = user_id
 
     for template in service.templates:
         if not template.archived:

--- a/app/models.py
+++ b/app/models.py
@@ -633,6 +633,8 @@ class Service(BaseModel, Versioned):
     sms_annual_limit = db.Column(db.BigInteger, nullable=False, default=DEFAULT_SMS_ANNUAL_LIMIT)
     suspended_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), nullable=True)
     suspended_at = db.Column(db.DateTime, nullable=True)
+    archived_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), nullable=True)
+    archived_at = db.Column(db.DateTime, nullable=True)
 
     email_branding = db.relationship(
         "EmailBranding",

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -784,19 +784,21 @@ def update_safelist(service_id):
         return "", 204
 
 
+@service_blueprint.route("/<uuid:service_id>/archive/<uuid:user_id>", methods=["POST"])
 @service_blueprint.route("/<uuid:service_id>/archive", methods=["POST"])
-def archive_service(service_id):
+def archive_service(service_id, user_id=None):
     """
     When a service is archived the service is made inactive, templates are archived and api keys are revoked.
     There is no coming back from this operation.
     :param service_id:
+    :param user_id: optional ID of the user performing the archive, recorded for audit purposes
     :return:
     """
     service: Service = dao_fetch_service_by_id(service_id)
 
     if service.active:
         try:
-            service_name = dao_archive_service(service.id)
+            service_name = dao_archive_service(service.id, user_id)
             send_notification_to_service_users(
                 service_id=service_id,
                 template_id=current_app.config["SERVICE_DEACTIVATED_TEMPLATE_ID"],

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -1082,7 +1082,7 @@ def deactivate_user(user_id):
 
                 # Deactivate if no active members would remain
                 if len(remaining_active_members) == 0:
-                    dao_archive_service_no_transaction(service.id)
+                    dao_archive_service_no_transaction(service.id, user.id)
                     services_deactivated.append(service.id)
                 # Suspend if it's a live service and only 1 active member would remain
                 elif service_is_live and len(remaining_active_members) == 1:

--- a/migrations/versions/0521_add_archived_columns.py
+++ b/migrations/versions/0521_add_archived_columns.py
@@ -1,0 +1,31 @@
+"""
+Revision ID: 0521_add_archived_columns
+Revises: 0520_update_bounce_rate_susp
+Create Date: 2026-07-23
+
+Add archived_at and archived_by_id columns to the services and services_history
+tables to provide a proper audit trail of who archived a service and when.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0521_add_archived_columns"
+down_revision = "0520_update_bounce_rate_susp"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("services", sa.Column("archived_by_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id"), nullable=True))
+    op.add_column("services", sa.Column("archived_at", sa.DateTime(), nullable=True))
+    op.add_column("services_history", sa.Column("archived_by_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id"), nullable=True))
+    op.add_column("services_history", sa.Column("archived_at", sa.DateTime(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("services", "archived_by_id")
+    op.drop_column("services", "archived_at")
+    op.drop_column("services_history", "archived_by_id")
+    op.drop_column("services_history", "archived_at")


### PR DESCRIPTION
# Summary | Résumé
This PR adds two new columns to the services table:
- `archived_by_id`
- `archived_at`

Currently we only have `suspended_by_id` and `suspended_at` columns to track and audit service state. These two new columns will provide the same auditability when a service is archived. 

There are two triggers for this:
1. This includes when a service owner archives via the service settings page. -> user who confirmed the deletion is recorded in the `archived_by_id`
2. When the only remaining user on a service is deactivated, then archival is triggered. In this case either the **user** or **platform admin** who deactivated the final remaining user is recorded in the `archived_by_id` column.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/3396

# Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.