### PR TITLE
Emit a log line to search on for international messages

### DIFF
--- a/app/aws/metrics.py
+++ b/app/aws/metrics.py
@@ -156,3 +156,16 @@ def put_batch_saving_bulk_processed(
         message = "Error sending CloudWatch Metric: {}".format(e)
         current_app.logger.warning(message)
     return
+
+
+def put_international_sms_metric(metrics_logger: MetricsLogger, service_id: str, count: int = 1):
+    if metrics_logger.metrics_config.disable_metric_extraction:
+        return
+    try:
+        metrics_logger.set_namespace("NotificationCanadaCa")
+        metrics_logger.put_metric("international_sms_sent", count, "Count")
+        metrics_logger.set_dimensions({"service_id": str(service_id)})
+        metrics_logger.flush()
+    except ClientError as e:
+        current_app.logger.warning(f"Error sending CloudWatch Metric: {e}")
+    return

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -27,9 +27,11 @@ from app import (
     clients,
     create_uuid,
     document_download_client,
+    metrics_logger,
     redis_store,
     statsd_client,
 )
+from app.aws.metrics import put_international_sms_metric
 from app.celery.research_mode_tasks import send_email_response, send_sms_response
 from app.clients.sms import SmsSendingVehicles
 from app.config import Config
@@ -299,6 +301,7 @@ def send_sms_to_provider(notification):
             "International text sent, service_id=%(service_id)s notification_id=%(notification_id)s",
             {"service_id": notification.service_id, "notification_id": notification.id},
         )
+        put_international_sms_metric(metrics_logger, notification.service_id)
 
     # Record StatsD stats to compute SLOs
     statsd_client.timing_with_dates("sms.total-time", notification.sent_at, notification.created_at)

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -294,6 +294,12 @@ def send_sms_to_provider(notification):
                     send_sms_response(provider.get_name(), notification.to, reference)
                 update_notification_to_sending(notification, provider)
 
+    if notification.international:
+        current_app.logger.info(
+            "International text sent, service_id=%(service_id)s notification_id=%(notification_id)s",
+            {"service_id": notification.service_id, "notification_id": notification.id},
+        )
+
     # Record StatsD stats to compute SLOs
     statsd_client.timing_with_dates("sms.total-time", notification.sent_at, notification.created_at)
     statsd_key = f"sms.process_type-{template_dict['process_type']}"

--- a/app/delivery/send_to_providers.py
+++ b/app/delivery/send_to_providers.py
@@ -258,6 +258,8 @@ def send_sms_to_provider(notification):
         empty_message_failure(notification=notification)
         return
 
+    sent_to_provider_successfully = False
+
     if service.research_mode or notification.key_type == KEY_TYPE_TEST or sending_to_internal_test_number:
         current_app.logger.info(f"notification {notification.id} is sending to INTERNAL_TEST_NUMBER, no boto call to AWS.")
         notification.reference = str(create_uuid())
@@ -295,8 +297,9 @@ def send_sms_to_provider(notification):
                 if sending_to_dryrun_number:
                     send_sms_response(provider.get_name(), notification.to, reference)
                 update_notification_to_sending(notification, provider)
+                sent_to_provider_successfully = True
 
-    if notification.international:
+    if notification.international and sent_to_provider_successfully:
         current_app.logger.info(
             "International text sent, service_id=%(service_id)s notification_id=%(notification_id)s",
             {"service_id": notification.service_id, "notification_id": notification.id},

--- a/tests/app/delivery/test_send_to_providers.py
+++ b/tests/app/delivery/test_send_to_providers.py
@@ -213,6 +213,74 @@ def test_should_handle_opted_out_phone_numbers_if_using_pinpoint(notify_api, sam
         assert notification.provider_response == "Phone number is opted out"
 
 
+def test_should_not_emit_international_signal_for_key_type_test_sms(sample_template, mocker):
+    notification = save_notification(
+        create_notification(
+            template=sample_template,
+            to_field="+447512501324",
+            international=True,
+            key_type=KEY_TYPE_TEST,
+            status="created",
+            reply_to_text=sample_template.service.get_default_sms_sender(),
+        )
+    )
+
+    info_log_mock = mocker.patch("app.delivery.send_to_providers.current_app.logger.info")
+    metric_mock = mocker.patch("app.delivery.send_to_providers.put_international_sms_metric")
+    send_mock = mocker.patch("app.aws_sns_client.send_sms")
+    mocker.patch("app.delivery.send_to_providers.send_sms_response", return_value="not-used")
+
+    send_to_providers.send_sms_to_provider(notification)
+
+    send_mock.assert_not_called()
+    assert not any(call.args and call.args[0].startswith("International text sent") for call in info_log_mock.call_args_list)
+    metric_mock.assert_not_called()
+
+
+def test_should_not_emit_international_signal_for_opted_out_sms(sample_template, mocker):
+    notification = save_notification(
+        create_notification(
+            template=sample_template,
+            to_field="+447512501324",
+            international=True,
+            status="created",
+            reply_to_text=sample_template.service.get_default_sms_sender(),
+        )
+    )
+
+    info_log_mock = mocker.patch("app.delivery.send_to_providers.current_app.logger.info")
+    metric_mock = mocker.patch("app.delivery.send_to_providers.put_international_sms_metric")
+    mocker.patch("app.aws_sns_client.send_sms", return_value="opted_out")
+
+    send_to_providers.send_sms_to_provider(notification)
+
+    persisted_notification = Notification.query.filter_by(id=notification.id).one()
+    assert persisted_notification.status == "technical-failure"
+    assert not any(call.args and call.args[0].startswith("International text sent") for call in info_log_mock.call_args_list)
+    metric_mock.assert_not_called()
+
+
+def test_should_emit_international_signal_for_successfully_sent_sms(sample_template, mocker):
+    notification = save_notification(
+        create_notification(
+            template=sample_template,
+            to_field="+447512501324",
+            international=True,
+            status="created",
+            reply_to_text=sample_template.service.get_default_sms_sender(),
+        )
+    )
+
+    info_log_mock = mocker.patch("app.delivery.send_to_providers.current_app.logger.info")
+    metric_mock = mocker.patch("app.delivery.send_to_providers.put_international_sms_metric")
+    mocker.patch("app.aws_sns_client.send_sms", return_value="message_id_from_sns")
+
+    send_to_providers.send_sms_to_provider(notification)
+
+    assert any(call.args and call.args[0].startswith("International text sent") for call in info_log_mock.call_args_list)
+    metric_mock.assert_called_once_with(send_to_providers.metrics_logger, notification.service_id)
+
+
 def test_should_send_personalised_template_to_correct_sms_provider_and_persist(sample_sms_template_with_html, mocker):
     db_notification = save_notification(
         create_notification(


### PR DESCRIPTION
# Summary | Résumé

Emit a log line to capture if we have sent an international text message
https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/3367