### PR TITLE
Set TimeToLive for SMS messages to 259200 seconds

### DIFF
--- a/app/clients/sms/aws_pinpoint.py
+++ b/app/clients/sms/aws_pinpoint.py
@@ -26,7 +26,7 @@ class AwsPinpointClient(SmsClient):
 
     def send_sms(self, to, content, reference, multi=True, sender=None, template_id=None, service_id=None, sending_vehicle=None):
         messageType = "TRANSACTIONAL"
-        ttl_seconds = 259200
+        ttl_seconds = 3 * 24 * 60 * 60  # 3 days (AWS Pinpoint maximum)
         matched = False
         opted_out = False
         response = {}

--- a/app/clients/sms/aws_pinpoint.py
+++ b/app/clients/sms/aws_pinpoint.py
@@ -26,6 +26,7 @@ class AwsPinpointClient(SmsClient):
 
     def send_sms(self, to, content, reference, multi=True, sender=None, template_id=None, service_id=None, sending_vehicle=None):
         messageType = "TRANSACTIONAL"
+        ttl_seconds = 259200
         matched = False
         opted_out = False
         response = {}
@@ -54,6 +55,7 @@ class AwsPinpointClient(SmsClient):
                         MessageBody=content,
                         MessageType=messageType,
                         ConfigurationSetName=self.current_app.config["AWS_PINPOINT_CONFIGURATION_SET_NAME"],
+                        TimeToLive=ttl_seconds,
                     )
                 elif send_with_dedicated_phone_number:
                     dryrun = destinationNumber == self.current_app.config["EXTERNAL_TEST_NUMBER"]
@@ -64,6 +66,7 @@ class AwsPinpointClient(SmsClient):
                         MessageType=messageType,
                         ConfigurationSetName=self.current_app.config["AWS_PINPOINT_CONFIGURATION_SET_NAME"],
                         DryRun=dryrun,
+                        TimeToLive=ttl_seconds,
                     )
                     if dryrun:
                         self.current_app.logger.info(
@@ -78,6 +81,7 @@ class AwsPinpointClient(SmsClient):
                         MessageBody=content,
                         MessageType=messageType,
                         ConfigurationSetName=self.current_app.config["AWS_PINPOINT_CONFIGURATION_SET_NAME"],
+                        TimeToLive=ttl_seconds,
                     )
                 else:
                     dryrun = destinationNumber == self.current_app.config["EXTERNAL_TEST_NUMBER"]
@@ -88,6 +92,7 @@ class AwsPinpointClient(SmsClient):
                         MessageType=messageType,
                         ConfigurationSetName=self.current_app.config["AWS_PINPOINT_CONFIGURATION_SET_NAME"],
                         DryRun=dryrun,
+                        TimeToLive=ttl_seconds,
                     )
                     if dryrun:
                         self.current_app.logger.info(

--- a/tests/app/clients/test_aws_pinpoint.py
+++ b/tests/app/clients/test_aws_pinpoint.py
@@ -33,6 +33,7 @@ def test_send_sms_sends_to_default_pool(notify_api, mocker, sample_template, tem
         MessageType="TRANSACTIONAL",
         ConfigurationSetName="config_set_name",
         DryRun=False,
+        TimeToLive=259200,
     )
 
 
@@ -62,6 +63,7 @@ def test_send_sms_sends_notify_sms_to_shortcode_pool(notify_api, mocker, sample_
         MessageType="TRANSACTIONAL",
         ConfigurationSetName="config_set_name",
         DryRun=False,
+        TimeToLive=259200,
     )
 
 
@@ -154,6 +156,7 @@ def test_respects_sending_vehicle_if_FF_enabled(notify_api, mocker, sample_templ
         MessageType="TRANSACTIONAL",
         ConfigurationSetName="config_set_name",
         DryRun=False,
+        TimeToLive=259200,
     )
 
 
@@ -181,6 +184,7 @@ def test_send_sms_sends_international_without_pool_id(notify_api, mocker, sample
         MessageBody=content,
         MessageType="TRANSACTIONAL",
         ConfigurationSetName="config_set_name",
+        TimeToLive=259200,
     )
 
 
@@ -211,6 +215,7 @@ def test_send_sms_uses_dryrun(notify_api, mocker, sample_template, template_id):
         MessageType="TRANSACTIONAL",
         ConfigurationSetName="config_set_name",
         DryRun=True,
+        TimeToLive=259200,
     )
 
 
@@ -249,6 +254,7 @@ def test_send_sms_uses_dedicated_number_with_long_code_sender(notify_api, mocker
         MessageType="TRANSACTIONAL",
         ConfigurationSetName="config_set_name",
         DryRun=False,
+        TimeToLive=259200,
     )
 
     # Default client NOT used
@@ -280,6 +286,7 @@ def test_send_sms_to_us_number_uses_US_toll_free_number(notify_api, mocker):
         MessageBody=content,
         MessageType="TRANSACTIONAL",
         ConfigurationSetName="config_set_name",
+        TimeToLive=259200,
     )
 
     # Default client NOT used


### PR DESCRIPTION
# Summary | Résumé
This pull request updates the AWS Pinpoint SMS client to include a `TimeToLive` (TTL) parameter when sending SMS messages, ensuring messages expire after a set period if not delivered. The TTL is set to 259200 seconds (3 days, which is the maximum value) for all outgoing messages. Corresponding unit tests have been updated to check for the presence of the new parameter.

According to [the AWS docs](https://docs.aws.amazon.com/pinpoint/latest/apireference_smsvoicev2/API_SendTextMessage.html), the default value is already 3 days, but we are seeing some messages time out sooner than that, so here we will explicitly set this value.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/3285

# Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.