### PR TITLE
Remove the unused scheduling permission from the one-off endpoints

### DIFF
--- a/app/notifications/process_notifications.py
+++ b/app/notifications/process_notifications.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from typing import List, Optional
 
 from flask import current_app
+from iso8601 import parse_date
 from notifications_utils.clients import redis
 from notifications_utils.decorators import parallel_process_iterable
 from notifications_utils.recipients import (
@@ -10,7 +11,6 @@ from notifications_utils.recipients import (
     get_international_phone_info,
     validate_and_format_phone_number,
 )
-from notifications_utils.timezones import convert_local_timezone_to_utc
 
 from app import redis_store
 from app.celery import provider_tasks
@@ -493,6 +493,7 @@ def simulated_recipient(to_address: str, notification_type: NotificationType) ->
 
 
 def persist_scheduled_notification(notification_id, scheduled_for):
-    scheduled_datetime = convert_local_timezone_to_utc(datetime.strptime(scheduled_for, "%Y-%m-%d %H:%M"))
+    # scheduled_for is UTC already, same as the bulk/job scheduling endpoint - accepts full ISO 8601
+    scheduled_datetime = parse_date(scheduled_for).replace(tzinfo=None)
     scheduled_notification = ScheduledNotification(notification_id=notification_id, scheduled_for=scheduled_datetime)
     dao_created_scheduled_notification(scheduled_notification)

--- a/app/notifications/validators.py
+++ b/app/notifications/validators.py
@@ -38,7 +38,6 @@ from app.models import (
     INTERNATIONAL_SMS_TYPE,
     KEY_TYPE_TEAM,
     LETTER_TYPE,
-    SCHEDULE_NOTIFICATIONS,
     SMS_TYPE,
     ApiKey,
     ApiKeyType,
@@ -558,12 +557,6 @@ def check_service_has_permission(notify_type, permissions: list[Permission]):
         raise BadRequestError(
             message="Service is not allowed to send {}".format(get_public_notify_type_text(notify_type, plural=True))
         )
-
-
-def check_service_can_schedule_notification(permissions: list[Permission], scheduled_for):
-    if scheduled_for:
-        if not service_has_permission(SCHEDULE_NOTIFICATIONS, permissions):
-            raise BadRequestError(message="Cannot schedule notifications (this feature is invite-only)")
 
 
 def validate_and_format_recipient(

--- a/app/schema_validation/__init__.py
+++ b/app/schema_validation/__init__.py
@@ -46,23 +46,6 @@ def validate_schema_postage(instance):
     return True
 
 
-@format_checker.checks("datetime_within_next_day", raises=ValidationError)
-def validate_schema_date_with_hour(instance):
-    if isinstance(instance, str):
-        try:
-            dt = iso8601.parse_date(instance).replace(tzinfo=None)
-            if dt < datetime.utcnow():
-                raise ValidationError("datetime cannot be in the past")
-            if dt > datetime.utcnow() + timedelta(hours=24):
-                raise ValidationError("datetime can only be 24 hours in the future")
-        except ParseError:
-            raise ValidationError(
-                "datetime format is invalid. It must be a valid ISO8601 date time format, "
-                "https://en.wikipedia.org/wiki/ISO_8601"
-            )
-    return True
-
-
 @format_checker.checks("datetime_schedule_job", raises=ValidationError)
 def validate_schema_date_for_job(instance):
     max_hours = current_app.config["JOBS_MAX_SCHEDULE_HOURS_AHEAD"]

--- a/app/v2/notifications/notification_schemas.py
+++ b/app/v2/notifications/notification_schemas.py
@@ -137,7 +137,7 @@ post_sms_request = {
         "personalisation": personalisation,
         "scheduled_for": {
             "type": ["string", "null"],
-            "format": "datetime_within_next_day",
+            "format": "datetime_schedule_job",
         },
         "sms_sender_id": uuid,
     },
@@ -183,7 +183,7 @@ post_email_request = {
         "personalisation": personalisation,
         "scheduled_for": {
             "type": ["string", "null"],
-            "format": "datetime_within_next_day",
+            "format": "datetime_schedule_job",
         },
         "email_reply_to_id": uuid,
     },

--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -75,7 +75,6 @@ from app.notifications.validators import (
     check_email_annual_limit,
     check_email_daily_limit,
     check_rate_limiting,
-    check_service_can_schedule_notification,
     check_service_email_reply_to_id,
     check_service_has_permission,
     check_service_sms_sender_id,
@@ -307,8 +306,6 @@ def post_notification(notification_type: NotificationType):
     check_service_has_permission(notification_type, authenticated_service.permissions)
 
     scheduled_for = form.get("scheduled_for", None)
-
-    check_service_can_schedule_notification(authenticated_service.permissions, scheduled_for)
 
     check_rate_limiting(authenticated_service, api_user)
 

--- a/openapi/v2-notifications-api-en.yaml
+++ b/openapi/v2-notifications-api-en.yaml
@@ -1472,7 +1472,7 @@ components:
           type: string
           format: date-time
           nullable: true
-          description: Schedule notification for future delivery
+          description: If you want to send notifications in the future, you can specify a datetime up to 4 days in the future, in ISO 8601 format, UTC time.
         email_reply_to_id:
           $ref: '#/components/schemas/UUID'
           description: ID of the reply-to address to use
@@ -1503,7 +1503,7 @@ components:
           type: string
           format: date-time
           nullable: true
-          description: Schedule notification for future delivery
+          description: If you want to send notifications in the future, you can specify a datetime up to 4 days in the future, in ISO 8601 format, UTC time.
         sms_sender_id:
           $ref: '#/components/schemas/UUID'
           description: ID of the SMS sender to use

--- a/openapi/v2-notifications-api-fr.yaml
+++ b/openapi/v2-notifications-api-fr.yaml
@@ -1472,7 +1472,7 @@ components:
           type: string
           format: date-time
           nullable: true
-          description: Planifier la notification pour un envoi ultérieur
+          description: Si vous souhaitez envoyer des notifications dans le futur, vous pouvez spécifier une date et une heure jusqu’à 4 jours à l’avance, au format ISO 8601, heure UTC.
         email_reply_to_id:
           $ref: '#/components/schemas/UUID'
           description: ID de l'adresse de réponse à utiliser
@@ -1503,7 +1503,7 @@ components:
           type: string
           format: date-time
           nullable: true
-          description: Planifier la notification pour un envoi ultérieur
+          description: Si vous souhaitez envoyer des notifications dans le futur, vous pouvez spécifier une date et une heure jusqu’à 4 jours à l’avance, au format ISO 8601, heure UTC.
         sms_sender_id:
           $ref: '#/components/schemas/UUID'
           description: ID de l'expéditeur SMS à utiliser

--- a/openapi/v2-notifications-api.yaml.j2
+++ b/openapi/v2-notifications-api.yaml.j2
@@ -1472,7 +1472,7 @@ components:
           type: string
           format: date-time
           nullable: true
-          description: {{ t("Schedule notification for future delivery") }}
+          description: {{ t("If you want to send notifications in the future, you can specify a datetime up to 4 days in the future, in ISO 8601 format, UTC time.") }}
         email_reply_to_id:
           $ref: '#/components/schemas/UUID'
           description: {{ t("ID of the reply-to address to use") }}
@@ -1503,7 +1503,7 @@ components:
           type: string
           format: date-time
           nullable: true
-          description: {{ t("Schedule notification for future delivery") }}
+          description: {{ t("If you want to send notifications in the future, you can specify a datetime up to 4 days in the future, in ISO 8601 format, UTC time.") }}
         sms_sender_id:
           $ref: '#/components/schemas/UUID'
           description: {{ t("ID of the SMS sender to use") }}

--- a/tests/app/notifications/test_process_notification.py
+++ b/tests/app/notifications/test_process_notification.py
@@ -810,14 +810,20 @@ class TestSimulatedRecipient:
         assert is_simulated_address == expected
 
 
-# This test assumes the local timezone is EST
 class TestScheduledNotification:
     def test_persist_scheduled_notification(self, sample_notification):
+        # scheduled_for is treated as UTC, matching the bulk/job scheduling endpoint - no local timezone conversion
         persist_scheduled_notification(sample_notification.id, "2017-05-12 14:15")
         scheduled_notification = ScheduledNotification.query.all()
         assert len(scheduled_notification) == 1
         assert scheduled_notification[0].notification_id == sample_notification.id
-        assert scheduled_notification[0].scheduled_for == datetime.datetime(2017, 5, 12, 18, 15)
+        assert scheduled_notification[0].scheduled_for == datetime.datetime(2017, 5, 12, 14, 15)
+
+    def test_persist_scheduled_notification_accepts_full_iso8601(self, sample_notification):
+        persist_scheduled_notification(sample_notification.id, "2017-05-12T14:15:00")
+        scheduled_notification = ScheduledNotification.query.all()
+        assert len(scheduled_notification) == 1
+        assert scheduled_notification[0].scheduled_for == datetime.datetime(2017, 5, 12, 14, 15)
 
 
 class TestChooseQueue:

--- a/tests/app/v2/notifications/test_notification_schemas.py
+++ b/tests/app/v2/notifications/test_notification_schemas.py
@@ -348,11 +348,11 @@ def test_scheduled_for_raises_validation_error_when_in_the_past():
 
 
 @freeze_time("2017-05-12 13:00:00")
-def test_scheduled_for_raises_validation_error_when_more_than_24_hours_in_the_future():
+def test_scheduled_for_raises_validation_error_when_more_than_96_hours_in_the_future():
     j = {
         "phone_number": "6502532222",
         "template_id": str(uuid.uuid4()),
-        "scheduled_for": "2017-05-13 14:00",
+        "scheduled_for": "2017-05-16 14:00",
     }
     with pytest.raises(ValidationError) as e:
         validate(j, post_sms_request_schema)
@@ -361,6 +361,6 @@ def test_scheduled_for_raises_validation_error_when_more_than_24_hours_in_the_fu
     assert error["errors"] == [
         {
             "error": "ValidationError",
-            "message": "scheduled_for datetime can only be 24 hours in the future",
+            "message": "scheduled_for datetime can only be up to 96 hours in the future",
         }
     ]

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -1105,7 +1105,7 @@ class TestSchedulingSends:
     ):
         service = create_service(
             service_name=str(uuid.uuid4()),
-            service_permissions=[EMAIL_TYPE, SMS_TYPE, SCHEDULE_NOTIFICATIONS],
+            service_permissions=[EMAIL_TYPE, SMS_TYPE],
         )
         template = create_template(service=service, template_type=notification_type)
         data = {
@@ -1135,7 +1135,7 @@ class TestSchedulingSends:
         ],
     )
     @freeze_time("2017-05-14 14:00:00")
-    def test_post_notification_raises_bad_request_if_service_not_invited_to_schedule(
+    def test_post_notification_allows_scheduling_without_schedule_notifications_permission(
         self,
         client,
         sample_template,
@@ -1143,6 +1143,7 @@ class TestSchedulingSends:
         notification_type,
         key_send_to,
         send_to,
+        mock_annual_limits,
     ):
         data = {
             key_send_to: send_to,
@@ -1156,14 +1157,9 @@ class TestSchedulingSends:
             data=json.dumps(data),
             headers=[("Content-Type", "application/json"), auth_header],
         )
-        assert response.status_code == 400
-        error_json = json.loads(response.get_data(as_text=True))
-        assert error_json["errors"] == [
-            {
-                "error": "BadRequestError",
-                "message": "Cannot schedule notifications (this feature is invite-only)",
-            }
-        ]
+        assert response.status_code == 201
+        resp_json = json.loads(response.get_data(as_text=True))
+        assert resp_json["scheduled_for"] == "2017-05-14 14:15"
 
 
 class TestSendingDocuments:

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -1135,6 +1135,40 @@ class TestSchedulingSends:
         ],
     )
     @freeze_time("2017-05-14 14:00:00")
+    def test_post_notification_with_scheduled_for_in_full_iso8601_format(
+        self, client, notify_db_session, notification_type, key_send_to, send_to, mock_annual_limits
+    ):
+        # regression test: real API clients send full ISO 8601 (with 'T' separator and seconds), not "%Y-%m-%d %H:%M"
+        service = create_service(
+            service_name=str(uuid.uuid4()),
+            service_permissions=[EMAIL_TYPE, SMS_TYPE],
+        )
+        template = create_template(service=service, template_type=notification_type)
+        data = {
+            key_send_to: send_to,
+            "template_id": str(template.id),
+            "scheduled_for": "2017-05-14T14:15:00",
+        }
+        auth_header = create_authorization_header(service_id=service.id)
+
+        response = client.post(
+            "/v2/notifications/{}".format(notification_type),
+            data=json.dumps(data),
+            headers=[("Content-Type", "application/json"), auth_header],
+        )
+        assert response.status_code == 201
+        resp_json = json.loads(response.get_data(as_text=True))
+        scheduled_notification = ScheduledNotification.query.filter_by(notification_id=resp_json["id"]).all()
+        assert len(scheduled_notification) == 1
+
+    @pytest.mark.parametrize(
+        "notification_type, key_send_to, send_to",
+        [
+            ("sms", "phone_number", "6502532222"),
+            ("email", "email_address", "sample@email.com"),
+        ],
+    )
+    @freeze_time("2017-05-14 14:00:00")
     def test_post_notification_allows_scheduling_without_schedule_notifications_permission(
         self,
         client,


### PR DESCRIPTION
# Summary | Résumé

Remove the unused scheduling permission from the one-off endpoints, and make it work the same way as the bulk endpoint. Also update the open api spec to match. The content added in this PR is just recycled from what we already were using for the bulk endpoint.

It seems that no one has ever tried to schedule a one-off send via our API before. We are enforcing a permission there to allow services to schedule a notification. No existing services in prod have this permission, and we are not enforcing it on the bulk endpoint or for scheduled sends via the UI. The code for this is 9 years old so it looks like this is just a left over from GDS that is not consistent with what we are doing on the bulk endpoint.

## Related Issues | Cartes liées

This was raised in a support ticket https://cds-snc.freshdesk.com/a/tickets/29383

https://github.com/cds-snc/notification-planning/issues/3380

# Test instructions | Instructions pour tester la modification

## Reproduce the bug
1. try the following api request on staging:
```
curl -X POST https://api.staging.notification.cdssandbox.xyz/v2/notifications/email \
  -H "Content-Type: application/json" \
  -H "Authorization: ApiKey-v1 your-api-key" \
  -d '{
    "email_address": "stephen.mcmurtry@cds-snc.ca",
    "template_id": "your-template-id",
    "scheduled_for": "2026-08-01T15:15:00"
  }'
```
3. verify that you get the following error response
```
{"status_code": 400, "errors": [{"error": "BadRequestError", "message": "Cannot schedule notifications (this feature is invite-only)"}]}```
```

## Test the fix

1. Run the api locally
2. try the api request again:
```
curl -X POST http://localhost:6011/v2/notifications/email \
  -H "Content-Type: application/json" \
  -H "Authorization: ApiKey-v1 your-api-key" \
  -d '{
    "email_address": "stephen.mcmurtry@cds-snc.ca",
    "template_id": "your-template-id",
    "scheduled_for": "2026-08-01T15:15:00"
  }'
```
3. verify that you get a success response

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.