### PR TITLE
Introduced concurrency safety into the rate_limiter module.

### DIFF
--- a/app/rate_limiter.py
+++ b/app/rate_limiter.py
@@ -212,10 +212,10 @@ class InMemoryRateLimiter(RateLimiter):
 
     def get_current_usage(self) -> int:
         """Get the current unit count in the active 60-second window."""
-        now = time()
-        window_start = now - self.WINDOW_SIZE_SECONDS
-
         with self._lock:
+            now = time()
+            window_start = now - self.WINDOW_SIZE_SECONDS
+
             # Remove expired entries and update running total
             while self.window and self.window[0][0] < window_start:
                 _, old_units = self.window.popleft()

--- a/app/rate_limiter.py
+++ b/app/rate_limiter.py
@@ -10,6 +10,7 @@ of units that can be acquired per minute.
 
 import logging
 import math
+import threading
 import uuid
 from abc import ABC, abstractmethod
 from collections import deque
@@ -106,6 +107,16 @@ class InMemoryRateLimiter(RateLimiter):
     - If capacity available, records the entry and updates running total.
     - If capacity exhausted, calculates when enough entries will have expired
       to accommodate the new request.
+
+    Thread safety:
+    A ``threading.Lock`` serialises all compound read-modify-write operations
+    so multiple threads in the same process share one consistent view of the
+    sliding window.
+
+    Deployment note:
+    Suitable only for single-process deployments (e.g. one Celery worker with
+    multiple threads).  State is not shared across multiple worker processes,
+    pods, or hosts — use a Redis-backed implementation for multi-process setups.
     """
 
     WINDOW_SIZE_SECONDS = 60
@@ -122,6 +133,7 @@ class InMemoryRateLimiter(RateLimiter):
         super().__init__(cap_per_minute, namespace)
         self.window: deque = deque()  # Stores (timestamp, units) tuples
         self.current_usage: int = 0  # Running total of units in the current window
+        self._lock = threading.Lock()
 
     def acquire_lease(self, units: int) -> Tuple[bool, int]:
         """
@@ -143,57 +155,59 @@ class InMemoryRateLimiter(RateLimiter):
         if units > self.cap_per_minute:
             raise ValueError("units must be smaller than or equal to the cap_per_minute")
 
-        now = time()
-        window_start = now - self.WINDOW_SIZE_SECONDS
+        with self._lock:
+            now = time()
+            window_start = now - self.WINDOW_SIZE_SECONDS
 
-        # Remove entries older than the 60-second window and update running total
-        while self.window and self.window[0][0] < window_start:
-            _, old_units = self.window.popleft()
-            self.current_usage -= old_units
+            # Remove entries older than the 60-second window and update running total
+            while self.window and self.window[0][0] < window_start:
+                _, old_units = self.window.popleft()
+                self.current_usage -= old_units
 
