### PR TITLE
fix: omit rate_multiplier from billable_units calculation in monthly stats

### DIFF
--- a/app/dao/fact_billing_dao.py
+++ b/app/dao/fact_billing_dao.py
@@ -396,7 +396,7 @@ def fetch_monthly_billing_for_year(service_id, year):
         db.session.query(
             func.date_trunc("month", FactBilling.bst_date).cast(Date).label("month"),
             func.sum(FactBilling.notifications_sent).label("notifications_sent"),
-            func.sum(FactBilling.billable_units * FactBilling.rate_multiplier).label("billable_units"),
+            func.sum(FactBilling.billable_units).label("billable_units"),
             FactBilling.rate,
             FactBilling.notification_type,
             FactBilling.postage,

--- a/tests/app/billing/test_billing.py
+++ b/tests/app/billing/test_billing.py
@@ -440,13 +440,13 @@ def test_get_yearly_usage_by_monthly_from_ft_billing_all_cases(client, notify_db
     assert json_response[3]["month"] == "May"
     assert json_response[3]["notification_type"] == "sms"
     assert json_response[3]["rate"] == 0.0150
-    assert json_response[3]["billing_units"] == 4
+    assert json_response[3]["billing_units"] == 2
     assert json_response[3]["postage"] == "none"
 
     assert json_response[4]["month"] == "May"
     assert json_response[4]["notification_type"] == "sms"
     assert json_response[4]["rate"] == 0.162
-    assert json_response[4]["billing_units"] == 5
+    assert json_response[4]["billing_units"] == 3
     assert json_response[4]["postage"] == "none"
 
 

--- a/tests/app/dao/test_ft_billing_dao.py
+++ b/tests/app/dao/test_ft_billing_dao.py
@@ -575,7 +575,7 @@ def test_fetch_monthly_billing_for_year(notify_db_session):
     assert len(results) == 2
     assert str(results[0].month) == "2018-06-01"
     assert results[0].notifications_sent == 30
-    assert results[0].billable_units == Decimal("60")
+    assert results[0].billable_units == Decimal("30")
     assert results[0].rate == Decimal("0.162")
     assert results[0].notification_type == "sms"
     assert results[0].postage == "none"


### PR DESCRIPTION
# Summary | Résumé
This pull request updates the calculation of billable units in the monthly billing summary by removing the application of the `rate_multiplier` when summing `billable_units`. Corresponding test assertions are updated to reflect the new calculation logic.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/3299

# Test instructions | Instructions pour tester la modification
- Send an international text message
- Run billing for the day (via `make run-billing-for-day DAY=2026-07-30`)
- In admin, go to the monthly stats page (`/monthly?year=2026`)
- [ ] SMS total is parts only, and not multiplied by international rate

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [x] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [x] This PR does not significantly alter performance.
- [x] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.