### PR TITLE
Add a db column to record which API key requests a report

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -2855,6 +2855,10 @@ class Report(BaseModel):
         UUID(as_uuid=True), db.ForeignKey("users.id"), nullable=True
     )  # only set if report is requested by a user
     requesting_user = db.relationship("User")
+    api_key_id = db.Column(
+        UUID(as_uuid=True), db.ForeignKey("api_keys.id"), index=True, nullable=True
+    )  # only set if report is requested via the API
+    api_key = db.relationship("ApiKey")
     service_id = db.Column(
         UUID(as_uuid=True),
         db.ForeignKey("services.id"),
@@ -2877,4 +2881,5 @@ class Report(BaseModel):
             "completed_at": self.completed_at.strftime(DATETIME_FORMAT) if self.completed_at else None,
             "expires_at": self.expires_at.strftime(DATETIME_FORMAT) if self.expires_at else None,
             "url": self.url,
+            "api_key_id": str(self.api_key_id) if self.api_key_id else None,
         }

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -858,6 +858,7 @@ class ReportSchema(BaseSchema):
 
     id = fields.UUID()
     requesting_user_id = fields.UUID()
+    api_key_id = fields.UUID(required=False, allow_none=True)
     report_type = fields.String()
     service_id = fields.UUID()
     status = fields.String()
@@ -871,6 +872,15 @@ class ReportSchema(BaseSchema):
 
     requesting_user = fields.Nested(
         UserSchema,
+        only=[
+            "id",
+            "name",
+        ],
+        dump_only=True,
+    )
+
+    api_key = fields.Nested(
+        ApiKeySchema,
         only=[
             "id",
             "name",

--- a/app/v2/reports/post_reports.py
+++ b/app/v2/reports/post_reports.py
@@ -57,6 +57,7 @@ def post_report():
         service_id=authenticated_service.id,
         status=ReportStatus.REQUESTED.value,
         requesting_user_id=None,
+        api_key_id=api_user.id,
         language=data["language"],
         job_id=data.get("job_id"),
     )

--- a/migrations/versions/0522_add_api_key_to_reports.py
+++ b/migrations/versions/0522_add_api_key_to_reports.py
@@ -1,0 +1,26 @@
+"""
+
+Revision ID: 0522_add_api_key_to_reports
+Revises: 0521_update_bounce_rate_warn
+Create Date: 2026-07-30
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0522_add_api_key_to_reports"
+down_revision = "0521_update_bounce_rate_warn"
+
+
+def upgrade():
+    op.add_column("reports", sa.Column("api_key_id", postgresql.UUID(as_uuid=True), nullable=True))
+    op.create_index(op.f("ix_reports_api_key_id"), "reports", ["api_key_id"], unique=False)
+    op.create_foreign_key("reports_api_key_id_fkey", "reports", "api_keys", ["api_key_id"], ["id"])
+
+
+def downgrade():
+    op.drop_constraint("reports_api_key_id_fkey", "reports", type_="foreignkey")
+    op.drop_index(op.f("ix_reports_api_key_id"), table_name="reports")
+    op.drop_column("reports", "api_key_id")

--- a/migrations/versions/0522_add_api_key_to_reports.py
+++ b/migrations/versions/0522_add_api_key_to_reports.py
@@ -8,6 +8,7 @@ Create Date: 2026-07-30
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy import inspect
 from sqlalchemy.dialects import postgresql
 
 revision = "0522_add_api_key_to_reports"
@@ -15,9 +16,19 @@ down_revision = "0521_update_bounce_rate_warn"
 
 
 def upgrade():
-    op.add_column("reports", sa.Column("api_key_id", postgresql.UUID(as_uuid=True), nullable=True))
-    op.create_index(op.f("ix_reports_api_key_id"), "reports", ["api_key_id"], unique=False)
-    op.create_foreign_key("reports_api_key_id_fkey", "reports", "api_keys", ["api_key_id"], ["id"])
+    inspector = inspect(op.get_bind())
+
+    existing_columns = [column["name"] for column in inspector.get_columns("reports")]
+    if "api_key_id" not in existing_columns:
+        op.add_column("reports", sa.Column("api_key_id", postgresql.UUID(as_uuid=True), nullable=True))
+
+    existing_indexes = [index["name"] for index in inspector.get_indexes("reports")]
+    if "ix_reports_api_key_id" not in existing_indexes:
+        op.create_index(op.f("ix_reports_api_key_id"), "reports", ["api_key_id"], unique=False)
+
+    existing_fks = [fk["name"] for fk in inspector.get_foreign_keys("reports")]
+    if "reports_api_key_id_fkey" not in existing_fks:
+        op.create_foreign_key("reports_api_key_id_fkey", "reports", "api_keys", ["api_key_id"], ["id"])
 
 
 def downgrade():

--- a/tests/app/v2/reports/test_post_reports.py
+++ b/tests/app/v2/reports/test_post_reports.py
@@ -9,7 +9,8 @@ from tests import create_authorization_header
 
 def test_post_report_returns_202(client, sample_service, mocker, create_api_key_with_manage_reports_perm):
     mock_task = mocker.patch("app.v2.reports.post_reports.generate_report.apply_async")
-    auth_header = create_authorization_header(api_key=create_api_key_with_manage_reports_perm)
+    api_key = create_api_key_with_manage_reports_perm
+    auth_header = create_authorization_header(api_key=api_key)
 
     response = client.post(
         path="/v2/reports",
@@ -23,6 +24,7 @@ def test_post_report_returns_202(client, sample_service, mocker, create_api_key_
     assert str(report.service_id) == str(sample_service.id)
     assert report.status == ReportStatus.REQUESTED.value
     assert report.requesting_user_id is None
+    assert report.api_key_id == api_key.id
     assert report.language == "en"
     assert response.headers["Location"] == f"/v2/reports/{report.id}"
     mock_task.assert_called_once_with([str(report.id), []], queue="generate-reports")


### PR DESCRIPTION
# Summary | Résumé

Add a db column to record which API key requests a report. This will allow us to display this info in notification-admin.

# Test instructions | Instructions pour tester la modification

Test alongside the admin changes using the test instructions over here: https://github.com/cds-snc/notification-admin/pull/2750

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.