-        # Check if adding new units exceeds the cap
-        if self.current_usage + units <= self.cap_per_minute:
-            # Enough capacity available: record the entry and update running total
-            self.window.append((now, units))
-            self.current_usage += units
-            current_app.logger.info(
-                f"Rate limiter [{self.namespace}]: acquired {units} units. "
-                f"Window usage: {self.current_usage}/{self.cap_per_minute}"
+            # Check if adding new units exceeds the cap
+            if self.current_usage + units <= self.cap_per_minute:
+                # Enough capacity available: record the entry and update running total
+                self.window.append((now, units))
+                self.current_usage += units
+                current_app.logger.info(
+                    f"Rate limiter [{self.namespace}]: acquired {units} units. "
+                    f"Window usage: {self.current_usage}/{self.cap_per_minute}"
+                )
+                return True, 0
+
+            # Not enough capacity: calculate when enough units will be available for the new request
+            units_needed = self.current_usage + units - self.cap_per_minute
+            units_freed = 0
+            last_timestamp_to_wait_for = None
+
+            # Iterate through window entries (oldest first) to find when we'll have enough space
+            for timestamp, entry_units in self.window:
+                units_freed += entry_units
+                last_timestamp_to_wait_for = timestamp
+                if units_freed >= units_needed:
+                    # This entry needs to expire to free enough space
+                    break
+
+            # Calculate seconds to wait for the last entry to expire
+            if last_timestamp_to_wait_for is not None:
+                seconds_until_expires = self.WINDOW_SIZE_SECONDS - (now - last_timestamp_to_wait_for)
+                seconds_to_wait = max(1, math.ceil(seconds_until_expires))
+            else:
+                # Fallback (shouldn't reach here)
+                seconds_to_wait = 1
+
+            current_app.logger.warning(
+                f"Rate limiter [{self.namespace}]: capacity exhausted. Requested {units} units "
+                f"but only {self.cap_per_minute - self.current_usage} available in current window. "
+                f"Will retry in {seconds_to_wait} seconds."
             )
-            return True, 0
-
-        # Not enough capacity: calculate when enough units will be available for the new request
-        units_needed = self.current_usage + units - self.cap_per_minute
-        units_freed = 0
-        last_timestamp_to_wait_for = None
-
-        # Iterate through window entries (oldest first) to find when we'll have enough space
-        for timestamp, entry_units in self.window:
-            units_freed += entry_units
-            last_timestamp_to_wait_for = timestamp
-            if units_freed >= units_needed:
-                # This entry needs to expire to free enough space
-                break
-
-        # Calculate seconds to wait for the last entry to expire
-        if last_timestamp_to_wait_for is not None:
-            seconds_until_expires = self.WINDOW_SIZE_SECONDS - (now - last_timestamp_to_wait_for)
-            seconds_to_wait = max(1, math.ceil(seconds_until_expires))
-        else:
-            # Fallback (shouldn't reach here)
-            seconds_to_wait = 1
-
-        current_app.logger.warning(
-            f"Rate limiter [{self.namespace}]: capacity exhausted. Requested {units} units "
-            f"but only {self.cap_per_minute - self.current_usage} available in current window. "
-            f"Will retry in {seconds_to_wait} seconds."
-        )
-        return False, seconds_to_wait
+            return False, seconds_to_wait
 
     def reset_limiter(self):
         """Reset the rate limiter (clears all entries and running total)."""
-        self.window.clear()
-        self.current_usage = 0
+        with self._lock:
+            self.window.clear()
+            self.current_usage = 0
         current_app.logger.info(f"Rate limiter [{self.namespace}]: reset (window cleared)")
 
     def get_current_usage(self) -> int:
@@ -201,12 +215,13 @@ class InMemoryRateLimiter(RateLimiter):
         now = time()
         window_start = now - self.WINDOW_SIZE_SECONDS
 
-        # Remove expired entries and update running total
-        while self.window and self.window[0][0] < window_start:
-            _, old_units = self.window.popleft()
-            self.current_usage -= old_units
+        with self._lock:
+            # Remove expired entries and update running total
+            while self.window and self.window[0][0] < window_start:
+                _, old_units = self.window.popleft()
+                self.current_usage -= old_units
 
-        return self.current_usage
+            return self.current_usage
 
 
 # ============================================================================
@@ -704,8 +719,12 @@ class BufferedRateLimiter(RateLimiter):
     batch, so already-claimed tokens are never wasted.
 
     Thread safety:
-    Not needed — Celery prefork runs one task at a time per process, and each
-    worker process owns its own ``BufferedRateLimiter`` instance independently.
+    Buffer state (``_local_tokens`` and ``_acquired_at``) is stored in a
+    ``threading.local()`` so each thread maintains an independent token buffer,
+    mirroring the one-buffer-per-worker isolation that prefork provided via
+    separate processes.  The shared ``BufferedRateLimiter`` instance is held in
+    the registry; only its buffer fields are thread-local.  The underlying
+    backend (Redis) is already protected by atomic Lua scripts.
     """
 
     TOKEN_WINDOW_SECONDS = 60
@@ -721,8 +740,23 @@ class BufferedRateLimiter(RateLimiter):
         super().__init__(rate_limiter.cap_per_minute, rate_limiter.namespace)
         self._rate_limiter = rate_limiter
         self._size = size
-        self._local_tokens: int = 0
-        self._acquired_at: float = 0.0
+        self._local = threading.local()
+
+    @property
+    def _local_tokens(self) -> int:
+        return getattr(self._local, "tokens", 0)
+
+    @_local_tokens.setter
+    def _local_tokens(self, value: int) -> None:
+        self._local.tokens = value
+
+    @property
+    def _acquired_at(self) -> float:
+        return getattr(self._local, "acquired_at", 0.0)
+
+    @_acquired_at.setter
+    def _acquired_at(self, value: float) -> None:
+        self._local.acquired_at = value
 
     def acquire_lease(self, units: int) -> Tuple[bool, int]:
         """

--- a/tests/app/test_rate_limiter.py
+++ b/tests/app/test_rate_limiter.py
@@ -1,3 +1,4 @@
+import threading
 from time import time
 from unittest.mock import MagicMock, patch
 
@@ -199,6 +200,30 @@ class TestInMemoryRateLimiter:
                 mock_time.return_value = base_time + 59.9
                 limiter.get_current_usage()
                 assert limiter.current_usage == 50
+
+    def test_concurrent_threads_do_not_exceed_cap(self, client):
+        """Multiple concurrent threads must never collectively exceed cap_per_minute."""
+        cap = 50
+        limiter = InMemoryRateLimiter(cap_per_minute=cap, namespace="concurrent-test")
+        acquired_count = 0
+        results_lock = threading.Lock()
+
+        def try_acquire():
+            nonlocal acquired_count
+            with client.application.app_context():
+                ok, _ = limiter.acquire_lease(1)
+            if ok:
+                with results_lock:
+                    acquired_count += 1
+
+        threads = [threading.Thread(target=try_acquire) for _ in range(cap + 20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert acquired_count == cap
+        assert limiter.get_current_usage() == cap
 
 
 class TestRedisSlidingWindowLogRateLimiter:
@@ -788,3 +813,29 @@ class TestBufferedRateLimiter:
             buf = raw_limiter.buffered(10)
             assert get_rate_limiter("test") is buf
             rate_limiter._rate_limiter_instances.pop("test", None)
+
+    def test_each_thread_gets_independent_local_buffer(self, client):
+        """Each thread maintains an independent token buffer (thread-local semantics)."""
+        mock_raw = MagicMock(spec=InMemoryRateLimiter)
+        mock_raw.cap_per_minute = 1000
+        mock_raw.max_units_per_acquire = 1000
+        mock_raw.namespace = "tl-test"
+        mock_raw.acquire_lease.return_value = (True, 0)
+        buf = BufferedRateLimiter(mock_raw, size=10)
+
+        per_thread_remainder: dict[int, int] = {}
+
+        def fetch_and_check(thread_id: int) -> None:
+            with client.application.app_context():
+                buf.acquire_lease(1)
+            per_thread_remainder[thread_id] = buf._local_tokens
+
+        threads = [threading.Thread(target=fetch_and_check, args=(i,)) for i in range(3)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Each thread fetched a fresh batch of 10 and spent 1 → 9 remaining in its own buffer
+        assert all(count == 9 for count in per_thread_remainder.values())
+        assert mock_raw.acquire_lease.call_count == 3


### PR DESCRIPTION
# Summary | Résumé

Switches the `BufferedRateLimiter` buffer state (`_local_tokens`, `_acquired_at`) to `threading.local` storage so that each Celery worker thread owns an independent token cache, matching the one-buffer-per-worker isolation that the prefork model provided via separate processes. 

Adds a `threading.Lock` to `InMemoryRateLimiter` to serialise its compound read-modify-write operations and make the shared sliding-window state safe for concurrent threads.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/909
* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/786

# Test instructions | Instructions pour tester la modification

1. Run the rate limiter unit tests to verify all existing behaviour and the new concurrency tests pass:
   ```
   python -m pytest tests/app/test_rate_limiter.py -v
   ```
   Expected: **73 passed**.

2. Two new tests exercise thread safety directly:

   - `TestInMemoryRateLimiter::test_concurrent_threads_do_not_exceed_cap` — 70 threads race against a cap of 50; asserts exactly 50 acquisitions succeed.
   - `TestBufferedRateLimiter::test_each_thread_gets_independent_local_buffer` — 3 threads each acquire from a shared `BufferedRateLimiter`; asserts each thread's local buffer is independent and the backend is called once per thread (not shared).

3. To verify at a system level, deploy a Celery worker configured with `--pool threads` (or `CELERYD_POOL=threads`) and confirm that `deliver_sms_rate_limited` tasks run without over-consuming tokens or triggering unexpected retries under concurrent load.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.