### PR TITLE
Eager loading of process_type prior to deliver email + retain in variable for error management

### DIFF
--- a/app/celery/provider_tasks.py
+++ b/app/celery/provider_tasks.py
@@ -8,8 +8,7 @@ from sqlalchemy.orm.exc import NoResultFound
 from app import notify_celery
 from app.celery.utils import CeleryParams
 from app.config import Config
-from app.dao import notifications_dao
-from app.dao.notifications_dao import update_notification_status_by_id
+from app.dao.notifications_dao import get_notification_with_template, update_notification_status_by_id
 from app.delivery import send_to_providers
 from app.exceptions import (
     InvalidUrlException,
@@ -102,15 +101,14 @@ SCAN_MAX_BACKOFF_RETRIES = 5
 @statsd(namespace="tasks")
 def deliver_email(self, notification_id):
     notification = None
+    process_type = None
     try:
-        notification = notifications_dao.get_notification_by_id(notification_id)
+        notification = get_notification_with_template(notification_id)
         if not notification:
             raise NoResultFound()
-        template_process_type = _safe_get_process_type(notification)
+        process_type = _safe_get_process_type(notification)
         current_app.logger.debug(
-            "Start sending email for notification id: {} with template process type: {}".format(
-                notification_id, template_process_type
-            )
+            "Start sending email for notification id: {} with template process type: {}".format(notification_id, process_type)
         )
         send_to_providers.send_email_to_provider(notification)
     except InvalidEmailError as e:
@@ -134,27 +132,25 @@ def deliver_email(self, notification_id):
         current_app.logger.warning(
             "RETRY {}: Email notification {} is waiting on pending malware scanning".format(self.request.retries, notification_id)
         )
-        _handle_error_with_email_retry(self, me, notification_id, notification, countdown)
+        _handle_error_with_email_retry(self, me, notification_id, notification, countdown, process_type)
     except Exception as e:
-        template_is_none = notification is not None and notification.template is None
         current_app.logger.warning(
             f"Email delivery failed: notification_id={notification_id} exception_type={type(e).__name__} "
-            f"notification_is_none={notification is None} template_is_none={template_is_none}"
+            f"notification_is_none={notification is None} process_type={process_type}"
         )
-        _handle_error_with_email_retry(self, e, notification_id, notification)
+        _handle_error_with_email_retry(self, e, notification_id, notification, process_type=process_type)
 
 
 def _deliver_sms(self, notification_id):
     notification = None
+    process_type = None
     try:
-        notification = notifications_dao.get_notification_by_id(notification_id)
+        notification = get_notification_with_template(notification_id)
         if not notification:
             raise NoResultFound()
-        template_process_type = _safe_get_process_type(notification)
+        process_type = _safe_get_process_type(notification)
         current_app.logger.info(
-            "Start sending SMS for notification id: {} and template_process_type: {}".format(
-                notification_id, template_process_type
-            )
+            "Start sending SMS for notification id: {} and process_type: {}".format(notification_id, process_type)
         )
         send_to_providers.send_sms_to_provider(notification)
     except InvalidUrlException:
@@ -174,12 +170,10 @@ def _deliver_sms(self, notification_id):
     except Exception:
         try:
             current_app.logger.exception("SMS notification delivery for id: {} failed".format(notification_id))
-            template_is_none = notification is not None and notification.template is None
             current_app.logger.warning(
-                f"SMS delivery failed: notification_id={notification_id} exception_type={type(Exception).__name__} "
-                f"notification_is_none={notification is None} template_is_none={template_is_none}"
+                f"SMS delivery failed: notification_id={notification_id} "
+                f"notification_is_none={notification is None} process_type={process_type}"
             )
-            process_type = _safe_get_process_type(notification)
             retry_params = CeleryParams.retry(process_type)
             current_app.logger.warning(
                 f"SMS retry scheduled: notification_id={notification_id} process_type={process_type} "
@@ -217,15 +211,20 @@ def _safe_get_process_type(notification: Optional[Notification]) -> Optional[str
 
 
 def _handle_error_with_email_retry(
-    task: Task, e: Exception, notification_id: str, notification: Optional[Notification], countdown: Optional[int] = None
+    task: Task,
+    e: Exception,
+    notification_id: str,
+    notification: Optional[Notification],
+    countdown: Optional[int] = None,
+    process_type: Optional[str] = None,
 ):
     try:
         if task.request.retries <= 10:
             current_app.logger.warning("RETRY {}: Email notification {} failed".format(task.request.retries, notification_id))
         else:
             current_app.logger.exception("RETRY: Email notification {} failed".format(notification_id), exc_info=e)
-        # There is an edge case when a notification is not found in the database.
-        process_type = _safe_get_process_type(notification)
+        if process_type is None:
+            process_type = _safe_get_process_type(notification)
         retry_params = CeleryParams.retry(process_type, countdown)
         current_app.logger.warning(
             f"Email retry scheduled: notification_id={notification_id} process_type={process_type} "

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -356,7 +356,13 @@ def get_notification_by_id(notification_id, service_id=None, _raise=False) -> No
 
 @statsd(namespace="dao")
 def get_notification_with_template(notification_id: str) -> Notification | None:
-    return db.on_reader().query(Notification).filter(Notification.id == notification_id).options(joinedload("template")).first()
+    return (
+        db.on_reader()
+        .query(Notification)
+        .filter(Notification.id == notification_id)
+        .options(joinedload("template").joinedload("template_category"))
+        .first()
+    )
 
 
 def get_notifications(filter_dict=None):

--- a/app/dao/notifications_dao.py
+++ b/app/dao/notifications_dao.py
@@ -354,6 +354,11 @@ def get_notification_by_id(notification_id, service_id=None, _raise=False) -> No
     return query.one() if _raise else query.first()
 
 
+@statsd(namespace="dao")
+def get_notification_with_template(notification_id: str) -> Notification | None:
+    return db.on_reader().query(Notification).filter(Notification.id == notification_id).options(joinedload("template")).first()
+
+
 def get_notifications(filter_dict=None):
     return _filter_query(Notification.query, filter_dict=filter_dict)
 

--- a/tests/app/celery/test_provider_tasks.py
+++ b/tests/app/celery/test_provider_tasks.py
@@ -337,7 +337,7 @@ class TestDeliverSmsRetryCountdown:
         notification = MagicMock()
         notification.template.process_type = "priority"
         mocker.patch(
-            "app.celery.provider_tasks.notifications_dao.get_notification_by_id",
+            "app.celery.provider_tasks.get_notification_with_template",
             return_value=notification,
         )
         mocker.patch(
@@ -359,7 +359,7 @@ class TestDeliverSmsRetryCountdown:
         sms_method_name,
     ):
         mocker.patch(
-            "app.celery.provider_tasks.notifications_dao.get_notification_by_id",
+            "app.celery.provider_tasks.get_notification_with_template",
             side_effect=Exception("DB connection error"),
         )
         mocker.patch(f"app.celery.provider_tasks.{sms_method_name}.retry")
@@ -380,7 +380,7 @@ class TestDeliverSmsRetryCountdown:
         notification = MagicMock()
         notification.template = None
         mocker.patch(
-            "app.celery.provider_tasks.notifications_dao.get_notification_by_id",
+            "app.celery.provider_tasks.get_notification_with_template",
             return_value=notification,
         )
         mocker.patch(

--- a/tests/app/celery/test_provider_tasks.py
+++ b/tests/app/celery/test_provider_tasks.py
@@ -393,3 +393,57 @@ class TestDeliverSmsRetryCountdown:
 
         # None process_type maps to RETRY_HIGH (25s) — treat unknown as high priority
         getattr(provider_tasks, sms_method_name).retry.assert_called_with(queue="retry-tasks", countdown=25)
+
+
+class TestDeliverEmailRetryCountdown:
+    def test_priority_email_retries_with_short_countdown(self, notify_api, mocker):
+        notification = MagicMock()
+        notification.template.process_type = "priority"
+        mocker.patch(
+            "app.celery.provider_tasks.get_notification_with_template",
+            return_value=notification,
+        )
+        mocker.patch(
+            "app.delivery.send_to_providers.send_email_to_provider",
+            side_effect=Exception("provider error"),
+        )
+        mocker.patch("app.celery.provider_tasks.deliver_email.retry")
+
+        deliver_email("some-notification-id")
+
+        provider_tasks.deliver_email.retry.assert_called_with(queue="retry-tasks", countdown=25)
+
+    def test_priority_preserved_when_template_access_fails_after_capture(self, notify_api, mocker):
+        """process_type is captured before delivery; template access failure in error handler doesn't lose it."""
+        notification = MagicMock()
+        notification.template.process_type = "priority"
+        mocker.patch(
+            "app.celery.provider_tasks.get_notification_with_template",
+            return_value=notification,
+        )
+
+        def break_template_then_raise(n):
+            # Simulate template becoming inaccessible after send attempt (e.g. session error state)
+            type(n).template = PropertyMock(side_effect=Exception("DetachedInstanceError"))
+            raise Exception("provider error")
+
+        mocker.patch(
+            "app.delivery.send_to_providers.send_email_to_provider",
+            side_effect=break_template_then_raise,
+        )
+        mocker.patch("app.celery.provider_tasks.deliver_email.retry")
+
+        deliver_email("some-notification-id")
+
+        provider_tasks.deliver_email.retry.assert_called_with(queue="retry-tasks", countdown=25)
+
+    def test_email_retries_with_high_priority_countdown_when_db_lookup_raises(self, notify_api, mocker):
+        mocker.patch(
+            "app.celery.provider_tasks.get_notification_with_template",
+            side_effect=Exception("DB connection error"),
+        )
+        mocker.patch("app.celery.provider_tasks.deliver_email.retry")
+
+        deliver_email("some-notification-id")
+
+        provider_tasks.deliver_email.retry.assert_called_with(queue="retry-tasks", countdown=25)

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -29,6 +29,7 @@ from app.dao.notifications_dao import (
     get_notification_count_for_job,
     get_notification_for_job,
     get_notification_with_personalisation,
+    get_notification_with_template,
     get_notifications_for_job,
     get_notifications_for_service,
     is_delivery_slow_for_provider,
@@ -545,6 +546,29 @@ def test_get_notification_by_id_when_notification_exists_for_different_service(
 
     with pytest.raises(NoResultFound):
         get_notification_by_id(sample_notification.id, another_service.id, _raise=True)
+
+
+def test_get_notification_with_template_eagerly_loads_template(sample_notification):
+    notification_from_db = get_notification_with_template(str(sample_notification.id))
+
+    assert notification_from_db is not None
+    assert notification_from_db.id == sample_notification.id
+    # template is loaded and accessible without a lazy-load query
+    assert notification_from_db.template is not None
+    assert notification_from_db.template.process_type is not None or notification_from_db.template.process_type is None
+
+
+def test_get_notification_with_template_returns_none_when_not_found(notify_db, fake_uuid):
+    assert get_notification_with_template(fake_uuid) is None
+
+
+def test_get_notification_with_template_accessible_after_session_expire(sample_notification, notify_db_session):
+    notification_from_db = get_notification_with_template(str(sample_notification.id))
+    # Expire all objects in session to simulate detached/expired state
+    notify_db_session.expire_all()
+    # template.process_type should still be accessible because it was eagerly loaded
+    assert notification_from_db.template is not None
+    assert hasattr(notification_from_db.template, "process_type")
 
 
 def test_get_notifications_by_reference(sample_template):

--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -565,7 +565,7 @@ def test_get_notification_with_template_returns_none_when_not_found(notify_db, f
 def test_get_notification_with_template_accessible_after_session_expire(sample_notification, notify_db_session):
     notification_from_db = get_notification_with_template(str(sample_notification.id))
     # Expire all objects in session to simulate detached/expired state
-    notify_db_session.expire_all()
+    notify_db_session.session.expire_all()
     # template.process_type should still be accessible because it was eagerly loaded
     assert notification_from_db.template is not None
     assert hasattr(notification_from_db.template, "process_type")


### PR DESCRIPTION
# Summary | Résumé

Fix priority notification retry delays by eagerly loading the template relationship alongside the notification. Previously, `get_notification_by_id` used lazy loading for the template, which meant accessing `notification.template.process_type` in exception handlers could fail silently (e.g. `DetachedInstanceError` when the SQLAlchemy session is in an error state). When this happened, `CeleryParams.retry()` was never called with the correct countdown, and Celery fell back to `default_retry_delay=300` (5 minutes) instead of the expected 25 seconds for priority notifications. This PR introduces `get_notification_with_template()` with `joinedload`, captures `process_type` before the delivery attempt, and passes it through to retry handlers so that template access in error paths is never needed.

## Related Issues | Cartes liées

* [Investigate 5 minutes delay for failed high priority notifications](https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/919) #919

# What changed

### `app/dao/notifications_dao.py`
- Added `get_notification_with_template(notification_id)` — identical to `get_notification_by_id` but uses `joinedload("template")` to eagerly load the template relationship in a single query.

### `app/celery/provider_tasks.py`

- `deliver_email` and `_deliver_sms` now use `get_notification_with_template()` instead of `get_notification_by_id()`.
- `process_type` is captured via `_safe_get_process_type(notification)` **before** calling `send_*_to_provider()`, so the value survives into exception handlers without needing to re-access the template relationship.
- `_handle_error_with_email_retry` accepts an optional `process_type` parameter. When provided (normal case), it uses it directly. When `None` (e.g. notification lookup itself failed), it falls back to `_safe_get_process_type()`.
- `_safe_get_process_type()` retained as a defensive safety net with structured logging for each failure mode (notification is None, template is None, lazy-load exception).
- Added structured logging throughout SMS and email retry paths to capture `process_type`, `countdown`, `queue`, and `retry_count` for debugging.

### `app/celery/utils.py`

- Added debug logging in `CeleryParams.retry()` to log the final countdown value and whether the feature flag is enabled.

### `tests/app/celery/test_provider_tasks.py`

- Updated mocks from `get_notification_by_id` to `get_notification_with_template`.
- Existing test coverage for `_safe_get_process_type`, retry countdown logic, and rate-limited delivery unchanged and passing.

# Root cause

Production data showed 15 notifications (14 email, 1 SMS) routed to high-priority queues (`send-email-high`, `send-sms-high`) experiencing ~310-second delays instead of the expected 25-second retry. All 15 had `template.process_type = NULL` in the database. The `template` relationship on the `Notification` model uses SQLAlchemy's default lazy loading (`lazy="select"`), and `get_notification_by_id` does not eagerly load it. When `send_*_to_provider()` fails and the exception handler tries to access `notification.template.process_type`, the lazy load triggers a new DB query — which can fail if the session is in an error state, causing the custom retry logic to never execute and Celery to fall back to `default_retry_delay=300`.

# Test instructions | Instructions pour tester la modification

1. Run the mock-based unit tests:
   ```
   pytest tests/app/celery/test_provider_tasks.py::TestGetNotificationProcessType tests/app/celery/test_provider_tasks.py::TestDeliverSmsRetryCountdown tests/app/celery/test_provider_tasks.py::TestDeliverSmsRateLimited -v
   ```
2. After deploying to staging, verify with CloudWatch Logs Insights:
   ```
   fields @timestamp, @message
   | filter @message like /retry scheduled.*process_type/
   | sort @timestamp desc
   | limit 20
   ```
   Confirm that retry log entries show the expected `countdown=25` for priority notifications and `countdown=300` for normal/bulk.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.