### PR TITLE
PR3: automate callback suspension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 queues.csv
+core
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/app/celery/service_callback_suspension_tasks.py
+++ b/app/celery/service_callback_suspension_tasks.py
@@ -1,0 +1,29 @@
+from flask import current_app
+
+from app import notify_celery
+from app.dao.services_dao import dao_fetch_service_by_id
+from app.service.sender import send_notification_to_email_address, send_notification_to_service_users
+
+
+@notify_celery.task(name="send-service-callback-suspension-email")
+def send_service_callback_suspension_email(service_id: str):
+    service = dao_fetch_service_by_id(service_id)
+    personalisation = {
+        "service_name": service.name,
+        "service_id": str(service.id),
+    }
+
+    send_notification_to_service_users(
+        service_id=service_id,
+        template_id=current_app.config["SERVICE_CALLBACK_SUSPENDED_TEMPLATE_ID"],
+        personalisation=personalisation.copy(),
+        include_user_fields=["name"],
+    )
+
+    # Keep support-copy behavior production-only to avoid noise in test/sandbox environments.
+    if current_app.config["NOTIFY_ENVIRONMENT"] == "production":
+        send_notification_to_email_address(
+            email_address=current_app.config["FRESHDESK_SUPPORT_EMAIL_ID"],
+            template_id=current_app.config["SERVICE_CALLBACK_SUSPENDED_TEMPLATE_ID"],
+            personalisation={**personalisation, "name": "Freshdesk support"},
+        )

--- a/app/celery/service_callback_tasks.py
+++ b/app/celery/service_callback_tasks.py
@@ -1,4 +1,5 @@
 import json
+import random
 
 from flask import current_app
 from notifications_utils.statsd_decorators import statsd
@@ -6,6 +7,21 @@ from requests import HTTPError, RequestException, request
 
 from app import notify_celery, signer_complaint, signer_delivery_status
 from app.config import QueueNames
+
+
+def _calculate_callback_retry_countdown(retries: int) -> int:
+    """Compute exponential retry delay with jitter and a hard cap."""
+    base_delay_seconds = max(1, int(current_app.config["CALLBACK_RETRY_BACKOFF_BASE_SECONDS"]))
+    max_delay_seconds = max(base_delay_seconds, int(current_app.config["CALLBACK_RETRY_BACKOFF_MAX_SECONDS"]))
+    jitter_factor = float(current_app.config["CALLBACK_RETRY_JITTER_FACTOR"])
+    jitter_factor = min(max(jitter_factor, 0.0), 1.0)
+
+    backoff_seconds = min(base_delay_seconds * (2**retries), max_delay_seconds)
+    jitter_delta = backoff_seconds * jitter_factor
+    jittered_seconds = random.uniform(backoff_seconds - jitter_delta, backoff_seconds + jitter_delta)
+
+    # Keep retry delay bounded so we can tune behavior safely with config values.
+    return max(1, min(max_delay_seconds, int(round(jittered_seconds))))
 
 
 @notify_celery.task(bind=True, name="send-delivery-status", max_retries=5, default_retry_delay=300)
@@ -86,8 +102,9 @@ def _send_data_to_service_callback_api(self, service_id, data, service_callback_
         )
         # Retry if the response status code is server-side or 429 (too many requests).
         if not isinstance(e, HTTPError) or e.response.status_code >= 500 or e.response.status_code == 429:
+            countdown = _calculate_callback_retry_countdown(self.request.retries)
             try:
