### PR TITLE
Fix errors in the openapi spec

### DIFF
--- a/openapi/v2-notifications-api-en.yaml
+++ b/openapi/v2-notifications-api-en.yaml
@@ -90,29 +90,16 @@ paths:
                     errors:
                       - error: "AuthError"
                         message: "Unauthorized, authentication token must be provided"
-        '404':
-          description: Notification not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              example:
-                notification_not_found:
-                  summary: Notification not found
-                  value:
-                    result: "error"
-                    message: "Notification not found in database"
         '500':
           description: Internal server error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
               example:
-                internal_server_error:
-                  summary: Internal server error
-                  value:
-                    result: "error"
+                status_code: 500
+                errors:
+                  - error: "Exception"
                     message: "Internal server error"
       security:
         - apiKey: []
@@ -203,12 +190,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_server_error:
-                  summary: Internal server error
-                  value:
-                    result: "error"
+                $ref: '#/components/schemas/ValidationErrorResponse'
+              example:
+                status_code: 500
+                errors:
+                  - error: "Exception"
                     message: "Internal server error"
       security:
         - apiKey: []
@@ -314,12 +300,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_server_error:
-                  summary: Internal server error
-                  value:
-                    result: "error"
+                $ref: '#/components/schemas/ValidationErrorResponse'
+              example:
+                status_code: 500
+                errors:
+                  - error: "Exception"
                     message: "Internal server error"
       security:
         - apiKey: []
@@ -470,10 +455,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
               example:
-                result: "error"
-                message: "Unauthorized"
+                status_code: 401
+                errors:
+                  - error: "AuthError"
+                    message: "Unauthorized, authentication token must be provided"
         '403':
           description: Forbidden - authentication or authorization errors
           content:
@@ -521,12 +508,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_server_error:
-                  summary: Internal server error
-                  value:
-                    result: "error"
+                $ref: '#/components/schemas/ValidationErrorResponse'
+              example:
+                status_code: 500
+                errors:
+                  - error: "Exception"
                     message: "Internal server error"
       security:
         - apiKey: []
@@ -642,12 +628,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
               example:
-                internal_server_error:
-                  summary: Internal server error
-                  value:
-                    result: "error"
+                status_code: 500
+                errors:
+                  - error: "Exception"
                     message: "Internal server error"
       security:
         - apiKey: []
@@ -685,26 +670,34 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
               example:
-                bad_request:
-                  value:
-                    status_code: 400
-                    errors:
-                      - error: "ValidationError"
-                        message: "Unauthorized, authentication token must be provided"
+                status_code: 400
+                errors:
+                  - error: "ValidationError"
+                    message: "type bad is not one of [sms, email, letter]"
         '401':
           description: Unauthorized
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
+              example:
+                status_code: 401
+                errors:
+                  - error: "AuthError"
+                    message: "Unauthorized, authentication token must be provided"
         '500':
           description: Internal server error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
+              example:
+                status_code: 500
+                errors:
+                  - error: "Exception"
+                    message: "Internal server error"
       security:
         - apiKey: []
 
@@ -761,7 +754,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
               examples:
                 system_clock_error:
                   summary: System clock not accurate
@@ -782,19 +775,23 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
               example:
-                template_not_found:
-                  summary: Template not found
-                  value:
-                    result: "error"
-                    message: "Template not found in database"
+                status_code: 404
+                errors:
+                  - error: "NoResultFound"
+                    message: "No result found"
         '500':
           description: Internal server error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
+              example:
+                status_code: 500
+                errors:
+                  - error: "Exception"
+                    message: "Internal server error"
       security:
         - apiKey: []
 
@@ -1301,7 +1298,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
       security:
         - apiKey: []
     post:
@@ -1493,12 +1490,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_server_error:
-                  summary: Internal server error
-                  value:
-                    result: "error"
+                $ref: '#/components/schemas/ValidationErrorResponse'
+              example:
+                status_code: 500
+                errors:
+                  - error: "Exception"
                     message: "Internal server error"
       security:
         - apiKey: []
