### PR TITLE
Task/bounce rate support

### DIFF
--- a/app/celery/bounce_rate_tasks.py
+++ b/app/celery/bounce_rate_tasks.py
@@ -2,40 +2,60 @@ from flask import current_app
 
 from app import notify_celery
 from app.models import Service
-from app.service.sender import send_notification_to_service_users
+from app.service.sender import send_notification_to_email_address, send_notification_to_service_users
+
+
+def _build_bounce_rate_personalisation(service_name: str, service_id: str, bounce_rate: float) -> dict:
+    return {
+        "service_name": service_name,
+        "bounce_rate": round(bounce_rate * 100, 2),
+        "failed_notifications_url_en": f"{current_app.config['ADMIN_BASE_URL']}/services/{service_id}/notifications/email?status=failed",
+        "failed_notifications_url_fr": f"{current_app.config['ADMIN_BASE_URL']}/services/{service_id}/notifications/email?status=failed&lang=fr",
+        "service_dashboard_url_en": f"{current_app.config['ADMIN_BASE_URL']}/services/{service_id}",
+        "service_dashboard_url_fr": f"{current_app.config['ADMIN_BASE_URL']}/services/{service_id}?lang=fr",
+    }
+
+
+def _send_bounce_rate_email(
+    service_id: str,
+    bounce_rate: float,
+    template_id: str,
+    send_support_copy: bool = False,
+):
+    service = Service.query.get(service_id)
+    personalisation = _build_bounce_rate_personalisation(
+        service_name=service.name, service_id=service_id, bounce_rate=bounce_rate
+    )
+
+    send_notification_to_service_users(
+        service_id=service_id,
+        template_id=template_id,
+        personalisation=personalisation.copy(),
+        include_user_fields=["name"],
+    )
+
+    if send_support_copy:
+        send_notification_to_email_address(
+            email_address=current_app.config["FRESHDESK_SUPPORT_EMAIL_ID"],
+            template_id=template_id,
+            personalisation={**personalisation, "name": "Freshdesk support"},
+        )
 
 
 @notify_celery.task(name="send-bounce-rate-suspension-email")
 def send_bounce_rate_suspension_email(service_id: str, bounce_rate: float):
