### PR TITLE
Fix quarterly email percentages to display two decimal places

### DIFF
--- a/app/celery/reporting_tasks.py
+++ b/app/celery/reporting_tasks.py
@@ -311,21 +311,21 @@ def _create_quarterly_email_markdown_list(service_info, service_ids, cummulative
         markdown_list_en += f"## {service_name} \n"
         markdown_list_fr += f"## {service_name} \n"
 
-        email_percentage = round(float(email_count / email_annual_limit), 4) * 100 if email_count else 0
+        email_percentage = round(float(email_count / email_annual_limit) * 100, 2) if email_count else 0
         email_count_en = _format_number(email_count)
         email_annual_limit_en = _format_number(email_annual_limit)
         email_count_fr = _format_number(email_count, use_space=True)
         email_annual_limit_fr = _format_number(email_annual_limit, use_space=True)
-        markdown_list_en += f"Emails: you've sent {email_count_en} out of {email_annual_limit_en} ({email_percentage}%)\n"
-        markdown_list_fr += f"Courriels: {email_count_fr} envoyés sur {email_annual_limit_fr} ({email_percentage}%)\n"
+        markdown_list_en += f"Emails: you've sent {email_count_en} out of {email_annual_limit_en} ({email_percentage:.2f}%)\n"
+        markdown_list_fr += f"Courriels: {email_count_fr} envoyés sur {email_annual_limit_fr} ({email_percentage:.2f}%)\n"
 
-        sms_percentage = round(float(sms_count / sms_annual_limit), 4) * 100 if sms_count else 0
+        sms_percentage = round(float(sms_count / sms_annual_limit) * 100, 2) if sms_count else 0
         sms_count_en = _format_number(sms_count)
         sms_annual_limit_en = _format_number(sms_annual_limit)
         sms_count_fr = _format_number(sms_count, use_space=True)
         sms_annual_limit_fr = _format_number(sms_annual_limit, use_space=True)
-        markdown_list_en += f"Text messages: you've sent {sms_count_en} out of {sms_annual_limit_en} ({sms_percentage}%)\n"
-        markdown_list_fr += f"Messages texte : {sms_count_fr} envoyés sur {sms_annual_limit_fr} ({sms_percentage}%)\n"
+        markdown_list_en += f"Text messages: you've sent {sms_count_en} out of {sms_annual_limit_en} ({sms_percentage:.2f}%)\n"
+        markdown_list_fr += f"Messages texte : {sms_count_fr} envoyés sur {sms_annual_limit_fr} ({sms_percentage:.2f}%)\n"
 
         markdown_list_en += "\n"
         markdown_list_fr += "\n"

--- a/tests/app/celery/test_reporting_tasks.py
+++ b/tests/app/celery/test_reporting_tasks.py
@@ -1,6 +1,7 @@
 import uuid
 from datetime import date, datetime, timedelta
 from decimal import Decimal
+from unittest.mock import call
 
 import pytest
 from freezegun import freeze_time
@@ -19,6 +20,7 @@ from tests.conftest import set_config
 
 from app import annual_limit_client
 from app.celery.reporting_tasks import (
+    _create_quarterly_email_markdown_list,
     create_monthly_notification_stats_summary,
     create_nightly_billing,
     create_nightly_billing_for_day,
@@ -592,6 +594,19 @@ class TestInsertQuarterData:
 
 
 class TestSendQuarterEmail:
+    def test_quarterly_email_rounds_percentages(self):
+        service_id = uuid.uuid4()
+
+        markdown_list_en, _markdown_list_fr = _create_quarterly_email_markdown_list(
+            {service_id: ("service", 20_000_000, 400_000)},
+            [service_id],
+            {str(service_id): {"email": 56_428, "sms": 66_518}},
+        )
+
+        assert "(0.28%)" in markdown_list_en
+        assert "(16.63%)" in markdown_list_en
+        assert "0.27999999999999997" not in markdown_list_en
+
     def test_send_quarter_email(self, sample_user, mocker, notify_db_session):
         service_1 = create_service(service_name="service_1")
         service_2 = create_service(service_name="service_2")
@@ -608,13 +623,27 @@ class TestSendQuarterEmail:
         service_2.users = [sample_user]
         send_mock = mocker.patch("app.celery.reporting_tasks.send_annual_usage_data")
 
-        markdown_list_en = "## service_1 \nText messages: you've sent 4 out of 25,000 (0.0%)\n\n## service_2 \nText messages: you've sent 1 100 out of 25 000 (4.0%)\n\n"
-        markdown_list_fr = "## service_1 \n\n## service_2 \n\n"
+        markdown_list_en = (
+            "## service_1 \n"
+            "Emails: you've sent 0 out of 10,000,000 (0.00%)\n"
+            "Text messages: you've sent 4 out of 25,000 (0.02%)\n\n"
+            "## service_2 \n"
+            "Emails: you've sent 0 out of 10,000,000 (0.00%)\n"
+            "Text messages: you've sent 1,100 out of 25,000 (4.40%)\n\n"
+        )
+        markdown_list_fr = (
+            "## service_1 \n"
+            "Courriels: 0 envoyés sur 10 000 000 (0.00%)\n"
+            "Messages texte : 4 envoyés sur 25 000 (0.02%)\n\n"
+            "## service_2 \n"
+            "Courriels: 0 envoyés sur 10 000 000 (0.00%)\n"
+            "Messages texte : 1 100 envoyés sur 25 000 (4.40%)\n\n"
+        )
         send_quarter_email(datetime(2018, 4, 1))
-        assert send_mock.call_args(
+        assert send_mock.call_args == call(
             sample_user.id,
+            2017,
             2018,
-            2019,
             markdown_list_en,
             markdown_list_fr,
         )


### PR DESCRIPTION
# Summary | Résumé
This pull request improves the calculation and formatting of percentage values in the quarterly email markdown reports, ensuring percentages are rounded to two decimal places and displayed consistently. 

Before, the calculation could have displayed `4.3999999999999995`, now it would show `4.40`.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/3428

# Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.