@@ -1663,10 +1659,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
               example:
-                result: "error"
-                message: "Internal server error"
+                status_code: 500
+                errors:
+                  - error: "Exception"
+                    message: "Internal server error"
       security:
         - apiKey: []
 
@@ -1865,13 +1863,23 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
+              example:
+                status_code: 404
+                errors:
+                  - error: "JobNotFoundError"
+                    message: "Job not found in database"
         '500':
           description: Internal server error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
+              example:
+                status_code: 500
+                errors:
+                  - error: "Exception"
+                    message: "Internal server error"
       security:
         - apiKey: []
     delete:
@@ -1948,7 +1956,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
+              example:
+                status_code: 500
+                errors:
+                  - error: "Exception"
+                    message: "Internal server error"
       security:
         - apiKey: []
 

--- a/openapi/v2-notifications-api-fr.yaml
+++ b/openapi/v2-notifications-api-fr.yaml
@@ -90,30 +90,17 @@ paths:
                     errors:
                       - error: "AuthError"
                         message: "Non autorisé, le jeton d'authentification doit être fourni"
-        '404':
-          description: Notification non trouvée
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              example:
-                notification_not_found:
-                  summary: Notification non trouvée
-                  value:
-                    result: "error"
-                    message: "Notification non trouvée dans la base de données"
         '500':
           description: Erreur interne du serveur
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
               example:
-                internal_server_error:
-                  summary: Erreur interne du serveur
-                  value:
-                    result: "error"
-                    message: "Erreur interne du serveur"
+                status_code: 500
+                errors:
+                  - error: "Exception"
+                    message: "Internal server error"
       security:
         - apiKey: []
 
@@ -203,12 +190,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_server_error:
-                  summary: Internal server error
-                  value:
-                    result: "error"
+                $ref: '#/components/schemas/ValidationErrorResponse'
+              example:
+                status_code: 500
+                errors:
+                  - error: "Exception"
                     message: "Internal server error"
       security:
         - apiKey: []
@@ -314,12 +300,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_server_error:
-                  summary: Internal server error
-                  value:
-                    result: "error"
+                $ref: '#/components/schemas/ValidationErrorResponse'
+              example:
+                status_code: 500
+                errors:
+                  - error: "Exception"
                     message: "Internal server error"
       security:
         - apiKey: []
@@ -470,10 +455,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
               example:
-                result: "error"
-                message: "Unauthorized"
+                status_code: 401
+                errors:
+                  - error: "AuthError"
+                    message: "Unauthorized, authentication token must be provided"
         '403':
           description: Interdit - erreurs d’authentification ou d’autorisation
           content:
@@ -521,12 +508,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_server_error:
-                  summary: Internal server error
-                  value:
-                    result: "error"
+                $ref: '#/components/schemas/ValidationErrorResponse'
+              example:
+                status_code: 500
+                errors:
+                  - error: "Exception"
                     message: "Internal server error"
       security:
         - apiKey: []
@@ -642,12 +628,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
               example:
-                internal_server_error:
-                  summary: Internal server error
-                  value:
-                    result: "error"
+                status_code: 500
+                errors:
+                  - error: "Exception"
                     message: "Internal server error"
       security:
         - apiKey: []
@@ -685,26 +670,34 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
               example:
-                bad_request:
-                  value:
-                    status_code: 400
-                    errors:
-                      - error: "ValidationError"
-                        message: "Unauthorized, authentication token must be provided"
+                status_code: 400
+                errors:
+                  - error: "ValidationError"
+                    message: "type bad is not one of [sms, email, letter]"
         '401':
           description: Non autorisé
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
+              example:
+                status_code: 401
+                errors:
+                  - error: "AuthError"
+                    message: "Unauthorized, authentication token must be provided"
         '500':
           description: Erreur interne du serveur
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
+              example:
+                status_code: 500
+                errors:
+                  - error: "Exception"
+                    message: "Internal server error"
       security:
         - apiKey: []
 
