### PR TITLE
feat: add logging for file upload acceptance in document processing

### DIFF
--- a/app/v2/notifications/post_notifications.py
+++ b/app/v2/notifications/post_notifications.py
@@ -539,6 +539,25 @@ def process_document_uploads(personalisation_data, service: Service, simulated, 
         else:
             try:
                 personalisation_data[key] = document_download_client.upload_document(service.id, personalisation_data[key])
+                uploaded_document = personalisation_data[key]["document"]
+                current_app.logger.info(
+                    "File upload accepted: service_id=%s template_id=%s filename=%s file_extension=%s "
+                    "mime_type=%s sending_method=%s",
+                    service.id,
+                    template_id,
+                    uploaded_document.get("filename"),
+                    uploaded_document.get("file_extension"),
+                    uploaded_document.get("mime_type"),
+                    uploaded_document.get("sending_method"),
+                    extra={
+                        "service_id": str(service.id),
+                        "template_id": str(template_id),
+                        "file_name": uploaded_document.get("filename"),
+                        "file_extension": uploaded_document.get("file_extension"),
+                        "mime_type": uploaded_document.get("mime_type"),
+                        "sending_method": uploaded_document.get("sending_method"),
+                    },
+                )
             except DocumentDownloadError as e:
                 raise BadRequestError(message=e.message, status_code=e.status_code)
 

--- a/tests/app/v2/notifications/test_post_notifications.py
+++ b/tests/app/v2/notifications/test_post_notifications.py
@@ -1214,9 +1214,17 @@ class TestSendingDocuments:
         template = create_template(service=service, template_type="email", content=content)
 
         statsd_mock = mocker.patch("app.v2.notifications.post_notifications.statsd_client")
+        logger_mock = mocker.patch("app.v2.notifications.post_notifications.current_app.logger.info")
         mock_publish = mocker.patch("app.email_normal_publish.publish")
         document_download_mock = mocker.patch("app.v2.notifications.post_notifications.document_download_client.upload_document")
-        document_response = document_download_response({"sending_method": sending_method, "mime_type": "text/plain"})
+        document_response = document_download_response(
+            {
+                "filename": filename,
+                "file_extension": "txt",
+                "sending_method": sending_method,
+                "mime_type": "text/plain",
+            }
+        )
         document_download_mock.return_value = document_response
         decoded_file = base64.b64decode(file_data)
 
@@ -1245,6 +1253,27 @@ class TestSendingDocuments:
         document_download_mock.assert_called_once_with(
             service.id,
             {"file": decoded_file, "filename": filename, "sending_method": sending_method},
+        )
+        assert (
+            call(
+                "File upload accepted: service_id=%s template_id=%s filename=%s file_extension=%s "
+                "mime_type=%s sending_method=%s",
+                service.id,
+                template.id,
+                filename,
+                "txt",
+                "text/plain",
+                sending_method,
+                extra={
+                    "service_id": str(service.id),
+                    "template_id": str(template.id),
+                    "file_name": filename,
+                    "file_extension": "txt",
+                    "mime_type": "text/plain",
+                    "sending_method": sending_method,
+                },
+            )
+            in logger_mock.call_args_list
         )
 
         mock_publish_args = mock_publish.call_args.args[0]


### PR DESCRIPTION
# Summary | Résumé
This pull request adds detailed logging when a file is uploaded so we can begin to track/audit the specific types and extensions sent.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/3438

# Test instructions | Instructions pour tester la modification

- send a file via api
- [ ] file info is logged

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.