### PR TITLE
Update template categories

### DIFF
--- a/migrations/versions/0525_sync_template_hist_cat.py
+++ b/migrations/versions/0525_sync_template_hist_cat.py
@@ -18,7 +18,7 @@ down_revision = "0524_update_callback_susp_word"
 def upgrade():
     conn = op.get_bind()
 
-    result = conn.execute(
+    conn.execute(
         sa.text(
             """
             UPDATE templates_history th

--- a/migrations/versions/0525_sync_template_hist_cat.py
+++ b/migrations/versions/0525_sync_template_hist_cat.py
@@ -1,0 +1,39 @@
+"""Sync template category between templates and current history rows.
+
+Revision ID: 0525_sync_template_hist_cat
+Revises: 0524_update_callback_susp_word
+Create Date: 2026-08-20
+
+This migration aligns templates_history.template_category_id with templates
+for rows that represent the same template version (id + version).
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0525_sync_template_hist_cat"
+down_revision = "0524_update_callback_susp_word"
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    result = conn.execute(
+        sa.text(
+            """
+            UPDATE templates_history th
+            SET template_category_id = t.template_category_id
+            FROM templates t
+            WHERE th.id = t.id
+              AND th.version = t.version
+              AND th.template_category_id IS DISTINCT FROM t.template_category_id
+            """
+        )
+    )
+
+    print(f"Updated {result.rowcount} templates_history rows")
+
+
+def downgrade():
+    # Data correction migration; no safe automatic rollback.
+    pass

--- a/migrations/versions/0525_sync_template_hist_cat.py
+++ b/migrations/versions/0525_sync_template_hist_cat.py
@@ -31,8 +31,6 @@ def upgrade():
         )
     )
 
-    print(f"Updated {result.rowcount} templates_history rows")
-
 
 def downgrade():
     # Data correction migration; no safe automatic rollback.


### PR DESCRIPTION
# Summary | Résumé

As a followup PR to the template category mismatch (template categories in the templates table are different from the template categories in the template table) (https://github.com/cds-snc/notification-api/pull/3009)

We need this PR to update the categories accordingly.

I tested this on PRd and there were 216 categories that were incorrect.