### PR TITLE
Fix template history drift for category and process-type updates

### DIFF
--- a/app/dao/templates_dao.py
+++ b/app/dao/templates_dao.py
@@ -40,6 +40,9 @@ def _create_template_history_row(template):
             "process_type": template.process_type_column,
             "template_category_id": template.template_category_id,
             "service_letter_contact_id": template.service_letter_contact_id,
+            "hidden": template.hidden,
+            "text_direction_rtl": template.text_direction_rtl,
+            "use_custom_unsubscribe_url": template.use_custom_unsubscribe_url,
         }
     )
 

--- a/app/dao/templates_dao.py
+++ b/app/dao/templates_dao.py
@@ -6,7 +6,7 @@ from typing import Union
 from flask import current_app
 from notifications_utils.clients.redis import template_version_cache_key
 from sqlalchemy import asc, desc
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import attributes, joinedload
 
 from app import db, redis_store
 from app.dao.dao_utils import VersionOptions, transactional, version_class
@@ -15,6 +15,7 @@ from app.models import (
     LETTER_TYPE,
     SECOND_CLASS,
     Template,
+    TemplateCategory,
     TemplateHistory,
     TemplateRedacted,
 )
@@ -43,6 +44,31 @@ def _create_template_history_row(template):
     )
 
 
+def _sync_template_category_state(template):
+    state_dict = attributes.instance_state(template).dict
+    category_relationship_loaded = "template_category" in state_dict
+    loaded_category = state_dict.get("template_category") if category_relationship_loaded else None
+
+    category_id_loaded = "template_category_id" in state_dict
+    loaded_category_id = state_dict.get("template_category_id") if category_id_loaded else None
+
+    if category_id_loaded:
+        if loaded_category_id is None:
+            if category_relationship_loaded and loaded_category is not None:
+                template.template_category_id = loaded_category.id
+            return
+
+        if category_relationship_loaded and (loaded_category is None or loaded_category.id != loaded_category_id):
+            with db.session.no_autoflush:
+                category = TemplateCategory.query.get(loaded_category_id)
+            if category is not None:
+                template.template_category = category
+        return
+
+    if category_relationship_loaded and loaded_category is not None:
+        template.template_category_id = loaded_category.id
+
+
 @transactional
 @version_class(VersionOptions(Template, history_class=TemplateHistory))
 def dao_create_template(template, redact_personalisation=False, folder=None):
@@ -55,6 +81,8 @@ def dao_create_template(template, redact_personalisation=False, folder=None):
     # function can assign the id — leading to a PK-changing UPDATE that violates FKs.
     if folder:
         template.folder = folder
+
+    _sync_template_category_state(template)
 
     redacted_dict = {
         "template": template,
@@ -73,6 +101,7 @@ def dao_create_template(template, redact_personalisation=False, folder=None):
 @transactional
 @version_class(VersionOptions(Template, history_class=TemplateHistory))
 def dao_update_template(template):
+    _sync_template_category_state(template)
     db.session.add(template)
 
 

--- a/app/dao/templates_dao.py
+++ b/app/dao/templates_dao.py
@@ -20,6 +20,29 @@ from app.models import (
 )
 
 
+def _create_template_history_row(template):
+    return TemplateHistory(
+        **{
+            "id": template.id,
+            "name": template.name,
+            "template_type": template.template_type,
+            "created_at": template.created_at,
+            "updated_at": template.updated_at,
+            "content": template.content,
+            "service_id": template.service_id,
+            "subject": template.subject,
+            "postage": template.postage,
+            "created_by_id": template.created_by_id,
+            "version": template.version,
+            "archived": template.archived,
+            # Keep history aligned with the DB column: only explicit overrides are stored here.
+            "process_type": template.process_type_column,
+            "template_category_id": template.template_category_id,
+            "service_letter_contact_id": template.service_letter_contact_id,
+        }
+    )
+
+
 @transactional
 @version_class(VersionOptions(Template, history_class=TemplateHistory))
 def dao_create_template(template, redact_personalisation=False, folder=None):
@@ -64,25 +87,7 @@ def dao_update_template_reply_to(template_id, reply_to):
     )
     template = Template.query.filter_by(id=template_id).one()
 
