### PR TITLE
Add a rate limit to calls to the "create report" endpoint

### DIFF
--- a/app/v2/errors.py
+++ b/app/v2/errors.py
@@ -148,6 +148,19 @@ class TemplateCategoryNotFoundError(BadRequestError):
         super().__init__(message=self.__class__.message)
 
 
+class ReportRateLimitError(InvalidRequest):
+    status_code = 429
+
+    def __init__(self, limit: int, retry_after: int, reset_at: int):
+        self.limit = limit
+        self.retry_after = retry_after
+        self.reset_at = reset_at
+        self.message = f"Maximum {self.limit} report requests per hour"
+
+    def to_dict_v2(self):
+        return {"errors": [{"error": "RateLimitExceeded", "message": self.message}]}
+
+
 class PDFNotReadyError(BadRequestError):
     def __init__(self):
         super().__init__(message="PDF not available yet, try again later", status_code=400)

--- a/app/v2/reports/__init__.py
+++ b/app/v2/reports/__init__.py
@@ -1,7 +1,18 @@
-from flask import Blueprint
+from flask import Blueprint, jsonify
 
-from app.v2.errors import register_errors
+from app.v2.errors import ReportRateLimitError, register_errors
 
 v2_reports_blueprint = Blueprint("v2_reports", __name__, url_prefix="/v2/reports")
 
 register_errors(v2_reports_blueprint)
+
+
+@v2_reports_blueprint.errorhandler(ReportRateLimitError)
+def report_rate_limit_error(error):
+    response = jsonify(error.to_dict_v2())
+    response.status_code = 429
+    response.headers["Retry-After"] = str(error.retry_after)
+    response.headers["X-RateLimit-Limit"] = str(error.limit)
+    response.headers["X-RateLimit-Remaining"] = "0"
+    response.headers["X-RateLimit-Reset"] = str(error.reset_at)
+    return response

--- a/app/v2/reports/post_reports.py
+++ b/app/v2/reports/post_reports.py
@@ -18,8 +18,8 @@ from app.v2.errors import ForbiddenError, ReportRateLimitError
 from app.v2.reports import v2_reports_blueprint
 from app.v2.reports.report_schemas import post_report_request
 
-REPORT_RATE_LIMIT = 2
-REPORT_RATE_WINDOW = 60  # 1 hour in seconds
+REPORT_RATE_LIMIT = 10
+REPORT_RATE_WINDOW = 3600  # 1 hour in seconds
 
 
 def _check_report_rate_limit(service_id):

--- a/app/v2/reports/post_reports.py
+++ b/app/v2/reports/post_reports.py
@@ -3,6 +3,12 @@ import uuid
 from time import time
 
 from flask import current_app, jsonify, request
+from notifications_utils.clients.redis.sliding_window_rate_limit import (
+    check_and_count_window,
+    get_window_oldest_entry,
+    record_window_request,
+    report_rate_limit_cache_key,
+)
 
 from app import api_user, authenticated_service, redis_store
 from app.celery.tasks import generate_report
@@ -27,31 +33,21 @@ def _check_report_rate_limit(service_id):
     if not current_app.config.get("API_RATE_LIMIT_ENABLED") or not current_app.config.get("REDIS_ENABLED"):
         return
 
-    cache_key = f"report-rate-limit:{service_id}"
+    cache_key = report_rate_limit_cache_key(service_id)
     now = time()
-    window_start = now - REPORT_RATE_WINDOW
 
-    pipe = redis_store.redis_store.pipeline()
-    pipe.zremrangebyscore(cache_key, "-inf", window_start)
-    pipe.zcard(cache_key)
-    results = pipe.execute()
-
-    count = results[1]
+    count = check_and_count_window(redis_store, cache_key, REPORT_RATE_WINDOW, now)
 
     if count >= REPORT_RATE_LIMIT:
-        oldest = redis_store.redis_store.zrange(cache_key, 0, 0, withscores=True)
-        if oldest:
-            reset_at = math.ceil(oldest[0][1] + REPORT_RATE_WINDOW)
+        oldest_ts = get_window_oldest_entry(redis_store, cache_key)
+        if oldest_ts:
+            reset_at = math.ceil(oldest_ts + REPORT_RATE_WINDOW)
         else:
             reset_at = math.ceil(now + REPORT_RATE_WINDOW)
         retry_after = max(1, reset_at - math.ceil(now))
         raise ReportRateLimitError(limit=REPORT_RATE_LIMIT, retry_after=retry_after, reset_at=reset_at)
 
