### PR TITLE
Task/misc thread safety fixes

### DIFF
--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -36,20 +36,20 @@ def make_task(app):
         def message_group_id(self):
             return self.request.get("notify_message_group_id")
 
+        def before_start(self, task_id, args, kwargs):
+            self.request._notify_start_time = time.monotonic()
+
         def on_success(self, retval, task_id, args, kwargs):
             start_time = getattr(self.request, "_notify_start_time", None)
             if start_time is None:
                 return
 
-            elapsed_time = time.time() - start_time
+            elapsed_time = time.monotonic() - start_time
             app.logger.info("{task_name} took {time}s".format(task_name=self.name, time="{0:.4f}".format(elapsed_time)))
 
         def __call__(self, *args, **kwargs):
             # ensure task has flask context to access config, logger, etc
             with app.app_context():
-                # Store timing on the per-request context to avoid cross-task
-                # races when using thread/gevent pools.
-                self.request._notify_start_time = time.time()
                 return super().__call__(*args, **kwargs)
 
     return NotifyTask

--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -31,20 +31,25 @@ def worker_process_shutdown(sender, signal, pid, exitcode, **kwargs):
 def make_task(app):
     class NotifyTask(Task):
         abstract = True
-        start = None
 
         @property
         def message_group_id(self):
             return self.request.get("notify_message_group_id")
 
         def on_success(self, retval, task_id, args, kwargs):
-            elapsed_time = time.time() - self.start
+            start_time = getattr(self.request, "_notify_start_time", None)
+            if start_time is None:
+                return
+
+            elapsed_time = time.time() - start_time
             app.logger.info("{task_name} took {time}s".format(task_name=self.name, time="{0:.4f}".format(elapsed_time)))
 
         def __call__(self, *args, **kwargs):
             # ensure task has flask context to access config, logger, etc
             with app.app_context():
-                self.start = time.time()
+                # Store timing on the per-request context to avoid cross-task
+                # races when using thread/gevent pools.
+                self.request._notify_start_time = time.time()
                 return super().__call__(*args, **kwargs)
 
     return NotifyTask

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -890,7 +890,7 @@ def send_method_stats_by_service(start_time, end_time):
 
 @statsd(namespace="dao")
 @transactional
-def overall_bounce_rate_for_day(min_emails_sent=1000, default_time=datetime.utcnow()):
+def overall_bounce_rate_for_day(min_emails_sent=1000, default_time=None):
     """
     This function returns the bounce rate for all services for the last 24 hours.
     The bounce rate is calculated by dividing the number of hard bounces by the total number of emails sent.
@@ -900,6 +900,8 @@ def overall_bounce_rate_for_day(min_emails_sent=1000, default_time=datetime.utcn
     :param default_time: the time to calculate the bounce rate for
     :return: a list of tuple of the service_id, total number of email, # of hard bounces and the bounce rate
     """
+    if default_time is None:
+        default_time = datetime.utcnow()
     twenty_four_hours_ago = default_time - timedelta(hours=24)
     query = (
         db.session.query(
@@ -920,7 +922,7 @@ def overall_bounce_rate_for_day(min_emails_sent=1000, default_time=datetime.utcn
 
 @statsd(namespace="dao")
 @transactional
-def service_bounce_rate_for_day(service_id, min_emails_sent=1000, default_time=datetime.utcnow()):
+def service_bounce_rate_for_day(service_id, min_emails_sent=1000, default_time=None):
     """
     This function returns the bounce rate for a single services for the last 24 hours.
     The bounce rate is calculated by dividing the number of hard bounces by the total number of emails sent.
@@ -931,6 +933,8 @@ def service_bounce_rate_for_day(service_id, min_emails_sent=1000, default_time=d
     :param default_time: the time to calculate the bounce rate for
     :return: a tuple of the total number of emails sent, # of bounced emails and the bounce rate or None if not enough emails
     """
+    if default_time is None:
+        default_time = datetime.utcnow()
     twenty_four_hours_ago = default_time - timedelta(hours=24)
     query = (
         db.session.query(
@@ -950,7 +954,9 @@ def service_bounce_rate_for_day(service_id, min_emails_sent=1000, default_time=d
 
 @statsd(namespace="dao")
 @transactional
-def total_notifications_grouped_by_hour(service_id, default_time=datetime.utcnow(), interval: int = 24):
+def total_notifications_grouped_by_hour(service_id, default_time=None, interval: int = 24):
+    if default_time is None:
+        default_time = datetime.utcnow()
     twenty_four_hours_ago = default_time - timedelta(hours=interval)
     query = (
         db.session.query(
@@ -968,7 +974,9 @@ def total_notifications_grouped_by_hour(service_id, default_time=datetime.utcnow
 
 @statsd(namespace="dao")
 @transactional
-def total_hard_bounces_grouped_by_hour(service_id, default_time=datetime.utcnow(), interval: int = 24):
+def total_hard_bounces_grouped_by_hour(service_id, default_time=None, interval: int = 24):
+    if default_time is None:
+        default_time = datetime.utcnow()
     twenty_four_hours_ago = default_time - timedelta(hours=interval)
     query = (
         db.session.query(


### PR DESCRIPTION
# Summary | Résumé

This PR is a followup to [#2990](https://github.com/cds-snc/notification-api/pull/2990), making improvements to thread-safety.

## Changes
### Updated several methods that used `datetime.utcnow()` as default method parameters 
These defaults result in the param values being frozen at import time. For long running celery workers this could quickly become stale, so instead we'll default them to None, and initialize them inside of the method instead.
- overall_bounce_rate_for_day
- service_bounce_rate_for_day
- total_notifications_grouped_by_hour
- total_hard_bounces_grouped_by_hour

### Update make_task so start is request-scoped

Celery classes are singletons, so instance fields are shared across executions. This change ensures that the start time is isolated to a per request, per task context. This should ensure that logged start_time data is accurate under a threaded/gevent environment. 

## Related Issues | Cartes liées
* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/909

# Test instructions | Instructions pour tester la modification
- [ ] CI is passing
- [ ] Threading has been turned on in dev / staging and the changes have been tested.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.