### PR TITLE
security: use dedicated OIDC role for performance test image pushes

### DIFF
--- a/.github/workflows/build_and_push_performance_test.yml
+++ b/.github/workflows/build_and_push_performance_test.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Configure credentials to Notify using OIDC
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:
-          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-api-apply
+          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-api-build-push-performance-test
           role-session-name: NotifyApiApply
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 

--- a/.github/workflows/build_and_push_performance_test.yml
+++ b/.github/workflows/build_and_push_performance_test.yml
@@ -60,8 +60,8 @@ jobs:
       - name: Configure credentials to Notify using OIDC
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:
-          role-to-assume: arn:aws:iam::${{env.ACCOUNT_ID}}:role/notification-api-build-push-performance-test
-          role-session-name: NotifyApiApply
+          role-to-assume: arn:aws:iam::${{ env.ACCOUNT_ID }}:role/notification-api-build-push-performance-test
+          role-session-name: NotifyApiBuildPushPerformanceTest
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
       - name: Login to ECR


### PR DESCRIPTION
## Description

Use the dedicated least-privilege OIDC role when the performance test container is pushed to staging ECR.

This removes the stress-test build workflow's dependency on the broad `notification-api-apply` role while retaining GitHub Actions OIDC authentication.

## Acceptance criteria

- [x] No IAM access keys or secrets are used by the stress-test build workflow
- [x] OIDC authentication is used through `aws-actions/configure-aws-credentials`
- [x] The workflow assumes `notification-api-build-push-performance-test`, a dedicated role for this operation

## Validation

- Ruby YAML parse passed
- `git diff --check` passed
- Workspace diagnostics reported no errors for the changed workflow