-    # Record this request in the sliding window
-    pipe2 = redis_store.redis_store.pipeline()
-    pipe2.zadd(cache_key, {now: now})
-    pipe2.expire(cache_key, REPORT_RATE_WINDOW + 60)
-    pipe2.execute()
+    record_window_request(redis_store, cache_key, REPORT_RATE_WINDOW, now)
 
 
 @v2_reports_blueprint.route("", methods=["POST"])

--- a/app/v2/reports/post_reports.py
+++ b/app/v2/reports/post_reports.py
@@ -4,9 +4,7 @@ from time import time
 
 from flask import current_app, jsonify, request
 from notifications_utils.clients.redis.sliding_window_rate_limit import (
-    check_and_count_window,
-    get_window_oldest_entry,
-    record_window_request,
+    check_and_record_window_request,
     report_rate_limit_cache_key,
 )
 
@@ -20,8 +18,8 @@ from app.v2.errors import ForbiddenError, ReportRateLimitError
 from app.v2.reports import v2_reports_blueprint
 from app.v2.reports.report_schemas import post_report_request
 
-REPORT_RATE_LIMIT = 10
-REPORT_RATE_WINDOW = 3600  # 1 hour in seconds
+REPORT_RATE_LIMIT = 2
+REPORT_RATE_WINDOW = 60  # 1 hour in seconds
 
 
 def _check_report_rate_limit(service_id):
@@ -36,18 +34,15 @@ def _check_report_rate_limit(service_id):
     cache_key = report_rate_limit_cache_key(service_id)
     now = time()
 
-    count = check_and_count_window(redis_store, cache_key, REPORT_RATE_WINDOW, now)
+    exceeded, oldest_ts = check_and_record_window_request(redis_store, cache_key, REPORT_RATE_LIMIT, REPORT_RATE_WINDOW, now)
 
-    if count >= REPORT_RATE_LIMIT:
-        oldest_ts = get_window_oldest_entry(redis_store, cache_key)
+    if exceeded:
         if oldest_ts:
             reset_at = math.ceil(oldest_ts + REPORT_RATE_WINDOW)
         else:
             reset_at = math.ceil(now + REPORT_RATE_WINDOW)
         retry_after = max(1, reset_at - math.ceil(now))
         raise ReportRateLimitError(limit=REPORT_RATE_LIMIT, retry_after=retry_after, reset_at=reset_at)
-
-    record_window_request(redis_store, cache_key, REPORT_RATE_WINDOW, now)
 
 
 @v2_reports_blueprint.route("", methods=["POST"])

--- a/app/v2/reports/post_reports.py
+++ b/app/v2/reports/post_reports.py
@@ -1,22 +1,65 @@
+import math
 import uuid
+from time import time
 
 from flask import current_app, jsonify, request
 
-from app import api_user, authenticated_service
+from app import api_user, authenticated_service, redis_store
 from app.celery.tasks import generate_report
 from app.config import QueueNames
 from app.dao.reports_dao import create_report
 from app.models import ApiKeyPermission, Report, ReportStatus
 from app.schema_validation import validate
-from app.v2.errors import ForbiddenError
+from app.v2.errors import ForbiddenError, ReportRateLimitError
 from app.v2.reports import v2_reports_blueprint
 from app.v2.reports.report_schemas import post_report_request
+
+REPORT_RATE_LIMIT = 10
+REPORT_RATE_WINDOW = 3600  # 1 hour in seconds
+
+
+def _check_report_rate_limit(service_id):
+    """Enforce a limit of 10 POST /v2/reports requests per hour per service.
+
+    Raises ReportRateLimitError if the limit is exceeded.
+    When Redis is unavailable or rate limiting is disabled, the check is skipped.
+    """
+    if not current_app.config.get("API_RATE_LIMIT_ENABLED") or not current_app.config.get("REDIS_ENABLED"):
+        return
+
+    cache_key = f"report-rate-limit:{service_id}"
+    now = time()
+    window_start = now - REPORT_RATE_WINDOW
+
+    pipe = redis_store.redis_store.pipeline()
+    pipe.zremrangebyscore(cache_key, "-inf", window_start)
+    pipe.zcard(cache_key)
+    results = pipe.execute()
+
+    count = results[1]
+
+    if count >= REPORT_RATE_LIMIT:
+        oldest = redis_store.redis_store.zrange(cache_key, 0, 0, withscores=True)
+        if oldest:
+            reset_at = math.ceil(oldest[0][1] + REPORT_RATE_WINDOW)
+        else:
+            reset_at = math.ceil(now + REPORT_RATE_WINDOW)
+        retry_after = max(1, reset_at - math.ceil(now))
+        raise ReportRateLimitError(limit=REPORT_RATE_LIMIT, retry_after=retry_after, reset_at=reset_at)
+
+    # Record this request in the sliding window
+    pipe2 = redis_store.redis_store.pipeline()
+    pipe2.zadd(cache_key, {now: now})
+    pipe2.expire(cache_key, REPORT_RATE_WINDOW + 60)
+    pipe2.execute()
 
 
 @v2_reports_blueprint.route("", methods=["POST"])
 def post_report():
     if not api_user.has_permission(ApiKeyPermission.MANAGE_REPORTS):
         raise ForbiddenError(message="This API key does not have permission to manage reports.")
