### PR TITLE
Fix py.test to pytest

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -188,6 +188,13 @@ jobs:
     - name: Generate version file
       run: make generate-version-file
 
+    - name: Ensure pytest is available
+      run: |
+        if ! poetry run pytest --version >/dev/null 2>&1; then
+          echo "pytest missing; repairing virtualenv dependencies"
+          poetry install --with test --no-interaction --no-ansi
+        fi
+
     - name: Run serial tests
       run: |
         poetry run pytest --disable-pytest-warnings --cov=app --cov-report=term-missing \
@@ -283,10 +290,18 @@ jobs:
       run: pip install poetry==${POETRY_VERSION} poetry-plugin-sort && poetry --version
 
     - name: Install requirements
+      if: steps.venv-cache.outputs.cache-hit != 'true'
       run: poetry install --with test --no-interaction --no-ansi
 
     - name: Generate version file
       run: make generate-version-file
+
+    - name: Ensure pytest is available
+      run: |
+        if ! poetry run pytest --version >/dev/null 2>&1; then
+          echo "pytest missing; repairing virtualenv dependencies"
+          poetry install --with test --no-interaction --no-ansi
+        fi
 
     - name: Run parallel tests (${{ matrix.name }})
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,6 +29,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Set up Python 3.12
+      id: setup-python
       uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa # v4.8.0
       with:
         python-version: '3.12'
@@ -47,9 +48,9 @@ jobs:
       id: venv-cache
       with:
         path: .venv
