### PR TITLE
Ensure attachments aren't sent when setting is off

### DIFF
--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -397,6 +397,30 @@ def _validate_unsubscribe_url(url, notification_id):
     return url
 
 
+def _normalise_file_personalisation(personalisation_data: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Convert nested document objects in personalisation to safe values for template rendering."""
+    if not personalisation_data:
+        return {}
+
+    normalised_personalisation = personalisation_data.copy()
+
+    for key, value in normalised_personalisation.items():
+        if not isinstance(value, dict):
+            continue
+
+        document = value.get("document")
+        if not isinstance(document, dict):
+            continue
+
+        if document.get("sending_method") == "template_attach":
+            normalised_personalisation[key] = ""
+            continue
+
+        normalised_personalisation[key] = document.get("url") or document.get("direct_file_url") or ""
+
+    return normalised_personalisation
+
+
 def send_email_to_provider(notification: Notification):
     current_app.logger.info(f"Sending email to provider for notification id {notification.id}")
     service = notification.service
@@ -463,6 +487,7 @@ def send_email_to_provider(notification: Notification):
     # Fetch and merge template file attachments
     template_attachments = _get_template_attachments(notification)
     attachments = attachments + template_attachments
+    personalisation_data = _normalise_file_personalisation(personalisation_data)
 
     template_obj = dao_get_template_by_id(notification.template_id, notification.template_version)
     template_dict = template_obj.__dict__

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -65,6 +65,7 @@ from app.models import (
     PINPOINT_PROVIDER,
     SMS_TYPE,
     SNS_PROVIDER,
+    UPLOAD_DOCUMENT,
     Notification,
     Service,
 )
@@ -164,6 +165,12 @@ def _get_template_attachments(notification: Notification) -> List[Dict[str, Any]
 
     Returns list of attachment dicts: [{"name": str, "data": bytes, "mime_type": str}, ...]
     """
+    if not notification.service.has_permission(UPLOAD_DOCUMENT):
+        current_app.logger.info(
+            f"Skipping template file attachments for notification {notification.id}; service {notification.service_id} does not have upload_document permission"
+        )
+        return []
+
     template_attachments = []
 
     # Get file metadata from cache or DB
@@ -405,48 +412,53 @@ def send_email_to_provider(notification: Notification):
 
     provider = provider_to_use(EMAIL_TYPE, notification.id)
 
-    # Extract any file objects from the personalization (but exclude template attachments)
-    file_keys = [
-        k
-        for k, v in (notification.personalisation or {}).items()
-        if isinstance(v, dict) and "document" in v and v["document"].get("sending_method") != "template_attach"
-    ]
     attachments = []
+    personalisation_data = (notification.personalisation or {}).copy()
 
-    personalisation_data = notification.personalisation.copy()
-
-    for key in file_keys:
-        check_file_url(personalisation_data[key]["document"], notification.id)
-        sending_method = personalisation_data[key]["document"].get("sending_method")
-        direct_file_url = personalisation_data[key]["document"]["direct_file_url"]
-        filename = personalisation_data[key]["document"].get("filename")
-        mime_type = personalisation_data[key]["document"].get("mime_type")
-        document_id = personalisation_data[key]["document"]["id"]
+    if not service.has_permission(UPLOAD_DOCUMENT):
         current_app.logger.info(
-            f"Calling document_download_client.check_scan_verdict() for document_id: {document_id} and notification_id: {notification.id}"
+            f"Skipping file attachments for notification {notification.id}; service {service.id} does not have upload_document permission"
         )
-        scan_verdict_response = document_download_client.check_scan_verdict(service.id, document_id, sending_method)
-        check_for_malware_errors(scan_verdict_response.status_code, notification)
-        current_app.logger.info(f"scan_verdict for document_id {document_id} is {scan_verdict_response.json()}")
-        if sending_method == "attach":
-            try:
-                retries = Retry(total=5)
-                http = PoolManager(retries=retries)
+    else:
+        # Extract any file objects from the personalization (but exclude template attachments)
+        file_keys = [
+            k
+            for k, v in (notification.personalisation or {}).items()
+            if isinstance(v, dict) and "document" in v and v["document"].get("sending_method") != "template_attach"
+        ]
 
-                response = http.request("GET", url=direct_file_url)
-                attachments.append(
-                    {
-                        "name": filename,
-                        "data": response.data,
-                        "mime_type": mime_type,
-                    }
-                )
-            except Exception as e:
-                current_app.logger.error(f"Could not download and attach {direct_file_url}\nException: {e}")
-                del personalisation_data[key]
+        for key in file_keys:
+            check_file_url(personalisation_data[key]["document"], notification.id)
+            sending_method = personalisation_data[key]["document"].get("sending_method")
+            direct_file_url = personalisation_data[key]["document"]["direct_file_url"]
+            filename = personalisation_data[key]["document"].get("filename")
+            mime_type = personalisation_data[key]["document"].get("mime_type")
+            document_id = personalisation_data[key]["document"]["id"]
+            current_app.logger.info(
+                f"Calling document_download_client.check_scan_verdict() for document_id: {document_id} and notification_id: {notification.id}"
+            )
+            scan_verdict_response = document_download_client.check_scan_verdict(service.id, document_id, sending_method)
+            check_for_malware_errors(scan_verdict_response.status_code, notification)
+            current_app.logger.info(f"scan_verdict for document_id {document_id} is {scan_verdict_response.json()}")
+            if sending_method == "attach":
+                try:
+                    retries = Retry(total=5)
+                    http = PoolManager(retries=retries)
 
-        else:
-            personalisation_data[key] = personalisation_data[key]["document"]["url"]
+                    response = http.request("GET", url=direct_file_url)
+                    attachments.append(
+                        {
+                            "name": filename,
+                            "data": response.data,
+                            "mime_type": mime_type,
+                        }
+                    )
+                except Exception as e:
+                    current_app.logger.error(f"Could not download and attach {direct_file_url}\nException: {e}")
+                    del personalisation_data[key]
+
+            else:
+                personalisation_data[key] = personalisation_data[key]["document"]["url"]
 
     # Fetch and merge template file attachments
     template_attachments = _get_template_attachments(notification)

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -43,6 +43,7 @@ from app.models import (
     NOTIFICATION_STATUS_TYPES_COMPLETED,
     SERVICE_PERMISSION_TYPES,
     SMS_TYPE,
+    UPLOAD_DOCUMENT,
     ApiKey,
     ApiKeyPermission,
     Fido2Key,
@@ -599,7 +600,7 @@ def create_sample_email_template(
     content="This is a template",
     subject_line="Email Subject",
     service=None,
-    permissions=[EMAIL_TYPE, SMS_TYPE],
+    permissions=[EMAIL_TYPE, SMS_TYPE, UPLOAD_DOCUMENT],
     template_category=None,
 ):
     if not template_category:
@@ -649,7 +650,7 @@ def sample_email_template(
         content,
         subject_line,
         service=None,
-        permissions=[EMAIL_TYPE, SMS_TYPE],
+        permissions=[EMAIL_TYPE, SMS_TYPE, UPLOAD_DOCUMENT],
     )
 
 

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -1469,7 +1469,7 @@ class TestMalware:
 
         with pytest.raises(MalwareScanInProgressException) as e:
             send_to_providers.send_email_to_provider(db_notification)
-            assert db_notification.id in e.value
+        assert isinstance(e.value, MalwareScanInProgressException)
         send_mock.assert_not_called()
 
         assert Notification.query.get(db_notification.id).status == "created"

--- a/tests/app/delivery/test_template_attachments.py
+++ b/tests/app/delivery/test_template_attachments.py
@@ -264,6 +264,38 @@ class TestGetTemplateAttachments:
         result = send_to_providers._get_template_attachments(notification)
         assert result == []
 
+    def test_does_not_download_template_files_when_service_lacks_upload_document_permission(
+        self, sample_service, sample_email_template, mocker
+    ):
+        """Template attachments should be skipped when file sending is disabled for the service."""
+        notification = save_notification(
+            create_notification(
+                template=sample_email_template,
+                to_field="test@example.com",
+            )
+        )
+
+        mocker.patch.object(notification.service, "has_permission", return_value=False)
+        get_files_mock = mocker.patch(
+            "app.delivery.send_to_providers._get_template_files_from_cache_or_db",
+            return_value=[
+                {
+                    "name": "template.pdf",
+                    "document_id": "doc-1",
+                    "mime_type": "application/pdf",
+                    "service_id": str(sample_service.id),
+                    "file_id": "f1",
+                }
+            ],
+        )
+        download_mock = mocker.patch("app.delivery.send_to_providers._download_template_file")
+
+        result = send_to_providers._get_template_attachments(notification)
+
+        assert result == []
+        get_files_mock.assert_not_called()
+        download_mock.assert_not_called()
+
     def test_downloads_all_template_files(self, sample_service, sample_email_template, mocker):
         """Test that all template files are downloaded."""
         notification = save_notification(

--- a/tests/app/delivery/test_template_attachments.py
+++ b/tests/app/delivery/test_template_attachments.py
@@ -527,6 +527,55 @@ class TestSendEmailToProviderWithTemplateAttachments:
         assert len(attachments) == 1
         assert attachments[0]["name"] == "template-file.pdf"
 
+    def test_sanitizes_file_personalisation_values_when_upload_document_disabled(
+        self, sample_service, sample_email_template, mocker
+    ):
+        """File personalisation values should be converted to safe strings rather than passed through as raw document objects."""
+        notification = save_notification(
+            create_notification(
+                template=sample_email_template,
+                to_field="test@example.com",
+                personalisation={
+                    "document": {
+                        "document": {
+                            "sending_method": "attach",
+                            "id": "document-id",
+                            "filename": "template-file.pdf",
+                            "mime_type": "application/pdf",
+                            "file_size": 1024,
+                            "url": "https://example.com/file",
+                            "direct_file_url": "https://example.com/download",
+                        }
+                    }
+                },
+            )
+        )
+
+        mocker.patch("app.delivery.send_to_providers._get_template_attachments", return_value=[])
+        mocker.patch("app.delivery.send_to_providers.provider_to_use")
+        mocker.patch("app.delivery.send_to_providers.dao_get_template_by_id")
+        mocker.patch("app.delivery.send_to_providers.is_service_allowed_html", return_value=False)
+        mocker.patch("app.delivery.send_to_providers.get_html_email_options", return_value={})
+        mocker.patch("app.delivery.send_to_providers.send_email_response", return_value="ref-123")
+
+        template_mock = mocker.patch("app.delivery.send_to_providers.HTMLEmailTemplate")
+        mocker.patch("app.delivery.send_to_providers.PlainTextEmailTemplate")
+
+        provider_mock = MagicMock()
+        provider_mock.send_email.return_value = "ses-ref"
+        provider_mock.get_name.return_value = "ses"
+        mocker.patch("app.delivery.send_to_providers.provider_to_use", return_value=provider_mock)
+
+        mocker.patch.object(
+            notification.service, "has_permission", side_effect=lambda permission: permission != "upload_document"
+        )
+
+        send_to_providers.send_email_to_provider(notification)
+
+        _, kwargs = template_mock.call_args
+        assert kwargs["values"]["document"] == "https://example.com/file"
+        assert not isinstance(kwargs["values"]["document"], dict)
+
 
 class TestAllSendPathsIncludeTemplateAttachments:
     """Test that all 4 send paths (api one-off, api bulk, admin one-off, admin bulk) include template attachments."""


### PR DESCRIPTION
# Summary | Résumé
This PR adds a check to ensure that file attachments are not sent when the service setting is turned off and a template previously had files attached to it.

## Related Issues | Cartes liées

* https://docs.google.com/document/d/1m_EzXNJbqjJH-WLzxRKMtO4k5CAHwk51uCXi7xJQR44/edit?tab=t.0#task=qOCOyB5d8XEdq1bp

# Test instructions | Instructions pour tester la modification
1. Attach files to a template
2. Go to service settings and turn off file sending
3. Send a notification using the template from step 1
- [ ] Files were not attached to the email you recived

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.