+
+    _check_report_rate_limit(authenticated_service.id)
 
     data = validate(request.get_json(), post_report_request)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2861,7 +2861,7 @@ requests = ">=2.0.0"
 
 [[package]]
 name = "notifications-utils"
-version = "53.2.31"
+version = "53.2.33"
 description = "Shared python code for Notification - Provides logging utils etc."
 optional = false
 python-versions = "~3.12.7"
@@ -2897,8 +2897,8 @@ werkzeug = "3.1.6"
 [package.source]
 type = "git"
 url = "https://github.com/cds-snc/notifier-utils.git"
-reference = "53.2.31"
-resolved_reference = "036f39bf1996ac8b048fcdea68a3ed62fd937a6e"
+reference = "feat/sliding-window-rate-limit"
+resolved_reference = "7e351d439e0cf7e7702c8a5d6568ca9a76e128e1"
 
 [[package]]
 name = "opentelemetry-api"
@@ -5212,4 +5212,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.12.7"
-content-hash = "c08ca350875e36d9b63206443b34f94fc496de5642b557896cc909e0142961e4"
+content-hash = "b21426e0d95994cd928d1074bcd1406113be3d21aa794c93073f1e040087070c"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2861,7 +2861,7 @@ requests = ">=2.0.0"
 
 [[package]]
 name = "notifications-utils"
-version = "53.2.33"
+version = "53.2.32"
 description = "Shared python code for Notification - Provides logging utils etc."
 optional = false
 python-versions = "~3.12.7"
@@ -2897,8 +2897,8 @@ werkzeug = "3.1.6"
 [package.source]
 type = "git"
 url = "https://github.com/cds-snc/notifier-utils.git"
-reference = "53.2.31"
-resolved_reference = "036f39bf1996ac8b048fcdea68a3ed62fd937a6e"
+reference = "53.2.32"
+resolved_reference = "31c2f71682d968f40deede49bb1c3f6ba4ad4ea4"
 
 [[package]]
 name = "opentelemetry-api"
@@ -5212,4 +5212,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.12.7"
-content-hash = "c08ca350875e36d9b63206443b34f94fc496de5642b557896cc909e0142961e4"
+content-hash = "e6167724ea7b90b44b1ec9b83be24b009123a07a65f12516a06e3283013a4224"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2861,7 +2861,7 @@ requests = ">=2.0.0"
 
 [[package]]
 name = "notifications-utils"
-version = "53.2.32"
+version = "53.2.33"
 description = "Shared python code for Notification - Provides logging utils etc."
 optional = false
 python-versions = "~3.12.7"
@@ -2897,8 +2897,8 @@ werkzeug = "3.1.6"
 [package.source]
 type = "git"
 url = "https://github.com/cds-snc/notifier-utils.git"
-reference = "53.2.32"
-resolved_reference = "31c2f71682d968f40deede49bb1c3f6ba4ad4ea4"
+reference = "feat/sliding-window-rate-limit"
+resolved_reference = "792d8fdd36ce424690acaff136fc4fecb4ec131d"
 
 [[package]]
 name = "opentelemetry-api"
@@ -5212,4 +5212,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.12.7"
-content-hash = "e6167724ea7b90b44b1ec9b83be24b009123a07a65f12516a06e3283013a4224"
+content-hash = "b21426e0d95994cd928d1074bcd1406113be3d21aa794c93073f1e040087070c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ opentelemetry-instrumentation-celery = "0.55b1"
 opentelemetry-instrumentation-flask = "0.55b1"
 opentelemetry-instrumentation-redis = "0.55b1"
 opentelemetry-instrumentation-sqlalchemy = "0.55b1"
-notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", tag="53.2.32"}
+notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", branch="feat/sliding-window-rate-limit"}
 pre-commit = "^3.7.1"
 psycopg2-binary = "2.9.11"
 pwnedpasswords = "2.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ opentelemetry-instrumentation-celery = "0.55b1"
 opentelemetry-instrumentation-flask = "0.55b1"
 opentelemetry-instrumentation-redis = "0.55b1"
 opentelemetry-instrumentation-sqlalchemy = "0.55b1"
-notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", tag = "53.2.31"}
+notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", branch = "feat/sliding-window-rate-limit"}
 pre-commit = "^3.7.1"
 psycopg2-binary = "2.9.11"
 pwnedpasswords = "2.0.0"

--- a/tests/app/v2/reports/test_post_reports.py
+++ b/tests/app/v2/reports/test_post_reports.py
@@ -117,16 +117,10 @@ def test_post_report_rate_limit_returns_429(client, sample_service, mocker, crea
 
     mocker.patch("app.v2.reports.post_reports.time", return_value=fixed_now)
 
-    # Simulate 10 existing entries in the sliding window (pipeline returns [None, 10])
-    mock_pipeline = mocker.MagicMock()
-    mock_pipeline.execute.return_value = [None, 10]
-    mocker.patch("app.v2.reports.post_reports.redis_store.redis_store.pipeline", return_value=mock_pipeline)
     # Oldest entry is 60 seconds ago; reset = oldest + 3600
     oldest_ts = fixed_now - 60
-    mocker.patch(
-        "app.v2.reports.post_reports.redis_store.redis_store.zrange",
-        return_value=[(b"entry", oldest_ts)],
-    )
+    mocker.patch("app.v2.reports.post_reports.check_and_count_window", return_value=10)
+    mocker.patch("app.v2.reports.post_reports.get_window_oldest_entry", return_value=oldest_ts)
 
     response = client.post(
         path="/v2/reports",
@@ -154,14 +148,8 @@ def test_post_report_rate_limit_not_triggered_below_limit(
     mocker.patch("app.v2.reports.post_reports.time", return_value=fixed_now)
 
     # Simulate 9 existing entries (under the 10-per-hour limit)
-    mock_pipeline = mocker.MagicMock()
-    mock_pipeline.execute.return_value = [None, 9]
-    mock_pipeline2 = mocker.MagicMock()
-    mock_pipeline2.execute.return_value = [1, True]
-    mocker.patch(
-        "app.v2.reports.post_reports.redis_store.redis_store.pipeline",
-        side_effect=[mock_pipeline, mock_pipeline2],
-    )
+    mocker.patch("app.v2.reports.post_reports.check_and_count_window", return_value=9)
+    mocker.patch("app.v2.reports.post_reports.record_window_request")
 
     response = client.post(
         path="/v2/reports",
@@ -177,7 +165,7 @@ def test_post_report_rate_limit_skipped_when_redis_disabled(
 ):
     mocker.patch("app.v2.reports.post_reports.generate_report.apply_async")
     auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
-    mock_pipeline = mocker.patch("app.v2.reports.post_reports.redis_store.redis_store.pipeline")
+    mock_check = mocker.patch("app.v2.reports.post_reports.check_and_count_window")
 
     with notify_api.test_request_context():
         notify_api.config["REDIS_ENABLED"] = False
@@ -189,7 +177,7 @@ def test_post_report_rate_limit_skipped_when_redis_disabled(
     )
 
     assert response.status_code == 202
-    mock_pipeline.assert_not_called()
+    mock_check.assert_not_called()
 
 
 def test_post_report_requires_authentication(client):

--- a/tests/app/v2/reports/test_post_reports.py
+++ b/tests/app/v2/reports/test_post_reports.py
@@ -166,14 +166,12 @@ def test_post_report_rate_limit_skipped_when_redis_disabled(
     auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
     mock_check = mocker.patch("app.v2.reports.post_reports.check_and_record_window_request")
 
-    with notify_api.test_request_context():
-        notify_api.config["REDIS_ENABLED"] = False
-
-    response = client.post(
-        path="/v2/reports",
-        data=json.dumps({"report_type": "email", "language": "en"}),
-        headers=[("Content-Type", "application/json"), auth_header],
-    )
+    with mocker.patch.dict(notify_api.config, {"REDIS_ENABLED": False}):
+        response = client.post(
+            path="/v2/reports",
+            data=json.dumps({"report_type": "email", "language": "en"}),
+            headers=[("Content-Type", "application/json"), auth_header],
+        )
 
     assert response.status_code == 202
     mock_check.assert_not_called()

--- a/tests/app/v2/reports/test_post_reports.py
+++ b/tests/app/v2/reports/test_post_reports.py
@@ -3,6 +3,7 @@ import math
 
 from app.dao.reports_dao import get_report_by_id
 from app.models import ReportStatus
+from app.v2.reports.post_reports import REPORT_RATE_LIMIT, REPORT_RATE_WINDOW
 from tests import create_authorization_header
 
 
@@ -117,10 +118,9 @@ def test_post_report_rate_limit_returns_429(client, sample_service, mocker, crea
 
     mocker.patch("app.v2.reports.post_reports.time", return_value=fixed_now)
 
-    # Oldest entry is 60 seconds ago; reset = oldest + 3600
+    # Oldest entry is 60 seconds ago; reset = oldest + REPORT_RATE_WINDOW
     oldest_ts = fixed_now - 60
-    mocker.patch("app.v2.reports.post_reports.check_and_count_window", return_value=10)
-    mocker.patch("app.v2.reports.post_reports.get_window_oldest_entry", return_value=oldest_ts)
+    mocker.patch("app.v2.reports.post_reports.check_and_record_window_request", return_value=(True, oldest_ts))
 
     response = client.post(
         path="/v2/reports",
@@ -131,10 +131,10 @@ def test_post_report_rate_limit_returns_429(client, sample_service, mocker, crea
     assert response.status_code == 429
     data = json.loads(response.get_data(as_text=True))
     assert data["errors"][0]["error"] == "RateLimitExceeded"
-    assert data["errors"][0]["message"] == "Maximum 10 report requests per hour"
-    assert response.headers["X-RateLimit-Limit"] == "10"
+    assert data["errors"][0]["message"] == f"Maximum {REPORT_RATE_LIMIT} report requests per hour"
+    assert response.headers["X-RateLimit-Limit"] == str(REPORT_RATE_LIMIT)
     assert response.headers["X-RateLimit-Remaining"] == "0"
-    assert int(response.headers["X-RateLimit-Reset"]) == math.ceil(oldest_ts + 3600)
+    assert int(response.headers["X-RateLimit-Reset"]) == math.ceil(oldest_ts + REPORT_RATE_WINDOW)
     assert int(response.headers["Retry-After"]) > 0
 
 
@@ -147,9 +147,8 @@ def test_post_report_rate_limit_not_triggered_below_limit(
     fixed_now = 1_700_000_000.0
     mocker.patch("app.v2.reports.post_reports.time", return_value=fixed_now)
 
-    # Simulate 9 existing entries (under the 10-per-hour limit)
-    mocker.patch("app.v2.reports.post_reports.check_and_count_window", return_value=9)
-    mocker.patch("app.v2.reports.post_reports.record_window_request")
+    # Simulate request succeeds (under the 10-per-hour limit)
+    mocker.patch("app.v2.reports.post_reports.check_and_record_window_request", return_value=(False, None))
 
     response = client.post(
         path="/v2/reports",
@@ -165,7 +164,7 @@ def test_post_report_rate_limit_skipped_when_redis_disabled(
 ):
     mocker.patch("app.v2.reports.post_reports.generate_report.apply_async")
     auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
-    mock_check = mocker.patch("app.v2.reports.post_reports.check_and_count_window")
+    mock_check = mocker.patch("app.v2.reports.post_reports.check_and_record_window_request")
 
     with notify_api.test_request_context():
         notify_api.config["REDIS_ENABLED"] = False

--- a/tests/app/v2/reports/test_post_reports.py
+++ b/tests/app/v2/reports/test_post_reports.py
@@ -1,4 +1,5 @@
 import json
+import math
 
 from app.dao.reports_dao import get_report_by_id
 from app.models import ReportStatus
@@ -106,6 +107,89 @@ def test_post_report_returns_403_without_manage_reports_permission(client, mocke
     assert response.status_code == 403
     data = json.loads(response.get_data(as_text=True))
     assert "manage reports" in data["errors"][0]["message"].lower()
+
+
+def test_post_report_rate_limit_returns_429(client, sample_service, mocker, create_api_key_with_manage_reports_perm):
+    mocker.patch("app.v2.reports.post_reports.generate_report.apply_async")
+    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+
+    fixed_now = 1_700_000_000.0
+
+    mocker.patch("app.v2.reports.post_reports.time", return_value=fixed_now)
+
+    # Simulate 10 existing entries in the sliding window (pipeline returns [None, 10])
+    mock_pipeline = mocker.MagicMock()
+    mock_pipeline.execute.return_value = [None, 10]
+    mocker.patch("app.v2.reports.post_reports.redis_store.redis_store.pipeline", return_value=mock_pipeline)
+    # Oldest entry is 60 seconds ago; reset = oldest + 3600
+    oldest_ts = fixed_now - 60
+    mocker.patch(
+        "app.v2.reports.post_reports.redis_store.redis_store.zrange",
+        return_value=[(b"entry", oldest_ts)],
+    )
+
+    response = client.post(
+        path="/v2/reports",
+        data=json.dumps({"report_type": "email", "language": "en"}),
+        headers=[("Content-Type", "application/json"), auth_header],
+    )
+
+    assert response.status_code == 429
+    data = json.loads(response.get_data(as_text=True))
+    assert data["errors"][0]["error"] == "RateLimitExceeded"
+    assert data["errors"][0]["message"] == "Maximum 10 report requests per hour"
+    assert response.headers["X-RateLimit-Limit"] == "10"
+    assert response.headers["X-RateLimit-Remaining"] == "0"
+    assert int(response.headers["X-RateLimit-Reset"]) == math.ceil(oldest_ts + 3600)
+    assert int(response.headers["Retry-After"]) > 0
+
+
+def test_post_report_rate_limit_not_triggered_below_limit(
+    client, sample_service, mocker, create_api_key_with_manage_reports_perm
+):
+    mocker.patch("app.v2.reports.post_reports.generate_report.apply_async")
+    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+
+    fixed_now = 1_700_000_000.0
+    mocker.patch("app.v2.reports.post_reports.time", return_value=fixed_now)
+
+    # Simulate 9 existing entries (under the 10-per-hour limit)
+    mock_pipeline = mocker.MagicMock()
+    mock_pipeline.execute.return_value = [None, 9]
+    mock_pipeline2 = mocker.MagicMock()
+    mock_pipeline2.execute.return_value = [1, True]
+    mocker.patch(
+        "app.v2.reports.post_reports.redis_store.redis_store.pipeline",
+        side_effect=[mock_pipeline, mock_pipeline2],
+    )
+
+    response = client.post(
+        path="/v2/reports",
+        data=json.dumps({"report_type": "email", "language": "en"}),
+        headers=[("Content-Type", "application/json"), auth_header],
+    )
+
+    assert response.status_code == 202
+
+
+def test_post_report_rate_limit_skipped_when_redis_disabled(
+    client, sample_service, mocker, create_api_key_with_manage_reports_perm, notify_api
+):
+    mocker.patch("app.v2.reports.post_reports.generate_report.apply_async")
+    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+    mock_pipeline = mocker.patch("app.v2.reports.post_reports.redis_store.redis_store.pipeline")
+
+    with notify_api.test_request_context():
+        notify_api.config["REDIS_ENABLED"] = False
+
+    response = client.post(
+        path="/v2/reports",
+        data=json.dumps({"report_type": "email", "language": "en"}),
+        headers=[("Content-Type", "application/json"), auth_header],
+    )
+
+    assert response.status_code == 202
+    mock_pipeline.assert_not_called()
 
 
 def test_post_report_requires_authentication(client):


### PR DESCRIPTION
# Summary | Résumé

This feature is described in the ADR here: https://github.com/cds-snc/ADR/blob/main/adr/notify/0033_GC_Notify_API_Reports_Downloads.md#rate-limiting

This PR (along with https://github.com/cds-snc/notification-utils/pull/425) implements a 10 request/hr rate limit to the "create report" endpoint (v2/reports POST).

The AWS WAF check is failing currently - that will keep failing until we tag a new version of utils.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/3406

# Test instructions | Instructions pour tester la modification

1. check out this branch locally
2. run `poetry update notifications-utils`
3. update the constants in `app/v2/reports/post_reports.py` as follows for testing:
```
REPORT_RATE_LIMIT = 2
REPORT_RATE_WINDOW = 60  # 1 minute in seconds
```
5. `make run` 
6. send 2 requests to create reports, verify the 1st succeeds and the 2nd fails with the new error message:
```
curl -X POST "http://localhost:6011/v2/reports" \
  -H "Authorization: ApiKey-v1 YOUR_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"report_type": "email", "language": "en"}'
```
7. wait for 1 minute and then verify that a new request for a report succeeds

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.