### PR TITLE
Fix notifications skipping send when research mode leaks onto other services config

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -380,7 +380,7 @@ def save_smss(self, service_id: Optional[str], signed_notifications: List[Signed
 
     except SQLAlchemyError as e:
         signed_and_verified = list(zip(signed_notifications, verified_notifications))
-        handle_batch_error_and_forward(self, signed_and_verified, SMS_TYPE, e, receipt, template)
+        handle_batch_error_and_forward(self, signed_and_verified, SMS_TYPE, e, receipt)
 
     if saved_notifications:
         try_to_send_notifications_to_queue(notification_id_queue, saved_notifications)
@@ -478,7 +478,7 @@ def save_emails(self, _service_id: Optional[str], signed_notifications: List[Sig
             )
     except SQLAlchemyError as e:
         signed_and_verified = list(zip(signed_notifications, verified_notifications))
-        handle_batch_error_and_forward(self, signed_and_verified, EMAIL_TYPE, e, receipt, template)
+        handle_batch_error_and_forward(self, signed_and_verified, EMAIL_TYPE, e, receipt)
 
     if saved_notifications:
         try_to_send_notifications_to_queue(notification_id_queue, saved_notifications)
@@ -532,13 +532,13 @@ def handle_batch_error_and_forward(
     notification_type: Optional[str],
     exception,
     receipt: Optional[UUID] = None,
-    template: Any = None,
 ):
     if receipt:
         current_app.logger.warning(f"Batch saving: could not persist notifications with receipt {receipt}: {str(exception)}")
     else:
         current_app.logger.warning(f"Batch saving: could not persist notifications: {str(exception)}")
-    process_type = template.process_type if template else None
+    # process_type is resolved per-notification below; initialising to None avoids a stale outer value.
+    process_type = None
 
     notifications_in_job: List[str] = []
     for signed, notification in signed_and_verified:

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -383,7 +383,7 @@ def save_smss(self, service_id: Optional[str], signed_notifications: List[Signed
         handle_batch_error_and_forward(self, signed_and_verified, SMS_TYPE, e, receipt, template)
 
     if saved_notifications:
-        try_to_send_notifications_to_queue(notification_id_queue, service, saved_notifications)
+        try_to_send_notifications_to_queue(notification_id_queue, saved_notifications)
 
 
 @notify_celery.task(bind=True, name="save-emails", max_retries=5, default_retry_delay=300)
@@ -465,10 +465,6 @@ def save_emails(self, _service_id: Optional[str], signed_notifications: List[Sig
             f"Saved following notifications into db: {notification_id_queue.keys()} associated with receipt {receipt}"
         )
         if receipt:
-            # todo: fix this potential bug
-            # template is whatever it was set to last in the for loop above
-            # at this point in the code we have a list of notifications (saved_notifications)
-            # which could use multiple templates
             acknowledge_receipt(EMAIL_TYPE, process_type, receipt)
             current_app.logger.debug(
                 f"Batch saving: receipt_id {receipt} removed from buffer queue for notification_id {notification_id} for process_type {process_type}"
@@ -485,17 +481,12 @@ def save_emails(self, _service_id: Optional[str], signed_notifications: List[Sig
         handle_batch_error_and_forward(self, signed_and_verified, EMAIL_TYPE, e, receipt, template)
 
     if saved_notifications:
-        try_to_send_notifications_to_queue(notification_id_queue, service, saved_notifications)
+        try_to_send_notifications_to_queue(notification_id_queue, saved_notifications)
 
 
-def try_to_send_notifications_to_queue(notification_id_queue, service, saved_notifications):
+def try_to_send_notifications_to_queue(notification_id_queue, saved_notifications):
     """Route each saved notification to its delivery queue. Works for both SMS and email batches."""
     current_app.logger.debug(f"Sending following notifications to provider queue: {notification_id_queue.keys()}")
-    # todo: fix this potential bug
-    # service is whatever it was set to last in the for loop above.
-    # at this point in the code we have a list of notifications (saved_notifications)
-    # which could be from multiple services
-    research_mode = service.research_mode  # type: ignore
     for notification_obj in saved_notifications:
         try:
             # TODO: remove notification_id_queue once persist_notifications knows about the CSV bulk-redirect
@@ -509,6 +500,9 @@ def try_to_send_notifications_to_queue(notification_id_queue, service, saved_not
                 # per-notification correct value from persist_notifications
                 or notification_obj.queue_name
             )
+            # research_mode is derived per-notification: queue_name is already set correctly by
+            # persist_notifications → choose_queue.
+            research_mode = notification_obj.queue_name == QueueNames.RESEARCH_MODE
             send_notification_to_queue(
                 notification_obj,
                 research_mode,

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -545,6 +545,9 @@ def handle_batch_error_and_forward(
         notification_id = notification["notification_id"]
         notifications_in_job.append(notification_id)
         service = notification["service"]
+        # Fetch per-notification (cached) so process_type is always set before acknowledge_receipt.
+        template = dao_get_template_by_id(notification.get("template_id"), notification.get("template_version"), use_cache=True)
+        process_type = template.process_type
         # Sometimes, SQS plays the same message twice. We should be able to catch an IntegrityError, but it seems
         # SQLAlchemy is throwing a FlushError. So we check if the notification id already exists then do not
         # send to the retry queue.
@@ -557,10 +560,6 @@ def handle_batch_error_and_forward(
             current_app.logger.info(forward_msg)
             save_fn = save_emails if notification_type == EMAIL_TYPE else save_smss
 
-            template = dao_get_template_by_id(
-                notification.get("template_id"), notification.get("template_version"), use_cache=True
-            )
-            process_type = template.process_type
             retry_msg = "{task} notification for job {job} row number {row} and notification id {notif} and max_retries are {max_retry}".format(
                 task=task.__name__,
                 job=notification.get("job", None),

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -543,9 +543,7 @@ class TestTryToSendNotificationsToQueue:
         # signed payload from post_notifications does not include a "queue" key.
         notification_id_queue = {priority_id: None, normal_id: None, bulk_id: None}
 
-        service = MagicMock(research_mode=False)
-
-        try_to_send_notifications_to_queue(notification_id_queue, service, saved_notifications)
+        try_to_send_notifications_to_queue(notification_id_queue, saved_notifications)
 
         assert send_mock.call_count == 3
         assert send_mock.call_args_list[0] == call(saved_notifications[0], False, QueueNames.SEND_EMAIL_HIGH)
@@ -560,9 +558,8 @@ class TestTryToSendNotificationsToQueue:
         # Notification's own queue_name says HIGH, but the CSV bulk-redirect override says LOW.
         saved_notifications = [self._make_notification(notification_id, QueueNames.SEND_EMAIL_HIGH)]
         notification_id_queue = {notification_id: QueueNames.SEND_EMAIL_LOW}
-        service = MagicMock(research_mode=False)
 
-        try_to_send_notifications_to_queue(notification_id_queue, service, saved_notifications)
+        try_to_send_notifications_to_queue(notification_id_queue, saved_notifications)
 
         send_mock.assert_called_once_with(saved_notifications[0], False, QueueNames.SEND_EMAIL_LOW)
 
@@ -583,9 +580,8 @@ class TestTryToSendNotificationsToQueue:
             self._make_notification(normal_id, QueueNames.SEND_EMAIL_MEDIUM),
         ]
         notification_id_queue = {n.id: None for n in saved_notifications}
-        service = MagicMock(research_mode=False)
 
-        try_to_send_notifications_to_queue(notification_id_queue, service, saved_notifications)
+        try_to_send_notifications_to_queue(notification_id_queue, saved_notifications)
 
         # The priority notification (index 3) must go to send-email-high, not send-email-medium.
         priority_call = send_mock.call_args_list[3]
@@ -601,25 +597,15 @@ class TestTryToSendNotificationsToQueue:
         saved_notifications = [self._make_notification(raw_id, QueueNames.SEND_EMAIL_HIGH)]
         # Map keyed by string (matches what save_emails/save_smss build).
         notification_id_queue = {str(raw_id): QueueNames.SEND_EMAIL_LOW}
-        service = MagicMock(research_mode=False)
 
-        try_to_send_notifications_to_queue(notification_id_queue, service, saved_notifications)
+        try_to_send_notifications_to_queue(notification_id_queue, saved_notifications)
 
         # Even though notification.id is a UUID object here, the str() cast in the lookup finds it.
         send_mock.assert_called_once_with(saved_notifications[0], False, QueueNames.SEND_EMAIL_LOW)
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "stale service bug: try_to_send_notifications_to_queue uses the last service from the batch loop, "
-            "so if that service is research_mode=True, live-service notifications in the same batch are "
-            "incorrectly routed to research-mode-tasks. Fix: derive research_mode per-notification from "
-            "notification.queue_name instead of from the stale service parameter."
-        ),
-    )
     def test_live_service_notifications_not_routed_to_research_mode_when_stale_service_is_research(self, notify_api, mocker):
-        """Regression for the stale-service bug: a live-service notification must not be sent to
-        research-mode-tasks just because the last service in the batch has research_mode=True.
+        """Regression: research_mode is now derived per-notification from queue_name, not from the
+        stale service variable — so live-service notifications are never silently swallowed.
         """
         send_mock = mocker.patch("app.celery.tasks.send_notification_to_queue")
 
@@ -632,11 +618,8 @@ class TestTryToSendNotificationsToQueue:
         notification_id_queue = {live_id: None, research_id: None}
 
         # Stale service from the last loop iteration — happens to be the research-mode one.
-        stale_research_service = MagicMock(research_mode=True)
 
-        try_to_send_notifications_to_queue(
-            notification_id_queue, stale_research_service, [live_notification, research_notification]
-        )
+        try_to_send_notifications_to_queue(notification_id_queue, [live_notification, research_notification])
 
         # live_notification must be called with research_mode=False (its own correct value).
         # Currently fails because research_mode=True is passed for all notifications.

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -608,6 +608,45 @@ class TestTryToSendNotificationsToQueue:
         # Even though notification.id is a UUID object here, the str() cast in the lookup finds it.
         send_mock.assert_called_once_with(saved_notifications[0], False, QueueNames.SEND_EMAIL_LOW)
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "stale service bug: try_to_send_notifications_to_queue uses the last service from the batch loop, "
+            "so if that service is research_mode=True, live-service notifications in the same batch are "
+            "incorrectly routed to research-mode-tasks. Fix: derive research_mode per-notification from "
+            "notification.queue_name instead of from the stale service parameter."
+        ),
+    )
+    def test_live_service_notifications_not_routed_to_research_mode_when_stale_service_is_research(self, notify_api, mocker):
+        """Regression for the stale-service bug: a live-service notification must not be sent to
+        research-mode-tasks just because the last service in the batch has research_mode=True.
+        """
+        send_mock = mocker.patch("app.celery.tasks.send_notification_to_queue")
+
+        live_id = str(uuid.uuid4())
+        research_id = str(uuid.uuid4())
+
+        live_notification = self._make_notification(live_id, QueueNames.SEND_EMAIL_HIGH)
+        research_notification = self._make_notification(research_id, QueueNames.RESEARCH_MODE)
+
+        notification_id_queue = {live_id: None, research_id: None}
+
+        # Stale service from the last loop iteration — happens to be the research-mode one.
+        stale_research_service = MagicMock(research_mode=True)
+
+        try_to_send_notifications_to_queue(
+            notification_id_queue, stale_research_service, [live_notification, research_notification]
+        )
+
+        # live_notification must be called with research_mode=False (its own correct value).
+        # Currently fails because research_mode=True is passed for all notifications.
+        live_call = send_mock.call_args_list[0]
+        assert live_call == call(live_notification, False, QueueNames.SEND_EMAIL_HIGH)
+
+        # research_notification legitimately goes to research mode.
+        research_call = send_mock.call_args_list[1]
+        assert research_call == call(research_notification, True, QueueNames.RESEARCH_MODE)
+
 
 @pytest.mark.usefixtures("notify_db_session")
 class TestMixedPriorityBatchRouting:

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -622,7 +622,6 @@ class TestTryToSendNotificationsToQueue:
         try_to_send_notifications_to_queue(notification_id_queue, [live_notification, research_notification])
 
         # live_notification must be called with research_mode=False (its own correct value).
-        # Currently fails because research_mode=True is passed for all notifications.
         live_call = send_mock.call_args_list[0]
         assert live_call == call(live_notification, False, QueueNames.SEND_EMAIL_HIGH)
 

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -1673,7 +1673,7 @@ class TestSaveErrorHandling:
         signed_notifications = [1]
         verified_notifications = [n1]
         signed_and_verified = list(zip(signed_notifications, verified_notifications))
-        handle_batch_error_and_forward(save_smss, signed_and_verified, SMS_TYPE, expected_exception, receipt_id, sample_template)
+        handle_batch_error_and_forward(save_smss, signed_and_verified, SMS_TYPE, expected_exception, receipt_id)
         retry_func.assert_called_with(exc=expected_exception, queue="retry-tasks")
 
     def test_handler_send_3notifications(self, sample_template, mocker):
@@ -1699,7 +1699,7 @@ class TestSaveErrorHandling:
         signed_notifications = [1, 2, 3]
         verified_notifications = [n1, n2, n3]
         signed_and_verified = list(zip(signed_notifications, verified_notifications))
-        handle_batch_error_and_forward(save_smss, signed_and_verified, SMS_TYPE, expected_exception, receipt_id, sample_template)
+        handle_batch_error_and_forward(save_smss, signed_and_verified, SMS_TYPE, expected_exception, receipt_id)
 
         assert save_func.call_count == 3
         assert save_func.call_args_list == [


### PR DESCRIPTION
# Summary | Résumé

This fixes a bug for with the notifications queuing when processing batches. 

1. Fixing skip of notifications when `service.research_mode` is enabled for the last processed notification of a batch.

Additionally, note of the following:

* Removed unnecessary `template` parameter to error handling function, as only the process_type is necessary from it and this can be resolved within the function without further parameters. 
* Adding test that demonstrate research_mode bug preventing notifications send.
* Removing unnecessary `template` and `service` parameters to prevent further similar bugs, as these represent only one of the many notifications sent to these functions, and can't represent them all with proper values. We either have to send all associated services and templates for each notification or resolve their values at appropriate time.

## Related Issues | Cartes liées

* [Investigate 5 minutes delay for failed high priority notifications](https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/919)

# Test instructions | Instructions pour tester la modification

New unit-tests cover the behavior + regression tests.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.