### PR TITLE
security: remove staging smoke access keys

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -54,13 +54,6 @@ jobs:
       run: |
         docker push $DOCKER_SLUG:latest && docker push $DOCKER_SLUG:${GITHUB_SHA::7}
 
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
-      with:
-        aws-access-key-id: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
-        aws-region: ca-central-1                      
-
     - name: Set Docker Tag
       run: echo "DOCKER_TAG=${GITHUB_SHA::7}" >> $GITHUB_ENV
       env:

--- a/tests_smoke/smoke/common.py
+++ b/tests_smoke/smoke/common.py
@@ -30,8 +30,6 @@ class Config:
     AWS_REGION = "ca-central-1"
     CSV_UPLOAD_BUCKET_NAME = os.environ.get("SMOKE_CSV_UPLOAD_BUCKET_NAME", "notification-canada-ca-staging-csv-upload")
 
-    AWS_ACCESS_KEY_ID = os.environ.get("SMOKE_AWS_ACCESS_KEY_ID")
-    AWS_SECRET_ACCESS_KEY = os.environ.get("SMOKE_AWS_SECRET_ACCESS_KEY")
     SERVICE_ID = os.environ.get("SMOKE_SERVICE_ID", "")
     USER_ID = os.environ.get("SMOKE_USER_ID")
     EMAIL_TO = os.environ.get("SMOKE_EMAIL_TO", INTERNAL_TEST_EMAIL_ADDRESS)
@@ -42,14 +40,7 @@ class Config:
     JOB_SIZE = int(os.environ.get("SMOKE_JOB_SIZE", 2))
 
 
-# the workflows in notification-manifests have been changed to use OIDC to assume roles so SMOKE_AWS_ACCESS_KEY_ID and SMOKE_AWS_SECRET_ACCESS_KEY should no longer be set
-if Config.AWS_ACCESS_KEY_ID is None:
-    boto_session = Session()
-else:
-    boto_session = Session(
-        aws_access_key_id=Config.AWS_ACCESS_KEY_ID,
-        aws_secret_access_key=Config.AWS_SECRET_ACCESS_KEY,
-    )
+boto_session = Session()
 
 
 class Notification_type(Enum):


### PR DESCRIPTION
## Summary

Remove long-lived staging AWS access-key usage from the API repository's test paths.

## Changes

- Removed the static `STAGING_AWS_ACCESS_KEY_ID` / `STAGING_AWS_SECRET_ACCESS_KEY` credential step from `.github/workflows/docker.yaml`. The job already authenticates to ECR through GitHub Actions OIDC.
- Removed the optional `SMOKE_AWS_ACCESS_KEY_ID` / `SMOKE_AWS_SECRET_ACCESS_KEY` fallback from `tests_smoke/smoke/common.py`. Smoke tests now always use the ambient AWS credential provider chain, including OIDC-provided credentials.

## Validation

- YAML parsing passed
- Python compilation passed
- `git diff --check` passed
- Ruff passed
- Ruff-format passed
- No tracked workflow or smoke-test code consumes staging AWS access-key secrets

Terraform IAM-user deactivation should be performed separately after this change is deployed and staging behavior is observed, so any remaining consumers can be identified without disabling the identity prematurely.