### PR TITLE
PR3: automate callback suspension

### DIFF
--- a/app/notifications/notifications_ses_callback.py
+++ b/app/notifications/notifications_ses_callback.py
@@ -207,8 +207,15 @@ def remove_emails_from_complaint(complaint_dict):
 
 
 def _check_and_queue_complaint_callback_task(complaint, notification, recipient):
-    # queue callback task only if the service_callback_api exists
+    # queue callback task only if the service_callback_api exists and is not suspended
     service_callback_api = get_service_complaint_callback_api_for_service(service_id=notification.service_id)
     if service_callback_api:
+        if service_callback_api.is_suspended:
+            current_app.logger.warning(
+                f"Service complaint callback API: {service_callback_api.id} for service: {notification.service_id} is suspended. "
+                f"Cannot queue complaint callback task for notification: {notification.id}"
+            )
+            return
+
         complaint_data = create_complaint_callback_data(complaint, notification, service_callback_api, recipient)
         send_complaint_to_service.apply_async([complaint_data, notification.service_id], queue=QueueNames.CALLBACKS)

--- a/tests/app/notifications/test_callbacks.py
+++ b/tests/app/notifications/test_callbacks.py
@@ -7,6 +7,7 @@ from app.notifications.callbacks import (
     create_complaint_callback_data,
     create_delivery_status_callback_data,
 )
+from app.notifications.notifications_ses_callback import _check_and_queue_complaint_callback_task
 from tests.app.conftest import create_sample_notification
 from tests.app.db import create_complaint, create_service_callback_api
 
@@ -116,4 +117,60 @@ def test_check_and_queue_callback_task_does_not_call_delivery_task_when_notifica
 
     with patch("app.notifications.callbacks.send_delivery_status_to_service.apply_async") as mock_apply_async:
         _check_and_queue_callback_task(None)
+        mock_apply_async.assert_not_called()
+
+
+def test_check_and_queue_complaint_callback_task_calls_complaint_task(
+    notify_db,
+    notify_db_session,
+    sample_email_template,
+):
+    notification = create_sample_notification(
+        notify_db,
+        notify_db_session,
+        template=sample_email_template,
+        status="delivered",
+        sent_at=datetime.utcnow(),
+    )
+    complaint = create_complaint(notification=notification, service=notification.service)
+    callback_api = create_service_callback_api(
+        service=sample_email_template.service,
+        url="https://original_url.com",
+        callback_type="complaint",
+    )
+
+    with patch("app.notifications.notifications_ses_callback.send_complaint_to_service.apply_async") as mock_apply_async:
+        _check_and_queue_complaint_callback_task(complaint, notification, "recipient@example.com")
+
+        mock_apply_async.assert_called_once_with(
+            [
+                create_complaint_callback_data(complaint, notification, callback_api, "recipient@example.com"),
+                notification.service_id,
+            ],
+            queue="service-callbacks",
+        )
+
+
+def test_check_and_queue_complaint_callback_task_does_not_call_complaint_task_when_suspended(
+    notify_db,
+    notify_db_session,
+    sample_email_template,
+):
+    notification = create_sample_notification(
+        notify_db,
+        notify_db_session,
+        template=sample_email_template,
+        status="delivered",
+        sent_at=datetime.utcnow(),
+    )
+    complaint = create_complaint(notification=notification, service=notification.service)
+    create_service_callback_api(
+        service=sample_email_template.service,
+        url="https://original_url.com",
+        callback_type="complaint",
+        is_suspended=True,
+    )
+
+    with patch("app.notifications.notifications_ses_callback.send_complaint_to_service.apply_async") as mock_apply_async:
+        _check_and_queue_complaint_callback_task(complaint, notification, "recipient@example.com")
         mock_apply_async.assert_not_called()


### PR DESCRIPTION
## Summary
This PR makes complaint callback queueing consistent with delivery callback queueing by honoring callback suspension state before enqueueing outbound complaint callbacks.

## Why
A service-level callback suspension should block all outbound callbacks for that callback type. Before this change, complaint callbacks could still be queued even when suspended.

## What changed

1. Added a suspension guard in notifications_ses_callback.py:209.
1. If the complaint callback config is suspended, the code now logs and returns early instead of queueing.
1. Added tests in test_callbacks.py:123 and test_callbacks.py:154 to verify:
- complaint callback is queued when active
- complaint callback is not queued when suspended

### Behavior before
Complaint callbacks could still be enqueued while the service complaint callback was suspended.

### Behavior after
Complaint callbacks are not enqueued when suspended, matching delivery callback suspension behavior.

### Tests:
We are going to test suspending callbacks locally.

1. Go to beeceptor https://app.beeceptor.com/
2. Set it up so that you are changing the POST to return a 500/503 (you can add a wait time of 12s too)
3. Run the application with:
```make dev```
```CALLBACK_RETRY_BACKOFF_BASE_SECONDS=1 \
CALLBACK_RETRY_BACKOFF_MAX_SECONDS=1 \
CALLBACK_RETRY_JITTER_FACTOR=0 \
make run-celery-local-filtered
```
4. Go to localhost : 
### VERY important - you need to use a "TEST" KEY TYPE. This will create a mock of a response for sns/ ses
Send 10 or so notifications
5. You should see errors on beeceptor
6. You can see admin or DB:
```
select id, callback_type, url, is_suspended, suspended_at
from service_callback_api
where service_id = ''
```
the callback URL should be suspended and you should have received an email