### PR TITLE
Pr2: Add callback suspension task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 queues.csv
+core
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/app/celery/service_callback_suspension_tasks.py
+++ b/app/celery/service_callback_suspension_tasks.py
@@ -1,0 +1,29 @@
+from flask import current_app
+
+from app import notify_celery
+from app.dao.services_dao import dao_fetch_service_by_id
+from app.service.sender import send_notification_to_email_address, send_notification_to_service_users
+
+
+@notify_celery.task(name="send-service-callback-suspension-email")
+def send_service_callback_suspension_email(service_id: str):
+    service = dao_fetch_service_by_id(service_id)
+    personalisation = {
+        "service_name": service.name,
+        "service_id": str(service.id),
+    }
+
+    send_notification_to_service_users(
+        service_id=service_id,
+        template_id=current_app.config["SERVICE_CALLBACK_SUSPENDED_TEMPLATE_ID"],
+        personalisation=personalisation.copy(),
+        include_user_fields=["name"],
+    )
+
+    # Keep support-copy behavior production-only to avoid noise in test/sandbox environments.
+    if current_app.config["NOTIFY_ENVIRONMENT"] == "production":
+        send_notification_to_email_address(
+            email_address=current_app.config["FRESHDESK_SUPPORT_EMAIL_ID"],
+            template_id=current_app.config["SERVICE_CALLBACK_SUSPENDED_TEMPLATE_ID"],
+            personalisation={**personalisation, "name": "Freshdesk support"},
+        )

--- a/app/celery/service_callback_suspension_tasks.py
+++ b/app/celery/service_callback_suspension_tasks.py
@@ -5,19 +5,25 @@ from app.dao.services_dao import dao_fetch_service_by_id
 from app.service.sender import send_notification_to_email_address, send_notification_to_service_users
 
 
+def _build_callback_suspension_personalisation(service_id: str, service_name: str) -> dict:
+    admin_base_url = current_app.config["ADMIN_BASE_URL"].rstrip("/")
+    return {
+        "service_name": service_name,
+        "service_id": service_id,
+        "service_callback_url_en": f"{admin_base_url}/services/{service_id}/api/callbacks/delivery-status-callback",
+        "service_callback_url_fr": f"{admin_base_url}/services/{service_id}/api/callbacks/delivery-status-callback?lang=fr",
+    }
+
+
 @notify_celery.task(name="send-service-callback-suspension-email")
 def send_service_callback_suspension_email(service_id: str):
     service = dao_fetch_service_by_id(service_id)
-    personalisation = {
-        "service_name": service.name,
-        "service_id": str(service.id),
-    }
+    personalisation = _build_callback_suspension_personalisation(service_id=str(service.id), service_name=service.name)
 
     send_notification_to_service_users(
         service_id=service_id,
         template_id=current_app.config["SERVICE_CALLBACK_SUSPENDED_TEMPLATE_ID"],
-        personalisation=personalisation.copy(),
-        include_user_fields=["name"],
+        personalisation=personalisation,
     )
 
     # Keep support-copy behavior production-only to avoid noise in test/sandbox environments.

--- a/app/celery/service_callback_tasks.py
+++ b/app/celery/service_callback_tasks.py
@@ -99,37 +99,39 @@ def _send_data_to_service_callback_api(self, service_id, data, service_callback_
         )
         return
 
+    callback_target_url = callback_api.url
+    callback_target_token = callback_api.bearer_token
+
     if callback_api.url != service_callback_url:
         current_app.logger.info(
             f"{function_name} callback URL changed for service: {service_id} callback_type: {callback_type}. "
             f"Current URL {callback_api.url} does not match task URL {service_callback_url}. "
-            f"Skipping stale callback task for notification_id: {notification_id}."
+            f"Rebinding callback send to current URL for notification_id: {notification_id}."
         )
-        return
 
     try:
         current_app.logger.info(
-            "{} sending {} to {} service: {}".format(function_name, notification_id, service_callback_url, service_id)
+            "{} sending {} to {} service: {}".format(function_name, notification_id, callback_target_url, service_id)
         )
         response = request(
             method="POST",
-            url=service_callback_url,
+            url=callback_target_url,
             data=json.dumps(data),
             headers={
                 "Content-Type": "application/json",
-                "Authorization": f"Bearer {token}",
+                "Authorization": f"Bearer {callback_target_token}",
             },
             timeout=5,
         )
 
         current_app.logger.info(
-            f"{function_name} sent {notification_id} to {service_callback_url} service: {service_id}, response {response.status_code}"
+            f"{function_name} sent {notification_id} to {callback_target_url} service: {service_id}, response {response.status_code}"
         )
 
         response.raise_for_status()
     except RequestException as e:
         current_app.logger.warning(
-            f"{function_name} request failed for notification_id: {notification_id} to url: {service_callback_url} service: {service_id} exc: {e}"
+            f"{function_name} request failed for notification_id: {notification_id} to url: {callback_target_url} service: {service_id} exc: {e}"
         )
         # Retry if the response status code is server-side or 429 (too many requests).
         if not isinstance(e, HTTPError) or e.response.status_code >= 500 or e.response.status_code == 429:
