### PR TITLE
Feat/add bulk status endpoints

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -336,6 +336,7 @@ def register_v2_blueprints(application):
         v2_manage_template_blueprint,
     )
     from app.v2.notifications import (  # noqa
+        get_bulk_jobs,
         get_notifications,
         post_notifications,
         v2_notification_blueprint,

--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -53,9 +53,13 @@ def dao_get_notification_outcomes_for_job_batch(service_id, job_ids):
 
 
 def dao_get_job_statistics_for_jobs(jobs):
-    """Return notification statistics grouped by job ID for a collection of jobs."""
+    """Return statistics for jobs from a single service, grouped by job ID."""
     if not jobs:
         return {}
+
+    service_ids = {job.service_id for job in jobs}
+    if len(service_ids) > 1:
+        raise ValueError("Job statistics must be requested for one service at a time")
 
     cutoff = midnight_n_days_ago(3)
     recent_job_ids = [job.id for job in jobs if job.processing_started and job.processing_started >= cutoff]

--- a/app/dao/jobs_dao.py
+++ b/app/dao/jobs_dao.py
@@ -12,6 +12,7 @@ from sqlalchemy import asc, desc, func
 from app import db
 from app.dao.dao_utils import transactional
 from app.dao.date_util import get_query_date_based_on_retention_period
+from app.dao.fact_notification_status_dao import fetch_notification_statuses_for_job_batch
 from app.dao.templates_dao import dao_get_template_by_id
 from app.models import (
     JOB_STATUS_CANCELLED,
@@ -28,6 +29,7 @@ from app.models import (
     ServiceDataRetention,
     Template,
 )
+from app.utils import midnight_n_days_ago
 
 
 @statsd(namespace="dao")
@@ -48,6 +50,29 @@ def dao_get_notification_outcomes_for_job_batch(service_id, job_ids):
         .group_by(Notification.job_id, Notification.status)
         .all()
     )
+
+
+def dao_get_job_statistics_for_jobs(jobs):
+    """Return notification statistics grouped by job ID for a collection of jobs."""
+    if not jobs:
+        return {}
+
+    cutoff = midnight_n_days_ago(3)
+    recent_job_ids = [job.id for job in jobs if job.processing_started and job.processing_started >= cutoff]
+    old_job_ids = [job.id for job in jobs if job.processing_started and job.processing_started < cutoff]
+    statistics_by_job = {}
+
+    if recent_job_ids:
+        statistics = dao_get_notification_outcomes_for_job_batch(jobs[0].service_id, recent_job_ids)
+        for job_id, status, count in statistics:
+            statistics_by_job.setdefault(job_id, []).append({"status": status, "count": count})
+
+    if old_job_ids:
+        statistics = fetch_notification_statuses_for_job_batch(jobs[0].service_id, old_job_ids)
+        for job_id, status, count in statistics:
+            statistics_by_job.setdefault(job_id, []).append({"status": status, "count": count})
+
+    return statistics_by_job
 
 
 @statsd(namespace="dao")
@@ -80,6 +105,23 @@ def dao_get_jobs_by_service_id(service_id, limit_days=None, page=1, page_size=50
     if statuses is not None and statuses != [""]:
         query_filter.append(Job.job_status.in_(statuses))
     return Job.query.filter(*query_filter).order_by(Job.created_at.desc()).paginate(page=page, per_page=page_size)
+
+
+def dao_get_bulk_jobs_for_service(service_id, older_than=None, page_size=50):
+    filters = [Job.service_id == service_id]
+
+    if older_than:
+        older_than_row = (
+            db.session.query(Job.created_at, Job.id).filter(Job.id == older_than, Job.service_id == service_id).subquery()
+        )
+        filters.append(
+            db.or_(
+                Job.created_at < older_than_row.c.created_at,
+                db.and_(Job.created_at == older_than_row.c.created_at, Job.id < older_than_row.c.id),
+            )
+        )
+
+    return Job.query.filter(*filters).order_by(Job.created_at.desc(), Job.id.desc()).paginate(per_page=page_size, count=False)
 
 
 def dao_get_job_by_id(job_id) -> Job:

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -278,7 +278,7 @@ def get_paginated_jobs(service_id, limit_days, statuses, page, page_size=None):
         job_data["statistics"] = statistics_by_job.get(uuid.UUID(job_data["id"]), [])
 
     end_time = time.time()
-    current_app.logger.info(f"[get_paginated_jobs] took {"{:.3f}".format(end_time - start_time)} seconds")
+    current_app.logger.info(f"[get_paginated_jobs] took {end_time - start_time:.3f} seconds")
 
     # Build extra kwargs so pagination links preserve all original query params.
     link_kwargs = {"service_id": service_id}

--- a/app/job/rest.py
+++ b/app/job/rest.py
@@ -2,7 +2,6 @@ import time
 import uuid
 from datetime import datetime
 
-import dateutil
 from flask import Blueprint, current_app, jsonify, request
 from notifications_utils.recipients import RecipientCSV
 from notifications_utils.template import Template
@@ -11,16 +10,15 @@ from app.annual_limit_utils import get_annual_limit_notifications_v2
 from app.aws.s3 import get_job_from_s3, get_job_metadata_from_s3
 from app.celery.tasks import process_job
 from app.config import QueueNames
-from app.dao.fact_notification_status_dao import fetch_notification_statuses_for_job_batch
 from app.dao.jobs_dao import (
     can_letter_job_be_cancelled,
     dao_cancel_letter_job,
     dao_create_job,
     dao_get_future_scheduled_job_by_id_and_service_id,
     dao_get_job_by_service_id_and_job_id,
+    dao_get_job_statistics_for_jobs,
     dao_get_jobs_by_service_id,
     dao_get_notification_outcomes_for_job,
-    dao_get_notification_outcomes_for_job_batch,
     dao_service_has_jobs,
     dao_update_job,
 )
@@ -53,7 +51,7 @@ from app.schemas import (
     notifications_filter_schema,
     unarchived_template_schema,
 )
-from app.utils import midnight_n_days_ago, pagination_links
+from app.utils import pagination_links
 
 job_blueprint = Blueprint("job", __name__, url_prefix="/service/<uuid:service_id>/job")
 
@@ -275,52 +273,9 @@ def get_paginated_jobs(service_id, limit_days, statuses, page, page_size=None):
     )
     data = job_schema.dump(pagination.items, many=True)
 
-    cutoff = midnight_n_days_ago(3)
-    recent_job_ids = []
-    old_job_ids = []
-
-    # Find jobs < the cutoff (ft_notification_status) and those within the cutoff (notifications/notification_history)
-    # Categorize them into recent and old jobs based on their processing_started date
-    for job_data in data:  # TODO: figure out what idx is, job_id?
-        raw_start = job_data["processing_started"]
-        start = dateutil.parser.parse(raw_start).replace(tzinfo=None) if raw_start else None
-        # Temporarily store the parsed start time to avoid parsing it again later during stat assignment
-        job_data["_parsed_start"] = start
-
-        if start is None:
-            job_data["statistics"] = []
-            continue
-        if start < cutoff:
-            old_job_ids.append(job_data["id"])
-        else:
-            recent_job_ids.append(job_data["id"])
-
-    # Fetch statistics for recent and old jobs in batches instead of job by job to reduce # of DB queries
-    recent_stats = {}
-    if recent_job_ids:
-        stats = dao_get_notification_outcomes_for_job_batch(service_id, recent_job_ids)
-        for job_id, status, count in stats:
-            recent_stats.setdefault(job_id, []).append({"status": status, "count": count})
-
-    old_stats = {}
-    if old_job_ids:
-        stats = fetch_notification_statuses_for_job_batch(service_id, old_job_ids)
-        for job_id, status, count in stats:
-            old_stats.setdefault(job_id, []).append({"status": status, "count": count})
-
-    # Assign statistics to each job
+    statistics_by_job = dao_get_job_statistics_for_jobs(pagination.items)
     for job_data in data:
-        job_id = job_data["id"]
-        start = job_data.get("_parsed_start")
-
-        if start is None:
-            # We set this in the first loop so we can just skip it here
-            continue
-        elif start < cutoff:
-            job_data["statistics"] = old_stats.get(uuid.UUID(job_id), [])
-        else:
-            job_data["statistics"] = recent_stats.get(uuid.UUID(job_id), [])
-        del job_data["_parsed_start"]  # Clean up that temporary field
+        job_data["statistics"] = statistics_by_job.get(uuid.UUID(job_data["id"]), [])
 
     end_time = time.time()
     current_app.logger.info(f"[get_paginated_jobs] took {"{:.3f}".format(end_time - start_time)} seconds")

--- a/app/v2/errors.py
+++ b/app/v2/errors.py
@@ -148,6 +148,14 @@ class TemplateCategoryNotFoundError(BadRequestError):
         super().__init__(message=self.__class__.message)
 
 
+class JobNotFoundError(InvalidRequest):
+    status_code = 404
+    message = "Job not found in database"
+
+    def __init__(self):
+        super().__init__(message=self.__class__.message, status_code=self.__class__.status_code)
+
+
 class ReportRateLimitError(InvalidRequest):
     status_code = 429
 

--- a/app/v2/notifications/get_bulk_jobs.py
+++ b/app/v2/notifications/get_bulk_jobs.py
@@ -11,6 +11,7 @@ from app.dao.jobs_dao import (
 from app.errors import InvalidRequest
 from app.schema_validation import validate
 from app.schemas import job_schema
+from app.v2.errors import JobNotFoundError
 from app.v2.notifications import v2_notification_blueprint
 from app.v2.notifications.notification_schemas import (
     get_bulk_job_request,
@@ -24,7 +25,7 @@ def get_bulk_job(job_id):
     job = dao_get_job_by_service_id_and_job_id(authenticated_service.id, job_id)
 
     if job is None:
-        return jsonify(result="error", message="Job not found in database"), 404
+        raise JobNotFoundError()
 
     data = _serialize_jobs_with_statistics([job])[0]
     return jsonify(data=data), 200

--- a/app/v2/notifications/get_bulk_jobs.py
+++ b/app/v2/notifications/get_bulk_jobs.py
@@ -1,0 +1,69 @@
+import uuid
+
+from flask import current_app, jsonify, request, url_for
+
+from app import authenticated_service
+from app.dao.jobs_dao import (
+    dao_get_bulk_jobs_for_service,
+    dao_get_job_by_service_id_and_job_id,
+    dao_get_job_statistics_for_jobs,
+)
+from app.errors import InvalidRequest
+from app.schema_validation import validate
+from app.schemas import job_schema
+from app.v2.notifications import v2_notification_blueprint
+from app.v2.notifications.notification_schemas import (
+    get_bulk_job_request,
+    get_bulk_jobs_request,
+)
+
+
+@v2_notification_blueprint.route("/bulk/<job_id>", methods=["GET"])
+def get_bulk_job(job_id):
+    validate({"job_id": job_id}, get_bulk_job_request)
+    job = dao_get_job_by_service_id_and_job_id(authenticated_service.id, job_id)
+
+    if job is None:
+        return jsonify(result="error", message="Job not found in database"), 404
+
+    data = _serialize_jobs_with_statistics([job])[0]
+    return jsonify(data=data), 200
+
+
+@v2_notification_blueprint.route("/bulk", methods=["GET"])
+def get_bulk_jobs():
+    data = validate(request.args.to_dict(), get_bulk_jobs_request)
+    if data.get("older_than") and dao_get_job_by_service_id_and_job_id(authenticated_service.id, data["older_than"]) is None:
+        raise InvalidRequest({"older_than": ["Job does not exist for this service"]}, status_code=400)
+
+    paginated_jobs = dao_get_bulk_jobs_for_service(
+        authenticated_service.id,
+        older_than=data.get("older_than"),
+        page_size=current_app.config.get("API_PAGE_SIZE"),
+    )
+    jobs = _serialize_jobs_with_statistics(paginated_jobs.items)
+
+    links = {
+        "current": url_for("v2_notifications.get_bulk_jobs", _external=True, **data),
+    }
+    if paginated_jobs.items:
+        links["next"] = url_for(
+            "v2_notifications.get_bulk_jobs",
+            _external=True,
+            older_than=paginated_jobs.items[-1].id,
+        )
+
+    return jsonify(bulk_jobs=jobs, links=links), 200
+
+
+def _serialize_jobs_with_statistics(jobs):
+    data = job_schema.dump(jobs, many=True)
+    if not jobs:
+        return data
+
+    statistics_by_job = dao_get_job_statistics_for_jobs(jobs)
+
+    for job_data in data:
+        job_data["statistics"] = statistics_by_job.get(uuid.UUID(job_data["id"]), [])
+
+    return data

--- a/app/v2/notifications/notification_schemas.py
+++ b/app/v2/notifications/notification_schemas.py
@@ -125,6 +125,27 @@ get_notifications_response = {
     "definitions": {"notification": get_notification_response},
 }
 
+get_bulk_job_request = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "schema for path parameters when getting a bulk job",
+    "type": "object",
+    "properties": {
+        "job_id": uuid,
+    },
+    "required": ["job_id"],
+    "additionalProperties": False,
+}
+
+get_bulk_jobs_request = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "schema for query parameters allowed when getting bulk jobs",
+    "type": "object",
+    "properties": {
+        "older_than": uuid,
+    },
+    "additionalProperties": False,
+}
+
 post_sms_request = {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "description": "POST sms notification schema",

--- a/app/v2/notifications/notification_schemas.py
+++ b/app/v2/notifications/notification_schemas.py
@@ -126,7 +126,7 @@ get_notifications_response = {
 }
 
 get_bulk_job_request = {
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
     "description": "schema for path parameters when getting a bulk job",
     "type": "object",
     "properties": {
@@ -137,7 +137,7 @@ get_bulk_job_request = {
 }
 
 get_bulk_jobs_request = {
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
     "description": "schema for query parameters allowed when getting bulk jobs",
     "type": "object",
     "properties": {

--- a/openapi/v2-notifications-api-en.yaml
+++ b/openapi/v2-notifications-api-en.yaml
@@ -1147,6 +1147,52 @@ paths:
 
 
   /v2/notifications/bulk:
+    get:
+      summary: Get list of bulk jobs
+      description: Retrieve a paginated list of bulk jobs and their statuses
+      operationId: getBulkNotificationJobs
+      tags:
+        - Notifications
+      parameters:
+        - name: older_than
+          in: query
+          description: Filter bulk jobs older than this job ID (UUID)
+          required: false
+          schema:
+            $ref: '#/components/schemas/UUID'
+      responses:
+        '200':
+          description: Successfully retrieved bulk jobs
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BulkJobsResponse'
+        '400':
+          description: Bad request - invalid cursor
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationErrorResponse'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+        - apiKey: []
     post:
       summary: Send a batch of notifications
       description: |
@@ -1660,6 +1706,61 @@ paths:
                 errors:
                   - error: "S3ReportDownloadError"
                     message: "Failed to retrieve report content"
+      security:
+        - apiKey: []
+
+
+  /v2/notifications/bulk/{job_id}:
+    get:
+      summary: Get bulk job by ID
+      description: Retrieve a bulk job and its current status
+      operationId: getBulkNotificationJobById
+      tags:
+        - Notifications
+      parameters:
+        - name: job_id
+          in: path
+          description: Unique identifier for the bulk job
+          required: true
+          schema:
+            $ref: '#/components/schemas/UUID'
+      responses:
+        '200':
+          description: Bulk job retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostBulkResponse'
+        '400':
+          description: Bad request - invalid job ID format
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationErrorResponse'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationErrorResponse'
+        '404':
+          description: Bulk job not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
       security:
         - apiKey: []
 
@@ -2334,6 +2435,112 @@ components:
               $ref: '#/components/schemas/UUID'
               nullable: true
               description: The ID of the sender used for this job, if applicable
+            statistics:
+              type: array
+              items:
+                type: object
+                required: [status, count]
+                properties:
+                  status:
+                    type: string
+                  count:
+                    type: integer
+
+    BulkJob:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/UUID'
+        original_file_name:
+          type: string
+        notification_count:
+          type: integer
+        template:
+          $ref: '#/components/schemas/UUID'
+        template_version:
+          type: integer
+        service:
+          $ref: '#/components/schemas/UUID'
+        created_by:
+          type: object
+          properties:
+            id:
+              $ref: '#/components/schemas/UUID'
+            name:
+              type: string
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+        job_status:
+          type: string
+          enum: ['pending', 'in progress', 'finished', 'sending limits exceeded', 'scheduled', 'cancelled', 'ready to send', 'sent to dvla', 'error']
+        scheduled_for:
+          type: string
+          format: date-time
+          nullable: true
+        processing_started:
+          type: string
+          format: date-time
+          nullable: true
+        processing_finished:
+          type: string
+          format: date-time
+          nullable: true
+        service_name:
+          type: object
+          properties:
+            name:
+              type: string
+        template_type:
+          type: string
+          enum: [email, sms]
+        api_key:
+          type: object
+          nullable: true
+          properties:
+            id:
+              $ref: '#/components/schemas/UUID'
+            name:
+              type: string
+            key_type:
+              type: string
+              enum: [normal, team, test]
+        archived:
+          type: boolean
+        sender_id:
+          $ref: '#/components/schemas/UUID'
+          nullable: true
+        statistics:
+          type: array
+          items:
+            type: object
+            required: [status, count]
+            properties:
+              status:
+                type: string
+              count:
+                type: integer
+      required:
+        - id
+        - job_status
+        - notification_count
+
+    BulkJobsResponse:
+      type: object
+      properties:
+        bulk_jobs:
+          type: array
+          items:
+            $ref: '#/components/schemas/BulkJob'
+        links:
+          $ref: '#/components/schemas/Links'
+      required:
+        - bulk_jobs
+        - links
 
     Report:
       type: object

--- a/openapi/v2-notifications-api-fr.yaml
+++ b/openapi/v2-notifications-api-fr.yaml
@@ -1147,6 +1147,52 @@ paths:
 
 
   /v2/notifications/bulk:
+    get:
+      summary: Get list of bulk jobs
+      description: Retrieve a paginated list of bulk jobs and their statuses
+      operationId: getBulkNotificationJobs
+      tags:
+        - Notifications
+      parameters:
+        - name: older_than
+          in: query
+          description: Filter bulk jobs older than this job ID (UUID)
+          required: false
+          schema:
+            $ref: '#/components/schemas/UUID'
+      responses:
+        '200':
+          description: Successfully retrieved bulk jobs
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BulkJobsResponse'
+        '400':
+          description: Bad request - invalid cursor
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationErrorResponse'
+        '401':
+          description: Non autorisé
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationErrorResponse'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationErrorResponse'
+        '500':
+          description: Erreur interne du serveur
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+        - apiKey: []
     post:
       summary: Envoyer un lot de notifications
       description: |
@@ -1660,6 +1706,61 @@ paths:
                 errors:
                   - error: "S3ReportDownloadError"
                     message: "Failed to retrieve report content"
+      security:
+        - apiKey: []
+
+
+  /v2/notifications/bulk/{job_id}:
+    get:
+      summary: Get bulk job by ID
+      description: Retrieve a bulk job and its current status
+      operationId: getBulkNotificationJobById
+      tags:
+        - Notifications
+      parameters:
+        - name: job_id
+          in: path
+          description: Unique identifier for the bulk job
+          required: true
+          schema:
+            $ref: '#/components/schemas/UUID'
+      responses:
+        '200':
+          description: Bulk job retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostBulkResponse'
+        '400':
+          description: Bad request - invalid job ID format
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationErrorResponse'
+        '401':
+          description: Non autorisé
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationErrorResponse'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationErrorResponse'
+        '404':
+          description: Bulk job not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Erreur interne du serveur
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
       security:
         - apiKey: []
 
@@ -2334,6 +2435,112 @@ components:
               $ref: '#/components/schemas/UUID'
               nullable: true
               description: ID de l’expéditeur utilisé pour cette tâche, si applicable
+            statistics:
+              type: array
+              items:
+                type: object
+                required: [status, count]
+                properties:
+                  status:
+                    type: string
+                  count:
+                    type: integer
+
+    BulkJob:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/UUID'
+        original_file_name:
+          type: string
+        notification_count:
+          type: integer
+        template:
+          $ref: '#/components/schemas/UUID'
+        template_version:
+          type: integer
+        service:
+          $ref: '#/components/schemas/UUID'
+        created_by:
+          type: object
+          properties:
+            id:
+              $ref: '#/components/schemas/UUID'
+            name:
+              type: string
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+        job_status:
+          type: string
+          enum: ['pending', 'in progress', 'finished', 'sending limits exceeded', 'scheduled', 'cancelled', 'ready to send', 'sent to dvla', 'error']
+        scheduled_for:
+          type: string
+          format: date-time
+          nullable: true
+        processing_started:
+          type: string
+          format: date-time
+          nullable: true
+        processing_finished:
+          type: string
+          format: date-time
+          nullable: true
+        service_name:
+          type: object
+          properties:
+            name:
+              type: string
+        template_type:
+          type: string
+          enum: [email, sms]
+        api_key:
+          type: object
+          nullable: true
+          properties:
+            id:
+              $ref: '#/components/schemas/UUID'
+            name:
+              type: string
+            key_type:
+              type: string
+              enum: [normal, team, test]
+        archived:
+          type: boolean
+        sender_id:
+          $ref: '#/components/schemas/UUID'
+          nullable: true
+        statistics:
+          type: array
+          items:
+            type: object
+            required: [status, count]
+            properties:
+              status:
+                type: string
+              count:
+                type: integer
+      required:
+        - id
+        - job_status
+        - notification_count
+
+    BulkJobsResponse:
+      type: object
+      properties:
+        bulk_jobs:
+          type: array
+          items:
+            $ref: '#/components/schemas/BulkJob'
+        links:
+          $ref: '#/components/schemas/Links'
+      required:
+        - bulk_jobs
+        - links
 
     Report:
       type: object

--- a/openapi/v2-notifications-api-fr.yaml
+++ b/openapi/v2-notifications-api-fr.yaml
@@ -1148,8 +1148,8 @@ paths:
 
   /v2/notifications/bulk:
     get:
-      summary: Get list of bulk jobs
-      description: Retrieve a paginated list of bulk jobs and their statuses
+      summary: Obtenir la liste des tâches de lot
+      description: Récupérer une liste paginée de tâches de lot et leurs statuts
       operationId: getBulkNotificationJobs
       tags:
         - Notifications
@@ -1712,8 +1712,8 @@ paths:
 
   /v2/notifications/bulk/{job_id}:
     get:
-      summary: Get bulk job by ID
-      description: Retrieve a bulk job and its current status
+      summary: Obtenir une tâche de lot par identifiant
+      description: Récupérer une tâche de lot et son statut actuel
       operationId: getBulkNotificationJobById
       tags:
         - Notifications

--- a/openapi/v2-notifications-api.yaml.j2
+++ b/openapi/v2-notifications-api.yaml.j2
@@ -1147,6 +1147,52 @@ paths:
 
 
   /v2/notifications/bulk:
+    get:
+      summary: {{ t("Get list of bulk jobs") }}
+      description: {{ t("Retrieve a paginated list of bulk jobs and their statuses") }}
+      operationId: getBulkNotificationJobs
+      tags:
+        - Notifications
+      parameters:
+        - name: older_than
+          in: query
+          description: {{ t("Filter bulk jobs older than this job ID (UUID)") }}
+          required: false
+          schema:
+            $ref: '#/components/schemas/UUID'
+      responses:
+        '200':
+          description: {{ t("Successfully retrieved bulk jobs") }}
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BulkJobsResponse'
+        '400':
+          description: {{ t("Bad request - invalid cursor") }}
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationErrorResponse'
+        '401':
+          description: {{ t("Unauthorized") }}
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationErrorResponse'
+        '403':
+          description: {{ t("Forbidden") }}
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationErrorResponse'
+        '500':
+          description: {{ t("Internal server error") }}
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+        - apiKey: []
     post:
       summary: {{ t("Send a batch of notifications") }}
       description: |
@@ -1660,6 +1706,61 @@ paths:
                 errors:
                   - error: "S3ReportDownloadError"
                     message: "Failed to retrieve report content"
+      security:
+        - apiKey: []
+
+
+  /v2/notifications/bulk/{job_id}:
+    get:
+      summary: {{ t("Get bulk job by ID") }}
+      description: {{ t("Retrieve a bulk job and its current status") }}
+      operationId: getBulkNotificationJobById
+      tags:
+        - Notifications
+      parameters:
+        - name: job_id
+          in: path
+          description: {{ t("Unique identifier for the bulk job") }}
+          required: true
+          schema:
+            $ref: '#/components/schemas/UUID'
+      responses:
+        '200':
+          description: {{ t("Bulk job retrieved successfully") }}
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostBulkResponse'
+        '400':
+          description: {{ t("Bad request - invalid job ID format") }}
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationErrorResponse'
+        '401':
+          description: {{ t("Unauthorized") }}
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationErrorResponse'
+        '403':
+          description: {{ t("Forbidden") }}
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationErrorResponse'
+        '404':
+          description: {{ t("Bulk job not found") }}
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: {{ t("Internal server error") }}
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
       security:
         - apiKey: []
 
@@ -2334,6 +2435,112 @@ components:
               $ref: '#/components/schemas/UUID'
               nullable: true
               description: {{ t("The ID of the sender used for this job, if applicable") }}
+            statistics:
+              type: array
+              items:
+                type: object
+                required: [status, count]
+                properties:
+                  status:
+                    type: string
+                  count:
+                    type: integer
+
+    BulkJob:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/UUID'
+        original_file_name:
+          type: string
+        notification_count:
+          type: integer
+        template:
+          $ref: '#/components/schemas/UUID'
+        template_version:
+          type: integer
+        service:
+          $ref: '#/components/schemas/UUID'
+        created_by:
+          type: object
+          properties:
+            id:
+              $ref: '#/components/schemas/UUID'
+            name:
+              type: string
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+        job_status:
+          type: string
+          enum: ['pending', 'in progress', 'finished', 'sending limits exceeded', 'scheduled', 'cancelled', 'ready to send', 'sent to dvla', 'error']
+        scheduled_for:
+          type: string
+          format: date-time
+          nullable: true
+        processing_started:
+          type: string
+          format: date-time
+          nullable: true
+        processing_finished:
+          type: string
+          format: date-time
+          nullable: true
+        service_name:
+          type: object
+          properties:
+            name:
+              type: string
+        template_type:
+          type: string
+          enum: [email, sms]
+        api_key:
+          type: object
+          nullable: true
+          properties:
+            id:
+              $ref: '#/components/schemas/UUID'
+            name:
+              type: string
+            key_type:
+              type: string
+              enum: [normal, team, test]
+        archived:
+          type: boolean
+        sender_id:
+          $ref: '#/components/schemas/UUID'
+          nullable: true
+        statistics:
+          type: array
+          items:
+            type: object
+            required: [status, count]
+            properties:
+              status:
+                type: string
+              count:
+                type: integer
+      required:
+        - id
+        - job_status
+        - notification_count
+
+    BulkJobsResponse:
+      type: object
+      properties:
+        bulk_jobs:
+          type: array
+          items:
+            $ref: '#/components/schemas/BulkJob'
+        links:
+          $ref: '#/components/schemas/Links'
+      required:
+        - bulk_jobs
+        - links
 
     Report:
       type: object

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -67,6 +67,16 @@ def test_dao_get_job_statistics_for_jobs_returns_no_entry_without_fact_rows(samp
     assert dao_get_job_statistics_for_jobs([job]) == {}
 
 
+def test_dao_get_job_statistics_for_jobs_rejects_jobs_from_multiple_services(sample_template):
+    other_service = create_service(service_name="Other statistics service")
+    other_template = create_template(service=other_service)
+    job = create_job(sample_template)
+    other_job = create_job(other_template)
+
+    with pytest.raises(ValueError, match="one service at a time"):
+        dao_get_job_statistics_for_jobs([job, other_job])
+
+
 def test_should_count_of_statuses_for_notifications_associated_with_job(sample_template, sample_job):
     save_notification(create_notification(sample_template, job=sample_job, status="created"))
     save_notification(create_notification(sample_template, job=sample_job, status="created"))

--- a/tests/app/dao/test_jobs_dao.py
+++ b/tests/app/dao/test_jobs_dao.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from functools import partial
 
 import pytest
@@ -11,6 +11,7 @@ from app.dao.jobs_dao import (
     dao_create_job,
     dao_get_future_scheduled_job_by_id_and_service_id,
     dao_get_job_by_service_id_and_job_id,
+    dao_get_job_statistics_for_jobs,
     dao_get_jobs_by_service_id,
     dao_get_jobs_older_than_data_retention,
     dao_get_notification_outcomes_for_job,
@@ -21,6 +22,7 @@ from app.dao.jobs_dao import (
 from app.dao.service_data_retention_dao import insert_service_data_retention
 from app.models import EMAIL_TYPE, LETTER_TYPE, SMS_TYPE, Job
 from tests.app.db import (
+    create_ft_notification_status,
     create_job,
     create_notification,
     create_notification_history,
@@ -32,6 +34,37 @@ from tests.app.db import (
 
 def test_should_have_decorated_notifications_dao_functions():
     assert dao_get_notification_outcomes_for_job.__wrapped__.__name__ == "dao_get_notification_outcomes_for_job"  # noqa
+
+
+@freeze_time("2026-08-18")
+def test_dao_get_job_statistics_for_jobs_uses_notifications_for_recent_jobs(sample_template):
+    job = create_job(sample_template, processing_started=datetime(2026, 8, 17))
+    save_notification(create_notification(template=sample_template, job=job, status="sending"))
+
+    assert dao_get_job_statistics_for_jobs([job]) == {job.id: [{"status": "sending", "count": 1}]}
+
+
+@freeze_time("2026-08-18")
+def test_dao_get_job_statistics_for_jobs_uses_facts_for_old_jobs(sample_template):
+    job = create_job(sample_template, processing_started=datetime(2026, 8, 5))
+    create_ft_notification_status(date(2026, 8, 5), template=sample_template, job=job, notification_status="delivered")
+
+    assert dao_get_job_statistics_for_jobs([job]) == {job.id: [{"status": "delivered", "count": 1}]}
+
+
+@freeze_time("2026-08-18")
+def test_dao_get_job_statistics_for_jobs_uses_facts_for_archived_jobs(sample_template):
+    job = create_job(sample_template, processing_started=datetime(2026, 8, 5), archived=True)
+    create_ft_notification_status(date(2026, 8, 5), template=sample_template, job=job, notification_status="temporary-failure")
+
+    assert dao_get_job_statistics_for_jobs([job]) == {job.id: [{"status": "temporary-failure", "count": 1}]}
+
+
+@freeze_time("2026-08-18")
+def test_dao_get_job_statistics_for_jobs_returns_no_entry_without_fact_rows(sample_template):
+    job = create_job(sample_template, processing_started=datetime(2026, 8, 5), archived=True)
+
+    assert dao_get_job_statistics_for_jobs([job]) == {}
 
 
 def test_should_count_of_statuses_for_notifications_associated_with_job(sample_template, sample_job):

--- a/tests/app/v2/notifications/test_get_bulk_jobs.py
+++ b/tests/app/v2/notifications/test_get_bulk_jobs.py
@@ -1,0 +1,114 @@
+from datetime import date, datetime
+
+from freezegun import freeze_time
+
+from tests import create_authorization_header
+from tests.app.db import (
+    create_ft_notification_status,
+    create_job,
+    create_notification,
+    create_service,
+    create_template,
+    save_notification,
+)
+
+
+def _get_headers(service_id):
+    return [create_authorization_header(service_id=service_id)]
+
+
+@freeze_time("2026-08-18")
+def test_get_bulk_job_returns_job_with_recent_statistics(client, sample_template):
+    job = create_job(sample_template, processing_started=datetime(2026, 8, 18))
+    save_notification(create_notification(template=sample_template, job=job, status="sending"))
+
+    response = client.get(f"/v2/notifications/bulk/{job.id}", headers=_get_headers(sample_template.service_id))
+
+    assert response.status_code == 200
+    assert response.get_json()["data"]["id"] == str(job.id)
+    assert response.get_json()["data"]["statistics"] == [{"status": "sending", "count": 1}]
+
+
+@freeze_time("2026-08-18")
+def test_get_bulk_job_returns_archived_job_with_old_statistics(client, sample_template):
+    job = create_job(sample_template, processing_started=datetime(2026, 8, 5), archived=True)
+    create_ft_notification_status(
+        date(2026, 8, 5),
+        template=sample_template,
+        job=job,
+        notification_status="temporary-failure",
+    )
+
+    response = client.get(f"/v2/notifications/bulk/{job.id}", headers=_get_headers(sample_template.service_id))
+
+    assert response.status_code == 200
+    assert response.get_json()["data"]["archived"] is True
+    assert response.get_json()["data"]["statistics"] == [{"status": "temporary-failure", "count": 1}]
+
+
+def test_get_bulk_job_returns_404_for_unknown_job(client, sample_service):
+    response = client.get(
+        "/v2/notifications/bulk/201b64f0-0a3a-404b-96d4-d4a0f0d0c3bd",
+        headers=_get_headers(sample_service.id),
+    )
+
+    assert response.status_code == 404
+
+
+def test_get_bulk_jobs_returns_only_jobs_for_authenticated_service(client, sample_template):
+    job = create_job(sample_template)
+    other_service = create_service(service_name="Other service")
+    other_template = create_template(service=other_service)
+    other_job = create_job(other_template)
+
+    response = client.get("/v2/notifications/bulk", headers=_get_headers(sample_template.service_id))
+
+    assert response.status_code == 200
+    returned_ids = {item["id"] for item in response.get_json()["bulk_jobs"]}
+    assert str(job.id) in returned_ids
+    assert str(other_job.id) not in returned_ids
+
+
+def test_get_bulk_jobs_supports_cursor_pagination(client, sample_template):
+    first_job = create_job(sample_template, created_at=datetime(2026, 8, 18, 12, 0))
+    second_job = create_job(sample_template, created_at=datetime(2026, 8, 18, 11, 0))
+    client.application.config["API_PAGE_SIZE"] = 1
+
+    first_response = client.get("/v2/notifications/bulk", headers=_get_headers(sample_template.service_id))
+    first_page = first_response.get_json()
+
+    second_response = client.get(
+        "/v2/notifications/bulk",
+        query_string={"older_than": first_page["bulk_jobs"][0]["id"]},
+        headers=_get_headers(sample_template.service_id),
+    )
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 200
+    assert first_page["bulk_jobs"][0]["id"] == str(first_job.id)
+    assert second_response.get_json()["bulk_jobs"][0]["id"] == str(second_job.id)
+    assert first_page["links"]["next"]
+
+
+def test_get_bulk_jobs_rejects_cursor_from_another_service(client, sample_template):
+    other_service = create_service(service_name="Other service")
+    other_template = create_template(service=other_service)
+    other_job = create_job(other_template)
+
+    response = client.get(
+        "/v2/notifications/bulk",
+        query_string={"older_than": str(other_job.id)},
+        headers=_get_headers(sample_template.service_id),
+    )
+
+    assert response.status_code == 400
+
+
+def test_get_bulk_jobs_rejects_unknown_cursor(client, sample_service):
+    response = client.get(
+        "/v2/notifications/bulk",
+        query_string={"older_than": "201b64f0-0a3a-404b-96d4-d4a0f0d0c3bd"},
+        headers=_get_headers(sample_service.id),
+    )
+
+    assert response.status_code == 400

--- a/tests/app/v2/notifications/test_get_bulk_jobs.py
+++ b/tests/app/v2/notifications/test_get_bulk_jobs.py
@@ -53,6 +53,10 @@ def test_get_bulk_job_returns_404_for_unknown_job(client, sample_service):
     )
 
     assert response.status_code == 404
+    assert response.get_json() == {
+        "status_code": 404,
+        "errors": [{"error": "JobNotFoundError", "message": "Job not found in database"}],
+    }
 
 
 def test_get_bulk_jobs_returns_only_jobs_for_authenticated_service(client, sample_template):


### PR DESCRIPTION
# Summary | Résumé

This pull request introduces new API endpoints for retrieving bulk notification jobs and their statistics, along with supporting backend logic and OpenAPI documentation updates. The main focus is to allow clients to fetch a paginated list of bulk jobs and their statuses, as well as retrieve a specific bulk job by ID. The changes also refactor and centralize the logic for calculating job statistics, improving maintainability and efficiency.

## New endpoints:
- `GET /v2/notifications/bulk` - Get list of bulk jobs
- `GET /v2/notifications/bulk/{job_id}` - Get bulk job by ID

## Tests added
- Verify retrieving a single bulk job by ID.
- Verify listing bulk jobs for the authenticated service.
- Verify jobs from other services are excluded.
- Verify archived jobs are returned.
- Verify recent jobs use live notification statistics.
- Verify older and archived jobs use fact-table statistics.
- Verify jobs without available statistics return an empty [statistics](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) array.
- Verify cursor pagination using [older_than](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
- Verify invalid, unknown, and cross-service cursors return 400.
- Verify unknown job IDs return 404.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/1061

# Test instructions | Instructions pour tester la modification
## New endpoints work

- Call GET /v2/notifications/bulk.
- For every returned job, call `/v2/notifications/bulk/{job_id}`
- [x] Confirm each list item matches its individual response, including:
   - Job metadata
   - Archive status
   - Job status
   - Notification count
   - Statistics
- Follow the `links.next` cursor
- [x] confirm jobs do not repeat across pages.
- [x] Try an invalid UUID, unknown cursor, and cursor from another service.
- [x] Confirm the expected 400 response for invalid cursors.
- [x] A job ID belonging to another service and confirm it returns 404.

## Open API spec updated
- [ ] Open API spec contains new endpoints for `/v2/notifications/bulk`
- [ ] Open API spec contains new endpoints for `/v2/notifications/bulk/{job_id}`

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.