### PR TITLE
Set suspended_at columns during archival

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -239,7 +239,7 @@ def dao_fetch_all_services_by_user(user_id, only_active=False):
 
 
 @transactional
-def dao_archive_service(service_id):
+def dao_archive_service(service_id, user_id=None):
     """
     Archive a service and commit the change.
 
@@ -252,7 +252,7 @@ def dao_archive_service(service_id):
     atomicity.
     """
 
-    return dao_archive_service_no_transaction(service_id)
+    return dao_archive_service_no_transaction(service_id, user_id)
 
 
 @version_class(
@@ -260,7 +260,7 @@ def dao_archive_service(service_id):
     VersionOptions(Service),
     VersionOptions(Template, history_class=TemplateHistory, must_write_history=False),
 )
-def dao_archive_service_no_transaction(service_id):
+def dao_archive_service_no_transaction(service_id, user_id=None):
     """
     Core archive implementation that DOES NOT commit the session.
 
@@ -268,7 +268,7 @@ def dao_archive_service_no_transaction(service_id):
       - Call this function from within a caller-managed transaction, e.g.
         `with db.session.begin(): dao_archive_service_no_transaction(...)`.
       - This keeps multiple related DB mutations atomic and allows the caller
-        to commit or roll back as a single unit.
+        to commit or rollhttps://ca.slack-edge.com/T2G2S06PM-U037Q2VJ0CB-f337382106fa-72 back as a single unit.
 
     Note: callers that want the old behaviour (function commits itself) should
     call `dao_archive_service(...)` instead.
@@ -291,6 +291,9 @@ def dao_archive_service_no_transaction(service_id):
     service.active = False
     service.name = "_archived_" + time + "_" + service.name
     service.email_from = "_archived_" + time + "_" + service.email_from
+    service.suspended_at = datetime.now(tz=pytz.UTC)
+    if user_id is not None:
+        service.suspended_by_id = user_id
 
     for template in service.templates:
         if not template.archived:

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -268,7 +268,7 @@ def dao_archive_service_no_transaction(service_id, user_id=None):
       - Call this function from within a caller-managed transaction, e.g.
         `with db.session.begin(): dao_archive_service_no_transaction(...)`.
       - This keeps multiple related DB mutations atomic and allows the caller
-        to commit or rollhttps://ca.slack-edge.com/T2G2S06PM-U037Q2VJ0CB-f337382106fa-72 back as a single unit.
+        to commit or roll back as a single unit.
 
     Note: callers that want the old behaviour (function commits itself) should
     call `dao_archive_service(...)` instead.

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -784,19 +784,21 @@ def update_safelist(service_id):
         return "", 204
 
 
+@service_blueprint.route("/<uuid:service_id>/archive/<uuid:user_id>", methods=["POST"])
 @service_blueprint.route("/<uuid:service_id>/archive", methods=["POST"])
-def archive_service(service_id):
+def archive_service(service_id, user_id=None):
     """
     When a service is archived the service is made inactive, templates are archived and api keys are revoked.
     There is no coming back from this operation.
     :param service_id:
