### PR TITLE
perf test logging for waf

### DIFF
--- a/tests_nightly_performance/src/blast_api_legacy.py
+++ b/tests_nightly_performance/src/blast_api_legacy.py
@@ -23,9 +23,8 @@ logger = logging.getLogger(__name__)
 @events.test_start.add_listener
 def log_waf_secret_status(environment, **kwargs):
     if Config.WAF_SECRET:
-        secret_last_5 = Config.WAF_SECRET[-5:]
-        logger.info(f"WAF secret detected in config (ending in: ...{secret_last_5})")
-        print(f"[INFO] WAF secret detected in config (ending in: ...{secret_last_5})")
+        logger.info("WAF secret detected in config.")
+        print("[INFO] WAF secret detected in config.")
     else:
         logger.warning("ALERT: WAF secret NOT detected in config! WAF rate limiting will not be bypassed.")
         print("ALERT: WAF secret NOT detected in config! WAF rate limiting will not be bypassed.")

--- a/tests_nightly_performance/src/blast_api_legacy.py
+++ b/tests_nightly_performance/src/blast_api_legacy.py
@@ -8,13 +8,28 @@ is what caused the nightly test to run indefinitely when blast_api.py was rework
 For the open-ended, step-up / burst scenarios see blast_api.py.
 """
 
+import logging
 from datetime import datetime
 
 from common import Config, generate_job_rows, rows_to_csv
 from dotenv import load_dotenv
-from locust import HttpUser, constant_pacing, task
+from locust import HttpUser, constant_pacing, events, task
 
 load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+
+@events.test_start.add_listener
+def log_waf_secret_status(environment, **kwargs):
+    if Config.WAF_SECRET:
+        secret_last_5 = Config.WAF_SECRET[-5:]
+        logger.info(f"WAF secret detected in config (ending in: ...{secret_last_5})")
+        print(f"[INFO] WAF secret detected in config (ending in: ...{secret_last_5})")
+    else:
+        logger.warning("ALERT: WAF secret NOT detected in config! WAF rate limiting will not be bypassed.")
+        print("ALERT: WAF secret NOT detected in config! WAF rate limiting will not be bypassed.")
+
 
 # Note that task weights add up to 100
 # If you add / remove tasks please keep the sum 100


### PR DESCRIPTION
# Summary | Résumé

We're running into an issue with the perf test where new waf rules are blocking it even though they have the exception for waf-secret headers. It's almost like the waf-secret header is not getting passed. I'm adding some logging to detect whether or not the waf-secret is actually picked up by the script.

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/875

# Test instructions | Instructions pour tester la modification

Run new perf test and check the logs

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.