### PR TITLE
Make the 404 error consistent with the others

### DIFF
--- a/app/v2/errors.py
+++ b/app/v2/errors.py
@@ -156,6 +156,14 @@ class JobNotFoundError(InvalidRequest):
         super().__init__(message=self.__class__.message, status_code=self.__class__.status_code)
 
 
+class NotificationNotFoundError(InvalidRequest):
+    status_code = 404
+    message = "Notification not found in database"
+
+    def __init__(self):
+        super().__init__(message=self.__class__.message, status_code=self.__class__.status_code)
+
+
 class JobCancellationNotAllowedError(InvalidRequest):
     status_code = 409
     message = "Job cannot be cancelled because it is already being sent or has already been sent"

--- a/app/v2/notifications/delete_notifications.py
+++ b/app/v2/notifications/delete_notifications.py
@@ -3,7 +3,7 @@ from flask import jsonify
 from app import authenticated_service
 from app.dao import notifications_dao
 from app.schema_validation import validate
-from app.v2.errors import BadRequestError
+from app.v2.errors import BadRequestError, NotificationNotFoundError
 from app.v2.notifications import v2_notification_blueprint
 from app.v2.notifications.notification_schemas import notification_by_id
 
@@ -20,7 +20,7 @@ def delete_notification_by_id(notification_id):
     )
 
     if notification is None:
-        return jsonify(result="error", message="Notification not found in database"), 404
+        raise NotificationNotFoundError()
 
     scheduled_notification = notification.scheduled_notification
     if scheduled_notification is None:

--- a/openapi/v2-notifications-api-en.yaml
+++ b/openapi/v2-notifications-api-en.yaml
@@ -300,13 +300,15 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
               examples:
                 notification_not_found:
                   summary: Notification not found
                   value:
-                    result: "error"
-                    message: "Notification not found in database"
+                    status_code: 404
+                    errors:
+                      - error: "NotificationNotFoundError"
+                        message: "Notification not found in database"
         '500':
           description: Internal server error
           content:

--- a/openapi/v2-notifications-api-fr.yaml
+++ b/openapi/v2-notifications-api-fr.yaml
@@ -300,13 +300,15 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
               examples:
                 notification_not_found:
                   summary: Notification not found
                   value:
-                    result: "error"
-                    message: "Notification not found in database"
+                    status_code: 404
+                    errors:
+                      - error: "NotificationNotFoundError"
+                        message: "Notification not found in database"
         '500':
           description: Erreur interne du serveur
           content:

--- a/openapi/v2-notifications-api.yaml.j2
+++ b/openapi/v2-notifications-api.yaml.j2
@@ -300,13 +300,15 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
               examples:
                 notification_not_found:
                   summary: Notification not found
                   value:
-                    result: "error"
-                    message: "Notification not found in database"
+                    status_code: 404
+                    errors:
+                      - error: "NotificationNotFoundError"
+                        message: "Notification not found in database"
         '500':
           description: {{ t("Internal server error") }}
           content:

--- a/tests/app/v2/notifications/test_delete_notifications.py
+++ b/tests/app/v2/notifications/test_delete_notifications.py
@@ -123,7 +123,7 @@ def test_delete_notification_nonexistent_id_returns_404(client, sample_notificat
 
     assert response.status_code == 404
     json_response = json.loads(response.get_data(as_text=True))
-    assert json_response == {"message": "Notification not found in database", "result": "error"}
+    assert json_response["errors"] == [{"error": "NotificationNotFoundError", "message": "Notification not found in database"}]
 
 
 def test_delete_notification_belonging_to_another_service_returns_404(client, sample_template):


### PR DESCRIPTION
# Summary | Résumé

This changes the 404 error returned by the `DELETE /v2/notifications/{notification-id}` endpoint from:

```
{
  "message": "Notification not found in database",
  "result": "error"
}
```

to 
```
{
  "error": "NotificationNotFoundError",
  "message": "Notification not found in database"
}
```

So that it is more consistent with the other errors.


## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/3202

# Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.