@@ -761,7 +754,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
               examples:
                 system_clock_error:
                   summary: System clock not accurate
@@ -782,19 +775,23 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
               example:
-                template_not_found:
-                  summary: Template not found
-                  value:
-                    result: "error"
-                    message: "Template not found in database"
+                status_code: 404
+                errors:
+                  - error: "NoResultFound"
+                    message: "No result found"
         '500':
           description: Erreur interne du serveur
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
+              example:
+                status_code: 500
+                errors:
+                  - error: "Exception"
+                    message: "Internal server error"
       security:
         - apiKey: []
 
@@ -1301,7 +1298,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
       security:
         - apiKey: []
     post:
@@ -1493,12 +1490,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_server_error:
-                  summary: Internal server error
-                  value:
-                    result: "error"
+                $ref: '#/components/schemas/ValidationErrorResponse'
+              example:
+                status_code: 500
+                errors:
+                  - error: "Exception"
                     message: "Internal server error"
       security:
         - apiKey: []
@@ -1663,10 +1659,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
               example:
-                result: "error"
-                message: "Internal server error"
+                status_code: 500
+                errors:
+                  - error: "Exception"
+                    message: "Internal server error"
       security:
         - apiKey: []
 
@@ -1865,13 +1863,23 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
+              example:
+                status_code: 404
+                errors:
+                  - error: "JobNotFoundError"
+                    message: "Job not found in database"
         '500':
           description: Erreur interne du serveur
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
+              example:
+                status_code: 500
+                errors:
+                  - error: "Exception"
+                    message: "Internal server error"
       security:
         - apiKey: []
     delete:
@@ -1948,7 +1956,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
+              example:
+                status_code: 500
+                errors:
+                  - error: "Exception"
+                    message: "Internal server error"
       security:
         - apiKey: []
 

--- a/openapi/v2-notifications-api.yaml.j2
+++ b/openapi/v2-notifications-api.yaml.j2
@@ -90,30 +90,17 @@ paths:
                     errors:
                       - error: "AuthError"
                         message: "{{ t("Unauthorized, authentication token must be provided") }}"
-        '404':
-          description: {{ t("Notification not found") }}
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              example:
-                notification_not_found:
-                  summary: {{ t("Notification not found") }}
-                  value:
-                    result: "error"
-                    message: "{{ t("Notification not found in database") }}"
         '500':
           description: {{ t("Internal server error") }}
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
               example:
-                internal_server_error:
-                  summary: {{ t("Internal server error") }}
-                  value:
-                    result: "error"
-                    message: "{{ t("Internal server error") }}"
+                status_code: 500
+                errors:
+                  - error: "Exception"
+                    message: "Internal server error"
       security:
         - apiKey: []
 
@@ -203,12 +190,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_server_error:
-                  summary: Internal server error
-                  value:
-                    result: "error"
+                $ref: '#/components/schemas/ValidationErrorResponse'
+              example:
+                status_code: 500
+                errors:
+                  - error: "Exception"
                     message: "Internal server error"
       security:
         - apiKey: []
@@ -314,12 +300,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_server_error:
-                  summary: Internal server error
-                  value:
-                    result: "error"
+                $ref: '#/components/schemas/ValidationErrorResponse'
+              example:
+                status_code: 500
+                errors:
+                  - error: "Exception"
                     message: "Internal server error"
       security:
         - apiKey: []
@@ -470,10 +455,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
               example:
-                result: "error"
-                message: "Unauthorized"
+                status_code: 401
+                errors:
+                  - error: "AuthError"
+                    message: "Unauthorized, authentication token must be provided"
         '403':
           description: {{ t("Forbidden - authentication or authorization errors") }}
           content:
@@ -521,12 +508,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_server_error:
-                  summary: Internal server error
-                  value:
-                    result: "error"
+                $ref: '#/components/schemas/ValidationErrorResponse'
+              example:
+                status_code: 500
+                errors:
+                  - error: "Exception"
                     message: "Internal server error"
       security:
         - apiKey: []