-                self.retry(queue=QueueNames.CALLBACKS_RETRY)
+                self.retry(queue=QueueNames.CALLBACKS_RETRY, countdown=countdown)
             except self.MaxRetriesExceededError:
                 current_app.logger.warning(
                     "Retry: {function_name} has retried the max num of times for callback url {service_callback_url} notification_id: {notification_id} service: {service_id}"

--- a/app/celery/service_callback_tasks.py
+++ b/app/celery/service_callback_tasks.py
@@ -7,6 +7,12 @@ from requests import HTTPError, RequestException, request
 
 from app import notify_celery, signer_complaint, signer_delivery_status
 from app.config import QueueNames
+from app.dao.service_callback_api_dao import (
+    get_service_complaint_callback_api_for_service,
+    get_service_delivery_status_callback_api_for_service,
+    suspend_unsuspend_service_callback_api,
+)
+from app.models import COMPLAINT_CALLBACK_TYPE, DELIVERY_STATUS_CALLBACK_TYPE
 
 
 def _calculate_callback_retry_countdown(retries: int) -> int:
@@ -48,6 +54,7 @@ def send_delivery_status_to_service(self, notification_id, signed_status_update,
         status_update["service_callback_api_url"],
         status_update["service_callback_api_bearer_token"],
         "send_delivery_status_to_service",
+        DELIVERY_STATUS_CALLBACK_TYPE,
     )
 
 
@@ -71,10 +78,11 @@ def send_complaint_to_service(self, complaint_data, service_id):
         complaint["service_callback_api_url"],
         complaint["service_callback_api_bearer_token"],
         "send_complaint_to_service",
+        COMPLAINT_CALLBACK_TYPE,
     )
 
 