-    history = TemplateHistory(
-        **{
-            "id": template.id,
-            "name": template.name,
-            "template_type": template.template_type,
-            "created_at": template.created_at,
-            "updated_at": template.updated_at,
-            "content": template.content,
-            "service_id": template.service_id,
-            "subject": template.subject,
-            "postage": template.postage,
-            "created_by_id": template.created_by_id,
-            "version": template.version,
-            "archived": template.archived,
-            "process_type": template.process_type,
-            "service_letter_contact_id": template.service_letter_contact_id,
-        }
-    )
-    db.session.add(history)
+    db.session.add(_create_template_history_row(template))
     return template
 
 
@@ -90,30 +95,14 @@ def dao_update_template_reply_to(template_id, reply_to):
 def dao_update_template_process_type(template_id, process_type):
     Template.query.filter_by(id=template_id).update(
         {
-            "process_type": process_type,
+            Template.process_type_column: process_type,
+            Template.updated_at: datetime.utcnow(),
+            Template.version: Template.version + 1,
         }
     )
     template = Template.query.filter_by(id=template_id).one()
 
-    history = TemplateHistory(
-        **{
-            "id": template.id,
-            "name": template.name,
-            "template_type": template.template_type,
-            "created_at": template.created_at,
-            "updated_at": template.updated_at,
-            "content": template.content,
-            "service_id": template.service_id,
-            "subject": template.subject,
-            "postage": template.postage,
-            "created_by_id": template.created_by_id,
-            "version": template.version,
-            "archived": template.archived,
-            "process_type": template.process_type,
-            "service_letter_contact_id": template.service_letter_contact_id,
-        }
-    )
-    db.session.add(history)
+    db.session.add(_create_template_history_row(template))
     return template
 
 
@@ -129,25 +118,7 @@ def dao_update_template_category(template_id, category_id):
 
     template = Template.query.filter_by(id=template_id).one()
 
-    history = TemplateHistory(
-        **{
-            "id": template.id,
-            "name": template.name,
-            "template_type": template.template_type,
-            "created_at": template.created_at,
-            "updated_at": template.updated_at,
-            "content": template.content,
-            "service_id": template.service_id,
-            "subject": template.subject,
-            "postage": template.postage,
-            "created_by_id": template.created_by_id,
-            "version": template.version,
-            "archived": template.archived,
-            "process_type": template.process_type,
-            "service_letter_contact_id": template.service_letter_contact_id,
-        }
-    )
-    db.session.add(history)
+    db.session.add(_create_template_history_row(template))
     return template
 
 

--- a/app/history_meta.py
+++ b/app/history_meta.py
@@ -187,11 +187,10 @@ def create_history(obj, history_cls=None):
         # not yet have a value before insert
 
         elif isinstance(prop, RelationshipProperty):
-            foreign_key = prop.key + "_id"
-            if hasattr(history_cls, foreign_key) and foreign_key not in data:
+            if hasattr(history_cls, prop.key + "_id"):
                 foreign_obj = getattr(obj, prop.key)
-                # If it's a nullable relationship, foreign_obj will be None, and we want to record that.
-                data[foreign_key] = getattr(foreign_obj, "id", None)
+                # if it's a nullable relationship, foreign_obj will be None, and we actually want to record that
+                data[prop.key + "_id"] = getattr(foreign_obj, "id", None)
 
     if not obj.version:
         obj.version = 1

--- a/app/history_meta.py
+++ b/app/history_meta.py
@@ -187,10 +187,11 @@ def create_history(obj, history_cls=None):
         # not yet have a value before insert
 
         elif isinstance(prop, RelationshipProperty):
-            if hasattr(history_cls, prop.key + "_id"):
+            foreign_key = prop.key + "_id"
+            if hasattr(history_cls, foreign_key) and foreign_key not in data:
                 foreign_obj = getattr(obj, prop.key)
-                # if it's a nullable relationship, foreign_obj will be None, and we actually want to record that
-                data[prop.key + "_id"] = getattr(foreign_obj, "id", None)
+                # If it's a nullable relationship, foreign_obj will be None, and we want to record that.
+                data[foreign_key] = getattr(foreign_obj, "id", None)
 
     if not obj.version:
         obj.version = 1