@@ -642,12 +628,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
               example:
-                internal_server_error:
-                  summary: Internal server error
-                  value:
-                    result: "error"
+                status_code: 500
+                errors:
+                  - error: "Exception"
                     message: "Internal server error"
       security:
         - apiKey: []
@@ -685,26 +670,34 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
               example:
-                bad_request:
-                  value:
-                    status_code: 400
-                    errors:
-                      - error: "ValidationError"
-                        message: "Unauthorized, authentication token must be provided"
+                status_code: 400
+                errors:
+                  - error: "ValidationError"
+                    message: "type bad is not one of [sms, email, letter]"
         '401':
           description: {{ t("Unauthorized") }}
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
+              example:
+                status_code: 401
+                errors:
+                  - error: "AuthError"
+                    message: "Unauthorized, authentication token must be provided"
         '500':
           description: {{ t("Internal server error") }}
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
+              example:
+                status_code: 500
+                errors:
+                  - error: "Exception"
+                    message: "Internal server error"
       security:
         - apiKey: []
 
@@ -761,7 +754,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
               examples:
                 system_clock_error:
                   summary: System clock not accurate
@@ -782,19 +775,23 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
               example:
-                template_not_found:
-                  summary: Template not found
-                  value:
-                    result: "error"
-                    message: "Template not found in database"
+                status_code: 404
+                errors:
+                  - error: "NoResultFound"
+                    message: "No result found"
         '500':
           description: {{ t("Internal server error") }}
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
+              example:
+                status_code: 500
+                errors:
+                  - error: "Exception"
+                    message: "Internal server error"
       security:
         - apiKey: []
 
@@ -1301,7 +1298,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
       security:
         - apiKey: []
     post:
@@ -1493,12 +1490,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_server_error:
-                  summary: Internal server error
-                  value:
-                    result: "error"
+                $ref: '#/components/schemas/ValidationErrorResponse'
+              example:
+                status_code: 500
+                errors:
+                  - error: "Exception"
                     message: "Internal server error"
       security:
         - apiKey: []
@@ -1663,10 +1659,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
               example:
-                result: "error"
-                message: "Internal server error"
+                status_code: 500
+                errors:
+                  - error: "Exception"
+                    message: "Internal server error"
       security:
         - apiKey: []
 
@@ -1865,13 +1863,23 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
+              example:
+                status_code: 404
+                errors:
+                  - error: "JobNotFoundError"
+                    message: "Job not found in database"
         '500':
           description: {{ t("Internal server error") }}
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
+              example:
+                status_code: 500
+                errors:
+                  - error: "Exception"
+                    message: "Internal server error"
       security:
         - apiKey: []
     delete:
@@ -1948,7 +1956,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidationErrorResponse'
+              example:
+                status_code: 500
+                errors:
+                  - error: "Exception"
+                    message: "Internal server error"
       security:
         - apiKey: []
 


### PR DESCRIPTION
# Summary | Résumé

This PR fixes some places where the open api spec errors were inconsistent with what the v2 api actually returns. Here are the fixes:
- All 500 responses (11 of them): `Error` → `ValidationErrorResponse` with `{status_code:500, errors:[{error, message:"Internal server error"}]}` (confirmed shape via test_errors.py:160).
- `POST email` 401, `GET /v2/templates` 400/401, `GET /v2/template/{id}` 403/404, `GET /v2/notifications/bulk/{job_id}` 404: `Error` → `ValidationErrorResponse` with accurate examples.
- Removed the 404 on the `GET /v2/notifications` list endpoint — that handler never returns a "not found" 404.
- Left `GET /v2/notifications/{id}` 404 on the `Error` schema (it genuinely returns {result, message}) (I'll fix that in a follow up PR)

# Test instructions | Instructions pour tester la modification

You could check out the branch, and run the api and documentation site locally to view the new errors.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.