### PR TITLE
Allow local docsite with CORS

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -385,6 +385,9 @@ def init_app(app):
             "https://documentation.dev.notification.cdssandbox.xyz",
             "https://cds-snc.github.io",
         }
+        # allow the locally-run documentation site to hit this API for manual testing
+        if app.config.get("NOTIFY_ENVIRONMENT") == "development":
+            ALLOWED_ORIGINS.update({"http://localhost:8081", "http://0.0.0.0:8081"})
         origin = request.headers.get("Origin")
         if origin in ALLOWED_ORIGINS:
             response.headers["Access-Control-Allow-Origin"] = origin


### PR DESCRIPTION
# Summary | Résumé

Allow local docsite url with CORS - this is so we can run the documentation site locally and point it at an api spec being served from a locally running api.

## Related Issues | Cartes liées

- https://github.com/cds-snc/notification-planning/issues/3202