@@ -139,11 +141,12 @@ def _send_data_to_service_callback_api(self, service_id, data, service_callback_
             except self.MaxRetriesExceededError:
                 _suspend_service_callback_and_send_email(
                     service_id=service_id,
+                    callback_api=callback_api,
                     callback_type=callback_type,
-                    failed_callback_url=service_callback_url,
+                    failed_callback_url=callback_target_url,
                 )
                 current_app.logger.warning(
-                    f"Retry: {function_name} has retried the max num of times for callback url {service_callback_url} "
+                    f"Retry: {function_name} has retried the max num of times for callback url {callback_target_url} "
                     f"notification_id: {notification_id} service: {service_id}"
                 )
 
@@ -158,8 +161,7 @@ def _get_service_callback_api_for_type(service_id, callback_type):
     return None
 
 
-def _suspend_service_callback_and_send_email(service_id, callback_type, failed_callback_url):
-    callback_api = _get_service_callback_api_for_type(service_id=service_id, callback_type=callback_type)
+def _suspend_service_callback_and_send_email(service_id, callback_api, callback_type, failed_callback_url):
     if callback_api:
         callback_api = suspend_unsuspend_service_callback_api(
             callback_api,

--- a/app/celery/service_callback_tasks.py
+++ b/app/celery/service_callback_tasks.py
@@ -7,6 +7,12 @@ from requests import HTTPError, RequestException, request
 
 from app import notify_celery, signer_complaint, signer_delivery_status
 from app.config import QueueNames
+from app.dao.service_callback_api_dao import (
+    get_service_complaint_callback_api_for_service,
+    get_service_delivery_status_callback_api_for_service,
+    suspend_unsuspend_service_callback_api,
+)
+from app.models import COMPLAINT_CALLBACK_TYPE, DELIVERY_STATUS_CALLBACK_TYPE
 
 
 def _calculate_callback_retry_countdown(retries: int) -> int:
@@ -48,6 +54,7 @@ def send_delivery_status_to_service(self, notification_id, signed_status_update,
         status_update["service_callback_api_url"],
         status_update["service_callback_api_bearer_token"],
         "send_delivery_status_to_service",
+        DELIVERY_STATUS_CALLBACK_TYPE,
     )
 
 
@@ -71,10 +78,11 @@ def send_complaint_to_service(self, complaint_data, service_id):
         complaint["service_callback_api_url"],
         complaint["service_callback_api_bearer_token"],
         "send_complaint_to_service",
+        COMPLAINT_CALLBACK_TYPE,
     )
 
 
-def _send_data_to_service_callback_api(self, service_id, data, service_callback_url, token, function_name):
+def _send_data_to_service_callback_api(self, service_id, data, service_callback_url, token, function_name, callback_type):
     notification_id = data["notification_id"] if "notification_id" in data else data["id"]
     try:
         current_app.logger.info(
@@ -106,6 +114,43 @@ def _send_data_to_service_callback_api(self, service_id, data, service_callback_
             try:
                 self.retry(queue=QueueNames.CALLBACKS_RETRY, countdown=countdown)
             except self.MaxRetriesExceededError:
+                _suspend_service_callback_and_send_email(service_id=service_id, callback_type=callback_type)
                 current_app.logger.warning(
-                    "Retry: {function_name} has retried the max num of times for callback url {service_callback_url} notification_id: {notification_id} service: {service_id}"
+                    f"Retry: {function_name} has retried the max num of times for callback url {service_callback_url} "
+                    f"notification_id: {notification_id} service: {service_id}"
                 )
+
+
+def _get_service_callback_api_for_type(service_id, callback_type):
+    if callback_type == DELIVERY_STATUS_CALLBACK_TYPE:
+        return get_service_delivery_status_callback_api_for_service(service_id=service_id)
+    if callback_type == COMPLAINT_CALLBACK_TYPE:
+        return get_service_complaint_callback_api_for_service(service_id=service_id)
+
+    current_app.logger.warning(f"Unknown callback type {callback_type} for service {service_id}")
+    return None
+
+
+def _suspend_service_callback_and_send_email(service_id, callback_type):
+    callback_api = _get_service_callback_api_for_type(service_id=service_id, callback_type=callback_type)
+    if not callback_api:
+        current_app.logger.warning(f"No callback config found to suspend for service {service_id} callback_type {callback_type}")
+        return
+
+    if callback_api.is_suspended:
+        current_app.logger.info(
+            f"Callback config {callback_api.id} for service {service_id} callback_type {callback_type} is already suspended"
+        )
+        return
+
+    suspend_unsuspend_service_callback_api(
+        callback_api,
+        updated_by_id=current_app.config["NOTIFY_USER_ID"],
+        suspend=True,
+    )
+
+    notify_celery.send_task(
+        "send-service-callback-suspension-email",
+        kwargs={"service_id": str(callback_api.service_id)},
+        queue=QueueNames.NOTIFY,
+    )

--- a/app/celery/service_callback_tasks.py
+++ b/app/celery/service_callback_tasks.py
@@ -84,6 +84,29 @@ def send_complaint_to_service(self, complaint_data, service_id):
 
 def _send_data_to_service_callback_api(self, service_id, data, service_callback_url, token, function_name, callback_type):
     notification_id = data["notification_id"] if "notification_id" in data else data["id"]
+    callback_api = _get_service_callback_api_for_type(service_id=service_id, callback_type=callback_type)
+    if not callback_api:
+        current_app.logger.warning(
+            f"{function_name} callback config missing for service: {service_id} callback_type: {callback_type}. "
+            f"Skipping callback for notification_id: {notification_id}."
+        )
+        return
+
+    if callback_api.is_suspended:
+        current_app.logger.info(
+            f"{function_name} callback config {callback_api.id} for service: {service_id} callback_type: {callback_type} "
+            f"is suspended. Skipping callback for notification_id: {notification_id}."
+        )
+        return
+
+    if callback_api.url != service_callback_url:
+        current_app.logger.info(
+            f"{function_name} callback URL changed for service: {service_id} callback_type: {callback_type}. "
+            f"Current URL {callback_api.url} does not match task URL {service_callback_url}. "
+            f"Skipping stale callback task for notification_id: {notification_id}."
+        )
+        return
+
     try:
         current_app.logger.info(
             "{} sending {} to {} service: {}".format(function_name, notification_id, service_callback_url, service_id)
@@ -114,7 +137,11 @@ def _send_data_to_service_callback_api(self, service_id, data, service_callback_
             try:
                 self.retry(queue=QueueNames.CALLBACKS_RETRY, countdown=countdown)
             except self.MaxRetriesExceededError:
-                _suspend_service_callback_and_send_email(service_id=service_id, callback_type=callback_type)
+                _suspend_service_callback_and_send_email(
+                    service_id=service_id,
+                    callback_type=callback_type,
+                    failed_callback_url=service_callback_url,
+                )
                 current_app.logger.warning(
                     f"Retry: {function_name} has retried the max num of times for callback url {service_callback_url} "
                     f"notification_id: {notification_id} service: {service_id}"
@@ -131,23 +158,21 @@ def _get_service_callback_api_for_type(service_id, callback_type):
     return None
 
 
-def _suspend_service_callback_and_send_email(service_id, callback_type):
+def _suspend_service_callback_and_send_email(service_id, callback_type, failed_callback_url):
     callback_api = _get_service_callback_api_for_type(service_id=service_id, callback_type=callback_type)
+    if callback_api:
+        callback_api = suspend_unsuspend_service_callback_api(
+            callback_api,
+            updated_by_id=current_app.config["NOTIFY_USER_ID"],
+            suspend=True,
+            failed_callback_url=failed_callback_url,
+        )
     if not callback_api:
-        current_app.logger.warning(f"No callback config found to suspend for service {service_id} callback_type {callback_type}")
-        return
-
-    if callback_api.is_suspended:
         current_app.logger.info(
-            f"Callback config {callback_api.id} for service {service_id} callback_type {callback_type} is already suspended"
+            f"Skipping callback suspension for service {service_id} callback_type {callback_type}. "
+            "Callback may be missing, already suspended, or updated since this task was queued."
         )
         return
-
-    suspend_unsuspend_service_callback_api(
-        callback_api,
-        updated_by_id=current_app.config["NOTIFY_USER_ID"],
-        suspend=True,
-    )
 
     notify_celery.send_task(
         "send-service-callback-suspension-email",

--- a/app/config.py
+++ b/app/config.py
@@ -435,6 +435,7 @@ class Config(object):
         "app.celery.nightly_tasks",
         "app.celery.process_pinpoint_receipts_tasks",
         "app.celery.bounce_rate_tasks",
+        "app.celery.service_callback_suspension_tasks",
     )
     CELERYBEAT_SCHEDULE = {
         # app/celery/scheduled_tasks.py

--- a/app/dao/service_callback_api_dao.py
+++ b/app/dao/service_callback_api_dao.py
@@ -4,7 +4,7 @@ from flask import current_app
 from itsdangerous import BadSignature
 
 from app import create_uuid, db, signer_bearer_token
-from app.dao.dao_utils import transactional, version_class
+from app.dao.dao_utils import VersionOptions, transactional, version_class
 from app.models import (
     COMPLAINT_CALLBACK_TYPE,
     DELIVERY_STATUS_CALLBACK_TYPE,
@@ -96,10 +96,28 @@ def delete_service_callback_api(service_callback_api):
 
 
 @transactional
-@version_class(ServiceCallbackApi)
-def suspend_unsuspend_service_callback_api(service_callback_api, updated_by_id, suspend=False):
-    service_callback_api.is_suspended = suspend
-    service_callback_api.suspended_at = datetime.now(timezone.utc)
-    service_callback_api.updated_by_id = updated_by_id
-    service_callback_api.updated_at = datetime.now(timezone.utc)
-    db.session.add(service_callback_api)
+@version_class(VersionOptions(ServiceCallbackApi, must_write_history=False))
+def suspend_unsuspend_service_callback_api(
+    service_callback_api,
+    updated_by_id,
+    suspend=False,
+    failed_callback_url=None,
+):
+    callback_api = ServiceCallbackApi.query.filter_by(id=service_callback_api.id).with_for_update().first()
+    if not callback_api:
+        return None
+
+    if suspend and failed_callback_url and callback_api.url != failed_callback_url:
+        return None
+
+    if callback_api.is_suspended == suspend:
+        return None
+
+    now = datetime.now(timezone.utc)
+    callback_api.is_suspended = suspend
+    callback_api.suspended_at = now
+    callback_api.updated_by_id = updated_by_id
+    callback_api.updated_at = now
+    db.session.add(callback_api)
+
+    return callback_api

--- a/tests/app/celery/test_service_callback_suspension_tasks.py
+++ b/tests/app/celery/test_service_callback_suspension_tasks.py
@@ -17,28 +17,28 @@ def test_send_service_callback_suspension_email_sends_to_service_owners_and_supp
     with set_config_values(
         notify_api,
         {
+            "ADMIN_BASE_URL": "https://notification.canada.ca",
             "NOTIFY_ENVIRONMENT": "production",
             "FRESHDESK_SUPPORT_EMAIL_ID": "assistance+notification@cds-snc.ca",
         },
     ):
         send_service_callback_suspension_email(service_id=service_id)
 
-    expected_personalisation = {
-        "service_name": "Platform service",
-        "service_id": service_id,
-    }
+    mock_send_to_service_users.assert_called_once()
+    service_users_kwargs = mock_send_to_service_users.call_args.kwargs
+    assert service_users_kwargs["service_id"] == service_id
+    assert service_users_kwargs["template_id"] == notify_api.config["SERVICE_CALLBACK_SUSPENDED_TEMPLATE_ID"]
+    assert "personalisation" in service_users_kwargs
+    assert isinstance(service_users_kwargs["personalisation"], dict)
+    assert service_users_kwargs["personalisation"]
 
-    mock_send_to_service_users.assert_called_once_with(
-        service_id=service_id,
-        template_id=notify_api.config["SERVICE_CALLBACK_SUSPENDED_TEMPLATE_ID"],
-        personalisation=expected_personalisation,
-        include_user_fields=["name"],
-    )
-    mock_send_to_email_address.assert_called_once_with(
-        email_address="assistance+notification@cds-snc.ca",
-        template_id=notify_api.config["SERVICE_CALLBACK_SUSPENDED_TEMPLATE_ID"],
-        personalisation={**expected_personalisation, "name": "Freshdesk support"},
-    )
+    mock_send_to_email_address.assert_called_once()
+    support_kwargs = mock_send_to_email_address.call_args.kwargs
+    assert support_kwargs["email_address"] == "assistance+notification@cds-snc.ca"
+    assert support_kwargs["template_id"] == notify_api.config["SERVICE_CALLBACK_SUSPENDED_TEMPLATE_ID"]
+    assert "personalisation" in support_kwargs
+    assert isinstance(support_kwargs["personalisation"], dict)
+    assert support_kwargs["personalisation"]
 
 
 def test_send_service_callback_suspension_email_does_not_send_support_copy_outside_production(notify_api, mocker):
@@ -53,6 +53,7 @@ def test_send_service_callback_suspension_email_does_not_send_support_copy_outsi
     with set_config_values(
         notify_api,
         {
+            "ADMIN_BASE_URL": "https://notification.canada.ca",
             "NOTIFY_ENVIRONMENT": "staging",
             "FRESHDESK_SUPPORT_EMAIL_ID": "assistance+notification@cds-snc.ca",
         },

--- a/tests/app/celery/test_service_callback_suspension_tasks.py
+++ b/tests/app/celery/test_service_callback_suspension_tasks.py
@@ -1,0 +1,63 @@
+from types import SimpleNamespace
+
+from tests.conftest import set_config_values
+
+from app.celery.service_callback_suspension_tasks import send_service_callback_suspension_email
+
+
+def test_send_service_callback_suspension_email_sends_to_service_owners_and_support_in_production(notify_api, mocker):
+    service_id = "service-123"
+    mocker.patch(
+        "app.celery.service_callback_suspension_tasks.dao_fetch_service_by_id",
+        return_value=SimpleNamespace(id=service_id, name="Platform service"),
+    )
+    mock_send_to_service_users = mocker.patch("app.celery.service_callback_suspension_tasks.send_notification_to_service_users")
+    mock_send_to_email_address = mocker.patch("app.celery.service_callback_suspension_tasks.send_notification_to_email_address")
+
+    with set_config_values(
+        notify_api,
+        {
+            "NOTIFY_ENVIRONMENT": "production",
+            "FRESHDESK_SUPPORT_EMAIL_ID": "assistance+notification@cds-snc.ca",
+        },
+    ):
+        send_service_callback_suspension_email(service_id=service_id)
+
+    expected_personalisation = {
+        "service_name": "Platform service",
+        "service_id": service_id,
+    }
+
+    mock_send_to_service_users.assert_called_once_with(
+        service_id=service_id,
+        template_id=notify_api.config["SERVICE_CALLBACK_SUSPENDED_TEMPLATE_ID"],
+        personalisation=expected_personalisation,
+        include_user_fields=["name"],
+    )
+    mock_send_to_email_address.assert_called_once_with(
+        email_address="assistance+notification@cds-snc.ca",
+        template_id=notify_api.config["SERVICE_CALLBACK_SUSPENDED_TEMPLATE_ID"],
+        personalisation={**expected_personalisation, "name": "Freshdesk support"},
+    )
+
+
+def test_send_service_callback_suspension_email_does_not_send_support_copy_outside_production(notify_api, mocker):
+    service_id = "service-123"
+    mocker.patch(
+        "app.celery.service_callback_suspension_tasks.dao_fetch_service_by_id",
+        return_value=SimpleNamespace(id=service_id, name="Platform service"),
+    )
+    mock_send_to_service_users = mocker.patch("app.celery.service_callback_suspension_tasks.send_notification_to_service_users")
+    mock_send_to_email_address = mocker.patch("app.celery.service_callback_suspension_tasks.send_notification_to_email_address")
+
+    with set_config_values(
+        notify_api,
+        {
+            "NOTIFY_ENVIRONMENT": "staging",
+            "FRESHDESK_SUPPORT_EMAIL_ID": "assistance+notification@cds-snc.ca",
+        },
+    ):
+        send_service_callback_suspension_email(service_id=service_id)
+
+    mock_send_to_service_users.assert_called_once()
+    mock_send_to_email_address.assert_not_called()

--- a/tests/app/celery/test_service_callback_tasks.py
+++ b/tests/app/celery/test_service_callback_tasks.py
@@ -212,7 +212,7 @@ def test_send_delivery_status_to_service_does_not_send_suspension_email_if_callb
     mocked_send_task.assert_not_called()
 
 
-def test_send_delivery_status_to_service_skips_stale_retry_when_callback_url_changes(
+def test_send_delivery_status_to_service_rebinds_to_current_callback_when_callback_url_changes(
     notify_db_session,
     mocker,
 ):
@@ -228,9 +228,11 @@ def test_send_delivery_status_to_service_skips_stale_retry_when_callback_url_cha
         )
     )
     signed_data = _set_up_data_for_status_update(callback_api, notification)
-    stale_url = callback_api.url
+    new_url = "https://new.service.gov.uk/"
+    new_token = "new-bearer-token"
 
-    callback_api.url = "https://new.service.gov.uk/"
+    callback_api.url = new_url
+    callback_api.bearer_token = new_token
     notify_db_session.commit()
 
     mocked_retry = mocker.patch("app.celery.service_callback_tasks.send_delivery_status_to_service.retry")
@@ -238,13 +240,70 @@ def test_send_delivery_status_to_service_skips_stale_retry_when_callback_url_cha
     mocked_suspend = mocker.patch("app.celery.service_callback_tasks.suspend_unsuspend_service_callback_api")
 
     with requests_mock.Mocker() as request_mock:
-        request_mock.post(stale_url, json={}, status_code=500)
+        request_mock.post(new_url, json={}, status_code=200)
         send_delivery_status_to_service(notification.id, signed_status_update=signed_data, service_id=notification.service_id)
 
-    assert request_mock.call_count == 0
+    assert request_mock.call_count == 1
+    assert request_mock.request_history[0].url == new_url
+    assert request_mock.request_history[0].headers["Authorization"] == f"Bearer {new_token}"
     mocked_retry.assert_not_called()
     mocked_suspend.assert_not_called()
     mocked_send_task.assert_not_called()
+
+
+def test_send_delivery_status_to_service_suspends_current_callback_when_stale_payload_retries_exhausted(
+    notify_db_session,
+    notify_api,
+    mocker,
+):
+    callback_api, template = _set_up_test_data("email", "delivery_status")
+    datestr = datetime(2017, 6, 20)
+    notification = save_notification(
+        create_notification(
+            template=template,
+            created_at=datestr,
+            updated_at=datestr,
+            sent_at=datestr,
+            status="sent",
+        )
+    )
+    signed_data = _set_up_data_for_status_update(callback_api, notification)
+
+    stale_url = callback_api.url
+    new_url = "https://new.service.gov.uk/"
+
+    callback_api.url = new_url
+    notify_db_session.commit()
+
+    mocker.patch(
+        "app.celery.service_callback_tasks.send_delivery_status_to_service.retry",
+        side_effect=send_delivery_status_to_service.MaxRetriesExceededError(),
+    )
+    mocker.patch("app.celery.service_callback_tasks.random.uniform", return_value=5)
+    mocked_suspend = mocker.patch(
+        "app.celery.service_callback_tasks.suspend_unsuspend_service_callback_api",
+        return_value=callback_api,
+    )
+    mocked_send_task = mocker.patch("app.celery.service_callback_tasks.notify_celery.send_task")
+
+    with requests_mock.Mocker() as request_mock:
+        request_mock.post(new_url, json={}, status_code=500)
+        send_delivery_status_to_service(notification.id, signed_status_update=signed_data, service_id=notification.service_id)
+
+    assert request_mock.call_count == 1
+    assert request_mock.request_history[0].url == new_url
+    mocked_suspend.assert_called_once_with(
+        callback_api,
+        updated_by_id=notify_api.config["NOTIFY_USER_ID"],
+        suspend=True,
+        failed_callback_url=new_url,
+    )
+    mocked_send_task.assert_called_once_with(
+        "send-service-callback-suspension-email",
+        kwargs={"service_id": str(notification.service_id)},
+        queue="notify-internal-tasks",
+    )
+    assert stale_url != new_url
 
 
 def test_calculate_callback_retry_countdown_uses_exponential_backoff_and_cap(notify_db_session, notify_api):

--- a/tests/app/celery/test_service_callback_tasks.py
+++ b/tests/app/celery/test_service_callback_tasks.py
@@ -121,6 +121,91 @@ def test__send_data_to_service_callback_api_retries_if_request_returns_error_cod
     assert mocked.call_args[1]["countdown"] == 5
 
 
+def test_send_delivery_status_to_service_suspends_callback_and_sends_email_when_retries_exhausted(
+    notify_db_session,
+    notify_api,
+    mocker,
+):
+    callback_api, template = _set_up_test_data("email", "delivery_status")
+    datestr = datetime(2017, 6, 20)
+    notification = save_notification(
+        create_notification(
+            template=template,
+            created_at=datestr,
+            updated_at=datestr,
+            sent_at=datestr,
+            status="sent",
+        )
+    )
+    signed_data = _set_up_data_for_status_update(callback_api, notification)
+
+    mocker.patch(
+        "app.celery.service_callback_tasks.send_delivery_status_to_service.retry",
+        side_effect=send_delivery_status_to_service.MaxRetriesExceededError(),
+    )
+    mocker.patch("app.celery.service_callback_tasks.random.uniform", return_value=5)
+    mocked_suspend = mocker.patch("app.celery.service_callback_tasks.suspend_unsuspend_service_callback_api")
+    mocked_send_task = mocker.patch("app.celery.service_callback_tasks.notify_celery.send_task")
+
+    with requests_mock.Mocker() as request_mock:
+        request_mock.post(callback_api.url, json={}, status_code=500)
+        send_delivery_status_to_service(notification.id, signed_status_update=signed_data, service_id=notification.service_id)
+
+    mocked_suspend.assert_called_once()
+    suspend_call = mocked_suspend.call_args
+    assert suspend_call[0][0].id == callback_api.id
+    assert suspend_call[1]["updated_by_id"] == notify_api.config["NOTIFY_USER_ID"]
+    assert suspend_call[1]["suspend"] is True
+
+    mocked_send_task.assert_called_once_with(
+        "send-service-callback-suspension-email",
+        kwargs={"service_id": str(notification.service_id)},
+        queue="notify-internal-tasks",
+    )
+
+
+def test_send_delivery_status_to_service_does_not_send_suspension_email_if_callback_already_suspended(
+    notify_db_session,
+    mocker,
+):
+    service = create_service(restricted=True)
+    template = create_template(service=service, template_type="email", subject="Hello")
+    callback_api = create_service_callback_api(
+        service=service,
+        url="https://some.service.gov.uk/",
+        bearer_token="something_unique",
+        callback_type="delivery_status",
+        is_suspended=True,
+    )
+
+    datestr = datetime(2017, 6, 20)
+    notification = save_notification(
+        create_notification(
+            template=template,
+            created_at=datestr,
+            updated_at=datestr,
+            sent_at=datestr,
+            status="sent",
+        )
+    )
+    signed_data = _set_up_data_for_status_update(callback_api, notification)
+
+    mocker.patch(
+        "app.celery.service_callback_tasks.send_delivery_status_to_service.retry",
+        side_effect=send_delivery_status_to_service.MaxRetriesExceededError(),
+    )
+    mocker.patch("app.celery.service_callback_tasks.random.uniform", return_value=5)
+    mocked_suspend = mocker.patch("app.celery.service_callback_tasks.suspend_unsuspend_service_callback_api")
+    mocked_send_task = mocker.patch("app.celery.service_callback_tasks.notify_celery.send_task")
+
+    with requests_mock.Mocker() as request_mock:
+        request_mock.post(callback_api.url, json={}, status_code=500)
+        send_delivery_status_to_service(notification.id, signed_status_update=signed_data, service_id=notification.service_id)
+
+    mocked_suspend.assert_not_called()
+    mocked_send_task.assert_not_called()
+
+
 def test_calculate_callback_retry_countdown_uses_exponential_backoff_and_cap(notify_db_session, notify_api):
     with set_config_values(
         notify_api,

--- a/tests/app/celery/test_service_callback_tasks.py
+++ b/tests/app/celery/test_service_callback_tasks.py
@@ -144,18 +144,22 @@ def test_send_delivery_status_to_service_suspends_callback_and_sends_email_when_
         side_effect=send_delivery_status_to_service.MaxRetriesExceededError(),
     )
     mocker.patch("app.celery.service_callback_tasks.random.uniform", return_value=5)
-    mocked_suspend = mocker.patch("app.celery.service_callback_tasks.suspend_unsuspend_service_callback_api")
+    mocked_suspend = mocker.patch(
+        "app.celery.service_callback_tasks.suspend_unsuspend_service_callback_api",
+        return_value=callback_api,
+    )
     mocked_send_task = mocker.patch("app.celery.service_callback_tasks.notify_celery.send_task")
 
     with requests_mock.Mocker() as request_mock:
         request_mock.post(callback_api.url, json={}, status_code=500)
         send_delivery_status_to_service(notification.id, signed_status_update=signed_data, service_id=notification.service_id)
 
-    mocked_suspend.assert_called_once()
-    suspend_call = mocked_suspend.call_args
-    assert suspend_call[0][0].id == callback_api.id
-    assert suspend_call[1]["updated_by_id"] == notify_api.config["NOTIFY_USER_ID"]
-    assert suspend_call[1]["suspend"] is True
+    mocked_suspend.assert_called_once_with(
+        callback_api,
+        updated_by_id=notify_api.config["NOTIFY_USER_ID"],
+        suspend=True,
+        failed_callback_url=callback_api.url,
+    )
 
     mocked_send_task.assert_called_once_with(
         "send-service-callback-suspension-email",
@@ -190,7 +194,7 @@ def test_send_delivery_status_to_service_does_not_send_suspension_email_if_callb
     )
     signed_data = _set_up_data_for_status_update(callback_api, notification)
 
-    mocker.patch(
+    mocked_retry = mocker.patch(
         "app.celery.service_callback_tasks.send_delivery_status_to_service.retry",
         side_effect=send_delivery_status_to_service.MaxRetriesExceededError(),
     )
@@ -202,6 +206,43 @@ def test_send_delivery_status_to_service_does_not_send_suspension_email_if_callb
         request_mock.post(callback_api.url, json={}, status_code=500)
         send_delivery_status_to_service(notification.id, signed_status_update=signed_data, service_id=notification.service_id)
 
+    assert request_mock.call_count == 0
+    mocked_retry.assert_not_called()
+    mocked_suspend.assert_not_called()
+    mocked_send_task.assert_not_called()
+
+
+def test_send_delivery_status_to_service_skips_stale_retry_when_callback_url_changes(
+    notify_db_session,
+    mocker,
+):
+    callback_api, template = _set_up_test_data("email", "delivery_status")
+    datestr = datetime(2017, 6, 20)
+    notification = save_notification(
+        create_notification(
+            template=template,
+            created_at=datestr,
+            updated_at=datestr,
+            sent_at=datestr,
+            status="sent",
+        )
+    )
+    signed_data = _set_up_data_for_status_update(callback_api, notification)
+    stale_url = callback_api.url
+
+    callback_api.url = "https://new.service.gov.uk/"
+    notify_db_session.commit()
+
+    mocked_retry = mocker.patch("app.celery.service_callback_tasks.send_delivery_status_to_service.retry")
+    mocked_send_task = mocker.patch("app.celery.service_callback_tasks.notify_celery.send_task")
+    mocked_suspend = mocker.patch("app.celery.service_callback_tasks.suspend_unsuspend_service_callback_api")
+
+    with requests_mock.Mocker() as request_mock:
+        request_mock.post(stale_url, json={}, status_code=500)
+        send_delivery_status_to_service(notification.id, signed_status_update=signed_data, service_id=notification.service_id)
+
+    assert request_mock.call_count == 0
+    mocked_retry.assert_not_called()
     mocked_suspend.assert_not_called()
     mocked_send_task.assert_not_called()
 

--- a/tests/app/celery/test_service_callback_tasks.py
+++ b/tests/app/celery/test_service_callback_tasks.py
@@ -14,7 +14,7 @@ from tests.app.db import (
 )
 from tests.conftest import set_config_values
 
-from app import DATETIME_FORMAT, signer_complaint, signer_delivery_status
+from app import DATETIME_FORMAT, db, signer_complaint, signer_delivery_status
 from app.celery.service_callback_tasks import (
     _calculate_callback_retry_countdown,
     send_complaint_to_service,
@@ -154,12 +154,12 @@ def test_send_delivery_status_to_service_suspends_callback_and_sends_email_when_
         request_mock.post(callback_api.url, json={}, status_code=500)
         send_delivery_status_to_service(notification.id, signed_status_update=signed_data, service_id=notification.service_id)
 
-    mocked_suspend.assert_called_once_with(
-        callback_api,
-        updated_by_id=notify_api.config["NOTIFY_USER_ID"],
-        suspend=True,
-        failed_callback_url=callback_api.url,
-    )
+    mocked_suspend.assert_called_once()
+    suspend_call = mocked_suspend.call_args
+    assert suspend_call.args[0].id == callback_api.id
+    assert suspend_call.kwargs["updated_by_id"] == notify_api.config["NOTIFY_USER_ID"]
+    assert suspend_call.kwargs["suspend"] is True
+    assert suspend_call.kwargs["failed_callback_url"] == callback_api.url
 
     mocked_send_task.assert_called_once_with(
         "send-service-callback-suspension-email",
@@ -233,7 +233,7 @@ def test_send_delivery_status_to_service_rebinds_to_current_callback_when_callba
 
     callback_api.url = new_url
     callback_api.bearer_token = new_token
-    notify_db_session.commit()
+    db.session.commit()
 
     mocked_retry = mocker.patch("app.celery.service_callback_tasks.send_delivery_status_to_service.retry")
     mocked_send_task = mocker.patch("app.celery.service_callback_tasks.notify_celery.send_task")
@@ -273,7 +273,7 @@ def test_send_delivery_status_to_service_suspends_current_callback_when_stale_pa
     new_url = "https://new.service.gov.uk/"
 
     callback_api.url = new_url
-    notify_db_session.commit()
+    db.session.commit()
 
     mocker.patch(
         "app.celery.service_callback_tasks.send_delivery_status_to_service.retry",
@@ -292,12 +292,12 @@ def test_send_delivery_status_to_service_suspends_current_callback_when_stale_pa
 
     assert request_mock.call_count == 1
     assert request_mock.request_history[0].url == new_url
-    mocked_suspend.assert_called_once_with(
-        callback_api,
-        updated_by_id=notify_api.config["NOTIFY_USER_ID"],
-        suspend=True,
-        failed_callback_url=new_url,
-    )
+    mocked_suspend.assert_called_once()
+    suspend_call = mocked_suspend.call_args
+    assert suspend_call.args[0].id == callback_api.id
+    assert suspend_call.kwargs["updated_by_id"] == notify_api.config["NOTIFY_USER_ID"]
+    assert suspend_call.kwargs["suspend"] is True
+    assert suspend_call.kwargs["failed_callback_url"] == new_url
     mocked_send_task.assert_called_once_with(
         "send-service-callback-suspension-email",
         kwargs={"service_id": str(notification.service_id)},

--- a/tests/app/dao/test_service_callback_api_dao.py
+++ b/tests/app/dao/test_service_callback_api_dao.py
@@ -269,3 +269,58 @@ class TestSuspendedServiceCallback:
             assert x.service_id == sample_service.id
             assert x.updated_by_id == sample_service.users[0].id
             assert signer_bearer_token.verify(x._bearer_token) == "some_unique_string"
+
+    def test_suspend_unsuspend_service_callback_api_suspends_when_active(self, sample_service):
+        service_callback_api = create_service_callback_api(service=sample_service)
+
+        updated = suspend_unsuspend_service_callback_api(
+            service_callback_api,
+            updated_by_id=sample_service.users[0].id,
+            suspend=True,
+            failed_callback_url=service_callback_api.url,
+        )
+
+        assert updated.id == service_callback_api.id
+        refreshed = ServiceCallbackApi.query.get(service_callback_api.id)
+        assert refreshed.is_suspended is True
+        assert refreshed.suspended_at is not None
+
+    def test_suspend_unsuspend_service_callback_api_noops_when_already_suspended(self, sample_service):
+        service_callback_api = create_service_callback_api(service=sample_service, is_suspended=True)
+
+        updated = suspend_unsuspend_service_callback_api(
+            service_callback_api,
+            updated_by_id=sample_service.users[0].id,
+            suspend=True,
+            failed_callback_url=service_callback_api.url,
+        )
+
+        assert updated is None
+
+    def test_suspend_unsuspend_service_callback_api_noops_on_url_mismatch(self, sample_service):
+        service_callback_api = create_service_callback_api(service=sample_service, url="https://new.service/callback")
+
+        updated = suspend_unsuspend_service_callback_api(
+            service_callback_api,
+            updated_by_id=sample_service.users[0].id,
+            suspend=True,
+            failed_callback_url="https://old.service/callback",
+        )
+
+        assert updated is None
+        refreshed = ServiceCallbackApi.query.get(service_callback_api.id)
+        assert refreshed.is_suspended is False
+
+    def test_suspend_unsuspend_service_callback_api_unsuspends_when_suspended(self, sample_service):
+        service_callback_api = create_service_callback_api(service=sample_service, is_suspended=True)
+
+        updated = suspend_unsuspend_service_callback_api(
+            service_callback_api,
+            updated_by_id=sample_service.users[0].id,
+            suspend=False,
+        )
+
+        assert updated.id == service_callback_api.id
+        refreshed = ServiceCallbackApi.query.get(service_callback_api.id)
+        assert refreshed.is_suspended is False
+        assert refreshed.suspended_at is not None


### PR DESCRIPTION
## Summary
This PR adds automatic callback suspension when callback delivery retries are exhausted, and sends notification emails so both service owners and support have a record of the suspension event.

## Why
When a service callback endpoint keeps failing, retries alone do not protect overall callback system health. Suspending that callback after retry exhaustion limits repeated failures and creates a clear operational signal to owners and support.

## What Changed

1. Added retry-exhaustion suspension flow in notification-api/app/celery/service_callback_tasks.py.
1. On max retries exceeded, the callback config is suspended and an internal notify task is queued in notification-api/app/celery/service_callback_tasks.py.
1. Added a new task to send suspension emails to service owners and (production only) support in notification-api/app/celery/service_callback_suspension_tasks.py.
1. Registered the new task module in Celery imports in notification-api/app/config.py.
1. Added/updated tests for suspension and notification behavior in:
    notification-api/tests/app/celery/test_service_callback_tasks.py
    notification-api/tests/app/celery/test_service_callback_suspension_tasks.py

### Behavior Before
Callback retries stopped at max retries.
No automatic callback suspension on exhaustion.
No automatic service-owner/support email for callback suspension.

### Behavior After
Retryable callback failures still retry as before (including PR1 backoff+jitter).
When retries are exhausted, callback config is suspended automatically.
Suspension email is sent to service owners.
Support copy is sent in production for audit/operational visibility.
If callback is already suspended, duplicate suspend/email actions are avoided.