-        key: ${{ runner.os }}-py312-venv-${{ hashFiles('poetry.lock') }}
+        key: ${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-venv-${{ hashFiles('poetry.lock') }}
         restore-keys: |
-          ${{ runner.os }}-py312-venv-
+          ${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-venv-
 
     - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
@@ -74,7 +75,6 @@ jobs:
       run: poetry check --lock
 
     - name: Install requirements
-      if: steps.venv-cache.outputs.cache-hit != 'true'
       run: poetry install --with test --no-interaction --no-ansi
 
     - name: Ruff check
@@ -154,6 +154,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Set up Python 3.12
+      id: setup-python
       uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa # v4.8.0
       with:
         python-version: '3.12'
@@ -172,9 +173,9 @@ jobs:
       id: venv-cache
       with:
         path: .venv
-        key: ${{ runner.os }}-py312-venv-${{ hashFiles('poetry.lock') }}
+        key: ${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-venv-${{ hashFiles('poetry.lock') }}
         restore-keys: |
-          ${{ runner.os }}-py312-venv-
+          ${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-venv-
 
     - name: Install poetry
       env:
@@ -182,7 +183,6 @@ jobs:
       run: pip install poetry==${POETRY_VERSION} poetry-plugin-sort && poetry --version
 
     - name: Install requirements
-      if: steps.venv-cache.outputs.cache-hit != 'true'
       run: poetry install --with test --no-interaction --no-ansi
 
     - name: Generate version file
@@ -254,6 +254,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Set up Python 3.12
+      id: setup-python
       uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa # v4.8.0
       with:
         python-version: '3.12'
@@ -272,9 +273,9 @@ jobs:
       id: venv-cache
       with:
         path: .venv
-        key: ${{ runner.os }}-py312-venv-${{ hashFiles('poetry.lock') }}
+        key: ${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-venv-${{ hashFiles('poetry.lock') }}
         restore-keys: |
-          ${{ runner.os }}-py312-venv-
+          ${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-venv-
 
     - name: Install poetry
       env:
@@ -282,7 +283,6 @@ jobs:
       run: pip install poetry==${POETRY_VERSION} poetry-plugin-sort && poetry --version
 
     - name: Install requirements
-      if: steps.venv-cache.outputs.cache-hit != 'true'
       run: poetry install --with test --no-interaction --no-ansi
 
     - name: Generate version file

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -183,6 +183,7 @@ jobs:
       run: pip install poetry==${POETRY_VERSION} poetry-plugin-sort && poetry --version
 
     - name: Install requirements
+      if: steps.venv-cache.outputs.cache-hit != 'true'
       run: poetry install --with test --no-interaction --no-ansi
 
     - name: Generate version file

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -190,7 +190,7 @@ jobs:
 
     - name: Run serial tests
       run: |
-        poetry run py.test --disable-pytest-warnings --cov=app --cov-report=term-missing \
+        poetry run pytest --disable-pytest-warnings --cov=app --cov-report=term-missing \
           tests/ --junitxml=test_results_serial.xml -v --maxfail=10 -m "serial"
 
     - name: Upload test results on failure
@@ -290,7 +290,7 @@ jobs:
 
     - name: Run parallel tests (${{ matrix.name }})
       run: |
-        poetry run py.test --disable-pytest-warnings --cov=app --cov-report=term-missing \
+        poetry run pytest --disable-pytest-warnings --cov=app --cov-report=term-missing \
           --junitxml=test_results_${{ matrix.name }}.xml -v --maxfail=10 \
           -m "not serial" -n auto \
           ${{ matrix.test-args }}

--- a/.github/workflows/test_production_ff.yaml
+++ b/.github/workflows/test_production_ff.yaml
@@ -78,7 +78,7 @@ jobs:
 
     - name: Run serial tests
       run: |
-        poetry run py.test --disable-pytest-warnings --cov=app --cov-report=term-missing \
+        poetry run pytest --disable-pytest-warnings --cov=app --cov-report=term-missing \
           tests/ --junitxml=test_results_serial.xml -v --maxfail=10 -m "serial"
 
     - name: Notify Slack channel if this job fails
@@ -158,7 +158,7 @@ jobs:
 
     - name: Run parallel tests (${{ matrix.name }})
       run: |
-        poetry run py.test --disable-pytest-warnings --cov=app --cov-report=term-missing \
+        poetry run pytest --disable-pytest-warnings --cov=app --cov-report=term-missing \
           --junitxml=test_results_${{ matrix.name }}.xml -v --maxfail=10 \
           -m "not serial" -n auto \
           ${{ matrix.test-args }}

--- a/app/celery/reporting_tasks.py
+++ b/app/celery/reporting_tasks.py
@@ -360,8 +360,9 @@ def send_quarter_email(process_date=None):
             cummulative_data = fetch_quarter_cummulative_stats(quarters_list, all_service_ids)
             cummulative_data_dict = {str(c_data_id): c_data for c_data_id, c_data in cummulative_data}
             for user_id, _, service_ids in chunk:
+                sorted_service_ids = sorted(service_ids, key=lambda service_id: service_info[service_id][0])
                 markdown_list_en, markdown_list_fr = _create_quarterly_email_markdown_list(
-                    service_info, service_ids, cummulative_data_dict
+                    service_info, sorted_service_ids, cummulative_data_dict
                 )
                 send_annual_usage_data(user_id, start_year, end_year, markdown_list_en, markdown_list_fr)
                 current_app.logger.info("send_quarter_email task completed for user {} ".format(user_id))

--- a/scripts/run_single_test.sh
+++ b/scripts/run_single_test.sh
@@ -2,4 +2,4 @@
 # run a single unit test, pass in the unit test name for example: tests/app/service/test_rest.py::test_get_template_list
 # shellcheck source=/dev/null # Not finding this file in code base
 . environment_test.sh
-py.test "$@"
+pytest "$@"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -49,9 +49,9 @@ if ! docker info > /dev/null 2>&1; then
   echo "This test uses docker, and it isn't running - please start docker and try again."
   exit 1
 fi
-py.test --disable-pytest-warnings --cov=app --cov-report=term-missing tests/ --junitxml=test_results_serial.xml -v --maxfail=10 -m "serial"
+pytest --disable-pytest-warnings --cov=app --cov-report=term-missing tests/ --junitxml=test_results_serial.xml -v --maxfail=10 -m "serial"
 display_result $? 2 "Unit tests [serial]"
 
 # Run with auto-detected concurrent workers.
-py.test --disable-pytest-warnings --cov=app --cov-report=term-missing tests/ --junitxml=test_results.xml -n auto -v --maxfail=10 -m "not serial"
+pytest --disable-pytest-warnings --cov=app --cov-report=term-missing tests/ --junitxml=test_results.xml -n auto -v --maxfail=10 -m "not serial"
 display_result $? 2 "Unit tests [concurrent]"


### PR DESCRIPTION
# Summary | Résumé

Most likely because of cache + venv recreation timing, not because your test code changed.

What changed underneath:

The GitHub runner Python patch version changed (your log shows 3.12.14).
Your venv cache key in test.yaml:47 and test.yaml:172 is keyed as py312 + lock hash, so a cached venv from an earlier patch can still be restored.
Poetry then detected that restored venv as broken and recreated it during the test step (exactly what your log says).
In this workflow, install is skipped on cache hit at test.yaml:77, test.yaml:185, and test.yaml:285, so the recreated venv can be empty.
Then the command fails with command not found.