### PR TITLE
Improve redis script registry thread safety

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -110,7 +110,7 @@ jobs:
         cp -f .env.example .env
 
     - name: Checks for new endpoints against AWS WAF rules
-      uses: cds-snc/notification-utils/.github/actions/waffles@53.2.32
+      uses: cds-snc/notification-utils/.github/actions/waffles@53.2.34
       with:
         app-loc: '/github/workspace'
         app-libs: '/github/workspace/env/site-packages'

--- a/app/queue.py
+++ b/app/queue.py
@@ -2,6 +2,7 @@ import random
 import string
 from abc import ABC, abstractmethod
 from enum import Enum
+from threading import Lock
 from typing import Any, Dict, Optional
 from uuid import UUID, uuid4
 
@@ -118,8 +119,6 @@ class RedisQueue(Queue):
     LUA_MOVE_TO_INFLIGHT = "move-in-inflight"
     LUA_EXPIRE_INFLIGHTS = "expire-inflights"
 
-    scripts: Dict[str, Any] = {}
-
     def __init__(self, suffix=None, expire_inflight_after_seconds=300, process_type=None) -> None:
         """
         Constructor for the Redis Queue
@@ -141,6 +140,8 @@ class RedisQueue(Queue):
         self._suffix = suffix
         self._process_type = process_type
         self._expire_inflight_after_seconds = expire_inflight_after_seconds
+        self._scripts: Dict[str, Any] = {}
+        self._scripts_lock = Lock()
 
     def init_app(self, redis: Redis, metrics_logger: MetricsLogger):
         self._redis_client = redis
@@ -169,7 +170,7 @@ class RedisQueue(Queue):
                 self._inbox,
                 self._expire_inflight_after_seconds,
             ]
-        expired = self.scripts[self.LUA_EXPIRE_INFLIGHTS](args=args)
+        expired = self._scripts[self.LUA_EXPIRE_INFLIGHTS](args=args)
         if expired:
             put_batch_saving_expiry_metric(self.__metrics_logger, self, len(expired))
             current_app.logger.warning(f"Moved inflights {expired} back to inbox {self._inbox}")
@@ -198,13 +199,14 @@ class RedisQueue(Queue):
         put_batch_saving_metric(self.__metrics_logger, self, 1)
 
     def __move_to_inflight(self, in_flight_key: str, count: int) -> list[str]:
-        results = self.scripts[self.LUA_MOVE_TO_INFLIGHT](args=[self._inbox, in_flight_key, count])
+        results = self._scripts[self.LUA_MOVE_TO_INFLIGHT](args=[self._inbox, in_flight_key, count])
         decoded = [result.decode("utf-8") for result in results]
         return decoded
 
     def __register_scripts(self):
-        self.scripts[self.LUA_MOVE_TO_INFLIGHT] = self._redis_client.register_script(
-            """
+        with self._scripts_lock:
+            self._scripts[self.LUA_MOVE_TO_INFLIGHT] = self._redis_client.register_script(
+                """
             local DEFAULT_CHUNK = 99
 
             local source        = ARGV[1]
@@ -227,11 +229,11 @@ class RedisQueue(Queue):
             end
 
             return all
-            """
-        )
+                """
+            )
 
-        self.scripts[self.LUA_EXPIRE_INFLIGHTS] = self._redis_client.register_script(
-            """
+            self._scripts[self.LUA_EXPIRE_INFLIGHTS] = self._redis_client.register_script(
+                """
             local DEFAULT_CHUNK   = 99
             local inflight_prefix = ARGV[1]
             local destination     = ARGV[2]
@@ -263,8 +265,8 @@ class RedisQueue(Queue):
                 end
             until cursor == "0";
             return expired_inflights
-            """
-        )
+                """
+            )
 
 
 class MockQueue(Queue):

--- a/app/queue.py
+++ b/app/queue.py
@@ -170,7 +170,8 @@ class RedisQueue(Queue):
                 self._inbox,
                 self._expire_inflight_after_seconds,
             ]
-        expired = self._scripts[self.LUA_EXPIRE_INFLIGHTS](args=args)
+        expire_script = self.__get_script(self.LUA_EXPIRE_INFLIGHTS)
+        expired = expire_script(args=args)
         if expired:
             put_batch_saving_expiry_metric(self.__metrics_logger, self, len(expired))
             current_app.logger.warning(f"Moved inflights {expired} back to inbox {self._inbox}")
@@ -199,9 +200,14 @@ class RedisQueue(Queue):
         put_batch_saving_metric(self.__metrics_logger, self, 1)
 
     def __move_to_inflight(self, in_flight_key: str, count: int) -> list[str]:
-        results = self._scripts[self.LUA_MOVE_TO_INFLIGHT](args=[self._inbox, in_flight_key, count])
+        move_script = self.__get_script(self.LUA_MOVE_TO_INFLIGHT)
+        results = move_script(args=[self._inbox, in_flight_key, count])
         decoded = [result.decode("utf-8") for result in results]
         return decoded
+
+    def __get_script(self, script_name: str):
+        with self._scripts_lock:
+            return self._scripts[script_name]
 
     def __register_scripts(self):
         with self._scripts_lock:

--- a/poetry.lock
+++ b/poetry.lock
@@ -253,22 +253,22 @@ wrapt = "*"
 
 [[package]]
 name = "awscli"
-version = "1.44.55"
+version = "1.45.59"
 description = "Universal Command Line Environment for AWS."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "awscli-1.44.55-py3-none-any.whl", hash = "sha256:e674ddfa8999213eb09003bcebf8ce215c14f5ab99b8ce8bcc1a87aa96839f8c"},
-    {file = "awscli-1.44.55.tar.gz", hash = "sha256:bac2914ce13bc40283ce80f00faaf28587854ee9fb855dc883ce70cfc427e93b"},
+    {file = "awscli-1.45.59-py3-none-any.whl", hash = "sha256:9625b4f308791e95430a314d74ecd76ebe763eee0a9e92e24da5770bd54a5237"},
+    {file = "awscli-1.45.59.tar.gz", hash = "sha256:7a1e8473bb85a63e5bc09f0d8b4a9094e93135307341476e5e32182cf239cac8"},
 ]
 
 [package.dependencies]
-botocore = "1.42.65"
+botocore = "1.43.59"
 colorama = ">=0.2.5,<0.4.7"
 docutils = ">=0.18.1,<=0.19"
 PyYAML = ">=3.10,<6.1"
 rsa = ">=3.1.2,<4.8"
-s3transfer = ">=0.16.0,<0.17.0"
+s3transfer = ">=0.19.0,<0.20.0"
 
 [[package]]
 name = "awscli-cwlogs"
@@ -414,41 +414,41 @@ files = [
 
 [[package]]
 name = "boto3"
-version = "1.42.65"
+version = "1.43.54"
 description = "The AWS SDK for Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "boto3-1.42.65-py3-none-any.whl", hash = "sha256:cc7f2e0aec6c68ee5b10232cf3e01326acf6100bc785a770385b61a0474b31f4"},
-    {file = "boto3-1.42.65.tar.gz", hash = "sha256:c740af6bdaebcc1a00f3827a5729050bf6fc820ee148bf7d06f28db11c80e2a1"},
+    {file = "boto3-1.43.54-py3-none-any.whl", hash = "sha256:8353beda3ce4037758b24ab6bce7162e6cc084fd14c88637956d208d76cee244"},
+    {file = "boto3-1.43.54.tar.gz", hash = "sha256:3fe21f37f5b34e00fc360190f363229cef425f3c0e80a6f2b6a52f6501c3ec90"},
 ]
 
 [package.dependencies]
-botocore = ">=1.42.65,<1.43.0"
+botocore = ">=1.43.54,<1.44.0"
 jmespath = ">=0.7.1,<2.0.0"
-s3transfer = ">=0.16.0,<0.17.0"
+s3transfer = ">=0.19.0,<0.20.0"
 
 [package.extras]
 crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.42.65"
+version = "1.43.59"
 description = "Low-level, data-driven core of boto 3."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "botocore-1.42.65-py3-none-any.whl", hash = "sha256:0283c332ce00cbd1b894e86b7bed89dd624a5ca3a4ee62ec4db3898d16652e98"},
-    {file = "botocore-1.42.65.tar.gz", hash = "sha256:7d52c148df07f70c375eeda58f99b439c7c7836c25df74cccfba3bb6e12444d2"},
+    {file = "botocore-1.43.59-py3-none-any.whl", hash = "sha256:21393c35d23b19d7ba95cc4156b59f4013f80696d667997e1abd9d4e29651708"},
+    {file = "botocore-1.43.59.tar.gz", hash = "sha256:8016da69ecc1d705249a8ef13548d3c95eec87ac1cd26133a8bdfa73ca175be0"},
 ]
 
 [package.dependencies]
 jmespath = ">=0.7.1,<2.0.0"
 python-dateutil = ">=2.1,<3.0.0"
-urllib3 = {version = ">=1.25.4,<2.2.0 || >2.2.0,<3", markers = "python_version >= \"3.10\""}
+urllib3 = ">=1.25.4,<2.2.0 || >2.2.0,<3"
 
 [package.extras]
-crt = ["awscrt (==0.31.2)"]
+crt = ["awscrt (==0.36.0)"]
 
 [[package]]
 name = "brotli"
@@ -2861,7 +2861,7 @@ requests = ">=2.0.0"
 
 [[package]]
 name = "notifications-utils"
-version = "53.2.32"
+version = "53.2.34"
 description = "Shared python code for Notification - Provides logging utils etc."
 optional = false
 python-versions = "~3.12.7"
@@ -2869,9 +2869,9 @@ files = []
 develop = false
 
 [package.dependencies]
-awscli = "1.44.55"
+awscli = "1.45.59"
 bleach = "6.3.0"
-boto3 = "1.42.65"
+boto3 = "1.43.54"
 cachetools = "4.2.4"
 certifi = "^2024.0.0"
 cryptography = "^46.0.5"
@@ -2897,8 +2897,8 @@ werkzeug = "3.1.6"
 [package.source]
 type = "git"
 url = "https://github.com/cds-snc/notifier-utils.git"
-reference = "53.2.32"
-resolved_reference = "31c2f71682d968f40deede49bb1c3f6ba4ad4ea4"
+reference = "53.2.34"
+resolved_reference = "a27df2c71ab173d57c384e65bdeb2d10dd5196a8"
 
 [[package]]
 name = "opentelemetry-api"
@@ -4331,13 +4331,13 @@ files = [
 
 [[package]]
 name = "s3transfer"
-version = "0.16.1"
+version = "0.19.2"
 description = "An Amazon S3 Transfer Manager"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "s3transfer-0.16.1-py3-none-any.whl", hash = "sha256:61bcd00ccb83b21a0fe7e91a553fff9729d46c83b4e0106e7c314a733891f7c2"},
-    {file = "s3transfer-0.16.1.tar.gz", hash = "sha256:8e424355754b9ccb32467bdc568edf55be82692ef2002d934b1311dbb3b9e524"},
+    {file = "s3transfer-0.19.2-py3-none-any.whl", hash = "sha256:d8168eccca828cbb2cd573675333f3bddd254313a9c42494b84c76b539e8ba25"},
+    {file = "s3transfer-0.19.2.tar.gz", hash = "sha256:ba0309fd86be3c27dbf78cdd813c13c5e1df16e5874b99d2535ebbdfb9892993"},
 ]
 
 [package.dependencies]
@@ -5212,4 +5212,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.12.7"
-content-hash = "2f80c11879bf69d4bf304c8a59c24ebbf7c9a509c766b0873e25645baa9835c4"
+content-hash = "5ecc832d72b660126e740edb813012dad2d00722770ab50afa0f4a6c36238171"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ opentelemetry-instrumentation-celery = "0.55b1"
 opentelemetry-instrumentation-flask = "0.55b1"
 opentelemetry-instrumentation-redis = "0.55b1"
 opentelemetry-instrumentation-sqlalchemy = "0.55b1"
-notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", tag="53.2.32"}
+notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", tag="53.2.34"}
 pre-commit = "^3.7.1"
 psycopg2-binary = "2.9.11"
 pwnedpasswords = "2.0.0"

--- a/tests-perf/individual_emails/individual-emails.py
+++ b/tests-perf/individual_emails/individual-emails.py
@@ -13,7 +13,7 @@ def _(parser):
 
 
 class NotifyApiUser(HttpUser):
-    wait_time = constant_pacing(0.5)  # each user makes one post per second
+    wait_time = constant_pacing(1)  # each user makes one post per second
 
     def __init__(self, *args, **kwargs):
         super(NotifyApiUser, self).__init__(*args, **kwargs)

--- a/tests-perf/individual_emails/individual-emails.py
+++ b/tests-perf/individual_emails/individual-emails.py
@@ -13,7 +13,7 @@ def _(parser):
 
 
 class NotifyApiUser(HttpUser):
-    wait_time = constant_pacing(1)  # each user makes one post per second
+    wait_time = constant_pacing(0.5)  # each user makes one post per second
 
     def __init__(self, *args, **kwargs):
         super(NotifyApiUser, self).__init__(*args, **kwargs)

--- a/tests/app/test_queue.py
+++ b/tests/app/test_queue.py
@@ -304,6 +304,32 @@ class TestRedisQueue:
 
         self.delete_all_list(redis)
 
+    def test_scripts_registry_is_isolated_per_instance(self):
+        queue_one = RedisQueue("sms")
+        queue_two = RedisQueue("sms")
+
+        script_one_move = object()
+        script_one_expire = object()
+        script_two_move = object()
+        script_two_expire = object()
+
+        redis_client_one = mock.Mock()
+        redis_client_one.register_script.side_effect = [script_one_move, script_one_expire]
+        redis_client_two = mock.Mock()
+        redis_client_two.register_script.side_effect = [script_two_move, script_two_expire]
+
+        queue_one.init_app(redis_client_one, metrics_logger)
+        queue_two.init_app(redis_client_two, metrics_logger)
+
+        queue_one_scripts = queue_one._scripts
+        queue_two_scripts = queue_two._scripts
+
+        assert queue_one_scripts is not queue_two_scripts
+        assert queue_one_scripts[RedisQueue.LUA_MOVE_TO_INFLIGHT] is script_one_move
+        assert queue_one_scripts[RedisQueue.LUA_EXPIRE_INFLIGHTS] is script_one_expire
+        assert queue_two_scripts[RedisQueue.LUA_MOVE_TO_INFLIGHT] is script_two_move
+        assert queue_two_scripts[RedisQueue.LUA_EXPIRE_INFLIGHTS] is script_two_expire
+
 
 @pytest.mark.usefixtures("notify_api")
 class TestMockQueue:


### PR DESCRIPTION
# Summary | Résumé
This PR improves thread safety of the LUA script registry found in `RedisQueue` instances.

- Previously `RedisQueue` used a class-level mutable registry dict. This PR makes the `scripts` dict instance-scoped.
- `__register_scripts` now utilizes a lock to prevent cross-instance overwrites and mixed registry states during queue initialization
- Bumped utils version to include decorator thread-safety fixes

## Examples
Since we initialize multiple queues at module import time (sms_queue, bulk_queue, email_queue, etc.) and init them during application startup there's a couple different threading/concurrency risks that could occur here.

**1. Cross-instance overwrites (not currently a concern but could be in the future)**
Queue instance **A** could register lua scripts, then instance **B** overwrites those same script keys. This would result in instance **A** executing scripts created for instance **B**.

**2. Mixed registry state during initialization**
Script registration is two writes, (move_inflights & expire_inflights). Threads could read the registry in between writes and see a partially initialized state, leading to missing key errors.

## Future concerns
Once we start using highly threaded workers there the chance that, under high load/polling rate, that lock contention could should up. The impact should be minor as the lock is established only for the duration needed to acquire the registry dict and doesn't affect any of the Redis round-trips.
 

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning-core/issues/909

# Test instructions | Instructions pour tester la modification

- [ ] CI is passing
- [ ] We test in staging once merged.

# Release Instructions | Instructions pour le déploiement

- [ ] Keep an eye on any lock contention around acquisition of the scripts registry dict under heavy system load.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.