--- a/tests/app/dao/test_templates_dao.py
+++ b/tests/app/dao/test_templates_dao.py
@@ -604,6 +604,37 @@ class TestTemplateHistoryManualUpdatePaths:
         history = TemplateHistory.query.filter_by(id=template.id, version=updated.version).one()
         assert history.template_category_id == sample_template_category.id
 
+    def test_reply_to_update_preserves_template_flags_in_history(
+        self,
+        sample_service,
+        sample_user,
+        sample_template_category,
+    ):
+        letter_contact = create_letter_contact(sample_service, "Edinburgh, ED1 1AA")
+        template = Template(
+            **{
+                "name": "Sample Template",
+                "template_type": "letter",
+                "content": "Template content",
+                "service": sample_service,
+                "created_by": sample_user,
+                "postage": "second",
+                "template_category_id": sample_template_category.id,
+                "hidden": True,
+                "text_direction_rtl": True,
+                "use_custom_unsubscribe_url": True,
+            }
+        )
+        dao_create_template(template)
+
+        dao_update_template_reply_to(template_id=template.id, reply_to=letter_contact.id)
+
+        updated = Template.query.get(template.id)
+        history = TemplateHistory.query.filter_by(id=template.id, version=updated.version).one()
+        assert history.hidden is True
+        assert history.text_direction_rtl is True
+        assert history.use_custom_unsubscribe_url is True
+
     def test_process_type_update_increments_version_and_creates_matching_history(
         self,
         sample_service,
@@ -630,6 +661,30 @@ class TestTemplateHistoryManualUpdatePaths:
         assert history.template_category_id == sample_template_category.id
         assert history.updated_at == updated.updated_at
 
+    def test_process_type_update_preserves_template_flags_in_history(
+        self,
+        sample_service,
+        sample_template_category,
+    ):
+        template = create_template(
+            service=sample_service,
+            template_type="sms",
+            template_category=sample_template_category,
+            process_type="normal",
+            text_direction_rtl=True,
+        )
+        template.hidden = True
+        template.use_custom_unsubscribe_url = True
+        dao_update_template(template)
+
+        dao_update_template_process_type(template.id, "priority")
+
+        updated = Template.query.get(template.id)
+        history = TemplateHistory.query.filter_by(id=template.id, version=updated.version).one()
+        assert history.hidden is True
+        assert history.text_direction_rtl is True
+        assert history.use_custom_unsubscribe_url is True
+
     def test_process_type_update_to_none_stores_null_override_and_keeps_category(
         self,
         sample_service,
@@ -655,6 +710,31 @@ class TestTemplateHistoryManualUpdatePaths:
         assert history.process_type == sample_template_category.sms_process_type
         assert history.template_category_id == sample_template_category.id
         assert history.updated_at == updated.updated_at
+
+    def test_category_update_preserves_template_flags_in_history(
+        self,
+        sample_service,
+        sample_template_category,
+        sample_template_category_bulk,
+    ):
+        template = create_template(
+            service=sample_service,
+            template_type="email",
+            template_category=sample_template_category,
+            process_type=None,
+            text_direction_rtl=True,
+        )
+        template.hidden = True
+        template.use_custom_unsubscribe_url = True
+        dao_update_template(template)
+
+        dao_update_template_category(template.id, sample_template_category_bulk.id)
+
+        updated = Template.query.get(template.id)
+        history = TemplateHistory.query.filter_by(id=template.id, version=updated.version).one()
+        assert history.hidden is True
+        assert history.text_direction_rtl is True
+        assert history.use_custom_unsubscribe_url is True
 
 
 class TestTemplateHistoryRegressionCoverage:

--- a/tests/app/dao/test_templates_dao.py
+++ b/tests/app/dao/test_templates_dao.py
@@ -18,6 +18,7 @@ from app.dao.templates_dao import (
     dao_redact_template,
     dao_update_template,
     dao_update_template_category,
+    dao_update_template_process_type,
     dao_update_template_reply_to,
 )
 from app.models import Template, TemplateHistory, TemplateRedacted
@@ -416,7 +417,7 @@ def test_create_template_creates_a_history_record_with_current_data(sample_servi
     assert template_from_db.created_by.id == template_history.created_by_id
 
 
-def test_update_template_creates_a_history_record_with_current_data(sample_service, sample_user):
+def test_update_template_creates_a_history_record_with_current_data(sample_service, sample_user, sample_template_category):
     assert Template.query.count() == 0
     assert TemplateHistory.query.count() == 0
     data = {
@@ -448,6 +449,12 @@ def test_update_template_creates_a_history_record_with_current_data(sample_servi
 
     assert TemplateHistory.query.filter_by(name="Sample Template").one().version == 1
     assert TemplateHistory.query.filter_by(name="new name").one().version == 2
+
+    created.template_category_id = sample_template_category.id
+    dao_update_template(created)
+
+    history = TemplateHistory.query.filter_by(id=created.id, version=3).one()
+    assert history.template_category_id == sample_template_category.id
 
 
 def test_get_template_history_version(sample_user, sample_service, sample_template):
@@ -536,7 +543,7 @@ def test_dao_update_template_category(sample_template, sample_template_category)
     assert updated_template.version == 2
 
     history = TemplateHistory.query.filter_by(id=sample_template.id, version=updated_template.version).one()
-    assert not history.template_category_id
+    assert history.template_category_id == sample_template_category.id
     assert history.updated_at == updated_template.updated_at
 
 
@@ -568,3 +575,83 @@ class TestProcessType:
         assert template.template_category_id == sample_template_category.id
         assert template.process_type == sample_template_category.email_process_type
         assert template.process_type_column is None
+
+
+class TestTemplateHistoryManualUpdatePaths:
+    def test_reply_to_update_preserves_template_category_id_in_history(
+        self,
+        sample_service,
+        sample_user,
+        sample_template_category,
+    ):
+        letter_contact = create_letter_contact(sample_service, "Edinburgh, ED1 1AA")
+        template = Template(
+            **{
+                "name": "Sample Template",
+                "template_type": "letter",
+                "content": "Template content",
+                "service": sample_service,
+                "created_by": sample_user,
+                "postage": "second",
+                "template_category_id": sample_template_category.id,
+            }
+        )
+        dao_create_template(template)
+
+        dao_update_template_reply_to(template_id=template.id, reply_to=letter_contact.id)
+
+        updated = Template.query.get(template.id)
+        history = TemplateHistory.query.filter_by(id=template.id, version=updated.version).one()
+        assert history.template_category_id == sample_template_category.id
+
+    def test_process_type_update_increments_version_and_creates_matching_history(
+        self,
+        sample_service,
+        sample_template_category,
+    ):
+        template = create_template(
+            service=sample_service,
+            template_type="sms",
+            template_category=sample_template_category,
+            process_type="normal",
+        )
+
+        original_version = template.version
+        dao_update_template_process_type(template.id, "priority")
+
+        updated = Template.query.get(template.id)
+        assert updated.version == original_version + 1
+        assert updated.updated_at is not None
+        assert updated.process_type_column == "priority"
+
+        history = TemplateHistory.query.filter_by(id=template.id, version=updated.version).one()
+        assert history.process_type_column == "priority"
+        assert history.process_type == "priority"
+        assert history.template_category_id == sample_template_category.id
+        assert history.updated_at == updated.updated_at
+
+    def test_process_type_update_to_none_stores_null_override_and_keeps_category(
+        self,
+        sample_service,
+        sample_template_category,
+    ):
+        template = create_template(
+            service=sample_service,
+            template_type="sms",
+            template_category=sample_template_category,
+            process_type="bulk",
+        )
+
+        dao_update_template_process_type(template.id, None)
+
+        updated = Template.query.get(template.id)
+        assert updated.version == 2
+        assert updated.updated_at is not None
+        assert updated.process_type_column is None
+        assert updated.process_type == sample_template_category.sms_process_type
+
+        history = TemplateHistory.query.filter_by(id=template.id, version=updated.version).one()
+        assert history.process_type_column is None
+        assert history.process_type == sample_template_category.sms_process_type
+        assert history.template_category_id == sample_template_category.id
+        assert history.updated_at == updated.updated_at

--- a/tests/app/dao/test_templates_dao.py
+++ b/tests/app/dao/test_templates_dao.py
@@ -655,3 +655,53 @@ class TestTemplateHistoryManualUpdatePaths:
         assert history.process_type == sample_template_category.sms_process_type
         assert history.template_category_id == sample_template_category.id
         assert history.updated_at == updated.updated_at
+
+
+class TestTemplateHistoryRegressionCoverage:
+    def test_update_template_category_id_wins_over_loaded_stale_relationship(
+        self,
+        sample_service,
+        sample_template_category,
+        sample_template_category_bulk,
+    ):
+        create_template(
+            service=sample_service,
+            template_type="email",
+            template_category=sample_template_category,
+            process_type=None,
+        )
+
+        # dao_get_all_templates_for_service eager-loads template_category, which reproduces
+        # the stale-relationship scenario if only template_category_id is changed.
+        loaded_template = dao_get_all_templates_for_service(sample_service.id)[0]
+        assert loaded_template.template_category_id == sample_template_category.id
+        assert loaded_template.template_category.id == sample_template_category.id
+
+        loaded_template.template_category_id = sample_template_category_bulk.id
+        dao_update_template(loaded_template)
+
+        history = TemplateHistory.query.filter_by(id=loaded_template.id, version=2).one()
+        assert history.template_category_id == sample_template_category_bulk.id
+
+    def test_create_template_history_records_category_id_when_set_via_relationship(
+        self,
+        sample_service,
+        sample_user,
+        sample_template_category,
+    ):
+        template = Template(
+            **{
+                "name": "Sample Template",
+                "template_type": "email",
+                "subject": "subject",
+                "content": "Template content",
+                "service": sample_service,
+                "created_by": sample_user,
+                "template_category": sample_template_category,
+            }
+        )
+
+        dao_create_template(template)
+
+        history = TemplateHistory.query.filter_by(id=template.id, version=1).one()
+        assert history.template_category_id == sample_template_category.id


### PR DESCRIPTION
# Summary:
This PR fixes Template history drift by making Template-specific history writes deterministic and keeping template category state consistent before versioned history capture.

It removes reliance on shared history behavior changes and keeps the fix scoped to Template paths only.

## What Changed
- Consolidated manual Template history row creation in templates_dao.py so all manual update paths write a consistent set of fields, including template_category_id and process_type override column.
- Fixed process type update path in templates_dao.py to:
    update mapped attributes correctly
    increment version
    set updated_at
    persist matching history rows
- Added Template-only category state synchronization in templates_dao.py before create and update versioned writes, so FK and relationship state cannot diverge in ways that cause stale history values.
- Expanded regression coverage in test_templates_dao.py, including:
    category history correctness on normal updates
    manual update-path history correctness (reply-to, process type set/unset)
    stale loaded relationship scenario where template_category_id changes
    create path where category is set via relationship
    
### Why This Fix
The mismatch came from in-memory FK and relationship state not always being aligned at history-copy time. This PR fixes that in Template DAO flows directly, while keeping shared history behavior unchanged for other models.

## Tests:

Case 1
1. Create a template, with category "authentication"
2. Check the template category is the same in "templates" and "template_history" for the same version

Case 2:
1. Edit the above template
2. Add an "admin" override for the process_type (at the bottom of the edit page). Click "NORMAL" or "BULK"
3. "Templates" table should have the process_type column filled and "template_history" as well. Make sure it is the same version (for the edit)
4. Open a python shell CHANGE the UUID.
```
python - <<'PY'
from uuid import UUID
from application import app
from app.models import Template, TemplateHistory

tid = UUID("202d52a2-1c74-4ca5-93eb-8d00436cc3ed")

print("---------------------------------------------")
with app.app_context():
    t = Template.query.filter_by(id=tid).one_or_none()
    if t is None:
        print("Template not found")
    else:
        print("template_type:", t.template_type)
        print("override process_type_column:", t.process_type_column)
        print("resolved process_type:", t.process_type)
        print("template_category_id:", t.template_category_id)
        if t.template_category:
            print("category sms_process_type:", t.template_category.sms_process_type)
            print("category email_process_type:", t.template_category.email_process_type)

    print("\nHistory:")
    rows = (
        TemplateHistory.query
        .filter_by(id=tid)
        .order_by(TemplateHistory.version.asc())
        .all()
    )
    for h in rows:
        print(
            "v=", h.version,
            "override=", h.process_type_column,
            "resolved=", h.process_type,
            "category_id=", h.template_category_id,
            "updated_at=", h.updated_at,
        )
PY
```

Case 3:
1. Edit the above template
2. Under admin click "Use template category"
3. Both templates and template history, the process_type column should be None
4. When you get the template it will use the process type from the template cat
5. you can use the above script to figure out the process types