+    :param user_id: optional ID of the user performing the archive, recorded for audit purposes
     :return:
     """
     service: Service = dao_fetch_service_by_id(service_id)
 
     if service.active:
         try:
-            service_name = dao_archive_service(service.id)
+            service_name = dao_archive_service(service.id, user_id)
             send_notification_to_service_users(
                 service_id=service_id,
                 template_id=current_app.config["SERVICE_DEACTIVATED_TEMPLATE_ID"],

--- a/app/user/rest.py
+++ b/app/user/rest.py
@@ -1082,7 +1082,7 @@ def deactivate_user(user_id):
 
                 # Deactivate if no active members would remain
                 if len(remaining_active_members) == 0:
-                    dao_archive_service_no_transaction(service.id)
+                    dao_archive_service_no_transaction(service.id, user.id)
                     services_deactivated.append(service.id)
                 # Suspend if it's a live service and only 1 active member would remain
                 elif service_is_live and len(remaining_active_members) == 1:

--- a/tests/app/service/test_archived_service.py
+++ b/tests/app/service/test_archived_service.py
@@ -11,7 +11,7 @@ from app.dao.services_dao import dao_archive_service_no_transaction
 from app.dao.templates_dao import dao_update_template
 from app.models import Service
 from tests import create_authorization_header, unwrap_function
-from tests.app.db import create_api_key, create_template
+from tests.app.db import create_api_key, create_service, create_template, create_user
 
 
 def test_archive_only_allows_post(client, notify_db_session):
@@ -76,6 +76,37 @@ def archived_service(client, notify_db, sample_service, mocker):
 def test_deactivating_service_changes_name_and_email(archived_service):
     assert archived_service.name == "_archived_2018-04-21_14:00:00_Sample service"
     assert archived_service.email_from == "_archived_2018-04-21_14:00:00_sample.service"
+
+
+@freeze_time("2018-04-21 14:00")
+def test_archive_service_without_user_id_sets_suspended_at_but_not_suspended_by(client, sample_service, mocker):
+    """Archiving without a user_id records the timestamp but leaves suspended_by_id unset."""
+    mocker.patch("app.service.rest.send_notification_to_service_users")
+    auth_header = create_authorization_header()
+    response = client.post(f"/service/{sample_service.id}/archive", headers=[auth_header])
+
+    assert response.status_code == 204
+    svc = Service.query.get(sample_service.id)
+    assert svc.active is False
+    assert svc.suspended_at == datetime(2018, 4, 21, 14, 0, 0)
+    assert svc.suspended_by_id is None
+
+
+@freeze_time("2018-04-21 14:00")
+def test_archive_service_with_user_id_sets_suspended_at_and_suspended_by(client, notify_db_session, mocker):
+    """Archiving with a user_id records both the timestamp and who performed the action."""
+    mocker.patch("app.service.rest.send_notification_to_service_users")
+    user = create_user()
+    service = create_service(user=user)
+
+    auth_header = create_authorization_header()
+    response = client.post(f"/service/{service.id}/archive/{user.id}", headers=[auth_header])
+
+    assert response.status_code == 204
+    svc = Service.query.get(service.id)
+    assert svc.active is False
+    assert svc.suspended_at == datetime(2018, 4, 21, 14, 0, 0)
+    assert svc.suspended_by_id == user.id
 
 
 def test_deactivating_service_revokes_api_keys(archived_service):

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -1892,15 +1892,15 @@ class TestUserDeactivation:
             assert called_template == user_deactivated_template_id
 
             # Service should only have suspended_at/suspended_by_id if it was actually suspended
-            # (not deactivated). Deactivated services don't set these fields.
+            # or archived (both operations now record these fields).
             if should_send_suspension_email:
                 assert svc_db.suspended_at == datetime(2025, 10, 21, 12, 0, 0)
                 assert svc_db.suspended_by_id == user_id
             elif not expected_service_active:
-                # If service is inactive but not suspended (i.e., deactivated/archived),
-                # it should not have these timestamps set
-                assert svc_db.suspended_at is None
-                assert svc_db.suspended_by_id is None
+                # Archived (deactivated) services also record suspended_at and suspended_by_id
+                # (set to the deactivated user's id so there is an audit trail).
+                assert svc_db.suspended_at == datetime(2025, 10, 21, 12, 0, 0)
+                assert svc_db.suspended_by_id == user_id
 
     def test_deactivate_user_commits_on_success(self, client, notify_db_session, mocker):
         """Simple commit test: successful deactivate should persist changes."""


### PR DESCRIPTION
# Summary | Résumé

When a user deletes their service from the service settings page (`/archive` on our end) then set the `suspended_at` and `suspended_by` columns for auditability.

Additionally when the only remaining user on a service is deactivated, then archival is triggered. In this case the user who deactivated themself is recorded in the `suspended_by` column for the services they were the last member of. 

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/3396

# Test instructions | Instructions pour tester la modification
1. Check this branch and the [admin branch](https://github.com/cds-snc/notification-admin/pull/2746)
2. Create a new service
3. Navigate to the service settings page and click `Delete this service` at the bottom of the page
4. Note that the `suspended_at` and `suspended_by_id` columns were populated

**Last service user was self-deactivated**
1. Create a new user
2. Create a new service
3. Navigate to `Your account` -> `Your profile`
4. Click `Deactivate your account`
- [ ] `suspended_at` and `suspended_by_id` columns were populated for the service you created on that account


# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.