-def _send_data_to_service_callback_api(self, service_id, data, service_callback_url, token, function_name):
+def _send_data_to_service_callback_api(self, service_id, data, service_callback_url, token, function_name, callback_type):
     notification_id = data["notification_id"] if "notification_id" in data else data["id"]
     try:
         current_app.logger.info(
@@ -106,6 +114,43 @@ def _send_data_to_service_callback_api(self, service_id, data, service_callback_
             try:
                 self.retry(queue=QueueNames.CALLBACKS_RETRY, countdown=countdown)
             except self.MaxRetriesExceededError:
+                _suspend_service_callback_and_send_email(service_id=service_id, callback_type=callback_type)
                 current_app.logger.warning(
-                    "Retry: {function_name} has retried the max num of times for callback url {service_callback_url} notification_id: {notification_id} service: {service_id}"
+                    f"Retry: {function_name} has retried the max num of times for callback url {service_callback_url} "
+                    f"notification_id: {notification_id} service: {service_id}"
                 )
+
+
+def _get_service_callback_api_for_type(service_id, callback_type):
+    if callback_type == DELIVERY_STATUS_CALLBACK_TYPE:
+        return get_service_delivery_status_callback_api_for_service(service_id=service_id)
+    if callback_type == COMPLAINT_CALLBACK_TYPE:
+        return get_service_complaint_callback_api_for_service(service_id=service_id)
+
+    current_app.logger.warning(f"Unknown callback type {callback_type} for service {service_id}")
+    return None
+
+
+def _suspend_service_callback_and_send_email(service_id, callback_type):
+    callback_api = _get_service_callback_api_for_type(service_id=service_id, callback_type=callback_type)
+    if not callback_api:
+        current_app.logger.warning(f"No callback config found to suspend for service {service_id} callback_type {callback_type}")
+        return
+
+    if callback_api.is_suspended:
+        current_app.logger.info(
+            f"Callback config {callback_api.id} for service {service_id} callback_type {callback_type} is already suspended"
+        )
+        return
+
+    suspend_unsuspend_service_callback_api(
+        callback_api,
+        updated_by_id=current_app.config["NOTIFY_USER_ID"],
+        suspend=True,
+    )
+
+    notify_celery.send_task(
+        "send-service-callback-suspension-email",
+        kwargs={"service_id": str(callback_api.service_id)},
+        queue=QueueNames.NOTIFY,
+    )

--- a/app/config.py
+++ b/app/config.py
@@ -633,6 +633,11 @@ class Config(object):
 
     SENDING_NOTIFICATIONS_TIMEOUT_PERIOD = 259_200  # 3 days
 
+    # Callback retry policy: exponential backoff with jitter.
+    CALLBACK_RETRY_BACKOFF_BASE_SECONDS = env.int("CALLBACK_RETRY_BACKOFF_BASE_SECONDS", 5)
+    CALLBACK_RETRY_BACKOFF_MAX_SECONDS = env.int("CALLBACK_RETRY_BACKOFF_MAX_SECONDS", 300)
+    CALLBACK_RETRY_JITTER_FACTOR = float(os.getenv("CALLBACK_RETRY_JITTER_FACTOR", 0.2))
+
     SIMULATED_EMAIL_ADDRESSES = (
         "simulate-delivered@notification.canada.ca",
         "simulate-delivered-2@notification.canada.ca",

--- a/app/config.py
+++ b/app/config.py
@@ -435,6 +435,7 @@ class Config(object):
         "app.celery.nightly_tasks",
         "app.celery.process_pinpoint_receipts_tasks",
         "app.celery.bounce_rate_tasks",
+        "app.celery.service_callback_suspension_tasks",
     )
     CELERYBEAT_SCHEDULE = {
         # app/celery/scheduled_tasks.py

--- a/app/notifications/notifications_ses_callback.py
+++ b/app/notifications/notifications_ses_callback.py
@@ -207,8 +207,15 @@ def remove_emails_from_complaint(complaint_dict):
 
 
 def _check_and_queue_complaint_callback_task(complaint, notification, recipient):
-    # queue callback task only if the service_callback_api exists
+    # queue callback task only if the service_callback_api exists and is not suspended
     service_callback_api = get_service_complaint_callback_api_for_service(service_id=notification.service_id)
     if service_callback_api:
+        if service_callback_api.is_suspended:
+            current_app.logger.warning(
+                f"Service complaint callback API: {service_callback_api.id} for service: {notification.service_id} is suspended. "
+                f"Cannot queue complaint callback task for notification: {notification.id}"
+            )
+            return
+
         complaint_data = create_complaint_callback_data(complaint, notification, service_callback_api, recipient)
         send_complaint_to_service.apply_async([complaint_data, notification.service_id], queue=QueueNames.CALLBACKS)

--- a/tests/app/celery/test_service_callback_suspension_tasks.py
+++ b/tests/app/celery/test_service_callback_suspension_tasks.py
@@ -1,0 +1,63 @@
+from types import SimpleNamespace
+
+from tests.conftest import set_config_values
+
+from app.celery.service_callback_suspension_tasks import send_service_callback_suspension_email
+
+
+def test_send_service_callback_suspension_email_sends_to_service_owners_and_support_in_production(notify_api, mocker):
+    service_id = "service-123"
+    mocker.patch(
+        "app.celery.service_callback_suspension_tasks.dao_fetch_service_by_id",
+        return_value=SimpleNamespace(id=service_id, name="Platform service"),
+    )
+    mock_send_to_service_users = mocker.patch("app.celery.service_callback_suspension_tasks.send_notification_to_service_users")
+    mock_send_to_email_address = mocker.patch("app.celery.service_callback_suspension_tasks.send_notification_to_email_address")
+
+    with set_config_values(
+        notify_api,
+        {
+            "NOTIFY_ENVIRONMENT": "production",
+            "FRESHDESK_SUPPORT_EMAIL_ID": "assistance+notification@cds-snc.ca",
+        },
+    ):
+        send_service_callback_suspension_email(service_id=service_id)
+
+    expected_personalisation = {
+        "service_name": "Platform service",
+        "service_id": service_id,
+    }
+
+    mock_send_to_service_users.assert_called_once_with(
+        service_id=service_id,
+        template_id=notify_api.config["SERVICE_CALLBACK_SUSPENDED_TEMPLATE_ID"],
+        personalisation=expected_personalisation,
+        include_user_fields=["name"],
+    )
+    mock_send_to_email_address.assert_called_once_with(
+        email_address="assistance+notification@cds-snc.ca",
+        template_id=notify_api.config["SERVICE_CALLBACK_SUSPENDED_TEMPLATE_ID"],
+        personalisation={**expected_personalisation, "name": "Freshdesk support"},
+    )
+
+
+def test_send_service_callback_suspension_email_does_not_send_support_copy_outside_production(notify_api, mocker):
+    service_id = "service-123"
+    mocker.patch(
+        "app.celery.service_callback_suspension_tasks.dao_fetch_service_by_id",
+        return_value=SimpleNamespace(id=service_id, name="Platform service"),
+    )
+    mock_send_to_service_users = mocker.patch("app.celery.service_callback_suspension_tasks.send_notification_to_service_users")
+    mock_send_to_email_address = mocker.patch("app.celery.service_callback_suspension_tasks.send_notification_to_email_address")
+
+    with set_config_values(
+        notify_api,
+        {
+            "NOTIFY_ENVIRONMENT": "staging",
+            "FRESHDESK_SUPPORT_EMAIL_ID": "assistance+notification@cds-snc.ca",
+        },
+    ):
+        send_service_callback_suspension_email(service_id=service_id)
+
+    mock_send_to_service_users.assert_called_once()
+    mock_send_to_email_address.assert_not_called()

--- a/tests/app/celery/test_service_callback_tasks.py
+++ b/tests/app/celery/test_service_callback_tasks.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 import pytest
 import requests_mock
+from flask import current_app
 from freezegun import freeze_time
 from tests.app.db import (
     create_complaint,
@@ -15,6 +16,7 @@ from tests.app.db import (
 
 from app import DATETIME_FORMAT, signer_complaint, signer_delivery_status
 from app.celery.service_callback_tasks import (
+    _calculate_callback_retry_countdown,
     send_complaint_to_service,
     send_delivery_status_to_service,
 )
@@ -109,12 +111,38 @@ def test__send_data_to_service_callback_api_retries_if_request_returns_error_cod
     )
     signed_data = _set_up_data_for_status_update(callback_api, notification)
     mocked = mocker.patch("app.celery.service_callback_tasks.send_delivery_status_to_service.retry")
+    mocker.patch("app.celery.service_callback_tasks.random.uniform", return_value=5)
     with requests_mock.Mocker() as request_mock:
         request_mock.post(callback_api.url, json={}, status_code=status_code)
         send_delivery_status_to_service(notification.id, signed_status_update=signed_data, service_id=notification.service_id)
 
     assert mocked.call_count == 1
     assert mocked.call_args[1]["queue"] == "service-callbacks-retry"
+    assert mocked.call_args[1]["countdown"] == 5
+
+
+def test_calculate_callback_retry_countdown_uses_exponential_backoff_and_cap(notify_db_session):
+    current_app.config["CALLBACK_RETRY_BACKOFF_BASE_SECONDS"] = 5
+    current_app.config["CALLBACK_RETRY_BACKOFF_MAX_SECONDS"] = 20
+    current_app.config["CALLBACK_RETRY_JITTER_FACTOR"] = 0.0
+
+    assert _calculate_callback_retry_countdown(retries=0) == 5
+    assert _calculate_callback_retry_countdown(retries=1) == 10
+    assert _calculate_callback_retry_countdown(retries=2) == 20
+    assert _calculate_callback_retry_countdown(retries=3) == 20
+
+
+def test_calculate_callback_retry_countdown_applies_jitter_with_expected_bounds(notify_db_session, mocker):
+    current_app.config["CALLBACK_RETRY_BACKOFF_BASE_SECONDS"] = 10
+    current_app.config["CALLBACK_RETRY_BACKOFF_MAX_SECONDS"] = 300
+    current_app.config["CALLBACK_RETRY_JITTER_FACTOR"] = 0.2
+
+    mocked_uniform = mocker.patch("app.celery.service_callback_tasks.random.uniform", return_value=13.1)
+
+    countdown = _calculate_callback_retry_countdown(retries=0)
+
+    mocked_uniform.assert_called_once_with(8.0, 12.0)
+    assert countdown == 13
 
 
 @pytest.mark.parametrize("notification_type", ["email", "letter", "sms"])

--- a/tests/app/celery/test_service_callback_tasks.py
+++ b/tests/app/celery/test_service_callback_tasks.py
@@ -121,6 +121,91 @@ def test__send_data_to_service_callback_api_retries_if_request_returns_error_cod
     assert mocked.call_args[1]["countdown"] == 5
 
 
+def test_send_delivery_status_to_service_suspends_callback_and_sends_email_when_retries_exhausted(
+    notify_db_session,
+    notify_api,
+    mocker,
+):
+    callback_api, template = _set_up_test_data("email", "delivery_status")
+    datestr = datetime(2017, 6, 20)
+    notification = save_notification(
+        create_notification(
+            template=template,
+            created_at=datestr,
+            updated_at=datestr,
+            sent_at=datestr,
+            status="sent",
+        )
+    )
+    signed_data = _set_up_data_for_status_update(callback_api, notification)
+
+    mocker.patch(
+        "app.celery.service_callback_tasks.send_delivery_status_to_service.retry",
+        side_effect=send_delivery_status_to_service.MaxRetriesExceededError(),
+    )
+    mocker.patch("app.celery.service_callback_tasks.random.uniform", return_value=5)
+    mocked_suspend = mocker.patch("app.celery.service_callback_tasks.suspend_unsuspend_service_callback_api")
+    mocked_send_task = mocker.patch("app.celery.service_callback_tasks.notify_celery.send_task")
+
+    with requests_mock.Mocker() as request_mock:
+        request_mock.post(callback_api.url, json={}, status_code=500)
+        send_delivery_status_to_service(notification.id, signed_status_update=signed_data, service_id=notification.service_id)
+
+    mocked_suspend.assert_called_once()
+    suspend_call = mocked_suspend.call_args
+    assert suspend_call[0][0].id == callback_api.id
+    assert suspend_call[1]["updated_by_id"] == notify_api.config["NOTIFY_USER_ID"]
+    assert suspend_call[1]["suspend"] is True
+
+    mocked_send_task.assert_called_once_with(
+        "send-service-callback-suspension-email",
+        kwargs={"service_id": str(notification.service_id)},
+        queue="notify-internal-tasks",
+    )
+
+
+def test_send_delivery_status_to_service_does_not_send_suspension_email_if_callback_already_suspended(
+    notify_db_session,
+    mocker,
+):
+    service = create_service(restricted=True)
+    template = create_template(service=service, template_type="email", subject="Hello")
+    callback_api = create_service_callback_api(
+        service=service,
+        url="https://some.service.gov.uk/",
+        bearer_token="something_unique",
+        callback_type="delivery_status",
+        is_suspended=True,
+    )
+
+    datestr = datetime(2017, 6, 20)
+    notification = save_notification(
+        create_notification(
+            template=template,
+            created_at=datestr,
+            updated_at=datestr,
+            sent_at=datestr,
+            status="sent",
+        )
+    )
+    signed_data = _set_up_data_for_status_update(callback_api, notification)
+
+    mocker.patch(
+        "app.celery.service_callback_tasks.send_delivery_status_to_service.retry",
+        side_effect=send_delivery_status_to_service.MaxRetriesExceededError(),
+    )
+    mocker.patch("app.celery.service_callback_tasks.random.uniform", return_value=5)
+    mocked_suspend = mocker.patch("app.celery.service_callback_tasks.suspend_unsuspend_service_callback_api")
+    mocked_send_task = mocker.patch("app.celery.service_callback_tasks.notify_celery.send_task")
+
+    with requests_mock.Mocker() as request_mock:
+        request_mock.post(callback_api.url, json={}, status_code=500)
+        send_delivery_status_to_service(notification.id, signed_status_update=signed_data, service_id=notification.service_id)
+
+    mocked_suspend.assert_not_called()
+    mocked_send_task.assert_not_called()
+
+
 def test_calculate_callback_retry_countdown_uses_exponential_backoff_and_cap(notify_db_session, notify_api):
     with set_config_values(
         notify_api,

--- a/tests/app/celery/test_service_callback_tasks.py
+++ b/tests/app/celery/test_service_callback_tasks.py
@@ -121,10 +121,16 @@ def test__send_data_to_service_callback_api_retries_if_request_returns_error_cod
     assert mocked.call_args[1]["countdown"] == 5
 
 
-def test_calculate_callback_retry_countdown_uses_exponential_backoff_and_cap(notify_db_session):
-    current_app.config["CALLBACK_RETRY_BACKOFF_BASE_SECONDS"] = 5
-    current_app.config["CALLBACK_RETRY_BACKOFF_MAX_SECONDS"] = 20
-    current_app.config["CALLBACK_RETRY_JITTER_FACTOR"] = 0.0
+def test_calculate_callback_retry_countdown_uses_exponential_backoff_and_cap(notify_db_session, mocker):
+    mocker.patch.dict(
+        current_app.config,
+        {
+            "CALLBACK_RETRY_BACKOFF_BASE_SECONDS": 5,
+            "CALLBACK_RETRY_BACKOFF_MAX_SECONDS": 20,
+            "CALLBACK_RETRY_JITTER_FACTOR": 0.0,
+        },
+        clear=False,
+    )
 
     assert _calculate_callback_retry_countdown(retries=0) == 5
     assert _calculate_callback_retry_countdown(retries=1) == 10

--- a/tests/app/celery/test_service_callback_tasks.py
+++ b/tests/app/celery/test_service_callback_tasks.py
@@ -3,7 +3,6 @@ from datetime import datetime
 
 import pytest
 import requests_mock
-from flask import current_app
 from freezegun import freeze_time
 from tests.app.db import (
     create_complaint,
@@ -13,6 +12,7 @@ from tests.app.db import (
     create_template,
     save_notification,
 )
+from tests.conftest import set_config_values
 
 from app import DATETIME_FORMAT, signer_complaint, signer_delivery_status
 from app.celery.service_callback_tasks import (
@@ -121,34 +121,36 @@ def test__send_data_to_service_callback_api_retries_if_request_returns_error_cod
     assert mocked.call_args[1]["countdown"] == 5
 
 
-def test_calculate_callback_retry_countdown_uses_exponential_backoff_and_cap(notify_db_session, mocker):
-    mocker.patch.dict(
-        current_app.config,
+def test_calculate_callback_retry_countdown_uses_exponential_backoff_and_cap(notify_db_session, notify_api):
+    with set_config_values(
+        notify_api,
         {
             "CALLBACK_RETRY_BACKOFF_BASE_SECONDS": 5,
             "CALLBACK_RETRY_BACKOFF_MAX_SECONDS": 20,
             "CALLBACK_RETRY_JITTER_FACTOR": 0.0,
         },
-        clear=False,
-    )
-
-    assert _calculate_callback_retry_countdown(retries=0) == 5
-    assert _calculate_callback_retry_countdown(retries=1) == 10
-    assert _calculate_callback_retry_countdown(retries=2) == 20
-    assert _calculate_callback_retry_countdown(retries=3) == 20
+    ):
+        assert _calculate_callback_retry_countdown(retries=0) == 5
+        assert _calculate_callback_retry_countdown(retries=1) == 10
+        assert _calculate_callback_retry_countdown(retries=2) == 20
+        assert _calculate_callback_retry_countdown(retries=3) == 20
 
 
-def test_calculate_callback_retry_countdown_applies_jitter_with_expected_bounds(notify_db_session, mocker):
-    current_app.config["CALLBACK_RETRY_BACKOFF_BASE_SECONDS"] = 10
-    current_app.config["CALLBACK_RETRY_BACKOFF_MAX_SECONDS"] = 300
-    current_app.config["CALLBACK_RETRY_JITTER_FACTOR"] = 0.2
+def test_calculate_callback_retry_countdown_applies_jitter_with_expected_bounds(notify_db_session, notify_api, mocker):
+    with set_config_values(
+        notify_api,
+        {
+            "CALLBACK_RETRY_BACKOFF_BASE_SECONDS": 10,
+            "CALLBACK_RETRY_BACKOFF_MAX_SECONDS": 300,
+            "CALLBACK_RETRY_JITTER_FACTOR": 0.2,
+        },
+    ):
+        mocked_uniform = mocker.patch("app.celery.service_callback_tasks.random.uniform", return_value=13.1)
 
-    mocked_uniform = mocker.patch("app.celery.service_callback_tasks.random.uniform", return_value=13.1)
+        countdown = _calculate_callback_retry_countdown(retries=0)
 
-    countdown = _calculate_callback_retry_countdown(retries=0)
-
-    mocked_uniform.assert_called_once_with(8.0, 12.0)
-    assert countdown == 13
+        mocked_uniform.assert_called_once_with(8.0, 12.0)
+        assert countdown == 13
 
 
 @pytest.mark.parametrize("notification_type", ["email", "letter", "sms"])

--- a/tests/app/notifications/test_callbacks.py
+++ b/tests/app/notifications/test_callbacks.py
@@ -7,6 +7,7 @@ from app.notifications.callbacks import (
     create_complaint_callback_data,
     create_delivery_status_callback_data,
 )
+from app.notifications.notifications_ses_callback import _check_and_queue_complaint_callback_task
 from tests.app.conftest import create_sample_notification
 from tests.app.db import create_complaint, create_service_callback_api
 
@@ -116,4 +117,60 @@ def test_check_and_queue_callback_task_does_not_call_delivery_task_when_notifica
 
     with patch("app.notifications.callbacks.send_delivery_status_to_service.apply_async") as mock_apply_async:
         _check_and_queue_callback_task(None)
+        mock_apply_async.assert_not_called()
+
+
+def test_check_and_queue_complaint_callback_task_calls_complaint_task(
+    notify_db,
+    notify_db_session,
+    sample_email_template,
+):
+    notification = create_sample_notification(
+        notify_db,
+        notify_db_session,
+        template=sample_email_template,
+        status="delivered",
+        sent_at=datetime.utcnow(),
+    )
+    complaint = create_complaint(notification=notification, service=notification.service)
+    callback_api = create_service_callback_api(
+        service=sample_email_template.service,
+        url="https://original_url.com",
+        callback_type="complaint",
+    )
+
+    with patch("app.notifications.notifications_ses_callback.send_complaint_to_service.apply_async") as mock_apply_async:
+        _check_and_queue_complaint_callback_task(complaint, notification, "recipient@example.com")
+
+        mock_apply_async.assert_called_once_with(
+            [
+                create_complaint_callback_data(complaint, notification, callback_api, "recipient@example.com"),
+                notification.service_id,
+            ],
+            queue="service-callbacks",
+        )
+
+
+def test_check_and_queue_complaint_callback_task_does_not_call_complaint_task_when_suspended(
+    notify_db,
+    notify_db_session,
+    sample_email_template,
+):
+    notification = create_sample_notification(
+        notify_db,
+        notify_db_session,
+        template=sample_email_template,
+        status="delivered",
+        sent_at=datetime.utcnow(),
+    )
+    complaint = create_complaint(notification=notification, service=notification.service)
+    create_service_callback_api(
+        service=sample_email_template.service,
+        url="https://original_url.com",
+        callback_type="complaint",
+        is_suspended=True,
+    )
+
+    with patch("app.notifications.notifications_ses_callback.send_complaint_to_service.apply_async") as mock_apply_async:
+        _check_and_queue_complaint_callback_task(complaint, notification, "recipient@example.com")
         mock_apply_async.assert_not_called()


### PR DESCRIPTION
## Summary
This PR makes complaint callback queueing consistent with delivery callback queueing by honoring callback suspension state before enqueueing outbound complaint callbacks.

## Why
A service-level callback suspension should block all outbound callbacks for that callback type. Before this change, complaint callbacks could still be queued even when suspended.

## What changed

1. Added a suspension guard in notifications_ses_callback.py:209.
1. If the complaint callback config is suspended, the code now logs and returns early instead of queueing.
1. Added tests in test_callbacks.py:123 and test_callbacks.py:154 to verify:
- complaint callback is queued when active
- complaint callback is not queued when suspended

### Behavior before
Complaint callbacks could still be enqueued while the service complaint callback was suspended.

### Behavior after
Complaint callbacks are not enqueued when suspended, matching delivery callback suspension behavior.