-    service = Service.query.get(service_id)
-    send_notification_to_service_users(
+    _send_bounce_rate_email(
         service_id=service_id,
+        bounce_rate=bounce_rate,
         template_id=current_app.config["SERVICE_BOUNCE_RATE_SUSPENDED_TEMPLATE_ID"],
-        personalisation={
-            "service_name": service.name,
-            "bounce_rate": round(bounce_rate * 100, 2),
-            "failed_notifications_url_en": f"{current_app.config['ADMIN_BASE_URL']}/services/{service_id}/notifications/email?status=failed",
-            "failed_notifications_url_fr": f"{current_app.config['ADMIN_BASE_URL']}/services/{service_id}/notifications/email?status=failed&lang=fr",
-            "service_dashboard_url_en": f"{current_app.config['ADMIN_BASE_URL']}/services/{service_id}",
-            "service_dashboard_url_fr": f"{current_app.config['ADMIN_BASE_URL']}/services/{service_id}?lang=fr",
-        },
-        include_user_fields=["name"],
+        send_support_copy=True,
     )
 
 
 @notify_celery.task(name="send-bounce-rate-warning-email")
 def send_bounce_rate_warning_email(service_id: str, bounce_rate: float):
-    service = Service.query.get(service_id)
-    send_notification_to_service_users(
+    _send_bounce_rate_email(
         service_id=service_id,
+        bounce_rate=bounce_rate,
         template_id=current_app.config["SERVICE_SUSPENDED_WARNING_TEMPLATE_ID"],
-        personalisation={
-            "service_name": service.name,
-            "bounce_rate": round(bounce_rate * 100, 2),
-            "failed_notifications_url_en": f"{current_app.config['ADMIN_BASE_URL']}/services/{service_id}/notifications/email?status=failed",
-            "failed_notifications_url_fr": f"{current_app.config['ADMIN_BASE_URL']}/services/{service_id}/notifications/email?status=failed&lang=fr",
-            "service_dashboard_url_en": f"{current_app.config['ADMIN_BASE_URL']}/services/{service_id}",
-            "service_dashboard_url_fr": f"{current_app.config['ADMIN_BASE_URL']}/services/{service_id}?lang=fr",
-        },
-        include_user_fields=["name"],
     )

--- a/app/celery/bounce_rate_tasks.py
+++ b/app/celery/bounce_rate_tasks.py
@@ -34,7 +34,7 @@ def _send_bounce_rate_email(
         include_user_fields=["name"],
     )
 
-    if send_support_copy:
+    if send_support_copy and current_app.config["NOTIFY_ENVIRONMENT"] == "production":
         send_notification_to_email_address(
             email_address=current_app.config["FRESHDESK_SUPPORT_EMAIL_ID"],
             template_id=template_id,

--- a/app/config.py
+++ b/app/config.py
@@ -620,6 +620,7 @@ class Config(object):
 
     CONTACT_FORM_EMAIL_ADDRESS = os.getenv("CONTACT_FORM_EMAIL_ADDRESS", "helpdesk@cds-snc.ca")
     SENSITIVE_SERVICE_EMAIL = os.getenv("SENSITIVE_SERVICE_EMAIL", "ESDC.Support.CDS-SNC.Soutien.EDSC@servicecanada.gc.ca")
+    FRESHDESK_SUPPORT_EMAIL_ID = "assistance+notification@cds-snc.ca"
 
     FROM_NUMBER = "development"
 

--- a/app/service/sender.py
+++ b/app/service/sender.py
@@ -63,6 +63,26 @@ def send_notification_to_single_user(user, template_id, personalisation=None, in
     send_notification_to_queue(notification, False, queue=QueueNames.NOTIFY)
 
 
+def send_notification_to_email_address(email_address, template_id, personalisation=None):
+    personalisation = personalisation or {}
+    template = dao_get_template_by_id(template_id)
+    notify_service = dao_fetch_service_by_id(current_app.config["NOTIFY_SERVICE_ID"])
+
+    notification = persist_notification(
+        template_id=template.id,
+        template_version=template.version,
+        recipient=email_address,
+        service=notify_service,
+        personalisation=personalisation,
+        notification_type=template.template_type,
+        api_key_id=None,
+        key_type=KEY_TYPE_NORMAL,
+        reply_to_text=notify_service.get_default_reply_to_email_address(),
+    )
+
+    send_notification_to_queue(notification, False, queue=QueueNames.NOTIFY)
+
+
 def _add_user_fields(user, personalisation, fields):
     for field in fields:
         personalisation[field] = getattr(user, field)

--- a/tests/app/celery/test_bounce_rate_tasks.py
+++ b/tests/app/celery/test_bounce_rate_tasks.py
@@ -33,6 +33,7 @@ def test_bounce_rate_tasks_send_to_service_owners(
         {
             "ADMIN_BASE_URL": "https://admin.notification.canada.ca",
             "FRESHDESK_SUPPORT_EMAIL_ID": "assistance+notification@cds-snc.ca",
+            "NOTIFY_ENVIRONMENT": "production",
         },
     ):
         task_function(service_id=service_id, bounce_rate=bounce_rate)

--- a/tests/app/celery/test_bounce_rate_tasks.py
+++ b/tests/app/celery/test_bounce_rate_tasks.py
@@ -1,0 +1,63 @@
+from types import SimpleNamespace
+
+import pytest
+from tests.conftest import set_config_values
+
+from app.celery.bounce_rate_tasks import send_bounce_rate_suspension_email, send_bounce_rate_warning_email
+
+
+@pytest.mark.parametrize(
+    "task_function, template_id_key, should_send_support_copy",
+    [
+        (send_bounce_rate_suspension_email, "SERVICE_BOUNCE_RATE_SUSPENDED_TEMPLATE_ID", True),
+        (send_bounce_rate_warning_email, "SERVICE_SUSPENDED_WARNING_TEMPLATE_ID", False),
+    ],
+)
+def test_bounce_rate_tasks_send_to_service_owners(
+    notify_api,
+    mocker,
+    task_function,
+    template_id_key,
+    should_send_support_copy,
+):
+    service_id = "service-123"
+    bounce_rate = 0.056789
+
+    mock_service = mocker.patch("app.celery.bounce_rate_tasks.Service")
+    mock_service.query.get.return_value = SimpleNamespace(name="Platform service")
+    mock_send_to_service_users = mocker.patch("app.celery.bounce_rate_tasks.send_notification_to_service_users")
+    mock_send_to_email_address = mocker.patch("app.celery.bounce_rate_tasks.send_notification_to_email_address")
+
+    with set_config_values(
+        notify_api,
+        {
+            "ADMIN_BASE_URL": "https://admin.notification.canada.ca",
+            "FRESHDESK_SUPPORT_EMAIL_ID": "assistance+notification@cds-snc.ca",
+        },
+    ):
+        task_function(service_id=service_id, bounce_rate=bounce_rate)
+
+    expected_personalisation = {
+        "service_name": "Platform service",
+        "bounce_rate": 5.68,
+        "failed_notifications_url_en": f"https://admin.notification.canada.ca/services/{service_id}/notifications/email?status=failed",
+        "failed_notifications_url_fr": f"https://admin.notification.canada.ca/services/{service_id}/notifications/email?status=failed&lang=fr",
+        "service_dashboard_url_en": f"https://admin.notification.canada.ca/services/{service_id}",
+        "service_dashboard_url_fr": f"https://admin.notification.canada.ca/services/{service_id}?lang=fr",
+    }
+
+    mock_service.query.get.assert_called_once_with(service_id)
+    mock_send_to_service_users.assert_called_once_with(
+        service_id=service_id,
+        template_id=notify_api.config[template_id_key],
+        personalisation=expected_personalisation,
+        include_user_fields=["name"],
+    )
+    if should_send_support_copy:
+        mock_send_to_email_address.assert_called_once_with(
+            email_address="assistance+notification@cds-snc.ca",
+            template_id=notify_api.config[template_id_key],
+            personalisation={**expected_personalisation, "name": "Freshdesk support"},
+        )
+    else:
+        mock_send_to_email_address.assert_not_called()

--- a/tests/app/service/test_sender.py
+++ b/tests/app/service/test_sender.py
@@ -1,9 +1,12 @@
+from types import SimpleNamespace
+
 import pytest
 from flask import current_app
 
+from app.config import QueueNames
 from app.dao.services_dao import dao_add_user_to_service
-from app.models import EMAIL_TYPE, SMS_TYPE, Notification
-from app.service.sender import send_notification_to_service_users
+from app.models import EMAIL_TYPE, KEY_TYPE_NORMAL, SMS_TYPE, Notification
+from app.service.sender import send_notification_to_email_address, send_notification_to_service_users
 from tests.app.conftest import create_sample_service
 from tests.app.conftest import notify_service as create_notify_service
 from tests.app.db import create_template, create_user
@@ -90,3 +93,38 @@ def test_send_notification_to_service_users_sends_to_active_users_only(notify_db
     assert pending_user.email_address not in notifications_recipients
     assert first_active_user.email_address in notifications_recipients
     assert second_active_user.email_address in notifications_recipients
+
+
+def test_send_notification_to_email_address_persists_and_queues_notification(notify_api, mocker):
+    fake_template = SimpleNamespace(id="template-123", version=4, template_type=EMAIL_TYPE)
+    fake_notify_service = SimpleNamespace(get_default_reply_to_email_address=lambda: "reply-to@notification.canada.ca")
+    saved_notification = object()
+
+    mock_get_template = mocker.patch("app.service.sender.dao_get_template_by_id", return_value=fake_template)
+    mock_get_service = mocker.patch("app.service.sender.dao_fetch_service_by_id", return_value=fake_notify_service)
+    mock_persist_notification = mocker.patch("app.service.sender.persist_notification", return_value=saved_notification)
+    mock_send_to_queue = mocker.patch("app.service.sender.send_notification_to_queue")
+
+    personalisation = {"service_name": "Platform service", "name": "Freshdesk support"}
+    recipient = "assistance+notification@cds-snc.ca"
+
+    send_notification_to_email_address(
+        email_address=recipient,
+        template_id="template-123",
+        personalisation=personalisation,
+    )
+
+    mock_get_template.assert_called_once_with("template-123")
+    mock_get_service.assert_called_once_with(current_app.config["NOTIFY_SERVICE_ID"])
+    mock_persist_notification.assert_called_once_with(
+        template_id=fake_template.id,
+        template_version=fake_template.version,
+        recipient=recipient,
+        service=fake_notify_service,
+        personalisation=personalisation,
+        notification_type=fake_template.template_type,
+        api_key_id=None,
+        key_type=KEY_TYPE_NORMAL,
+        reply_to_text="reply-to@notification.canada.ca",
+    )
+    mock_send_to_queue.assert_called_once_with(saved_notification, False, queue=QueueNames.NOTIFY)


### PR DESCRIPTION
# Summary | Résumé

This PR updates bounce-rate notification handling so Freshdesk support  receives a copy of the email when a service is actually suspended for bounce rate

## What changed
Added support-copy behavior for suspension emails only.
Explicitly does not send a support copy for warning emails.
Limited support-copy sending to production environment.
Added/used a dedicated configuration key for the Freshdesk support recipient: FRESHDESK_SUPPORT_EMAIL_ID.
